### PR TITLE
Document token budgets and PM merge authorization

### DIFF
--- a/.agents/skills/walkingpad-pr-lifecycle/SKILL.md
+++ b/.agents/skills/walkingpad-pr-lifecycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: walkingpad-pr-lifecycle
-description: Implement one WalkingPad GitHub issue from an exact main SHA through an isolated worktree, verified feature branch, fresh independent review, and Draft PR. Never use it to mark Ready, merge, deploy, install, or operate hardware.
+description: Implement one WalkingPad GitHub issue from an exact main SHA through an isolated worktree, verified feature branch, fresh independent review, and Draft PR. Delivery stops at Draft; a later PM review may merge only under the repository's conditional standing authorization.
 ---
 
 # WalkingPad PR lifecycle
@@ -14,6 +14,26 @@ description: Implement one WalkingPad GitHub issue from an exact main SHA throug
 7. Make the smallest in-scope implementation. Run focused checks and every applicable safe repository check without install, launch, BLE, or hardware activity.
 8. Inspect the complete base-to-head diff for correctness, scope, safety, secrets, generated artifacts, and missing tests.
 9. For substantial work, assign the completed diff to one fresh read-only reviewer. Fix in-scope material findings and use a fresh reviewer again; allow at most two correction cycles, then stop for PM if material findings remain.
-10. Push only the feature branch and open one Draft PR into `main`. Never mark Ready, merge, force-push, deploy, install, or perform unrelated GitHub administration.
+10. Push only the feature branch and open one Draft PR into `main`. Implementation delivery never marks Ready or merges. Do not force-push, deploy, install, or perform unrelated GitHub administration.
 11. Fetch `main` again. Confirm it still matches the approved base and required pull-request CI tests the exact current head against that base. Missing, queued, cancelled, stale, or failed required CI blocks handoff readiness.
 12. Report exact base/head, branch, changed files, preserved history, checks, CI, independent review, agent usage, and unresolved risks. End with `READY FOR PM REVIEW` only when every gate is satisfied.
+
+## Token and context efficiency
+
+- Unless the task overrides them, use soft planning ranges of about `200k-300k` tokens for small scoped maintenance or correction, `300k-500k` for a substantial feature, and `400k-600k` for large safety-critical work. Checkpoint substantial tasks near `500k`; about `700k` is a soft ceiling, never a hard cutoff.
+- A task-specific budget or checkpoint supersedes generic targets without weakening safety, review, build, or exact-head CI gates.
+- At a checkpoint or soft ceiling, report exposed usage, explain any concrete reason to continue, stop optional exploration, add no low-value agents, and choose a bounded completion path or PM escalation. Do not ship unsafe or knowingly incomplete work to save tokens.
+- Use agents only when they materially reduce risk or review cost. Do not repeat accepted repository archaeology without a new reason. Start corrections from the finding and relevant diff; summarize long successful logs.
+- Run focused tests during implementation, then one full applicable suite after the change is coherent. Repeat a successful full suite or build only after a relevant change or failure.
+- Give reviewers the contract, exact base-to-head diff, and concise evidence. Use exact historical references selectively instead of sending the full transcript or re-reading broad history.
+- Report final token/time usage when exposed, and explicitly mark unverifiable model, effort, token, or timing details.
+
+## PM review and standing merge authorization
+
+This skill's implementation run always stops at a Draft PR. If the user later hands the completed PR to PM with a completion report and asks for GitHub review, that request is standing authorization in the same PM review turn to merge only after PM gives an explicit final `GO` or `APPROVED` verdict.
+
+PM may then refresh the PR and live `main`; verify exact base/head, no base drift, exact-head required CI, any contract-required real app build, and no unresolved P0/P1/material P2; perform metadata-only PR cleanup; mark Ready; squash-merge using the exact expected head SHA; verify the new `main`; and verify or, when needed, close the completed linked issue.
+
+Do not use standing authorization if the verdict is not explicit `GO`/`APPROVED`; the head moved; the base drifted; CI is missing, queued, stale, cancelled, failed, or for the wrong head; a required build is absent or failed; any P0/P1/material P2, reviewer, or scope finding remains; scope or safety was violated; safety uncertainty needs an explicit decision; the merge is conflicted or non-clean; or a more specific policy requires separate `GO`.
+
+Standing authorization never covers hardware/BLE/treadmill experiments or physical commands, install/device launch outside explicit task scope, deploy/release, firmware/OTA/service-menu actions, controller preference or unit writes outside their own contract, force-push, branch/tag deletion or destructive cleanup, or work on the next issue. Those remain separate gates.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,11 +17,39 @@
 5. For substantial work, run one fresh independent read-only final reviewer. Fix in-scope material findings and repeat with a fresh reviewer, with at most two correction cycles before stopping for PM direction.
 6. Push only the feature branch, open one Draft PR into `main`, re-check the live base and exact-head CI, and stop for PM review.
 
