### PR TITLE
Add fail-closed controller units truth

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -35,6 +35,7 @@ let package = Package(
             ],
             sources: [
                 "BLETransportCodec.swift",
+                "ControllerUnitsSafetyPolicy.swift",
                 "CooldownRuntimeEngine.swift",
                 "HRDomainService.swift",
                 "HRSettingsDefaults.swift",

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BLETransportCodec.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BLETransportCodec.swift
@@ -25,6 +25,43 @@ enum BLETransportCodec {
         let rawHex: String
     }
 
+    struct WalkingPadParams {
+        let maxSpeedRawTenths: UInt8
+        let startSpeedRawTenths: UInt8
+        let rawControllerUnit: UInt8
+        let checksumOk: Bool
+        let rawHex: String
+    }
+
+    /// Read-only controller parameters query. A zero key requests state and does
+    /// not mutate any A6 preference.
+    static func buildWalkingPadQueryParamsPacket() -> Data {
+        Data([0xF7, 0xA6, 0x00, 0x00, 0x00, 0x00, 0x00, 0xA6, 0xFD])
+    }
+
+    static func parseWalkingPadParams(_ data: Data) -> WalkingPadParams? {
+        guard data.count == 16,
+              data[0] == 0xF8,
+              data[1] == 0xA6,
+              data[15] == 0xFD else {
+            return nil
+        }
+
+        let checksumIndex = data.count - 2
+        let expectedChecksum = data[checksumIndex]
+        let computedChecksum = data[1..<checksumIndex].reduce(UInt16(0)) {
+            ($0 + UInt16($1)) & 0xFF
+        }
+
+        return WalkingPadParams(
+            maxSpeedRawTenths: data[7],
+            startSpeedRawTenths: data[8],
+            rawControllerUnit: data[13],
+            checksumOk: UInt8(computedChecksum) == expectedChecksum,
+            rawHex: hexString(data)
+        )
+    }
+
     static func buildFtmsRequestControlPacket() -> Data {
         Data([0x00])
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -2555,14 +2555,15 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     private func recomputeHrStartAllowed() {
+        let now = Date()
         let existingGatesAllowStart = isConnected && watchReachable && hrStreamingActive
-        let unitsDecision = controllerUnitsGateDecision()
+        let unitsDecision = controllerUnitsGateDecision(now: now)
         let allowed = ControllerUnitsSafetyPolicy.allowsStart(
             path: .hrControl,
             existingGatesAllowStart: existingGatesAllowStart,
             state: controllerUnitsTruth,
             currentConnectionEpoch: controllerUnitsConnectionEpoch,
-            now: Date(),
+            now: now,
             requiresFreshMetricTruth: controllerUnitsTruthRequired
         )
         isHrControlStartAllowed = allowed
@@ -2588,6 +2589,11 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         } else {
             hrControlStartBlockReasonText = nil
         }
+        refreshControllerUnitsTruthIfNeeded(
+            existingGatesAllowStart: existingGatesAllowStart,
+            unitsDecision: unitsDecision,
+            now: now
+        )
     }
     private func startTelemetry() {
         stopTelemetry()
@@ -3233,14 +3239,15 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         stopTrainingStructuredLog(reason: decision.blockReason?.rawValue ?? "controller_units_blocked")
     }
 
-    private func requestControllerUnitsTruth(trigger: String) {
-        guard isConnected,
-              treadmillProtocol == .walkingPad,
-              controllerUnitsConnectionEpoch != nil,
-              commandCharacteristic != nil else {
+    private func requestControllerUnitsTruth(trigger: String, now: Date = Date()) {
+        guard controllerUnitsQueryTransportReady,
+              ControllerUnitsRefreshPolicy.throttleAllowsQuery(
+                lastQueryAt: lastControllerUnitsQueryAt,
+                now: now
+              ) else {
             return
         }
-        lastControllerUnitsQueryAt = Date()
+        lastControllerUnitsQueryAt = now
         lastControllerUnitsQueryTrigger = trigger
         appendLog("Controller units query: trigger=\(trigger) command=A6 key=0 read_only=true")
         logTrainingEvent("controller_units_query_requested", fields: [
@@ -3254,11 +3261,73 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     private func retryControllerUnitsQueryAfterBlockedStart(now: Date = Date()) {
         guard isConnected, treadmillProtocol == .walkingPad else { return }
-        if let lastControllerUnitsQueryAt,
-           now.timeIntervalSince(lastControllerUnitsQueryAt) < 5 {
+        guard ControllerUnitsRefreshPolicy.throttleAllowsQuery(
+            lastQueryAt: lastControllerUnitsQueryAt,
+            now: now
+        ) else {
             return
         }
-        requestControllerUnitsTruth(trigger: "gate_blocked")
+        requestControllerUnitsTruth(trigger: "gate_blocked", now: now)
+    }
+
+    private var controllerUnitsQueryTransportReady: Bool {
+        guard isConnected,
+              treadmillProtocol == .walkingPad,
+              controllerUnitsConnectionEpoch != nil,
+              commandCharacteristic?.uuid == charFE02,
+              notifyCharacteristic?.uuid == charFE01,
+              notifyCharacteristic?.isNotifying == true,
+              let connectedPeripheralID = connectedPeripheralId else {
+            return false
+        }
+        return connectedPeripheral?.identifier == connectedPeripheralID
+    }
+
+    private func requestInitialControllerUnitsTruthIfReady(now: Date = Date()) {
+        let decision = ControllerUnitsRefreshPolicy.initialQuery(
+            transportReady: controllerUnitsQueryTransportReady,
+            lastQueryAt: lastControllerUnitsQueryAt,
+            now: now
+        )
+        guard let trigger = decision.trigger else { return }
+        requestControllerUnitsTruth(trigger: trigger.rawValue, now: now)
+    }
+
+    private func refreshControllerUnitsTruthIfNeeded(
+        existingGatesAllowStart: Bool,
+        unitsDecision: ControllerUnitsGateDecision,
+        now: Date
+    ) {
+        let refreshDecision = ControllerUnitsRefreshPolicy.blockedStartRefresh(
+            existingGatesAllowStart: existingGatesAllowStart,
+            isHrControlRunning: isHrControlRunning,
+            transportReady: controllerUnitsQueryTransportReady,
+            unitsDecision: unitsDecision,
+            lastQueryAt: lastControllerUnitsQueryAt,
+            now: now
+        )
+        guard let trigger = refreshDecision.trigger else { return }
+        requestControllerUnitsTruth(trigger: trigger.rawValue, now: now)
+    }
+
+    private func controllerUnitsResponseContext(
+        peripheral: CBPeripheral,
+        characteristic: CBCharacteristic
+    ) -> ControllerUnitsResponseContext? {
+        guard characteristic.uuid == charFE01,
+              let currentPeripheralID = connectedPeripheralId,
+              peripheral.identifier == currentPeripheralID,
+              connectedPeripheral?.identifier == currentPeripheralID,
+              let currentNotifyCharacteristic = notifyCharacteristic,
+              characteristic === currentNotifyCharacteristic,
+              let connectionEpoch = controllerUnitsConnectionEpoch else {
+            return nil
+        }
+        return ControllerUnitsResponseContext(
+            peripheralID: currentPeripheralID,
+            connectionEpoch: connectionEpoch,
+            notifyCharacteristicID: ObjectIdentifier(currentNotifyCharacteristic)
+        )
     }
 
     private func selectTreadmillProtocol(from discoveredUuids: Set<CBUUID>) -> TreadmillProtocol {
@@ -3895,7 +3964,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             if let w = write {
                 commandCharacteristic = w
                 appendLog("WalkingPad: command characteristic set to \(w.uuid.uuidString)")
-                requestControllerUnitsTruth(trigger: "connection_ready")
+                requestInitialControllerUnitsTruthIfReady()
             } else {
                 appendLog("WalkingPad: FE02 write not found on FE00")
             }
@@ -3955,6 +4024,22 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
     }
 
+    func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
+        if let error {
+            appendLog("Notify state error for \(characteristic.uuid.uuidString): \(error.localizedDescription)")
+            return
+        }
+        guard treadmillProtocol == .walkingPad,
+              characteristic.uuid == charFE01,
+              characteristic.isNotifying,
+              peripheral.identifier == connectedPeripheralId,
+              characteristic === notifyCharacteristic else {
+            return
+        }
+        appendLog("WalkingPad: FE01 notifications active")
+        requestInitialControllerUnitsTruthIfReady()
+    }
+
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
         if let error {
             appendLog("Notify update error from \(characteristic.uuid.uuidString): \(error.localizedDescription)")
@@ -3965,6 +4050,23 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             return
         }
         guard let data = characteristic.value else { return }
+        let isControllerUnitsResponse = treadmillProtocol == .walkingPad
+            && data.count >= 2
+            && data[0] == 0xF8
+            && data[1] == 0xA6
+        let unitsResponseContext: ControllerUnitsResponseContext?
+        if isControllerUnitsResponse {
+            guard let context = controllerUnitsResponseContext(
+                peripheral: peripheral,
+                characteristic: characteristic
+            ) else {
+                appendLog("Controller units response ignored: stale peripheral or connection context")
+                return
+            }
+            unitsResponseContext = context
+        } else {
+            unitsResponseContext = nil
+        }
         let now = Date()
         lastNotifyAt = now
         if lastCommandAwaitingAck,
@@ -3977,15 +4079,32 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
         switch treadmillProtocol {
         case .walkingPad:
-            if let params = BLETransportCodec.parseWalkingPadParams(data) {
+            if isControllerUnitsResponse {
                 let observedAt = Date()
-                guard let responseConnectionEpoch = controllerUnitsConnectionEpoch else { return }
+                let params = BLETransportCodec.parseWalkingPadParams(data)
+                guard let responseContext = unitsResponseContext else { return }
                 DispatchQueue.main.async {
-                    self.controllerUnitsTruthTracker.record(
-                        params,
-                        for: responseConnectionEpoch,
-                        at: observedAt
-                    )
+                    guard responseContext.matches(
+                        currentPeripheralID: self.connectedPeripheralId,
+                        currentConnectionEpoch: self.controllerUnitsConnectionEpoch,
+                        currentNotifyCharacteristicID: self.notifyCharacteristic.map(ObjectIdentifier.init)
+                    ) else {
+                        self.appendLog("Controller units response ignored after connection context changed")
+                        return
+                    }
+                    if let params {
+                        self.controllerUnitsTruthTracker.record(
+                            params,
+                            for: responseContext.connectionEpoch,
+                            at: observedAt
+                        )
+                    } else {
+                        self.controllerUnitsTruthTracker.recordMalformed(
+                            rawHex: self.hex(data),
+                            for: responseContext.connectionEpoch,
+                            at: observedAt
+                        )
+                    }
                     self.controllerUnitsTruth = self.controllerUnitsTruthTracker.state
                     self.recomputeHrStartAllowed()
                     let decision = self.controllerUnitsGateDecision(now: observedAt)
@@ -3996,33 +4115,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     )["controller_units_fresh"] ?? false
                     self.appendLog(
                         "Controller units response: units=\(self.controllerUnitsTruth.units.rawValue) " +
-                        "checksum_ok=\(params.checksumOk) fresh=\(freshness)"
+                        "status=\(self.controllerUnitsTruth.status.rawValue) fresh=\(freshness)"
                     )
                     self.logTrainingEvent(
                         "controller_units_response",
                         fields: self.controllerUnitsTelemetryFields(action: "query_response", now: observedAt, decision: decision).merging([
-                            "max_speed_raw_tenths": params.maxSpeedRawTenths,
-                            "start_speed_raw_tenths": params.startSpeedRawTenths
+                            "max_speed_raw_tenths": params?.maxSpeedRawTenths ?? -1,
+                            "start_speed_raw_tenths": params?.startSpeedRawTenths ?? -1
                         ]) { current, _ in current }
-                    )
-                }
-            } else if data.count >= 2, data[0] == 0xF8, data[1] == 0xA6 {
-                let observedAt = Date()
-                let rawHex = hex(data)
-                guard let responseConnectionEpoch = controllerUnitsConnectionEpoch else { return }
-                DispatchQueue.main.async {
-                    self.controllerUnitsTruthTracker.recordMalformed(
-                        rawHex: rawHex,
-                        for: responseConnectionEpoch,
-                        at: observedAt
-                    )
-                    self.controllerUnitsTruth = self.controllerUnitsTruthTracker.state
-                    self.recomputeHrStartAllowed()
-                    let decision = self.controllerUnitsGateDecision(now: observedAt)
-                    self.appendLog("Controller units response: status=malformed")
-                    self.logTrainingEvent(
-                        "controller_units_response",
-                        fields: self.controllerUnitsTelemetryFields(action: "query_response", now: observedAt, decision: decision)
                     )
                 }
             } else if let status = parseFe01Status(data) {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -48,6 +48,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var pendingWatchCommand: String? = nil
 #endif
     private var connectingPeripheralId: UUID? = nil
+    private var controllerUnitsConnectionEpoch: UUID? = nil
+    private var controllerUnitsTruthTracker = ControllerUnitsTruthTracker()
+    private var lastControllerUnitsQueryAt: Date? = nil
+    private var lastControllerUnitsQueryTrigger: String? = nil
 
     // Peripheral/characteristics
     private var connectedPeripheral: CBPeripheral?
@@ -814,6 +818,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @Published var deviceReportedButton: Int = 0
     @Published var deviceReportedChecksumOk: Bool = true
     @Published var deviceReportedRawHex: String = ""
+    @Published private(set) var controllerUnitsTruth: ControllerUnitsTruth = .disconnected
 
     // HR control
     @Published var isHrControlRunning: Bool = false
@@ -1396,7 +1401,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 "cooldown_target_bpm": hrCooldownTargetBpm,
                 "cooldown_min_speed_kmh": hrCooldownMinSpeed,
                 "zone_bounds": [hrZone1Max, hrZone2Max, hrZone3Max, hrZone4Max]
-            ])
+            ].merging(controllerUnitsTelemetryFields(action: "session_start")) { current, _ in current })
             scheduleTrainingLogsInventoryRefresh()
         } catch {
             appendLog("Training log file open error: \(error.localizedDescription)")
@@ -2030,6 +2035,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             self.connectedPeripheral = peripheral
             peripheral.delegate = self
             self.resetProtocolState()
+            self.beginControllerUnitsConnection()
             peripheral.discoverServices(self.supportedServiceUuids)
             self.connectionStateText = "Connected"
             self.startTelemetry()
@@ -2423,8 +2429,32 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     func startHrControl() {
-        // Start only if allowed: must be connected, watch reachable, and HR stream active (fresh)
-        if isConnected && watchReachable && hrStreamingActive {
+        guard !isHrControlRunning else { return }
+        // Preserve the existing connection/watch/fresh-HR gates, then compose the
+        // legacy WalkingPad units gate before any automated motion can start.
+        let existingGatesAllowStart = isConnected && watchReachable && hrStreamingActive
+        guard existingGatesAllowStart else {
+            isHrControlRunning = false
+            if !isConnected {
+                hrControlStartBlockReasonText = "Нет подключения к дорожке"
+            } else if !watchReachable {
+                hrControlStartBlockReasonText = "Часы недоступны — откройте приложение на Apple Watch и дождитесь соединения."
+            } else if !hrStreamingActive {
+                hrControlStartBlockReasonText = "Пульс недоступен — откройте приложение на Apple Watch и дождитесь передачи пульса."
+            }
+            return
+        }
+
+        let unitsDecision = controllerUnitsGateDecision()
+        guard unitsDecision.allowed else {
+            isHrControlRunning = false
+            hrControlStartBlockReasonText = unitsDecision.blockReason?.userMessage ?? "Единицы контроллера не подтверждены"
+            persistBlockedControllerUnitsStart(decision: unitsDecision)
+            retryControllerUnitsQueryAfterBlockedStart()
+            return
+        }
+
+        if existingGatesAllowStart {
             let adaptiveStepDescription = hrAdaptiveStepEnabled
                 ? "adaptive_levels=0.1/0.2/0.3/0.4"
                 : "step=\(String(format: "%.2f", hrSpeedStepKmh))"
@@ -2459,22 +2489,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 "adaptive_levels_kmh": adaptiveLevels,
                 "start_speed_kmh": speedKmh,
                 "device_target_kmh": deviceTargetSpeedKmh
-            ])
+            ].merging(controllerUnitsTelemetryFields(action: "hr_control_start")) { current, _ in current })
             if deviceTargetSpeedKmh <= 0.1 && speedKmh <= 0.2 {
                 hrControlStartedBelt = true
                 startWithSpeed(3.0)
             } else if deviceTargetSpeedKmh <= 0.1 {
                 hrControlStartedBelt = true
                 startWithSpeed(desiredSpeedKmh)
-            }
-        } else {
-            isHrControlRunning = false
-            if !isConnected {
-                hrControlStartBlockReasonText = "Нет подключения к дорожке"
-            } else if !watchReachable {
-                hrControlStartBlockReasonText = "Часы недоступны — откройте приложение на Apple Watch и дождитесь соединения."
-            } else if !hrStreamingActive {
-                hrControlStartBlockReasonText = "Пульс недоступен — откройте приложение на Apple Watch и дождитесь передачи пульса."
             }
         }
     }
@@ -2534,7 +2555,16 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     private func recomputeHrStartAllowed() {
-        let allowed = isConnected && watchReachable && hrStreamingActive
+        let existingGatesAllowStart = isConnected && watchReachable && hrStreamingActive
+        let unitsDecision = controllerUnitsGateDecision()
+        let allowed = ControllerUnitsSafetyPolicy.allowsStart(
+            path: .hrControl,
+            existingGatesAllowStart: existingGatesAllowStart,
+            state: controllerUnitsTruth,
+            currentConnectionEpoch: controllerUnitsConnectionEpoch,
+            now: Date(),
+            requiresFreshMetricTruth: controllerUnitsTruthRequired
+        )
         isHrControlStartAllowed = allowed
         if !allowed {
             let withinGrace: Bool = {
@@ -2547,10 +2577,12 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 hrControlStartBlockReasonText = "Часы недоступны — откройте приложение на Apple Watch и дождитесь соединения."
             } else if !hrStreamingActive {
                 hrControlStartBlockReasonText = "Пульс недоступен — откройте приложение на Apple Watch и дождитесь передачи пульса."
+            } else if let unitsBlockReason = unitsDecision.blockReason {
+                hrControlStartBlockReasonText = unitsBlockReason.userMessage
             } else {
                 hrControlStartBlockReasonText = "Недоступно"
             }
-            if isHrControlRunning && !withinGrace {
+            if isHrControlRunning && !withinGrace && !existingGatesAllowStart {
                 hrStatusLine = "HR‑контроль: нет сигнала"
             }
         } else {
@@ -3121,6 +3153,112 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         treadmillMinSpeedKmh = 0.5
         treadmillMaxSpeedKmh = 12.0
         treadmillSpeedIncrementKmh = 0.1
+        controllerUnitsConnectionEpoch = nil
+        controllerUnitsTruthTracker.disconnect()
+        controllerUnitsTruth = controllerUnitsTruthTracker.state
+        lastControllerUnitsQueryAt = nil
+        lastControllerUnitsQueryTrigger = nil
+    }
+
+    private var controllerUnitsTruthRequired: Bool {
+        treadmillProtocol == .walkingPad || treadmillProtocol == .unknown
+    }
+
+    private func beginControllerUnitsConnection() {
+        let epoch = UUID()
+        controllerUnitsConnectionEpoch = epoch
+        controllerUnitsTruthTracker.beginConnection(epoch: epoch)
+        controllerUnitsTruth = controllerUnitsTruthTracker.state
+        lastControllerUnitsQueryAt = nil
+        lastControllerUnitsQueryTrigger = nil
+    }
+
+    private func controllerUnitsGateDecision(now: Date = Date()) -> ControllerUnitsGateDecision {
+        ControllerUnitsSafetyPolicy.evaluate(
+            path: .hrControl,
+            state: controllerUnitsTruth,
+            currentConnectionEpoch: controllerUnitsConnectionEpoch,
+            now: now,
+            requiresFreshMetricTruth: controllerUnitsTruthRequired
+        )
+    }
+
+    private func controllerUnitsTelemetryFields(
+        action: String,
+        now: Date = Date(),
+        decision: ControllerUnitsGateDecision? = nil
+    ) -> [String: Any] {
+        let gateDecision = decision ?? controllerUnitsGateDecision(now: now)
+        let age = controllerUnitsTruth.age(at: now)
+        let queryAge = lastControllerUnitsQueryAt.map { max(0, now.timeIntervalSince($0)) }
+        let fresh = controllerUnitsTruth.status == .valid
+            && controllerUnitsTruth.connectionEpoch == controllerUnitsConnectionEpoch
+            && (age.map { $0 <= ControllerUnitsSafetyPolicy.freshnessInterval } ?? false)
+        return [
+            "controller_units_action": action,
+            "controller_units_motion_path": gateDecision.path.rawValue,
+            "controller_units_query_requested": lastControllerUnitsQueryAt != nil,
+            "controller_units_query_trigger": lastControllerUnitsQueryTrigger ?? "",
+            "controller_units_query_age_s": queryAge ?? -1,
+            "controller_units": controllerUnitsTruth.units.rawValue,
+            "controller_units_status": controllerUnitsTruth.status.rawValue,
+            "controller_units_checksum_ok": controllerUnitsTruth.status == .valid,
+            "controller_units_fresh": fresh,
+            "controller_units_age_s": age ?? -1,
+            "controller_units_freshness_limit_s": ControllerUnitsSafetyPolicy.freshnessInterval,
+            "controller_units_gate_allowed": gateDecision.allowed,
+            "controller_units_block_reason": gateDecision.blockReason?.rawValue ?? ""
+        ]
+    }
+
+    private func recordControllerUnitsGate(action: String, decision: ControllerUnitsGateDecision) {
+        let fields = controllerUnitsTelemetryFields(action: action, decision: decision)
+        let ageValue = fields["controller_units_age_s"] ?? -1
+        let blockReason = decision.blockReason?.rawValue ?? "none"
+        appendLog(
+            "Controller units gate: action=\(action) units=\(controllerUnitsTruth.units.rawValue) " +
+            "status=\(controllerUnitsTruth.status.rawValue) age_s=\(ageValue) " +
+            "allowed=\(decision.allowed) block=\(blockReason)"
+        )
+        logTrainingEvent("controller_units_gate", fields: fields)
+    }
+
+    private func persistBlockedControllerUnitsStart(decision: ControllerUnitsGateDecision) {
+        guard !isHrControlRunning else {
+            recordControllerUnitsGate(action: "hr_control_start", decision: decision)
+            return
+        }
+        startTrainingStructuredLog(trigger: "start_hr_units_blocked")
+        recordControllerUnitsGate(action: "hr_control_start", decision: decision)
+        stopTrainingStructuredLog(reason: decision.blockReason?.rawValue ?? "controller_units_blocked")
+    }
+
+    private func requestControllerUnitsTruth(trigger: String) {
+        guard isConnected,
+              treadmillProtocol == .walkingPad,
+              controllerUnitsConnectionEpoch != nil,
+              commandCharacteristic != nil else {
+            return
+        }
+        lastControllerUnitsQueryAt = Date()
+        lastControllerUnitsQueryTrigger = trigger
+        appendLog("Controller units query: trigger=\(trigger) command=A6 key=0 read_only=true")
+        logTrainingEvent("controller_units_query_requested", fields: [
+            "trigger": trigger,
+            "command_family": "A6",
+            "key": 0,
+            "read_only": true
+        ])
+        writeCommand(BLETransportCodec.buildWalkingPadQueryParamsPacket(), label: "QUERY PARAMS")
+    }
+
+    private func retryControllerUnitsQueryAfterBlockedStart(now: Date = Date()) {
+        guard isConnected, treadmillProtocol == .walkingPad else { return }
+        if let lastControllerUnitsQueryAt,
+           now.timeIntervalSince(lastControllerUnitsQueryAt) < 5 {
+            return
+        }
+        requestControllerUnitsTruth(trigger: "gate_blocked")
     }
 
     private func selectTreadmillProtocol(from discoveredUuids: Set<CBUUID>) -> TreadmillProtocol {
@@ -3722,6 +3860,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 "protocol": selected.rawValue,
                 "services": services.map { $0.uuid.uuidString }
             ])
+            recomputeHrStartAllowed()
         }
         for s in services {
             appendLog("Service discovered: \(s.uuid.uuidString)")
@@ -3756,6 +3895,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             if let w = write {
                 commandCharacteristic = w
                 appendLog("WalkingPad: command characteristic set to \(w.uuid.uuidString)")
+                requestControllerUnitsTruth(trigger: "connection_ready")
             } else {
                 appendLog("WalkingPad: FE02 write not found on FE00")
             }
@@ -3837,7 +3977,55 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
         switch treadmillProtocol {
         case .walkingPad:
-            if let status = parseFe01Status(data) {
+            if let params = BLETransportCodec.parseWalkingPadParams(data) {
+                let observedAt = Date()
+                guard let responseConnectionEpoch = controllerUnitsConnectionEpoch else { return }
+                DispatchQueue.main.async {
+                    self.controllerUnitsTruthTracker.record(
+                        params,
+                        for: responseConnectionEpoch,
+                        at: observedAt
+                    )
+                    self.controllerUnitsTruth = self.controllerUnitsTruthTracker.state
+                    self.recomputeHrStartAllowed()
+                    let decision = self.controllerUnitsGateDecision(now: observedAt)
+                    let freshness = self.controllerUnitsTelemetryFields(
+                        action: "query_response",
+                        now: observedAt,
+                        decision: decision
+                    )["controller_units_fresh"] ?? false
+                    self.appendLog(
+                        "Controller units response: units=\(self.controllerUnitsTruth.units.rawValue) " +
+                        "checksum_ok=\(params.checksumOk) fresh=\(freshness)"
+                    )
+                    self.logTrainingEvent(
+                        "controller_units_response",
+                        fields: self.controllerUnitsTelemetryFields(action: "query_response", now: observedAt, decision: decision).merging([
+                            "max_speed_raw_tenths": params.maxSpeedRawTenths,
+                            "start_speed_raw_tenths": params.startSpeedRawTenths
+                        ]) { current, _ in current }
+                    )
+                }
+            } else if data.count >= 2, data[0] == 0xF8, data[1] == 0xA6 {
+                let observedAt = Date()
+                let rawHex = hex(data)
+                guard let responseConnectionEpoch = controllerUnitsConnectionEpoch else { return }
+                DispatchQueue.main.async {
+                    self.controllerUnitsTruthTracker.recordMalformed(
+                        rawHex: rawHex,
+                        for: responseConnectionEpoch,
+                        at: observedAt
+                    )
+                    self.controllerUnitsTruth = self.controllerUnitsTruthTracker.state
+                    self.recomputeHrStartAllowed()
+                    let decision = self.controllerUnitsGateDecision(now: observedAt)
+                    self.appendLog("Controller units response: status=malformed")
+                    self.logTrainingEvent(
+                        "controller_units_response",
+                        fields: self.controllerUnitsTelemetryFields(action: "query_response", now: observedAt, decision: decision)
+                    )
+                }
+            } else if let status = parseFe01Status(data) {
                 let hexStr = hex(data)
                 DispatchQueue.main.async {
                     self.deviceReportedSpeedKmh = status.speedKmh

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ControllerUnitsSafetyPolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ControllerUnitsSafetyPolicy.swift
@@ -121,6 +121,71 @@ struct ControllerUnitsGateDecision: Equatable {
     let ageSeconds: TimeInterval?
 }
 
+enum ControllerUnitsRefreshTrigger: String, Equatable {
+    case connectionReady = "connection_ready"
+    case gateBlockedAuto = "gate_blocked_auto"
+}
+
+struct ControllerUnitsRefreshDecision: Equatable {
+    let trigger: ControllerUnitsRefreshTrigger?
+
+    var shouldRequest: Bool { trigger != nil }
+}
+
+enum ControllerUnitsRefreshPolicy {
+    static let minimumQueryInterval: TimeInterval = 5
+
+    static func initialQuery(
+        transportReady: Bool,
+        lastQueryAt: Date?,
+        now: Date
+    ) -> ControllerUnitsRefreshDecision {
+        guard transportReady, throttleAllowsQuery(lastQueryAt: lastQueryAt, now: now) else {
+            return ControllerUnitsRefreshDecision(trigger: nil)
+        }
+        return ControllerUnitsRefreshDecision(trigger: .connectionReady)
+    }
+
+    static func blockedStartRefresh(
+        existingGatesAllowStart: Bool,
+        isHrControlRunning: Bool,
+        transportReady: Bool,
+        unitsDecision: ControllerUnitsGateDecision,
+        lastQueryAt: Date?,
+        now: Date
+    ) -> ControllerUnitsRefreshDecision {
+        guard existingGatesAllowStart,
+              !isHrControlRunning,
+              transportReady,
+              (unitsDecision.blockReason == .notRead || unitsDecision.blockReason == .stale),
+              throttleAllowsQuery(lastQueryAt: lastQueryAt, now: now) else {
+            return ControllerUnitsRefreshDecision(trigger: nil)
+        }
+        return ControllerUnitsRefreshDecision(trigger: .gateBlockedAuto)
+    }
+
+    static func throttleAllowsQuery(lastQueryAt: Date?, now: Date) -> Bool {
+        guard let lastQueryAt else { return true }
+        return now.timeIntervalSince(lastQueryAt) >= minimumQueryInterval
+    }
+}
+
+struct ControllerUnitsResponseContext: Equatable {
+    let peripheralID: UUID
+    let connectionEpoch: UUID
+    let notifyCharacteristicID: ObjectIdentifier
+
+    func matches(
+        currentPeripheralID: UUID?,
+        currentConnectionEpoch: UUID?,
+        currentNotifyCharacteristicID: ObjectIdentifier?
+    ) -> Bool {
+        peripheralID == currentPeripheralID
+            && connectionEpoch == currentConnectionEpoch
+            && notifyCharacteristicID == currentNotifyCharacteristicID
+    }
+}
+
 enum ControllerAutomatedMotionPath: String, CaseIterable {
     case hrControl = "hr_control"
     case testRun = "test_run"

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ControllerUnitsSafetyPolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ControllerUnitsSafetyPolicy.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+enum ControllerUnits: String, Equatable {
+    case metric
+    case imperial
+    case unknown
+
+    init(rawControllerUnit: UInt8) {
+        switch rawControllerUnit {
+        case 0:
+            self = .metric
+        case 1:
+            self = .imperial
+        default:
+            self = .unknown
+        }
+    }
+}
+
+enum ControllerUnitsTruthStatus: String, Equatable {
+    case notRead = "not_read"
+    case valid
+    case invalidChecksum = "invalid_checksum"
+    case malformed
+}
+
+struct ControllerUnitsTruth: Equatable {
+    static let disconnected = ControllerUnitsTruth(
+        connectionEpoch: nil,
+        units: .unknown,
+        status: .notRead,
+        observedAt: nil,
+        rawHex: nil
+    )
+
+    let connectionEpoch: UUID?
+    let units: ControllerUnits
+    let status: ControllerUnitsTruthStatus
+    let observedAt: Date?
+    let rawHex: String?
+
+    func age(at now: Date) -> TimeInterval? {
+        observedAt.map { max(0, now.timeIntervalSince($0)) }
+    }
+}
+
+struct ControllerUnitsTruthTracker {
+    private(set) var state: ControllerUnitsTruth = .disconnected
+
+    mutating func beginConnection(epoch: UUID) {
+        state = ControllerUnitsTruth(
+            connectionEpoch: epoch,
+            units: .unknown,
+            status: .notRead,
+            observedAt: nil,
+            rawHex: nil
+        )
+    }
+
+    mutating func disconnect() {
+        state = .disconnected
+    }
+
+    mutating func record(
+        _ params: BLETransportCodec.WalkingPadParams,
+        for connectionEpoch: UUID,
+        at date: Date
+    ) {
+        guard state.connectionEpoch == connectionEpoch else { return }
+        state = ControllerUnitsTruth(
+            connectionEpoch: connectionEpoch,
+            units: ControllerUnits(rawControllerUnit: params.rawControllerUnit),
+            status: params.checksumOk ? .valid : .invalidChecksum,
+            observedAt: date,
+            rawHex: params.rawHex
+        )
+    }
+
+    mutating func recordMalformed(rawHex: String, for connectionEpoch: UUID, at date: Date) {
+        guard state.connectionEpoch == connectionEpoch else { return }
+        state = ControllerUnitsTruth(
+            connectionEpoch: connectionEpoch,
+            units: .unknown,
+            status: .malformed,
+            observedAt: date,
+            rawHex: rawHex
+        )
+    }
+}
+
+enum ControllerUnitsBlockReason: String, Equatable {
+    case notRead = "units_not_read"
+    case stale = "units_stale"
+    case invalidChecksum = "units_invalid_checksum"
+    case malformed = "units_malformed"
+    case unknown = "units_unknown"
+    case imperial = "units_imperial"
+
+    var userMessage: String {
+        switch self {
+        case .notRead:
+            return "Единицы контроллера ещё не подтверждены"
+        case .stale:
+            return "Данные о единицах контроллера устарели"
+        case .invalidChecksum:
+            return "Ответ контроллера об единицах не прошёл проверку"
+        case .malformed:
+            return "Ответ контроллера об единицах имеет неверный формат"
+        case .unknown:
+            return "Контроллер сообщил неизвестные единицы"
+        case .imperial:
+            return "Контроллер использует имперские единицы; автоматический запуск заблокирован"
+        }
+    }
+}
+
+struct ControllerUnitsGateDecision: Equatable {
+    let path: ControllerAutomatedMotionPath
+    let allowed: Bool
+    let blockReason: ControllerUnitsBlockReason?
+    let ageSeconds: TimeInterval?
+}
+
+enum ControllerAutomatedMotionPath: String, CaseIterable {
+    case hrControl = "hr_control"
+    case testRun = "test_run"
+}
+
+enum ControllerUnitsSafetyPolicy {
+    static let freshnessInterval: TimeInterval = 30
+
+    static func evaluate(
+        path: ControllerAutomatedMotionPath,
+        state: ControllerUnitsTruth,
+        currentConnectionEpoch: UUID?,
+        now: Date,
+        requiresFreshMetricTruth: Bool
+    ) -> ControllerUnitsGateDecision {
+        guard requiresFreshMetricTruth else {
+            return ControllerUnitsGateDecision(path: path, allowed: true, blockReason: nil, ageSeconds: state.age(at: now))
+        }
+
+        guard let currentConnectionEpoch,
+              state.connectionEpoch == currentConnectionEpoch else {
+            return ControllerUnitsGateDecision(path: path, allowed: false, blockReason: .notRead, ageSeconds: nil)
+        }
+
+        let age = state.age(at: now)
+        switch state.status {
+        case .notRead:
+            return ControllerUnitsGateDecision(path: path, allowed: false, blockReason: .notRead, ageSeconds: age)
+        case .invalidChecksum:
+            return ControllerUnitsGateDecision(path: path, allowed: false, blockReason: .invalidChecksum, ageSeconds: age)
+        case .malformed:
+            return ControllerUnitsGateDecision(path: path, allowed: false, blockReason: .malformed, ageSeconds: age)
+        case .valid:
+            break
+        }
+
+        guard let age, age <= freshnessInterval else {
+            return ControllerUnitsGateDecision(path: path, allowed: false, blockReason: .stale, ageSeconds: age)
+        }
+
+        switch state.units {
+        case .metric:
+            return ControllerUnitsGateDecision(path: path, allowed: true, blockReason: nil, ageSeconds: age)
+        case .imperial:
+            return ControllerUnitsGateDecision(path: path, allowed: false, blockReason: .imperial, ageSeconds: age)
+        case .unknown:
+            return ControllerUnitsGateDecision(path: path, allowed: false, blockReason: .unknown, ageSeconds: age)
+        }
+    }
+
+    static func allowsStart(
+        path: ControllerAutomatedMotionPath,
+        existingGatesAllowStart: Bool,
+        state: ControllerUnitsTruth,
+        currentConnectionEpoch: UUID?,
+        now: Date,
+        requiresFreshMetricTruth: Bool
+    ) -> Bool {
+        existingGatesAllowStart && evaluate(
+            path: path,
+            state: state,
+            currentConnectionEpoch: currentConnectionEpoch,
+            now: now,
+            requiresFreshMetricTruth: requiresFreshMetricTruth
+        ).allowed
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TrainingTelemetryWriter.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TrainingTelemetryWriter.swift
@@ -165,6 +165,19 @@ enum TrainingTelemetryWriter {
         "delay_s",
         "status",
         "error",
+        "controller_units_action",
+        "controller_units_motion_path",
+        "controller_units_query_requested",
+        "controller_units_query_trigger",
+        "controller_units_query_age_s",
+        "controller_units",
+        "controller_units_status",
+        "controller_units_checksum_ok",
+        "controller_units_fresh",
+        "controller_units_age_s",
+        "controller_units_freshness_limit_s",
+        "controller_units_gate_allowed",
+        "controller_units_block_reason",
         "raw_json"
     ]
 
@@ -884,6 +897,19 @@ enum TrainingTelemetryWriter {
             csvString(payload["delay_s"]),
             csvString(payload["status"]),
             csvString(payload["error"]),
+            csvString(payload["controller_units_action"]),
+            csvString(payload["controller_units_motion_path"]),
+            csvString(payload["controller_units_query_requested"]),
+            csvString(payload["controller_units_query_trigger"]),
+            csvString(payload["controller_units_query_age_s"]),
+            csvString(payload["controller_units"]),
+            csvString(payload["controller_units_status"]),
+            csvString(payload["controller_units_checksum_ok"]),
+            csvString(payload["controller_units_fresh"]),
+            csvString(payload["controller_units_age_s"]),
+            csvString(payload["controller_units_freshness_limit_s"]),
+            csvString(payload["controller_units_gate_allowed"]),
+            csvString(payload["controller_units_block_reason"]),
             jsonString(payload)
         ]
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BLETransportCodecParamsTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BLETransportCodecParamsTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class BLETransportCodecParamsTests: XCTestCase {
+    func testQueryParamsPacketIsExactReadOnlyKeyZeroRequest() {
+        let packet = BLETransportCodec.buildWalkingPadQueryParamsPacket()
+
+        XCTAssertEqual([UInt8](packet), [0xF7, 0xA6, 0x00, 0x00, 0x00, 0x00, 0x00, 0xA6, 0xFD])
+        XCTAssertEqual(packet[2], 0, "A6 key zero is the read-only query form")
+    }
+
+    func testParsesValidMetricResponse() {
+        let params = BLETransportCodec.parseWalkingPadParams(frame(unit: 0))
+
+        XCTAssertEqual(params?.rawControllerUnit, 0)
+        XCTAssertEqual(params?.checksumOk, true)
+        XCTAssertEqual(params?.maxSpeedRawTenths, 0x3C)
+        XCTAssertEqual(params?.startSpeedRawTenths, 0x14)
+    }
+
+    func testParsesValidImperialResponse() {
+        let params = BLETransportCodec.parseWalkingPadParams(frame(unit: 1))
+
+        XCTAssertEqual(params?.rawControllerUnit, 1)
+        XCTAssertEqual(params?.checksumOk, true)
+    }
+
+    func testKeepsUnknownUnitAsRawEvidence() {
+        let params = BLETransportCodec.parseWalkingPadParams(frame(unit: 2))
+
+        XCTAssertEqual(params?.rawControllerUnit, 2)
+        XCTAssertEqual(params?.checksumOk, true)
+    }
+
+    func testReportsChecksumFailureWithoutAcceptingItAsValid() {
+        var bytes = [UInt8](frame(unit: 0))
+        bytes[14] ^= 0x01
+
+        let params = BLETransportCodec.parseWalkingPadParams(Data(bytes))
+
+        XCTAssertEqual(params?.checksumOk, false)
+    }
+
+    func testRejectsMalformedFramesAndMissingTerminator() {
+        XCTAssertNil(BLETransportCodec.parseWalkingPadParams(Data([0xF8, 0xA6])))
+        XCTAssertNil(BLETransportCodec.parseWalkingPadParams(Data([0xF8, 0xA2] + Array(repeating: 0, count: 14))))
+
+        var missingTerminator = [UInt8](frame(unit: 0))
+        missingTerminator[15] = 0x00
+        XCTAssertNil(BLETransportCodec.parseWalkingPadParams(Data(missingTerminator)))
+
+        var extraByte = [UInt8](frame(unit: 0))
+        extraByte.append(0x00)
+        XCTAssertNil(BLETransportCodec.parseWalkingPadParams(Data(extraByte)))
+    }
+
+    private func frame(unit: UInt8) -> Data {
+        var bytes: [UInt8] = [
+            0xF8, 0xA6, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x3C, 0x14, 0x01, 0x03, 0x7F, 0x00, unit, 0x00, 0xFD
+        ]
+        bytes[14] = UInt8(bytes[1..<14].reduce(UInt16(0)) { ($0 + UInt16($1)) & 0xFF })
+        return Data(bytes)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsReadOnlyContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsReadOnlyContractTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class ControllerUnitsReadOnlyContractTests: XCTestCase {
+    func testProductionUnitsImplementationContainsNoPreferenceWritePath() throws {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let sourceDirectory = testsDirectory.deletingLastPathComponent().appendingPathComponent("WalkingPadRemote")
+        let productionFiles = [
+            "BLETransportCodec.swift",
+            "BluetoothManager.swift",
+            "ControllerUnitsSafetyPolicy.swift"
+        ]
+        let forbiddenTokens = [
+            "buildWalkingPadUnitPreferencePacket",
+            "setUnit(",
+            "setMetric",
+            "setImperial",
+            "F7 A6 08"
+        ]
+
+        for fileName in productionFiles {
+            let source = try String(contentsOf: sourceDirectory.appendingPathComponent(fileName), encoding: .utf8)
+            for token in forbiddenTokens {
+                XCTAssertFalse(source.contains(token), "Unexpected controller unit write token \(token) in \(fileName)")
+            }
+        }
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsSafetyPolicyTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsSafetyPolicyTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class ControllerUnitsSafetyPolicyTests: XCTestCase {
+    private let epoch = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+    private let now = Date(timeIntervalSince1970: 1_000)
+
+    func testFreshVerifiedMetricAllowsBothCoveredAutomatedPaths() {
+        for path in ControllerAutomatedMotionPath.allCases {
+            let decision = evaluate(path: path, state: truth(units: .metric))
+            XCTAssertTrue(decision.allowed, "Expected fresh metric to allow \(path.rawValue)")
+            XCTAssertNil(decision.blockReason)
+        }
+    }
+
+    func testFreshImperialBlocksBothCoveredAutomatedPaths() {
+        for path in ControllerAutomatedMotionPath.allCases {
+            let decision = evaluate(path: path, state: truth(units: .imperial))
+            XCTAssertFalse(decision.allowed)
+            XCTAssertEqual(decision.blockReason, .imperial)
+        }
+    }
+
+    func testInvalidChecksumMalformedUnknownAndNotReadFailClosed() {
+        XCTAssertEqual(evaluate(state: truth(units: .metric, status: .invalidChecksum)).blockReason, .invalidChecksum)
+        XCTAssertEqual(evaluate(state: truth(units: .unknown, status: .malformed)).blockReason, .malformed)
+        XCTAssertEqual(evaluate(state: truth(units: .unknown)).blockReason, .unknown)
+        XCTAssertEqual(evaluate(state: notReadTruth()).blockReason, .notRead)
+    }
+
+    func testExpiredMetricTruthIsStale() {
+        let observedAt = now.addingTimeInterval(-ControllerUnitsSafetyPolicy.freshnessInterval - 0.001)
+        let decision = evaluate(state: truth(units: .metric, observedAt: observedAt))
+
+        XCTAssertFalse(decision.allowed)
+        XCTAssertEqual(decision.blockReason, .stale)
+    }
+
+    func testReconnectClearsPriorMetricTruthAndRejectsPreviousEpoch() {
+        var tracker = ControllerUnitsTruthTracker()
+        tracker.beginConnection(epoch: epoch)
+        tracker.record(validParams(unit: 0), for: epoch, at: now)
+        XCTAssertTrue(evaluate(state: tracker.state).allowed)
+
+        let reconnectedEpoch = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+        tracker.beginConnection(epoch: reconnectedEpoch)
+        tracker.record(validParams(unit: 0), for: epoch, at: now)
+
+        XCTAssertEqual(tracker.state.status, .notRead)
+        let decision = ControllerUnitsSafetyPolicy.evaluate(
+            path: .hrControl,
+            state: tracker.state,
+            currentConnectionEpoch: reconnectedEpoch,
+            now: now,
+            requiresFreshMetricTruth: true
+        )
+        XCTAssertFalse(decision.allowed)
+        XCTAssertEqual(decision.blockReason, .notRead)
+    }
+
+    func testExistingSafetyGatesStillBlockWithFreshMetricTruth() {
+        let state = truth(units: .metric)
+
+        XCTAssertFalse(ControllerUnitsSafetyPolicy.allowsStart(
+            path: .hrControl,
+            existingGatesAllowStart: false,
+            state: state,
+            currentConnectionEpoch: epoch,
+            now: now,
+            requiresFreshMetricTruth: true
+        ))
+        XCTAssertTrue(ControllerUnitsSafetyPolicy.allowsStart(
+            path: .hrControl,
+            existingGatesAllowStart: true,
+            state: state,
+            currentConnectionEpoch: epoch,
+            now: now,
+            requiresFreshMetricTruth: true
+        ))
+    }
+
+    func testNonLegacyProtocolsRemainSubjectOnlyToExistingGates() {
+        XCTAssertTrue(ControllerUnitsSafetyPolicy.allowsStart(
+            path: .hrControl,
+            existingGatesAllowStart: true,
+            state: .disconnected,
+            currentConnectionEpoch: nil,
+            now: now,
+            requiresFreshMetricTruth: false
+        ))
+        XCTAssertFalse(ControllerUnitsSafetyPolicy.allowsStart(
+            path: .hrControl,
+            existingGatesAllowStart: false,
+            state: .disconnected,
+            currentConnectionEpoch: nil,
+            now: now,
+            requiresFreshMetricTruth: false
+        ))
+    }
+
+    private func evaluate(
+        path: ControllerAutomatedMotionPath = .hrControl,
+        state: ControllerUnitsTruth
+    ) -> ControllerUnitsGateDecision {
+        ControllerUnitsSafetyPolicy.evaluate(
+            path: path,
+            state: state,
+            currentConnectionEpoch: epoch,
+            now: now,
+            requiresFreshMetricTruth: true
+        )
+    }
+
+    private func truth(
+        units: ControllerUnits,
+        status: ControllerUnitsTruthStatus = .valid,
+        observedAt: Date? = nil
+    ) -> ControllerUnitsTruth {
+        ControllerUnitsTruth(
+            connectionEpoch: epoch,
+            units: units,
+            status: status,
+            observedAt: observedAt ?? now.addingTimeInterval(-1),
+            rawHex: "F8 A6 ... FD"
+        )
+    }
+
+    private func notReadTruth() -> ControllerUnitsTruth {
+        ControllerUnitsTruth(
+            connectionEpoch: epoch,
+            units: .unknown,
+            status: .notRead,
+            observedAt: nil,
+            rawHex: nil
+        )
+    }
+
+    private func validParams(unit: UInt8) -> BLETransportCodec.WalkingPadParams {
+        BLETransportCodec.WalkingPadParams(
+            maxSpeedRawTenths: 60,
+            startSpeedRawTenths: 20,
+            rawControllerUnit: unit,
+            checksumOk: true,
+            rawHex: "F8 A6 ... FD"
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsSafetyPolicyTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsSafetyPolicyTests.swift
@@ -99,6 +99,152 @@ final class ControllerUnitsSafetyPolicyTests: XCTestCase {
         ))
     }
 
+    func testExpiredMetricAutoRefreshRestoresStartEligibilityWithoutReconnect() {
+        var tracker = ControllerUnitsTruthTracker()
+        tracker.beginConnection(epoch: epoch)
+        tracker.record(validParams(unit: 0), for: epoch, at: now)
+        XCTAssertTrue(evaluate(state: tracker.state).allowed)
+
+        let afterTTL = now.addingTimeInterval(ControllerUnitsSafetyPolicy.freshnessInterval + 1)
+        let staleDecision = ControllerUnitsSafetyPolicy.evaluate(
+            path: .hrControl,
+            state: tracker.state,
+            currentConnectionEpoch: epoch,
+            now: afterTTL,
+            requiresFreshMetricTruth: true
+        )
+        XCTAssertFalse(staleDecision.allowed)
+        XCTAssertEqual(staleDecision.blockReason, .stale)
+
+        let refreshDecision = ControllerUnitsRefreshPolicy.blockedStartRefresh(
+            existingGatesAllowStart: true,
+            isHrControlRunning: false,
+            transportReady: true,
+            unitsDecision: staleDecision,
+            lastQueryAt: now.addingTimeInterval(-ControllerUnitsRefreshPolicy.minimumQueryInterval),
+            now: afterTTL
+        )
+        XCTAssertEqual(refreshDecision.trigger, .gateBlockedAuto)
+
+        let refreshedAt = afterTTL.addingTimeInterval(1)
+        tracker.record(validParams(unit: 0), for: epoch, at: refreshedAt)
+        let refreshedDecision = ControllerUnitsSafetyPolicy.evaluate(
+            path: .hrControl,
+            state: tracker.state,
+            currentConnectionEpoch: epoch,
+            now: refreshedAt,
+            requiresFreshMetricTruth: true
+        )
+        XCTAssertTrue(refreshedDecision.allowed)
+        XCTAssertEqual(tracker.state.connectionEpoch, epoch)
+    }
+
+    func testAutoRefreshRequiresOtherStartGatesAndPreservesQueryThrottle() {
+        let staleDecision = evaluate(
+            state: truth(
+                units: .metric,
+                observedAt: now.addingTimeInterval(-ControllerUnitsSafetyPolicy.freshnessInterval - 1)
+            )
+        )
+
+        XCTAssertFalse(ControllerUnitsRefreshPolicy.blockedStartRefresh(
+            existingGatesAllowStart: false,
+            isHrControlRunning: false,
+            transportReady: true,
+            unitsDecision: staleDecision,
+            lastQueryAt: nil,
+            now: now
+        ).shouldRequest)
+        XCTAssertFalse(ControllerUnitsRefreshPolicy.blockedStartRefresh(
+            existingGatesAllowStart: true,
+            isHrControlRunning: false,
+            transportReady: true,
+            unitsDecision: staleDecision,
+            lastQueryAt: now.addingTimeInterval(-ControllerUnitsRefreshPolicy.minimumQueryInterval + 0.001),
+            now: now
+        ).shouldRequest)
+        XCTAssertTrue(ControllerUnitsRefreshPolicy.blockedStartRefresh(
+            existingGatesAllowStart: true,
+            isHrControlRunning: false,
+            transportReady: true,
+            unitsDecision: staleDecision,
+            lastQueryAt: now.addingTimeInterval(-ControllerUnitsRefreshPolicy.minimumQueryInterval),
+            now: now
+        ).shouldRequest)
+    }
+
+    func testNotReadAutoRefreshesButInvalidAndImperialTruthDoNot() {
+        XCTAssertTrue(ControllerUnitsRefreshPolicy.blockedStartRefresh(
+            existingGatesAllowStart: true,
+            isHrControlRunning: false,
+            transportReady: true,
+            unitsDecision: evaluate(state: notReadTruth()),
+            lastQueryAt: nil,
+            now: now
+        ).shouldRequest)
+        XCTAssertFalse(ControllerUnitsRefreshPolicy.blockedStartRefresh(
+            existingGatesAllowStart: true,
+            isHrControlRunning: false,
+            transportReady: true,
+            unitsDecision: evaluate(state: truth(units: .metric, status: .invalidChecksum)),
+            lastQueryAt: nil,
+            now: now
+        ).shouldRequest)
+        XCTAssertFalse(ControllerUnitsRefreshPolicy.blockedStartRefresh(
+            existingGatesAllowStart: true,
+            isHrControlRunning: false,
+            transportReady: true,
+            unitsDecision: evaluate(state: truth(units: .imperial)),
+            lastQueryAt: nil,
+            now: now
+        ).shouldRequest)
+    }
+
+    func testInitialQueryWaitsForNotificationReadyTransport() {
+        XCTAssertFalse(ControllerUnitsRefreshPolicy.initialQuery(
+            transportReady: false,
+            lastQueryAt: nil,
+            now: now
+        ).shouldRequest)
+        XCTAssertEqual(ControllerUnitsRefreshPolicy.initialQuery(
+            transportReady: true,
+            lastQueryAt: nil,
+            now: now
+        ).trigger, .connectionReady)
+    }
+
+    func testResponseContextRejectsPeripheralEpochAndCharacteristicChanges() {
+        final class CharacteristicToken {}
+        let currentCharacteristic = CharacteristicToken()
+        let staleCharacteristic = CharacteristicToken()
+        let context = ControllerUnitsResponseContext(
+            peripheralID: epoch,
+            connectionEpoch: epoch,
+            notifyCharacteristicID: ObjectIdentifier(currentCharacteristic)
+        )
+
+        XCTAssertTrue(context.matches(
+            currentPeripheralID: epoch,
+            currentConnectionEpoch: epoch,
+            currentNotifyCharacteristicID: ObjectIdentifier(currentCharacteristic)
+        ))
+        XCTAssertFalse(context.matches(
+            currentPeripheralID: UUID(),
+            currentConnectionEpoch: epoch,
+            currentNotifyCharacteristicID: ObjectIdentifier(currentCharacteristic)
+        ))
+        XCTAssertFalse(context.matches(
+            currentPeripheralID: epoch,
+            currentConnectionEpoch: UUID(),
+            currentNotifyCharacteristicID: ObjectIdentifier(currentCharacteristic)
+        ))
+        XCTAssertFalse(context.matches(
+            currentPeripheralID: epoch,
+            currentConnectionEpoch: epoch,
+            currentNotifyCharacteristicID: ObjectIdentifier(staleCharacteristic)
+        ))
+    }
+
     private func evaluate(
         path: ControllerAutomatedMotionPath = .hrControl,
         state: ControllerUnitsTruth

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TrainingTelemetryWriterTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TrainingTelemetryWriterTests.swift
@@ -3,6 +3,35 @@ import XCTest
 @testable import WalkingPadCoreLogic
 
 final class TrainingTelemetryWriterTests: XCTestCase {
+    func testCsvRowIncludesNormalizedControllerUnitsEvidence() {
+        let headers = TrainingTelemetryWriter.trainingCsvHeaders
+        let payload: [String: Any] = [
+            "controller_units_action": "hr_control_start",
+            "controller_units_motion_path": "hr_control",
+            "controller_units_query_requested": true,
+            "controller_units_query_trigger": "connection_ready",
+            "controller_units_query_age_s": 2.5,
+            "controller_units": "imperial",
+            "controller_units_status": "valid",
+            "controller_units_checksum_ok": true,
+            "controller_units_fresh": true,
+            "controller_units_age_s": 2,
+            "controller_units_freshness_limit_s": 30,
+            "controller_units_gate_allowed": false,
+            "controller_units_block_reason": "units_imperial"
+        ]
+
+        let row = TrainingTelemetryWriter.csvRow(sourceFile: "blocked.jsonl", payload: payload)
+
+        XCTAssertEqual(row.count, headers.count)
+        XCTAssertEqual(row[headers.firstIndex(of: "controller_units")!], "imperial")
+        XCTAssertEqual(row[headers.firstIndex(of: "controller_units_status")!], "valid")
+        XCTAssertEqual(row[headers.firstIndex(of: "controller_units_checksum_ok")!], "true")
+        XCTAssertEqual(row[headers.firstIndex(of: "controller_units_fresh")!], "true")
+        XCTAssertEqual(row[headers.firstIndex(of: "controller_units_gate_allowed")!], "false")
+        XCTAssertEqual(row[headers.firstIndex(of: "controller_units_block_reason")!], "units_imperial")
+    }
+
     func testCleanupExportedJsonlFilesRemovesJsonlFilesAndCountsBytes() throws {
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)


### PR DESCRIPTION
## Summary
- add strict read-only WalkingPad queryParams parsing with checksum validation and connection-scoped 30-second freshness
- compose a fail-closed fresh-metric units gate with the existing HR start gates and expose factual block reasons
- persist normalized units query/truth/gate telemetry and cover metric, imperial, invalid, unknown, stale, reconnect, existing gates, and the no-unit-write contract
- refresh stale/not-read units truth automatically when the other HR start prerequisites are ready, while preserving the fail-closed gate and 5-second query throttle
- wait for FE02 plus confirmed FE01 notifications before the initial query and reject A6 responses from stale peripheral/characteristic/connection contexts

Closes #5

## Verification
- focused Swift tests after PM correction: 19 passed, 0 failed
- full Swift package tests: 60 passed, 0 failed
- `PYTHONPYCACHEPREFIX=/private/tmp/walkingpad-issue-5-pycache python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py` — passed
- local unsigned generic iOS/watchOS build — `BUILD SUCCEEDED`
- `git diff --check origin/main...HEAD` — clean
- scope challenger: PASS, no P0/P1/P2 findings
- fresh independent final reviewer: PASS, no P0/P1/P2 findings
- exact-head CI run `31678610364` — success at `89a6925f376a3ce61b6616be47268d4251d4b574`
  - Python Checks (exact head) — success
  - Swift Package Tests (exact head) — success
  - Xcode Project Metadata (diagnostic only) — success
  - iOS/watchOS App Build (unsigned, exact head) — success

## Risks / Notes
- exact base: `48619868aee10a76f42cda19615978426d6c521f`
- exact head: `89a6925f376a3ce61b6616be47268d4251d4b574`
- current exact base does not contain Debug Test Run; this PR supplies its pure policy path but does not add or claim runtime Test Run integration
- no controller unit/preference writes, recovery UI, imperial enablement, Stop changes, install/device launch, BLE, or hardware experiments
- controller hardware/CoreBluetooth sequencing remains intentionally unvalidated under this issue contract
- rollback is the PR change set; no migration or configuration change
