### PR TITLE
Stabilize Stop-truth recovery marker

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/StopTruthExperimentController.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/StopTruthExperimentController.swift
@@ -352,7 +352,8 @@ final class StopTruthExperimentController {
                 marker,
                 timestamp: timestamp,
                 note: note,
-                operatorHadVisibility: operatorHadVisibility
+                operatorHadVisibility: operatorHadVisibility,
+                clock: clock
             ) else { return }
             recordPhysicalMarker(session.markers.last)
             finalizeTerminalState(note: note)
@@ -362,7 +363,8 @@ final class StopTruthExperimentController {
             marker,
             timestamp: timestamp,
             note: note,
-            operatorHadVisibility: operatorHadVisibility
+            operatorHadVisibility: operatorHadVisibility,
+            clock: clock
         ) else {
             if !isActive { finalizeTerminalState(note: session.terminalReason ?? "marker_rejected_terminal") }
             return

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/StopTruthExperimentSessionService.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/StopTruthExperimentSessionService.swift
@@ -311,13 +311,10 @@ struct StopTruthExperimentSessionService {
               executorQuiescentForRecovery,
               !renewedMotionAfterStop,
               authoritativeMarker(role: .firstPhysicalStop, repetition: completed) != nil,
-              let recoveryMarker = authoritativeMarker(
+              authoritativeMarker(
                 role: .recoveryStationaryConfirmation,
                 repetition: completed
-              ),
-              let latestStationaryObservation = fe01Observations.last,
-              recoveryMarker.timestamp.monotonicUptimeNanoseconds
-                >= latestStationaryObservation.receivedAt.monotonicUptimeNanoseconds,
+              ) != nil,
               StopTruthExperimentPlanService.baselineSatisfied(
                 observations: fe01Observations,
                 kind: .stationary,
@@ -345,7 +342,8 @@ struct StopTruthExperimentSessionService {
         _ marker: Marker,
         timestamp: StopTruthExperimentTimestamp,
         note: String,
-        operatorHadVisibility: Bool
+        operatorHadVisibility: Bool,
+        clock: StopTruthExperimentClock? = nil
     ) -> Bool {
         guard timestamp.originID == clockOriginID else {
             fail("marker_clock_origin_mismatch")
@@ -381,7 +379,8 @@ struct StopTruthExperimentSessionService {
                 repetition: repetition,
                 timestamp: timestamp,
                 note: note,
-                operatorHadVisibility: operatorHadVisibility
+                operatorHadVisibility: operatorHadVisibility,
+                clock: clock
             )
         case .abort:
             markers.append(.init(
@@ -425,13 +424,24 @@ struct StopTruthExperimentSessionService {
         repetition: Int,
         timestamp: StopTruthExperimentTimestamp,
         note: String,
-        operatorHadVisibility: Bool
+        operatorHadVisibility: Bool,
+        clock: StopTruthExperimentClock?
     ) -> Bool {
         if case .recoveryPause = phase {
             guard operatorHadVisibility,
                   authoritativeMarker(role: .recoveryStationaryConfirmation, repetition: repetition) == nil,
+                  executorQuiescentForRecovery,
                   let recoveryPauseStartedAt,
-                  timestamp.monotonicUptimeNanoseconds >= recoveryPauseStartedAt.monotonicUptimeNanoseconds else {
+                  timestamp.monotonicUptimeNanoseconds >= recoveryPauseStartedAt.monotonicUptimeNanoseconds,
+                  let clock,
+                  clock.originID == clockOriginID,
+                  StopTruthExperimentPlanService.baselineSatisfied(
+                    observations: fe01Observations,
+                    kind: .stationary,
+                    currentContext: context,
+                    clock: clock,
+                    nowUptimeNanoseconds: timestamp.monotonicUptimeNanoseconds
+                  ) else {
                 return false
             }
             markers.append(.init(

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/StopTruthExperimentEvidenceTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/StopTruthExperimentEvidenceTests.swift
@@ -152,7 +152,13 @@ final class StopTruthExperimentEvidenceTests: XCTestCase {
             timestamps: nextPair(origin: origin, uptime: &uptime),
             session: &session
         )
-        XCTAssertTrue(session.recordMarker(.stopped, timestamp: clock.now()!, note: "recovery", operatorHadVisibility: true))
+        XCTAssertTrue(session.recordMarker(
+            .stopped,
+            timestamp: clock.now()!,
+            note: "recovery",
+            operatorHadVisibility: true,
+            clock: clock
+        ))
         XCTAssertTrue(session.beginNextRepetition(
             clock: clock,
             nowUptimeNanoseconds: uptime,

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/StopTruthExperimentSafetyCorrectionTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/StopTruthExperimentSafetyCorrectionTests.swift
@@ -123,7 +123,8 @@ final class StopTruthExperimentSafetyCorrectionTests: XCTestCase {
                 .stopped,
                 timestamp: harness.now(),
                 note: "recovery stationary",
-                operatorHadVisibility: true
+                operatorHadVisibility: true,
+                clock: harness.clock
             ))
             XCTAssertTrue(harness.session.beginNextRepetition(
                 clock: harness.clock,
@@ -168,7 +169,8 @@ final class StopTruthExperimentSafetyCorrectionTests: XCTestCase {
             .stopped,
             timestamp: harness.now(),
             note: "recovery",
-            operatorHadVisibility: true
+            operatorHadVisibility: true,
+            clock: harness.clock
         ))
         XCTAssertEqual(harness.session.markers.filter { $0.role == .firstPhysicalStop }.count, 1)
         XCTAssertEqual(harness.session.markers.filter { $0.role == .recoveryStationaryConfirmation }.count, 1)
@@ -182,6 +184,81 @@ final class StopTruthExperimentSafetyCorrectionTests: XCTestCase {
             nowUptimeNanoseconds: harness.uptime,
             executorQuiescent: true
         ))
+    }
+
+    func testRecoveryMarkerSurvivesLaterStationaryFramesAndAuthoritiesStayImmutable() {
+        let harness = SessionHarness()
+        harness.advanceToRecoveryPause()
+        harness.advance(seconds: 30)
+        harness.recordPair(speed: 0, state: 0)
+
+        let moving = harness.session.markers.first { $0.role == .movingBaseline }
+        let firstPhysicalStop = harness.session.markers.first { $0.role == .firstPhysicalStop }
+        XCTAssertTrue(harness.recordRecoveryMarker(note: "authoritative recovery"))
+        let recovery = harness.session.markers.first { $0.role == .recoveryStationaryConfirmation }
+
+        harness.advance(seconds: 0.1)
+        harness.recordPair(speed: 0, state: 0)
+        XCTAssertFalse(harness.recordRecoveryMarker(note: "duplicate recovery"))
+        XCTAssertEqual(harness.session.markers.first { $0.role == .movingBaseline }, moving)
+        XCTAssertEqual(harness.session.markers.first { $0.role == .firstPhysicalStop }, firstPhysicalStop)
+        XCTAssertEqual(harness.session.markers.first { $0.role == .recoveryStationaryConfirmation }, recovery)
+
+        XCTAssertTrue(harness.session.beginNextRepetition(
+            clock: harness.clock,
+            nowUptimeNanoseconds: harness.uptime,
+            executorQuiescent: true
+        ))
+    }
+
+    func testRecoveryMarkerRequiresQualifyingStationaryPairAtMarkerTime() {
+        let noPair = SessionHarness()
+        noPair.advanceToRecoveryPause()
+        noPair.advance(seconds: 30)
+        XCTAssertFalse(noPair.recordRecoveryMarker())
+
+        let stale = SessionHarness()
+        stale.advanceToRecoveryPause()
+        stale.recordPair(speed: 0, state: 0)
+        stale.advance(seconds: 2.1)
+        XCTAssertFalse(stale.recordRecoveryMarker())
+
+        let invalidChecksum = SessionHarness()
+        invalidChecksum.advanceToRecoveryPause()
+        invalidChecksum.recordPair(speed: 0, state: 0, checksumValid: false)
+        XCTAssertFalse(invalidChecksum.recordRecoveryMarker())
+
+        let wrongContext = SessionHarness()
+        wrongContext.advanceToRecoveryPause()
+        wrongContext.recordPair(speed: 0, state: 0, context: TestFixtures.context())
+        XCTAssertFalse(wrongContext.recordRecoveryMarker())
+
+        let nonzero = SessionHarness()
+        nonzero.advanceToRecoveryPause()
+        nonzero.recordPair(speed: 1, state: 0)
+        XCTAssertFalse(nonzero.recordRecoveryMarker())
+    }
+
+    func testUnsafeTelemetryAfterValidRecoveryMarkerStillBlocksNext() {
+        let nonzero = SessionHarness.readyForNextRepetition()
+        nonzero.recordPair(speed: 1, state: 0)
+        XCTAssertFalse(nonzero.beginNextRepetition())
+
+        let invalid = SessionHarness.readyForNextRepetition()
+        invalid.recordPair(speed: 0, state: 0, checksumValid: false)
+        XCTAssertFalse(invalid.beginNextRepetition())
+
+        let ambiguous = SessionHarness.readyForNextRepetition()
+        ambiguous.recordPair(speed: nil, state: nil)
+        XCTAssertFalse(ambiguous.beginNextRepetition())
+
+        let wrongContext = SessionHarness.readyForNextRepetition()
+        wrongContext.recordPair(speed: 0, state: 0, context: TestFixtures.context())
+        XCTAssertFalse(wrongContext.beginNextRepetition())
+
+        let stale = SessionHarness.readyForNextRepetition()
+        stale.advance(seconds: 2.1)
+        XCTAssertFalse(stale.beginNextRepetition())
     }
 
     func testEveryTerminalPathAfterMotionRequiresPhysicalCutoff() {
@@ -227,7 +304,8 @@ final class StopTruthExperimentSafetyCorrectionTests: XCTestCase {
             .stopped,
             timestamp: harness.now(),
             note: "recovery",
-            operatorHadVisibility: true
+            operatorHadVisibility: true,
+            clock: harness.clock
         ))
         XCTAssertTrue(harness.session.beginNextRepetition(
             clock: harness.clock,
@@ -449,24 +527,75 @@ private final class SessionHarness {
         setUptime(uptime + UInt64(seconds * 1_000_000_000))
     }
 
-    func recordPair(speed: Int, state: Int) {
+    func recordPair(
+        speed: Int?,
+        state: Int?,
+        checksumValid: Bool = true,
+        context observationContext: StopTruthExperimentPlanService.Context? = nil
+    ) {
+        let observationContext = observationContext ?? context
         session.recordFE01(.init(
-            context: context,
+            context: observationContext,
             receivedAt: now(),
             rawHex: "first",
-            checksumValid: true,
+            checksumValid: checksumValid,
             speedRawTenths: speed,
             state: state
         ))
         advance(seconds: 0.1)
         session.recordFE01(.init(
-            context: context,
+            context: observationContext,
             receivedAt: now(),
             rawHex: "second",
-            checksumValid: true,
+            checksumValid: checksumValid,
             speedRawTenths: speed,
             state: state
         ))
+    }
+
+    func advanceToRecoveryPause() {
+        advanceToMovingReady()
+        XCTAssertTrue(session.beginStopObservation())
+        XCTAssertTrue(session.recordInitialStopInvocation(timestamp: now()))
+        advance(seconds: 0.5)
+        XCTAssertTrue(session.recordMarker(
+            .stopped,
+            timestamp: now(),
+            note: "first physical stop",
+            operatorHadVisibility: true
+        ))
+        XCTAssertTrue(session.finishObservationWindow())
+        XCTAssertTrue(session.finishPostWindowFreshness(
+            timestamp: now(),
+            executorQuiescent: true
+        ))
+    }
+
+    func recordRecoveryMarker(note: String = "recovery") -> Bool {
+        session.recordMarker(
+            .stopped,
+            timestamp: now(),
+            note: note,
+            operatorHadVisibility: true,
+            clock: clock
+        )
+    }
+
+    func beginNextRepetition() -> Bool {
+        session.beginNextRepetition(
+            clock: clock,
+            nowUptimeNanoseconds: uptime,
+            executorQuiescent: true
+        )
+    }
+
+    static func readyForNextRepetition() -> SessionHarness {
+        let harness = SessionHarness()
+        harness.advanceToRecoveryPause()
+        harness.advance(seconds: 30)
+        harness.recordPair(speed: 0, state: 0)
+        XCTAssertTrue(harness.recordRecoveryMarker())
+        return harness
     }
 
     func advanceToMovingStart() {


### PR DESCRIPTION
## Summary

- Stabilize the recovery stationary confirmation marker after it is accepted against the canonical stationary FE01 predicate.
- Validate the recovery marker at marker time using the current recovery phase, operator visibility, unique marker role, executor/recovery eligibility, matching monotonic clock origin, and the latest two fresh checksum-valid same-context stationary FE01 observations.
- Keep `beginNextRepetition()` independently gated by the current safe telemetry pair, the 30-second recovery pause, quiescent executor state, no renewed motion, and both physical marker roles.

Closes #16

## Verification

- `cd ios/WalkingPadRemote/WalkingPadRemote && swift test --filter StopTruthExperimentSafetyCorrectionTests` — 18 tests passed.
- `cd ios/WalkingPadRemote/WalkingPadRemote && swift test` — 133 tests passed.
- `git diff --check` and staged diff check — passed.
- `xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' -derivedDataPath /tmp/walkingpad-issue16-derived CODE_SIGNING_ALLOWED=NO build` — completed with 0 errors; one benign AppIntents metadata warning.
- Production Stop/start/speed behavior files, StopObservation, command whitelist/bounds, plan, and executor implementation were unchanged.
- Independent scope challenge and fresh final safety review: `NO MATERIAL FINDINGS` (gpt-5.6-terra / high).

## Risks / Notes

- Safety-critical Stop-truth experiment lifecycle change, intentionally limited to recovery marker validation and regression coverage.
- Later unsafe, stale, ambiguous, or wrong-context FE01 evidence still blocks `Next`; later valid stationary observations no longer invalidate an already accepted recovery marker.
- No BLE, treadmill, iPhone, Apple Watch, install, launch, or hardware activity was performed.
- Draft only. This PR is not authorization to mark Ready, merge, or run hardware.
- Base reviewed against `8a46a0255f910eec8279604255ad51641bf32798`; head is `d70d8e72ebfbac6e1bd8d9aeece4470ec8d2697b`.