-Do not mark Ready, merge, force-push, deploy, install, launch on a device, or run hardware/BLE experiments without separate explicit PM authorization. A Draft PR, review result, or green local check is not that authorization. Do not make custom GitHub labels a delivery dependency.
+Implementation delivery stops at a Draft PR and must not mark it Ready or merge it. A later PM GitHub review may use the standing merge authorization below, but a Draft PR, reviewer result, or green local check alone is not authorization. Do not force-push, deploy, install, launch on a device, run hardware/BLE experiments, or make custom GitHub labels a delivery dependency.
 
 Use [`walkingpad-pr-lifecycle`](.agents/skills/walkingpad-pr-lifecycle/SKILL.md) for normal implementation delivery. Report agent role, bounded task, effective model, reasoning effort, outcome, and any fallback. Default routing is Luna/medium for repository mapping or narrow documentation research and Terra/high for scope challenge or independent review; spawn only roles the task needs.
 
 For substantial autonomous work, select `gpt-5.6-sol` with `high` reasoning for the parent/Goal agent when the client exposes parent model and effort choice. Use cheaper effort only for genuinely simple scoped work. If the client does not expose the selection or the preferred model is unavailable, do not claim it was selected; report the effective parent model, effort, and fallback in the handoff.
+
+## Token and context efficiency
+
+- Use these soft planning ranges unless a task supplies its own budget: about `200k-300k` tokens for small scoped maintenance or correction, `300k-500k` for a substantial feature, and `400k-600k` for large safety-critical work. For substantial tasks, checkpoint near `500k`; treat about `700k` as a soft ceiling, not a hard cutoff.
+- A task-specific token budget or checkpoint supersedes these generic targets, but never weakens safety, review, build, or exact-head CI gates.
+- At a checkpoint or soft ceiling, report usage when the client exposes it, state the concrete reason for any continuation, stop optional exploration, avoid new low-value agents, and choose a bounded completion path or escalate to PM. Never ship unsafe or knowingly incomplete work merely to save tokens.
+- Use a subagent only when it materially reduces risk or review cost. Do not repeat accepted repository archaeology without a new reason; start correction work from the finding and relevant diff. Summarize long successful logs instead of reproducing them.
+- Prefer focused tests while implementing and one full applicable suite after the change is coherent. Do not repeat a successful full suite or build unless a relevant change or failure justifies it.
+- Give reviewers the contract, exact base-to-head diff, and concise evidence rather than a full transcript. Consult historical commits or files selectively and cite exact references.
+- In the handoff, report final token and elapsed-time usage when available. Mark model, effort, token, or timing details as unverifiable when the client does not expose them.
+
+## PM review and standing merge authorization
+
+When a user hands a completed Codex Draft PR back to PM with a completion report and asks PM to review it on GitHub, that request is standing authorization for the same PM review turn to complete the merge only if PM's final verdict is explicitly `GO` or `APPROVED`. It does not let the implementation agent merge during delivery.
+
+Under that authorization, PM may refresh the PR and live `main`, verify the exact base and head with no base drift, confirm required exact-head CI and any contract-required real app build, confirm there are no unresolved P0/P1 or material P2 findings, perform metadata-only PR cleanup, mark Draft as Ready, squash-merge with the exact expected head SHA, verify the new `main`, and verify linked issue closure (closing a completed linked issue if needed).
+
+The standing authorization is cancelled when any of these conditions applies:
+
+- the final PM verdict is not explicit `GO` or `APPROVED`;
+- the PR head moved, the base drifted, or the merge is conflicted or non-clean;
+- required CI is missing, queued, stale, cancelled, failed, or tests the wrong head;
+- a required build is missing or failed;
+- a P0, P1, material P2, reviewer finding, or scope finding remains unresolved;
+- scope or safety was violated, or safety uncertainty requires an explicit decision;
+- a more specific repository or task policy requires a separate `GO`.
+
+Standing merge authorization never covers hardware/BLE/treadmill experiments or physical commands; installation or device launch unless explicitly in task scope; deployment or release; firmware, OTA, or service-menu actions; controller preference or unit writes outside their own approved contract; branch/tag deletion or destructive cleanup; force-push; or automatic work on the next issue. Each remains a separate gate.
 
 ## Treadmill safety invariants
 


### PR DESCRIPTION
## Summary
- Add soft token and context planning budgets, task-specific override behavior, checkpoint actions, and efficient review/testing guidance.
- Define conditional standing PM merge authorization with fail-closed cancellation conditions and explicit excluded actions.
- Keep implementation delivery Draft-only and align the root repository contract with the WalkingPad PR lifecycle skill.
- Closes #10.

## Verification
- AGENTS instruction-chain check: 12,112 / 32,768 bytes; below the 24,576-byte warning threshold.
- Skill YAML frontmatter parsed and required name/description validated.
- All 10 local Markdown links in AGENTS.md resolve.
- git diff --check passed; exact base-to-head scope contains only AGENTS.md and .agents/skills/walkingpad-pr-lifecycle/SKILL.md.
- Fresh independent read-only review returned READY after one fail-closed wording correction.

## Risks / Notes
- Governance-only change: no Swift runtime, Xcode project, BLE tooling, Stop/start/speed command, telemetry, or persistence changes.
- Local Swift tests and app build are not applicable because no runtime or project files changed.
- No migrations, environment/configuration changes, deployment, installation, device launch, or hardware actions.
- Backward compatibility impact is limited to the documented PR governance contract. Rollback is a revert of the single governance commit.