### PR TITLE
Make exact-head app-build CI fail closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,31 @@ on:
 permissions:
   contents: read
 
+env:
+  CI_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   python-sanity:
-    name: Python Sanity
+    name: Python Checks (exact head)
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CI_HEAD_SHA }}
+
+      - name: Verify exact checked-out head
+        run: |
+          actual_head="$(git rev-parse HEAD)"
+          echo "Expected event head: $CI_HEAD_SHA"
+          echo "Checked out HEAD:    $actual_head"
+          test "$actual_head" = "$CI_HEAD_SHA"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -39,47 +51,100 @@ jobs:
             tools/mcp_xcode_server.py
 
   swift-tests:
-    name: Swift Package Tests
-    runs-on: macos-latest
+    name: Swift Package Tests (exact head)
+    runs-on: macos-26
     timeout-minutes: 15
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CI_HEAD_SHA }}
+
+      - name: Verify exact checked-out head
+        run: |
+          actual_head="$(git rev-parse HEAD)"
+          echo "Expected event head: $CI_HEAD_SHA"
+          echo "Checked out HEAD:    $actual_head"
+          test "$actual_head" = "$CI_HEAD_SHA"
 
       - name: Run core logic tests
         working-directory: ios/WalkingPadRemote/WalkingPadRemote
         run: swift test
 
+  xcode-metadata:
+    name: Xcode Project Metadata (diagnostic only)
+    runs-on: macos-26
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CI_HEAD_SHA }}
+
+      - name: Verify exact checked-out head
+        run: |
+          actual_head="$(git rev-parse HEAD)"
+          echo "Expected event head: $CI_HEAD_SHA"
+          echo "Checked out HEAD:    $actual_head"
+          test "$actual_head" = "$CI_HEAD_SHA"
+
+      - name: Validate project metadata (does not compile the app)
+        run: xcodebuild -list -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj
+
   xcode-build:
-    name: Xcode Build
-    runs-on: macos-latest
+    name: iOS/watchOS App Build (unsigned, exact head)
+    runs-on: macos-26
     timeout-minutes: 25
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CI_HEAD_SHA }}
 
-      - name: Inspect hosted Xcode and SDK availability
-        id: hosted_sdk
+      - name: Verify exact checked-out head
         run: |
+          actual_head="$(git rev-parse HEAD)"
+          echo "Expected event head: $CI_HEAD_SHA"
+          echo "Checked out HEAD:    $actual_head"
+          test "$actual_head" = "$CI_HEAD_SHA"
+
+      - name: Verify required hosted toolchain
+        run: |
+          set -euo pipefail
+
           xcodebuild -version
           xcodebuild -showsdks
 
-          if xcodebuild -showsdks | grep -q "iphoneos26" && xcodebuild -showsdks | grep -q "watchos26"; then
-            echo "can_full_build=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::Skipping full app build on this hosted runner because it does not provide the iOS 26 / watchOS 26 SDKs required by the current app targets."
-            echo "can_full_build=false" >> "$GITHUB_OUTPUT"
+          if ! ios_sdk_version="$(xcrun --sdk iphoneos --show-sdk-version)" ||
+             ! watchos_sdk_version="$(xcrun --sdk watchos --show-sdk-version)"; then
+            echo "::error title=Hosted runner toolchain limitation::The required iOS/watchOS SDKs are unavailable; the app-build gate fails closed."
+            exit 1
           fi
 
-      - name: Validate Xcode project metadata on older hosted runners
-        if: steps.hosted_sdk.outputs.can_full_build != 'true'
-        run: |
-          xcodebuild -list -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj
+          version_at_least() {
+            awk -v actual="$1" -v required="$2" 'BEGIN {
+              split(actual, actual_parts, ".")
+              split(required, required_parts, ".")
+              for (part_index = 1; part_index <= 3; part_index++) {
+                actual_part = actual_parts[part_index] + 0
+                required_part = required_parts[part_index] + 0
+                if (actual_part > required_part) exit 0
+                if (actual_part < required_part) exit 1
+              }
+              exit 0
+            }'
+          }
 
