### PR TITLE
Standardize production-path Test Run diagnostic

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -49,6 +49,7 @@ let package = Package(
                 "StopTruthExperimentObservationService.swift",
                 "StopTruthExperimentPlanService.swift",
                 "StopTruthExperimentSessionService.swift",
+                "TreadmillTestRunService.swift",
                 "TrainingTelemetryWriter.swift",
                 "CommandQueueService.swift",
                 "TreadmillSpeedBoundsService.swift"

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -72,6 +72,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var stopTruthExperimentController: StopTruthExperimentController?
     private var stopTruthExperimentTerminalLatch = false
 #endif
+    private struct TreadmillTestRunConnectionContext: Equatable {
+        let peripheralID: UUID
+        let connectionEpoch: UUID
+    }
+    private var treadmillTestRunService = TreadmillTestRunService()
+    private var treadmillTestRunTimer: Timer?
+    private var treadmillTestRunContext: TreadmillTestRunConnectionContext?
 
     // Peripheral/characteristics
     private var connectedPeripheral: CBPeripheral?
@@ -840,6 +847,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @Published var deviceReportedChecksumOk: Bool = true
     @Published var deviceReportedRawHex: String = ""
     @Published private(set) var controllerUnitsTruth: ControllerUnitsTruth = .disconnected
+    @Published private(set) var treadmillTestRunIsActive = false
+    @Published private(set) var treadmillTestRunStatusText = "READY"
 #if STOP_TRUTH_EXPERIMENT_CAPABILITY
     @Published private(set) var stopTruthExperimentStatus: String = "disabled"
     @Published private(set) var stopTruthExperimentArtifactPath: String = ""
@@ -1971,6 +1980,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 self.attemptAutoConnectIfNeeded()
             case .poweredOff:
                 self.appendLog("Bluetooth poweredOff; stopping scan and clearing discoveries")
+                self.cancelTreadmillTestRunForConnectionInvalidation()
                 self.stopDiscoveryScan()
                 self.discoveredPeripherals = []
                 self.discoveredMap.removeAll()
@@ -2102,6 +2112,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             "error": error?.localizedDescription ?? "none"
         ])
         DispatchQueue.main.async {
+            self.cancelTreadmillTestRunForConnectionInvalidation()
 #if STOP_TRUTH_EXPERIMENT_CAPABILITY
             self.stopTruthExperimentController?.connectionContextInvalidated()
 #endif
@@ -2158,6 +2169,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         if userInitiated {
             autoConnectSuppressed = true
         }
+        cancelTreadmillTestRunForConnectionInvalidation()
         finishActiveStopObservationUnconfirmed(reason: "disconnect_requested")
         if let pendingAttemptID = unavailableStopAttempt?.id {
             finalizeUnavailableStopAttempt(attemptID: pendingAttemptID)
@@ -2498,6 +2510,192 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 #endif
 
     // Treadmill control
+    var canStartTreadmillTestRun: Bool {
+        let unitsDecision = ControllerUnitsSafetyPolicy.evaluate(
+            path: .testRun,
+            state: controllerUnitsTruth,
+            currentConnectionEpoch: controllerUnitsConnectionEpoch,
+            now: Date(),
+            requiresFreshMetricTruth: controllerUnitsTruthRequired
+        )
+        guard !treadmillTestRunService.isActive,
+              !isHrControlRunning,
+              isConnected,
+              connectedPeripheralId != nil,
+              controllerUnitsConnectionEpoch != nil,
+              commandCharacteristic != nil,
+              treadmillProtocol != .unknown,
+              unitsDecision.allowed,
+              treadmillMinSpeedKmh <= 1.0,
+              treadmillMaxSpeedKmh >= 3.0 else {
+            return false
+        }
+#if STOP_TRUTH_EXPERIMENT_CAPABILITY
+        guard stopTruthExperimentController?.isActive != true else { return false }
+#endif
+        return true
+    }
+
+    var treadmillTestRunDisplayText: String {
+        guard case .idle = treadmillTestRunService.state else {
+            return treadmillTestRunStatusText
+        }
+        if !isConnected {
+            return "Подключите дорожку"
+        }
+        if isHrControlRunning {
+            return "Недоступно во время HR-контроля"
+        }
+        if commandCharacteristic == nil || treadmillProtocol == .unknown {
+            return "Дождитесь готовности управления"
+        }
+        let unitsDecision = ControllerUnitsSafetyPolicy.evaluate(
+            path: .testRun,
+            state: controllerUnitsTruth,
+            currentConnectionEpoch: controllerUnitsConnectionEpoch,
+            now: Date(),
+            requiresFreshMetricTruth: controllerUnitsTruthRequired
+        )
+        if let unitsBlockReason = unitsDecision.blockReason {
+            return unitsBlockReason.userMessage
+        }
+        if treadmillMinSpeedKmh > 1.0 || treadmillMaxSpeedKmh < 3.0 {
+            return "Диапазон дорожки не поддерживает сценарий 1.0–3.0 km/h"
+        }
+#if STOP_TRUTH_EXPERIMENT_CAPABILITY
+        if stopTruthExperimentController?.isActive == true {
+            return "Недоступно во время Stop-truth experiment"
+        }
+#endif
+        return treadmillTestRunStatusText
+    }
+
+    func startTreadmillTestRun() {
+        guard canStartTreadmillTestRun,
+              let context = currentTreadmillTestRunContext() else {
+            treadmillTestRunStatusText = treadmillTestRunDisplayText
+            return
+        }
+        let runID = UUID()
+        guard let transition = treadmillTestRunService.start(
+            at: ProcessInfo.processInfo.systemUptime,
+            runID: runID
+        ) else {
+            return
+        }
+
+        treadmillTestRunContext = context
+        syncTreadmillTestRunPresentation()
+        startTreadmillTestRunTimer(runID: runID)
+        executeTreadmillTestRunActions(transition.actions)
+    }
+
+    func stopTreadmillTestRun() {
+        let contextIsCurrent = treadmillTestRunContext == currentTreadmillTestRunContext()
+        cancelTreadmillTestRun(
+            reason: .userRequested,
+            requestProductionStop: isConnected && contextIsCurrent
+        )
+    }
+
+    func treadmillTestRunAppBecameInactive() {
+        guard treadmillTestRunService.isActive else { return }
+        let contextIsCurrent = treadmillTestRunContext == currentTreadmillTestRunContext()
+        cancelTreadmillTestRun(
+            reason: .appInactive,
+            requestProductionStop: isConnected && contextIsCurrent
+        )
+    }
+
+    private func currentTreadmillTestRunContext() -> TreadmillTestRunConnectionContext? {
+        guard isConnected,
+              let peripheralID = connectedPeripheralId,
+              let connectionEpoch = controllerUnitsConnectionEpoch else {
+            return nil
+        }
+        return TreadmillTestRunConnectionContext(
+            peripheralID: peripheralID,
+            connectionEpoch: connectionEpoch
+        )
+    }
+
+    private func startTreadmillTestRunTimer(runID: UUID) {
+        treadmillTestRunTimer?.invalidate()
+        treadmillTestRunTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
+            self?.advanceTreadmillTestRun(expectedRunID: runID)
+        }
+    }
+
+    private func advanceTreadmillTestRun(expectedRunID: UUID) {
+        guard treadmillTestRunService.activeRunID == expectedRunID else { return }
+        guard treadmillTestRunContext == currentTreadmillTestRunContext() else {
+            cancelTreadmillTestRunForConnectionInvalidation()
+            return
+        }
+        guard let transition = treadmillTestRunService.advance(
+            at: ProcessInfo.processInfo.systemUptime,
+            expectedRunID: expectedRunID
+        ) else {
+            return
+        }
+
+        syncTreadmillTestRunPresentation()
+        if !treadmillTestRunService.isActive {
+            invalidateTreadmillTestRunScheduling()
+        }
+        executeTreadmillTestRunActions(transition.actions)
+    }
+
+    private func cancelTreadmillTestRun(
+        reason: TreadmillTestRunService.CancellationReason,
+        requestProductionStop: Bool
+    ) {
+        guard let transition = treadmillTestRunService.cancel(
+            reason: reason,
+            requestProductionStop: requestProductionStop
+        ) else {
+            return
+        }
+
+        invalidateTreadmillTestRunScheduling()
+        syncTreadmillTestRunPresentation()
+        if !requestProductionStop {
+            resetCommandQueue(reason: "Test Run cancelled without safe Stop context")
+        }
+        executeTreadmillTestRunActions(transition.actions)
+    }
+
+    private func cancelTreadmillTestRunForConnectionInvalidation() {
+        cancelTreadmillTestRun(
+            reason: .connectionInvalidated,
+            requestProductionStop: false
+        )
+    }
+
+    private func invalidateTreadmillTestRunScheduling() {
+        treadmillTestRunTimer?.invalidate()
+        treadmillTestRunTimer = nil
+        treadmillTestRunContext = nil
+    }
+
+    private func syncTreadmillTestRunPresentation() {
+        treadmillTestRunIsActive = treadmillTestRunService.isActive
+        treadmillTestRunStatusText = treadmillTestRunService.statusText
+    }
+
+    private func executeTreadmillTestRunActions(_ actions: [TreadmillTestRunService.Action]) {
+        for action in actions {
+            switch action {
+            case .start(let speedKmh):
+                manualGo(targetSpeed: speedKmh)
+            case .setSpeed(let speedKmh):
+                setTargetSpeedFromSlider(speedKmh)
+            case .stop:
+                manualStop()
+            }
+        }
+    }
+
     func manualGo(targetSpeed: Double) {
         logUiAction("GO pressed (target \(String(format: "%.1f", targetSpeed)) km/h, speed=\(String(format: "%.1f", speedKmh)), deviceTarget=\(String(format: "%.1f", deviceTargetSpeedKmh)), status=\(treadmillStatusText))")
         startWithSpeed(targetSpeed)

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -81,6 +81,8 @@ struct ContentView: View {
         .onChange(of: scenePhase) { _, phase in
             if phase == .active {
                 manager.pingWatch()
+            } else {
+                manager.treadmillTestRunAppBecameInactive()
             }
 #if STOP_TRUTH_EXPERIMENT_CAPABILITY
             if phase != .active {
@@ -2796,6 +2798,9 @@ private struct DebugView: View {
         }
 
         return DebugTrainingLogsCard.Presentation(
+            testRunActive: manager.treadmillTestRunIsActive,
+            testRunStatusText: manager.treadmillTestRunDisplayText,
+            canStartTestRun: manager.canStartTreadmillTestRun,
             subtitle: "Активный профиль: \(manager.activeUserProfileLabel)",
             profileMetrics: [
                 .init(id: "profile_raw", title: "Raw", value: "\(inventory.matchingProfileSessionFiles)", tint: .accentColor),
@@ -2828,17 +2833,6 @@ private struct DebugView: View {
                 : nil
         )
     }
-
-#if STOP_TRUTH_EXPERIMENT_CAPABILITY
-    private var stopTruthExperimentPresentation: DebugStopTruthExperimentCard.Presentation {
-        .init(
-            capabilityAvailable: manager.stopTruthExperimentCapabilityAvailable,
-            active: manager.stopTruthExperimentIsActive,
-            status: manager.stopTruthExperimentStatus,
-            artifactPath: manager.stopTruthExperimentArtifactPath
-        )
-    }
-#endif
 
     private var hrFailuresCardPresentation: DebugHrFailuresCard.Presentation {
         let reports = manager.hrFailureReports
@@ -3065,6 +3059,13 @@ private struct DebugView: View {
 
                     DebugTrainingLogsCard(
                         presentation: trainingLogsCardPresentation,
+                        onToggleTestRun: {
+                            if manager.treadmillTestRunIsActive {
+                                manager.stopTreadmillTestRun()
+                            } else {
+                                manager.startTreadmillTestRun()
+                            }
+                        },
                         onExportRaw: { scope in
                             exportTrainingHistoryCsv(manager: manager, scope: scope)
                         },
@@ -3075,19 +3076,6 @@ private struct DebugView: View {
                             manager.clearTrainingLogsForActiveProfile()
                         }
                     )
-
-#if STOP_TRUTH_EXPERIMENT_CAPABILITY
-                    DebugStopTruthExperimentCard(
-                        presentation: stopTruthExperimentPresentation,
-                        onStart: manager.startStopTruthExperiment,
-                        onPrepareMotion: manager.prepareStopTruthExperimentMotion,
-                        onInitialStop: manager.beginStopTruthExperimentStop,
-                        onMovingMarker: manager.markStopTruthExperimentMoving,
-                        onStoppedMarker: manager.markStopTruthExperimentStopped,
-                        onAbortMarker: manager.abortStopTruthExperiment,
-                        onNextRepetition: manager.beginNextStopTruthExperimentRepetition
-                    )
-#endif
 
                     DebugHrFailuresCard(
                         presentation: hrFailuresCardPresentation,

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DebugTrainingLogsCard.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DebugTrainingLogsCard.swift
@@ -15,6 +15,9 @@ struct DebugTrainingLogsCard: View {
             let scope: TrainingLogCsvExportScope
         }
 
+        let testRunActive: Bool
+        let testRunStatusText: String
+        let canStartTestRun: Bool
         let subtitle: String
         let profileMetrics: [Metric]
         let deviceMetrics: [Metric]
@@ -32,6 +35,7 @@ struct DebugTrainingLogsCard: View {
     }
 
     let presentation: Presentation
+    let onToggleTestRun: () -> Void
     let onExportRaw: (TrainingLogCsvExportScope) -> Void
     let onExportSessionSummary: (TrainingLogCsvExportScope) -> Void
     let onClear: () -> Void
@@ -55,6 +59,25 @@ struct DebugTrainingLogsCard: View {
             subtitle: presentation.subtitle
         ) {
             VStack(alignment: .leading, spacing: 14) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Test Run")
+                        .font(.caption.weight(.medium))
+                        .foregroundColor(.secondary)
+
+                    Button(action: onToggleTestRun) {
+                        DebugActionTileLabel(
+                            title: presentation.testRunActive
+                                ? "Остановить Test Run"
+                                : "Запустить Test Run",
+                            subtitle: presentation.testRunStatusText,
+                            tint: presentation.testRunActive ? .red : .accentColor,
+                            enabled: presentation.testRunActive || presentation.canStartTestRun
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!presentation.testRunActive && !presentation.canStartTestRun)
+                }
+
                 metricsSection(title: "Активный профиль", items: presentation.profileMetrics)
                 metricsSection(title: "Всё устройство", items: presentation.deviceMetrics)
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TreadmillTestRunService.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TreadmillTestRunService.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+struct TreadmillTestRunService {
+    enum Action: Equatable {
+        case start(speedKmh: Double)
+        case setSpeed(speedKmh: Double)
+        case stop
+    }
+
+    enum Stage: Int, CaseIterable, Equatable {
+        case startAtOne
+        case increaseToTwo
+        case increaseToThree
+        case decreaseToTwo
+        case firstStop
+        case restartAtOnePointFive
+        case finalStop
+
+        var action: Action {
+            switch self {
+            case .startAtOne:
+                return .start(speedKmh: 1.0)
+            case .increaseToTwo:
+                return .setSpeed(speedKmh: 2.0)
+            case .increaseToThree:
+                return .setSpeed(speedKmh: 3.0)
+            case .decreaseToTwo:
+                return .setSpeed(speedKmh: 2.0)
+            case .firstStop, .finalStop:
+                return .stop
+            case .restartAtOnePointFive:
+                return .start(speedKmh: 1.5)
+            }
+        }
+
+        var holdDuration: TimeInterval? {
+            switch self {
+            case .startAtOne, .increaseToTwo, .increaseToThree, .decreaseToTwo, .firstStop:
+                return 15
+            case .restartAtOnePointFive:
+                return 10
+            case .finalStop:
+                return nil
+            }
+        }
+
+        var statusText: String {
+            switch self {
+            case .startAtOne:
+                return "START → 1.0 km/h"
+            case .increaseToTwo:
+                return "SPEED → 2.0 km/h"
+            case .increaseToThree:
+                return "SPEED → 3.0 km/h"
+            case .decreaseToTwo:
+                return "SPEED → 2.0 km/h"
+            case .firstStop:
+                return "STOP отправлен"
+            case .restartAtOnePointFive:
+                return "START → 1.5 km/h"
+            case .finalStop:
+                return "TEST COMPLETE · STOP отправлен"
+            }
+        }
+    }
+
+    enum CancellationReason: String, Equatable {
+        case userRequested = "user_requested"
+        case appInactive = "app_inactive"
+        case connectionInvalidated = "connection_invalidated"
+    }
+
+    enum State: Equatable {
+        case idle
+        case running(runID: UUID, stage: Stage)
+        case cancelled(reason: CancellationReason, stopRequested: Bool)
+        case completed
+    }
+
+    struct Transition: Equatable {
+        let actions: [Action]
+        let state: State
+    }
+
+    private(set) var state: State = .idle
+    private var nextStageDeadline: TimeInterval?
+
+    var isActive: Bool {
+        if case .running = state {
+            return true
+        }
+        return false
+    }
+
+    var activeRunID: UUID? {
+        guard case .running(let runID, _) = state else { return nil }
+        return runID
+    }
+
+    var statusText: String {
+        switch state {
+        case .idle:
+            return "READY"
+        case .running(_, let stage):
+            return stage.statusText
+        case .cancelled(let reason, let stopRequested):
+            let stopText = stopRequested ? " · STOP отправлен" : ""
+            return "TEST CANCELLED · \(reason.rawValue)\(stopText)"
+        case .completed:
+            return Stage.finalStop.statusText
+        }
+    }
+
+    mutating func start(at now: TimeInterval, runID: UUID = UUID()) -> Transition? {
+        guard !isActive else { return nil }
+        let firstStage = Stage.startAtOne
+        state = .running(runID: runID, stage: firstStage)
+        nextStageDeadline = now + (firstStage.holdDuration ?? 0)
+        return Transition(actions: [firstStage.action], state: state)
+    }
+
+    mutating func advance(at now: TimeInterval, expectedRunID: UUID) -> Transition? {
+        guard case .running(let runID, let currentStage) = state,
+              runID == expectedRunID,
+              let deadline = nextStageDeadline,
+              now >= deadline,
+              let nextStage = Stage(rawValue: currentStage.rawValue + 1) else {
+            return nil
+        }
+
+        if nextStage == .finalStop {
+            state = .completed
+            nextStageDeadline = nil
+        } else {
+            state = .running(runID: runID, stage: nextStage)
+            nextStageDeadline = now + (nextStage.holdDuration ?? 0)
+        }
+        return Transition(actions: [nextStage.action], state: state)
+    }
+
+    mutating func cancel(
+        reason: CancellationReason,
+        requestProductionStop: Bool
+    ) -> Transition? {
+        guard isActive else { return nil }
+        state = .cancelled(reason: reason, stopRequested: requestProductionStop)
+        nextStageDeadline = nil
+        return Transition(
+            actions: requestProductionStop ? [.stop] : [],
+            state: state
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TreadmillTestRunServiceTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TreadmillTestRunServiceTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class TreadmillTestRunServiceTests: XCTestCase {
+    private let runID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+
+    func testFixedScenarioUsesExactSemanticOrderAndCompletesAtEightyFiveSeconds() throws {
+        var service = TreadmillTestRunService()
+        var actions: [TreadmillTestRunService.Action] = []
+
+        actions += try XCTUnwrap(service.start(at: 100, runID: runID)).actions
+        for now in [115.0, 130.0, 145.0, 160.0, 175.0, 185.0] {
+            actions += try XCTUnwrap(service.advance(at: now, expectedRunID: runID)).actions
+        }
+
+        XCTAssertEqual(actions, [
+            .start(speedKmh: 1.0),
+            .setSpeed(speedKmh: 2.0),
+            .setSpeed(speedKmh: 3.0),
+            .setSpeed(speedKmh: 2.0),
+            .stop,
+            .start(speedKmh: 1.5),
+            .stop
+        ])
+        XCTAssertEqual(service.state, .completed)
+        XCTAssertEqual(service.statusText, "TEST COMPLETE · STOP отправлен")
+        XCTAssertFalse(service.isActive)
+        XCTAssertNil(service.advance(at: 1_000, expectedRunID: runID))
+    }
+
+    func testSecondRunCannotStartWhileOneIsActive() throws {
+        var service = TreadmillTestRunService()
+
+        _ = try XCTUnwrap(service.start(at: 0, runID: runID))
+        let secondStart = service.start(at: 1, runID: UUID())
+
+        XCTAssertNil(secondStart)
+        XCTAssertEqual(service.activeRunID, runID)
+    }
+
+    func testUserCancellationBecomesTerminalBeforeRequestingProductionStop() throws {
+        var service = TreadmillTestRunService()
+        _ = try XCTUnwrap(service.start(at: 0, runID: runID))
+
+        let transition = try XCTUnwrap(service.cancel(
+            reason: .userRequested,
+            requestProductionStop: true
+        ))
+
+        XCTAssertEqual(
+            transition.state,
+            .cancelled(reason: .userRequested, stopRequested: true)
+        )
+        XCTAssertEqual(service.state, transition.state)
+        XCTAssertFalse(service.isActive)
+        XCTAssertEqual(transition.actions, [.stop])
+        XCTAssertNil(service.advance(at: 1_000, expectedRunID: runID))
+    }
+
+    func testConnectionInvalidationCancelsWithoutLateActionOrAutomaticResume() throws {
+        var service = TreadmillTestRunService()
+        _ = try XCTUnwrap(service.start(at: 0, runID: runID))
+
+        let transition = try XCTUnwrap(service.cancel(
+            reason: .connectionInvalidated,
+            requestProductionStop: false
+        ))
+
+        XCTAssertEqual(transition.actions, [])
+        XCTAssertEqual(
+            service.state,
+            .cancelled(reason: .connectionInvalidated, stopRequested: false)
+        )
+        XCTAssertNil(service.advance(at: 15, expectedRunID: runID))
+        XCTAssertNil(service.advance(at: 30, expectedRunID: UUID()))
+        XCTAssertFalse(service.isActive)
+    }
+
+    func testAppInactiveCancellationPreventsFutureMotionAndRequestsStop() throws {
+        var service = TreadmillTestRunService()
+        _ = try XCTUnwrap(service.start(at: 0, runID: runID))
+        _ = try XCTUnwrap(service.advance(at: 15, expectedRunID: runID))
+
+        let transition = try XCTUnwrap(service.cancel(
+            reason: .appInactive,
+            requestProductionStop: true
+        ))
+
+        XCTAssertEqual(transition.actions, [.stop])
+        XCTAssertFalse(service.isActive)
+        XCTAssertNil(service.advance(at: 30, expectedRunID: runID))
+        XCTAssertNil(service.advance(at: 1_000, expectedRunID: runID))
+    }
+
+    func testDelayedTickAdvancesOnlyOneStageInsteadOfCatchingUpMotionActions() throws {
+        var service = TreadmillTestRunService()
+        _ = try XCTUnwrap(service.start(at: 0, runID: runID))
+
+        let delayedTransition = try XCTUnwrap(
+            service.advance(at: 100, expectedRunID: runID)
+        )
+
+        XCTAssertEqual(delayedTransition.actions, [.setSpeed(speedKmh: 2.0)])
+        XCTAssertNil(service.advance(at: 114.9, expectedRunID: runID))
+        XCTAssertEqual(
+            service.advance(at: 115, expectedRunID: runID)?.actions,
+            [.setSpeed(speedKmh: 3.0)]
+        )
+    }
+
+    func testStaleTimerRunIdentifierCannotAdvanceCurrentRun() throws {
+        var service = TreadmillTestRunService()
+        _ = try XCTUnwrap(service.start(at: 0, runID: runID))
+
+        XCTAssertNil(service.advance(at: 15, expectedRunID: UUID()))
+        XCTAssertEqual(
+            service.state,
+            .running(runID: runID, stage: .startAtOne)
+        )
+    }
+
+    func testOrchestrationSourceHasNoBleOrRawPacketSurface() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let sourceFile = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("WalkingPadRemote/TreadmillTestRunService.swift")
+        let source = try String(contentsOf: sourceFile, encoding: .utf8)
+
+        for forbidden in ["CoreBluetooth", "CBUUID", "FE02", "writeCommand", "buildCmdPacket", "Data("] {
+            XCTAssertFalse(source.contains(forbidden), "Unexpected command surface: \(forbidden)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one Debug Test Run control: `Запустить Test Run` while idle and `Остановить Test Run` while active, with the current requested stage/status visible.
- Runs the fixed bounded sequence: START 1.0 km/h (15s) → SPEED 2.0 (15s) → SPEED 3.0 (15s) → SPEED 2.0 (15s) → production STOP (15s) → START 1.5 (10s) → production STOP → complete.
- Delegates every action to existing production paths: START through `manualGo` / `startWithSpeed`, SPEED through `setTargetSpeedFromSlider` / `sendTreadmillSetSpeed`, and STOP through `manualStop` / `stopBeltWithToggle(reason: "manual")`.
- Terminally invalidates scheduled Test Run work before cancellation Stop. App-inactive and disconnect/context invalidation prevent late motion actions and automatic resume; unsafe/no-context cancellation also invalidates the production command queue epoch.
- Hides the historical marker-heavy Stop-truth card from routine Debug UX without deleting its implementation.

## Verification

- `swift test --filter TreadmillTestRunServiceTests` — 8 tests passed.
- `swift test` — 141 tests passed.
- `git diff --cached --check` — passed.
- `xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` — succeeded for the iOS app and embedded watchOS app.
- Fresh independent `gpt-5.6-terra` / high review — APPROVE; no material P0/P1 findings.
- Production Start/Speed/Stop bodies, packet builders, protocol branches, command queue behavior, and Stop retry semantics are unchanged.

## Risks / Notes

- No physical-device deployment, install, launch, BLE operation, treadmill connection, or hardware activity was performed.
- Routine post-merge iPhone deployment remains a manual user action.
- Draft PR only; this change is not authorized for merge by the implementation task.

Closes #18