-      - name: Build iOS app without code signing
-        if: steps.hosted_sdk.outputs.can_full_build == 'true'
+          if ! version_at_least "$ios_sdk_version" "26.2" ||
+             ! version_at_least "$watchos_sdk_version" "26.2"; then
+            echo "::error title=Hosted runner toolchain limitation::The app requires iOS/watchOS 26.2 or newer SDKs, but this runner provides iOS $ios_sdk_version and watchOS $watchos_sdk_version; the app-build gate fails closed."
+            exit 1
+          fi
+
+      - name: Build iOS/watchOS app without code signing
         run: >
           xcodebuild
           -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,10 @@ swift test
 xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build
 ```
 
-GitHub-hosted runners may lag behind the local Xcode/SDK version used by the app targets. In that case, the hosted CI keeps Python checks, Swift package tests, and Xcode project validation, while the full unsigned app build stays gated on hosted SDK availability.
+Hosted CI checks out and verifies the exact event head for every gate. The
+unsigned app-build job runs on the macOS 26 runner and fails closed when the
+required Xcode toolchain is unavailable. The separately named metadata job is
+diagnostic only and does not prove that the app compiled.
 
 ## Pull request expectations
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,14 @@ On macOS, Python needs Bluetooth permission in `System Settings -> Privacy & Sec
 
 GitHub Actions currently runs:
 
-- Python syntax compilation for the public BLE/MCP utilities
-- `swift test` for the pure core-logic package
-- unsigned `xcodebuild` for the iOS/watchOS project when the hosted runner has matching iOS/watchOS SDKs
-- transparent fallback project validation (`xcodebuild -list`) when GitHub-hosted Xcode lags behind the local app deployment targets
+- Python syntax compilation for the public BLE/MCP utilities at the exact event head
+- `swift test` for the pure core-logic package at the exact event head
+- a required unsigned `xcodebuild` for the iOS/watchOS project at the exact event head
+- separately named diagnostic-only project metadata validation (`xcodebuild -list`)
+
+The app-build job fails closed if the hosted runner cannot provide the required
+Xcode toolchain. A successful metadata check never substitutes for a successful
+app compile.
 
 ## Safety and privacy
 


### PR DESCRIPTION
## Summary

- check out and assert the exact event head in every CI job
- run the real unsigned iOS/watchOS app build unconditionally on `macos-26`
- fail closed in a separately named toolchain preflight when iOS/watchOS 26.2+ SDKs are unavailable
- keep `xcodebuild -list` as a separately named diagnostic-only job
- document that metadata validation never substitutes for compilation

Exact base: `bf6a5ca231f8eb3cad9159416501a789cf2277f8`
Exact head: `38c6616dd82bd5e754366c309b4ef536ed86cb90`

Closes #4 when merged.

## Verification

- workflow YAML parse and CI contract structure assertions passed
- `PYTHONPYCACHEPREFIX=/private/tmp/walkingpad-issue-4-pycache python3 -m compileall -q scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py`
- `cd ios/WalkingPadRemote/WalkingPadRemote && swift test` — 40 tests, 0 failures
- `xcodebuild -list -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj`
- `xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' -derivedDataPath /private/tmp/walkingpad-issue-4-derived-data CODE_SIGNING_ALLOWED=NO build` — local BUILD SUCCEEDED for the iOS app and embedded watchOS app
- `git diff --check bf6a5ca231f8eb3cad9159416501a789cf2277f8..38c6616dd82bd5e754366c309b4ef536ed86cb90`
- fresh independent `gpt-5.6-terra/high` review — APPROVE, no material findings
- [exact-head CI run](https://github.com/tourvald/walkingpad-remote/actions/runs/31639179619) — success at `38c6616dd82bd5e754366c309b4ef536ed86cb90`
  - Python Checks (exact head) — success
  - Swift Package Tests (exact head) — success
  - Xcode Project Metadata (diagnostic only) — success
  - iOS/watchOS App Build (unsigned, exact head) — success
  - hosted build used Xcode 26.6 with iOS/watchOS 26.5 SDKs and logged `BUILD SUCCEEDED`

No install, launch, device, BLE, or treadmill action was performed.

## Risks / Notes

- `macos-26` is a moving hosted image. Future SDK/toolchain regressions fail the required app-build job closed rather than producing a metadata-only green result.
- Runner allocation/capacity failures can still leave CI queued or unavailable; they are not successful build evidence.
- The hosted log currently warns that older action versions use the deprecated Node.js 20 runtime and are forced onto Node.js 24; this inherited warning did not affect this run and is not treated as app-build evidence.
- No runtime Swift, Xcode project, BLE, HR, units, or Stop behavior changed.
- No branch-protection or repository settings changes are included.