### PR TITLE
Document Telemetry V2 architecture contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,7 @@ This project is intentionally narrow. The goal is not to become a generic fitnes
 - Better contributor docs and safer bug-reporting flow
 - UI polish and accessibility improvements for the main workout flows
 - Better analysis tooling around exported training logs
+- Implement the [Telemetry V2 specification](docs/telemetry-v2/architecture.md) through its sequential, evidence-gated rollout
 
 ## Nice-to-have improvements
 

--- a/docs/telemetry-v2/architecture.md
+++ b/docs/telemetry-v2/architecture.md
@@ -1,0 +1,196 @@
+# Telemetry V2 architecture
+
+Status: normative contract for the Telemetry V2 implementation queue.
+
+This document defines component ownership and dependency direction. The related
+[data contract](data-contract.md), [persistence and retention policy](persistence-and-retention.md),
+[rollout plan](rollout-and-migration.md), [performance budget](performance-budget.md),
+and [safety boundary](safety-boundary.md) are equally normative.
+
+`MUST`, `MUST NOT`, `SHOULD`, `SHOULD NOT`, and `MAY` express requirement
+strength. A later issue MAY refine names and internal representation, but it
+MUST preserve the requirements in this specification or obtain a new explicit
+PM-approved behavior contract.
+
+## Scope and non-goals
+
+Telemetry V2 is a local data platform for timestamped workout evidence,
+causal control events, materialized state frames, and reproducible post-workout
+analysis. It replaces the prototype JSONL, wide-CSV, and capped `UserDefaults`
+architecture through the gated migration described in
+[rollout-and-migration.md](rollout-and-migration.md).
+
+This specification does not implement or authorize:
+
+- an interval engine, automatic adaptation, machine learning, or changes to
+  control behavior;
+- learning or expansion of any safety bound;
+- a HealthKit transport redesign or an Apple Watch-only HR architecture;
+- CloudKit, cloud synchronization, a backend, or remote telemetry;
+- device installation, physical validation, treadmill access, or BLE commands.
+
+## Platform boundary
+
+The core product baseline for this Epic is iOS 26. Issue #24 MUST express that
+package platform floor without silently changing the repository's
+`swift-tools-version: 5.10`, Swift language mode, or macOS test-host floor. If
+the actual toolchain cannot express and build the iOS 26 floor compatibly, #24
+MUST stop for PM decision with the exact compiler/package error.
+
+## Component graph
+
+```text
+HR providers                    decoded treadmill observations
+     |                                      |
+     +------ typed normalization -----------+
+                        |
+                  WorkoutEngine
+               /                  \
+       safety policies       control decisions
+               \                  /
+                 command service
+                        |
+              constant-time emission
+                        |
+               telemetry ingress
+                        |
+              bounded memory buffer
+                        |
+        isolated persistence consumer
+                        |
+          provisional SwiftData store
+                /               \
+      versioned analyzer     read projections
+                                   |
+                         history/charts/export
+```
+
+Dependencies MUST point downward. Telemetry components MUST NOT become a
+dependency of a control or safety decision. Views and exports MUST consume
+read projections and MUST NOT receive a persistence context directly.
+
+## Component responsibilities
+
+### Provider adapters and typed normalization
+
+Provider adapters translate HealthKit, Watch connectivity, BLE-decoded state,
+and future sources into the types defined by the
+[data contract](data-contract.md). They MUST preserve native values, units,
+arrival order, source metadata actually supplied by the provider, and both
+measurement and receipt timestamps when available.
+
+The normalized HR boundary MUST be provider-agnostic. HealthKit source metadata
+can identify an app or hardware such as an iPhone, Apple Watch, or Bluetooth HR
+monitor; code MUST NOT infer a physical sensor identity or assume Apple Watch
+when the provider reports only an unknown or selected HealthKit source. See
+[`HKSourceRevision`](https://developer.apple.com/documentation/healthkit/hksourcerevision).
+
+Normalization MAY add explicit quality flags. It MUST NOT reorder, deduplicate,
+drop, or alter the controller-facing HR stream. It MUST NOT turn an estimate or
+unit guess into a factual treadmill observation.
+
+### WorkoutEngine, safety policies, and command service
+
+These existing owners remain authoritative for workout state, safety decisions,
+and command behavior. They MAY emit immutable typed telemetry records. Emission
+MUST be constant-time, non-blocking, and independent of persistence success.
+
+The command service owns enqueue/send behavior and protocol outcomes. Telemetry
+records the resulting causal lifecycle; it does not initiate, retry, cancel, or
+confirm commands. Stop confirmation continues to require fresh factual device
+evidence as defined by the current safety contract.
+
+### Telemetry ingress and bounded buffer
+
+Ingress accepts already-formed value records and assigns recorder-local ordering
+metadata where required. It MUST NOT perform database access, JSON encoding,
+file I/O, export, analysis, or synchronous cross-process work in a control or
+sensor callback.
+
+The buffer MUST be bounded. Overflow behavior MUST follow the evidence classes
+and loss accounting in [performance-budget.md](performance-budget.md); it MUST
+never block control. Buffer health and any loss MUST be observable without
+logging private payloads.
+
+### Isolated persistence consumer
+
+One isolated consumer drains the buffer in bounded batches and is the only
+production writer to the V2 store. It owns transactions, relationships,
+deduplication by real identity, store lifecycle, and incomplete-session recovery.
+SwiftData is provisional until its explicit benchmark, protection, and recovery
+gate passes. Details are in
+[persistence-and-retention.md](persistence-and-retention.md).
+
+### Canonical frames
+
+A frame is an at-most-1-Hz materialized view of state actually available while
+the recorder is running. It MAY carry the latest known value only with the
+source record ID, original timestamp, and freshness/quality state. It MUST NOT
+claim that carried state is a new sensor observation.
+
+The recorder MUST persist at most one frame for a session's canonical elapsed
+second. It MUST NOT synthesize frames after a pause, process suspension, crash,
+restart, disconnect gap, or other interval in which no frame was materialized.
+Missing seconds remain gaps, and a later frame or recorder/lifecycle event MUST
+make the gap boundary explicit so analysis can distinguish an observed second
+with no new native sample from an unobserved or unpersisted second. Native
+observations and exact events retain their own cadence independently of frames.
+
+### Versioned analyzer
+
+The analyzer is a post-workout consumer. It MUST read immutable evidence, use
+timestamp- and freshness-aware calculations, and write a versioned result keyed
+by analyzer version and evidence identity/hash. The same inputs and version MUST
+produce the same result, and rerunning MUST be idempotent.
+
+Analysis and recommendations are derived data, not evidence. They MUST NOT feed
+the production controller in this Epic. No analyzer operation may run on a
+control or sensor callback.
+
+### Read projections, export, and instrumentation
+
+History, charts, statistics, and export consume bounded V2 queries and explicit
+projections. CSV and summaries become export formats, not independent stores.
+Export MUST be non-destructive.
+
+Performance instrumentation is a separate privacy-safe diagnostic channel. On
+the iOS 26 baseline it SHOULD use `OSSignposter`, Instruments, and
+availability-correct MetricKit APIs. The newer `MetricManager` async API is an
+iOS 27+ API; it MUST NOT be presented as an iOS 26 dependency. Instrumentation
+MUST NOT contain HR values, private identifiers, raw BLE payloads, or workout
+exports.
+
+## Availability and failure direction
+
+- Control and safety MUST operate when telemetry is disabled, unavailable,
+  backpressured, corrupt, or recovering.
+- Telemetry failure MUST be surfaced as recorder/session health and MUST NOT
+  authorize motion, weaken a safety gate, or delay a command.
+- A read, export, or analyzer failure MUST remain in that subsystem. It MUST NOT
+  fall back silently to contradictory legacy facts after V2 read cutover.
+- Debug, preview, benchmark, replay, and simulator paths MUST remain isolated
+  from production transport and MUST obey the same type/provenance rules.
+
+## Implementation ownership by queue
+
+| Issue | Contract-owned output |
+| --- | --- |
+| #24 | Pure typed domain, identifiers, timestamps, provenance, quality, events, and frames |
+| #25 | Versioned V1 schema and isolated local store |
+| #26 | Automated SwiftData scale, recovery, protection, and fallback gate |
+| #27 | Constant-time ingress, bounded buffering, batching, and loss accounting |
+| #28 | HR normalization with unchanged controller arrival behavior |
+| #29 | Factual treadmill truth and command/estimate separation |
+| #30 | Session lifecycle, observed frames, and production dual-write |
+| #31 | Privacy-safe instrumentation and soak harness |
+| #32 | Deterministic replay and legacy-to-V2 parity |
+| #33 | Versioned timestamp-weighted post-workout analysis |
+| #34 | Idempotent conservative legacy import/reconciliation |
+| #35 | V2 read cutover with temporary legacy shadow-write |
+| #37 | Separate user/PM-supplied real-evidence validation gate |
+| #36 | Legacy retirement only after the #37 gate authorizes it |
+
+Each issue MUST use the inputs and invariants defined here and in the linked
+documents. Sequential delivery and the gates in
+[rollout-and-migration.md](rollout-and-migration.md) prevent a later issue from
+silently changing an earlier contract.

--- a/docs/telemetry-v2/data-contract.md
+++ b/docs/telemetry-v2/data-contract.md
@@ -1,0 +1,275 @@
+# Telemetry V2 data contract
+
+Status: normative semantic contract.
+
+This document defines evidence, time, provenance, identity, units, records, and
+analysis semantics. Concrete Swift names MAY differ, but the distinctions below
+MUST remain representable and queryable.
+
+## Truth and provenance vocabulary
+
+| Term | Meaning | Required rule |
+| --- | --- | --- |
+| factual observation | A value reported by an identified provider or decoded from a device observation | MUST retain native value, unit, source/provenance, and timestamps; absence remains `nil`/unknown |
+| measured | The source says the value was measured by a sensor | MUST NOT be inferred from receipt alone |
+| reported | The source or device reported the value; measurement method may be unknown | MUST identify that source and MUST NOT be relabeled measured without evidence |
+| commanded | A value contained in a command that was queued or sent | MUST NOT be treated as observed device state |
+| desired | A controller target before transport/protocol effects | MUST remain distinct from commanded and observed values |
+| estimated | A model, interpolation, or app-side calculation | MUST carry method/version and MUST NOT populate a factual field |
+| derived | A reproducible calculation from persisted evidence | MUST carry analyzer/derivation version and evidence identity |
+
+`actual`, `current`, `target`, `speed`, `state`, and `duration` are forbidden as
+standalone persisted semantics when they do not identify which category above
+they mean. Missing factual evidence MUST remain `nil`/unknown. A commanded speed,
+desired speed, model estimate, stale last-known value, or controller-native unit
+guess MUST NOT fill a factual physical-speed field.
+
+## Time model
+
+Every persisted record MUST carry:
+
+1. wall-clock correlation (`recordedAt` or an equivalent absolute `Date`);
+2. a signed integer elapsed offset from the session's monotonic origin, using
+   one documented precision such as microseconds or milliseconds;
+3. the timestamp roles applicable to that record.
+
+Timestamp roles are distinct:
+
+- `measuredAt`: when the provider says a sample was measured; `nil` when unknown;
+- `receivedAt`: when this process received the observation;
+- `occurredAt`: when an app-owned event happened;
+- `enqueuedAt`, `sentAt`, `acknowledgedAt`, and `timedOutAt`: command lifecycle
+  event times, represented as exact events rather than overwritten fields;
+- `recordedAt`: wall time assigned when the immutable telemetry record was made.
+
+Control timing MUST use the runtime monotonic clock, never wall-clock deltas.
+Swift's [`ContinuousClock`](https://developer.apple.com/documentation/swift/continuousclock)
+is suitable at a runtime boundary because it advances monotonically, including
+during sleep, but its `Instant` MUST NOT be persisted as a cross-launch or
+cross-device identity. Persisted elapsed offsets and wall time MUST be explicit.
+
+Records MUST preserve arrival order even when `measuredAt` is duplicated,
+missing, or earlier than a previously received sample. Sorting for display or
+analysis MUST NOT rewrite evidence order. Clock regressions, impossible ordering,
+and excessive receive delay MUST be quality-flagged.
+
+Analysis MUST integrate over timestamp intervals for which evidence is fresh.
+It MUST define gap and boundary behavior and MUST NOT treat a sample count as a
+duration in seconds.
+
+### Time-weighted analysis semantics
+
+The default analytical time coordinate is the persisted monotonic elapsed offset.
+For a provider observation, analysis uses the provider measurement time mapped
+to that coordinate when it is present and trustworthy; otherwise it uses the
+receive-time coordinate and records the fallback as quality/provenance.
+
+For state-like HR, target, zone, and factual-speed metrics, Analyzer V1 MUST use
+a left-continuous, piecewise-constant hold from an observation's effective time
+until the earliest of the next applicable observation, the accepted freshness
+limit, a source/phase/session boundary, or an explicit gap. The interval starts
+at the observation and excludes its end boundary. It MUST NOT carry state beyond
+freshness expiry or interpolate across a gap.
+
+A metric MAY use bounded interpolation only when its versioned definition names
+the method, both bracketing observations are valid/fresh and from compatible
+sources, and their separation is inside an explicit maximum gap. Otherwise the
+point or interval is unavailable.
+
+Time in stale, missing, ambiguous, or unobserved intervals MUST be reported as
+uncovered and excluded from covered-duration denominators; it MUST NOT become
+zero or error-free time. Time-weighted MAE, RMSE, AUC, zone time, target-range
+time, overshoot/undershoot duration, recovery, and stable-speed drift MUST
+integrate their function over covered elapsed intervals. Event counts remain
+counts. HRR10/30/60/120 MUST be unavailable or low-confidence when the required
+timestamp coverage or permitted interpolation is absent; it MUST NOT select the
+Nth sample as though cadence were 1 Hz.
+
+## Identity and causal correlation
+
+Stable typed identifiers MUST exist for at least session, record, source,
+observation, decision, command, frame, and analysis. IDs from unrelated domains
+MUST NOT be interchangeable.
+
+The causal chain is:
+
+```text
+observation(s) used -> decision -> command enqueue/send
+                    -> ACK or timeout -> observed treadmill response
+```
+
+- A decision MUST reference every observation record it actually used, plus the
+  immutable configuration/safety-policy version under which it ran.
+- A command lifecycle event MUST reference its decision and command IDs when
+  applicable.
+- ACK, timeout, cancellation, retry, and transport failure MUST be separate
+  events referencing the command attempt they describe.
+- A later treadmill observation MAY reference the command as a candidate causal
+  response only when the implementation has real correlation evidence. Mere
+  temporal proximity MUST NOT be recorded as proven causation.
+- Absence of ACK or observed response remains absence, not success.
+
+## Units
+
+Native evidence MUST preserve the numeric value and native unit exactly as
+decoded or supplied. A normalized physical field MUST name its unit explicitly.
+The canonical physical treadmill-speed unit is km/h.
+
+- Conversion requires a known source unit and a versioned deterministic rule.
+- Unknown or unconfirmed controller unit semantics produce no factual normalized
+  km/h value.
+- Desired, commanded, reported-native, reported-physical, estimated, and derived
+  speed MUST use separate fields or types.
+- Distance and duration MUST identify whether they are a native cumulative
+  observation, a session projection, or a derived analysis result.
+
+## Source model
+
+A signal source records a provider kind and a stable local key. It MAY include
+HealthKit source revision, device metadata, and provider sample UUID only when
+those values are actually available. The provider/source kind MUST support at
+least `unknown` and a HealthKit-selected source without inventing a sensor name.
+
+HealthKit `sourceRevision` describes the app/device that saved an object and is
+not always a complete physical-sensor identity; supported hardware is not
+Apple Watch-only. The contract therefore MUST keep provider, saving source, and
+physical device metadata as separate optional facts. See
+[`HKObject.sourceRevision`](https://developer.apple.com/documentation/healthkit/hkobject/sourcerevision)
+and [`HKSourceRevision`](https://developer.apple.com/documentation/healthkit/hksourcerevision).
+
+## Quality and freshness
+
+Quality is additive metadata, not permission to discard evidence. The typed
+domain MUST represent at least:
+
+- missing source or measurement time;
+- duplicate provider identity/sequence;
+- out-of-arrival-order measurement time;
+- invalid or out-of-domain native value;
+- stale-at-use evidence and unknown freshness;
+- clock regression or implausible receive latency;
+- gap before the record;
+- recorder loss before the record;
+- estimated/derived provenance where applicable.
+
+Duplicate and out-of-order HR observations MUST be preserved and flagged. The
+controller-facing ordering and acceptance decision remain unchanged during V2
+normalization. A record MUST separately state whether it was accepted/used for
+control; quality flags alone MUST NOT reconstruct that decision.
+
+Freshness MUST be evaluated from the original observation time role and the
+policy/version that consumed it. A stale value carried into a frame remains
+stale and references its original record.
+
+## Conceptual records
+
+Telemetry V2 has seven conceptual records. The implementation MAY refine names
+or split storage tables, but MUST NOT collapse them into one giant nullable event
+table.
+
+### 1. Workout session
+
+Required semantics: stable session ID; profile-local identity; lifecycle and
+completion/incomplete reason; workout mode; start/end wall and elapsed times;
+app/build/OS; telemetry schema; algorithm, safety-policy, and workout-protocol
+versions; immutable configuration snapshot/hash; optional HealthKit workout UUID;
+and recorder health summary.
+
+### 2. Signal source
+
+Required semantics: source ID, provider kind, stable local key, optional known
+provider/device metadata, and first/last seen timestamps. Unknown facts remain
+absent.
+
+### 3. Heart-rate sample
+
+Required semantics: observation ID, session/source IDs, BPM, provider sequence
+or UUID when present, measured/received/recorded/elapsed times, arrival order,
+quality/freshness, and explicit accepted/used-for-control state.
+
+### 4. Treadmill sample
+
+Required semantics: observation ID, session/source IDs, raw/native value and
+unit, optional factual normalized physical value, device state, timestamps,
+arrival order, quality/freshness, and provenance. Estimates and command targets
+do not belong in factual observation fields.
+
+### 5. Event
+
+An event has a compact common envelope (record/session ID, event kind, event
+time, elapsed offset, source, causal IDs, payload schema version) and a typed,
+versioned payload. Routine query fields MUST remain indexable; event-specific
+detail MUST NOT create hundreds of nullable columns.
+
+The event taxonomy MUST cover:
+
+- session lifecycle and incomplete/recovery state;
+- workout phase transition;
+- HR source/provider transition;
+- treadmill connection/state transition;
+- control decision and observations used;
+- command enqueue, send/attempt, ACK, timeout, cancellation, retry, and failure;
+- manual stop, cooldown, safety-gate, and stop-confirmation evidence;
+- recorder pressure, loss, drain, persistence, and recovery health.
+
+Raw BLE payloads are diagnostic chatter, not normal event payloads.
+
+### 6. Canonical frame
+
+A frame is a query-oriented materialized state view keyed uniquely by session
+and canonical elapsed second. It MUST carry its materialization time and the IDs,
+timestamps, provenance, and freshness of evidence represented in the frame.
+
+At most one frame MAY exist per canonical second. A real-time materializer MAY
+carry the latest observation across an active second only as a last-known value
+with unchanged evidence identity and explicit freshness. It MUST NOT create a
+new native observation. It MUST NOT backfill a frame after a runtime gap. Missing
+seconds remain missing. A later frame or typed recorder/lifecycle event MUST
+identify the elapsed gap boundary and whether it reflects no observation,
+runtime suspension/stall, recorder outage/loss, or an unknown cause when that is
+all that is known.
+
+### 7. Workout analysis
+
+Required semantics: session ID, analyzer version, evidence identity/hash,
+generation time, data-quality grade, queryable key metrics, and a versioned
+detailed payload. Results MUST be deterministic, idempotent, and recomputable
+from retained evidence. Recommendations, if introduced after this Epic, MUST be
+separate from both analysis and evidence.
+
+## Source-of-truth matrix
+
+| Question | Authoritative evidence | Explicitly not authoritative |
+| --- | --- | --- |
+| HR received/used by control | Native HR observation plus accepted-for-control state and decision reference | Frame, chart point, average, inferred sensor name |
+| Treadmill factual state/speed | Native decoded treadmill observation with known unit/provenance | Desired, commanded, estimated, or last-known value without freshness |
+| Controller intent | Typed decision and desired value | Device observation |
+| Command requested/sent/outcome | Correlated command lifecycle events | Target snapshot or later speed alone |
+| Session/phase/source/connection/safety transition | Exact typed event | Frame-only state change inference |
+| Fast chart/replay join | Canonical frame with evidence references | Fabricated 1 Hz sensor series |
+| Metric or duration | Versioned timestamp-weighted analysis | Sample count treated as seconds |
+| Performance/recorder health | Privacy-safe diagnostic metrics and recorder-health events | Unified logs containing workout payloads |
+
+## Legacy terminology mapping
+
+Legacy fields are migration inputs, not V2 names. Import/replay code MUST map
+them explicitly and preserve ambiguity rather than guess.
+
+| Legacy term | Required V2 interpretation |
+| --- | --- |
+| `speed_actual_kmh` | factual only if the source proves physical treadmill speed; otherwise import as reported/estimated with provenance |
+| `speed_target_kmh` | desired controller speed |
+| `speed_device_target_kmh` | controller/device command-domain target, not observation |
+| `speed_reported_kmh`, `speed_reported_app_kmh` | reported values with their original source and unit semantics |
+| `target_bpm` | event-scoped target; main-workout and cooldown targets MUST be distinct |
+| `duration_s` | cumulative snapshot field, not automatically session wall duration |
+| `session_duration_s`, `workout_duration_s` | derived summary projections with documented start/end inputs |
+| `distance_km` | identify native cumulative observation versus derived session summary |
+| `phase`, `session_state`, `treadmill_status` | separate workout phase, app session lifecycle, and device state domains |
+| `steps` | identify cumulative source value versus delta/derived total; synthetic values are not factual |
+| `workout_history_v1` | legacy summary/history projection, not raw telemetry evidence |
+| raw/session-summary CSV | export/projection of legacy evidence, not an independent source of truth |
+
+Legacy Python diagnostic fields (`belt_state`, `speed`, `time`, `dist`, `steps`,
+and `app_speed`) and stop-truth experiment JSONL have their own schemas. They
+MUST NOT be silently interpreted as iOS Telemetry V2 records.

--- a/docs/telemetry-v2/performance-budget.md
+++ b/docs/telemetry-v2/performance-budget.md
@@ -1,0 +1,128 @@
+# Telemetry V2 performance budget
+
+Status: normative measurement and acceptance contract.
+
+Performance and storage numbers in this document are design targets and
+hypotheses to measure. They are not scientific justification to downsample,
+coalesce, reorder, or delete native training evidence. A miss requires analysis
+and PM decision, not a silent semantic change.
+
+## Control-path budget
+
+The primary hard requirement is architectural:
+
+- no database, JSON serialization, file synchronization, export, analysis, or
+  blocking wait may run synchronously in a control or sensor callback;
+- telemetry emission MUST be constant-time with respect to store size and MUST
+  not run on the main actor merely because UI state is involved;
+- the buffer MUST be bounded and telemetry backpressure MUST never propagate to
+  command or safety execution;
+- telemetry enabled and disabled MUST produce identical control outputs for the
+  same deterministic input replay.
+
+Wall-clock latency measurements do not replace inspection of actor/queue
+ownership and code paths.
+
+## Evidence pressure classes
+
+| Class | Records | Pressure behavior |
+| --- | --- | --- |
+| critical causal evidence | observations used by control, decisions, command lifecycle, safety/stop/session transitions | MUST NOT be intentionally sampled for storage targets; reserve capacity where practical; unavoidable loss marks the interval and session incomplete |
+| native scientific evidence | all HR/treadmill observations with native cadence and quality | MUST preserve arrival order and MUST NOT be silently downsampled; unavoidable loss is counted by type and time range |
+| canonical frames | at-most-one per canonical second | MAY coalesce candidates within the same second; MUST NOT backfill gaps or replace native evidence |
+| derived analysis | recomputable post-workout results | MAY be deferred/recomputed; MUST retain evidence identity/version |
+| diagnostic chatter | raw BLE/debug/benchmark detail | First class eligible for bounded dropping/rotation; MUST remain separate from training evidence |
+
+The implementation MUST define capacity, high-water mark, priority behavior, and
+drain strategy before production integration. When a bound is reached it MUST
+prefer dropping bounded diagnostic chatter, then eligible same-second frame
+candidates. It MUST NOT block control. Any native or critical loss MUST create a
+privacy-safe loss record containing record class, count, and elapsed interval,
+not the private payload.
+
+## Benchmark profiles
+
+Issue #26 MUST provide a deterministic fixture generator and runner with:
+
+- a fast CI profile;
+- a configurable full profile representing approximately 1,000 workout-hours
+  and several million records;
+- documented deterministic seed, schema/build/toolchain, hardware/OS, store
+  state, warm-up, repetitions, and percentile method;
+- realistic proportions of native HR, treadmill changes, exact causal/lifecycle
+  events, at-most-1-Hz frames, incomplete sessions, and analyses;
+- history, chart, analysis, export, and last-N-comparable-session query shapes;
+- reopen, forced interruption, partial-tail, and repeated migration scenarios.
+
+Fixture generation MUST NOT be exposed as a production debug action capable of
+accidentally allocating a full data set on a user's device.
+
+## Measurements and hypotheses
+
+The report MUST capture raw run summaries plus p50/p95 where meaningful for:
+
+- ingress-to-buffer time and buffer high-water mark;
+- batch size, transaction latency, throughput, retry/failure count, and drain
+  time;
+- recent-history, single-workout time-series, chart, analysis, export, and
+  comparable-session query latency;
+- peak memory during generation, persistence, fetch, analysis, export, and
+  reopen;
+- SQLite store/WAL/SHM size, growth per workout-hour, and post-checkpoint state;
+- interruption recovery, committed-batch preservation, incomplete marking, and
+  migration/reopen behavior;
+- file protection and backup-exclusion state for the main store and every
+  discovered sidecar after each relevant lifecycle operation.
+
+Initial product hypotheses from the implementation queue are:
+
+| Hypothesis | Measurement context |
+| --- | --- |
+| p95 transaction below 50 ms for a provisional 5-second/128-record batch | designated target device; batching parameters remain benchmark-derived |
+| median ordinary-workout storage at or below 1 MB/hour | representative session mix, including indices and sidecars under the documented measurement method |
+| p95 ordinary-workout storage at or below 2 MB/hour | same method; a miss does not authorize evidence loss |
+| recent history and a normal single-workout fetch remain interactive at full fixture scale | query-specific target MUST be declared before the acceptance run and reported with device/context |
+| previously committed batches survive interruption and reopen | forced-interruption scenario with evidence-count/hash comparison |
+
+`5 seconds / 128 records` is only a provisional internal batching default if
+measurements do not select a better bounded value. Changing it MUST NOT change
+evidence semantics.
+
+## Result classification and gates
+
+Each item is classified:
+
+- `PASS`: executed with the required environment/evidence and met the accepted
+  architectural or measured target;
+- `FAIL`: executed and violated a requirement or exposed material product risk;
+- `UNVERIFIED_ON_DEVICE`: automated evidence cannot establish a device-only
+  property. This is not a pass.
+
+CI and hosted automation form the first validation layer. Every device-only item
+MUST be carried verbatim to real-evidence gate #37. Physical validation is a
+separate PM/user activity; normal implementation MUST NOT perform it implicitly.
+
+A target miss MUST include the measured delta, confidence/variance, profiler
+evidence, and product impact. It blocks only when it violates a hard architecture,
+privacy, recovery, or safety requirement, or demonstrates material product risk.
+Otherwise PM decides whether to accept, tune, or revise the hypothesis. Native
+evidence MUST NOT be silently sampled to make a number pass.
+
+A material SwiftData failure triggers the explicit fallback process in
+[persistence-and-retention.md](persistence-and-retention.md), not an in-issue
+technology switch.
+
+## Privacy-safe observability
+
+On iOS 26, instrumentation SHOULD use
+[`OSSignposter`](https://developer.apple.com/documentation/os/ossignposter),
+Instruments, and availability-correct MetricKit APIs. `MXMetricManager` is the
+compatibility API for earlier systems and provides delayed aggregate reports;
+the replacement `MetricManager` async API is iOS 27+. Neither is durable workout
+telemetry or an immediate causal event stream.
+
+Signposts, unified logs, MetricKit payloads, and benchmark summaries MUST NOT
+include BPM/HR values, private identifiers, HealthKit UUIDs, raw BLE payloads,
+workout exports, or configuration snapshots. They MAY contain bounded opaque
+run IDs, record-class counts, durations, queue depths, sizes, and error classes
+that cannot reconstruct a private workout.

--- a/docs/telemetry-v2/performance-budget.md
+++ b/docs/telemetry-v2/performance-budget.md
@@ -122,7 +122,8 @@ the replacement `MetricManager` async API is iOS 27+. Neither is durable workout
 telemetry or an immediate causal event stream.
 
 Signposts, unified logs, MetricKit payloads, and benchmark summaries MUST NOT
-include BPM/HR values, private identifiers, HealthKit UUIDs, raw BLE payloads,
-workout exports, or configuration snapshots. They MAY contain bounded opaque
-run IDs, record-class counts, durations, queue depths, sizes, and error classes
-that cannot reconstruct a private workout.
+include BPM/HR values, person-linked speed trajectories, private identifiers,
+HealthKit UUIDs, raw BLE payloads, workout exports, or configuration snapshots.
+They MAY contain only bounded opaque run IDs and aggregate record-class counts,
+durations, queue depths, sizes, and error classes that cannot reconstruct or be
+linked back to a private workout.

--- a/docs/telemetry-v2/persistence-and-retention.md
+++ b/docs/telemetry-v2/persistence-and-retention.md
@@ -1,0 +1,130 @@
+# Telemetry V2 persistence and retention
+
+Status: normative storage, privacy, and retention contract.
+
+## Provisional persistence decision
+
+Telemetry V2 is SwiftData-first, using a versioned schema and explicit migration
+plan. This is a provisional architecture decision, not a permanent technology
+commitment. SwiftData MUST pass the automated scale, recovery, protection, and
+migration gate in issue #26 before production integration proceeds.
+
+The store MUST be local-only:
+
+- no CloudKit, backend, synchronization, or network write;
+- no persistence context exposed to control, provider, transport, view, or
+  export code;
+- injected in-memory and on-disk configurations for tests;
+- one repository/store boundary and one isolated production writer.
+
+Apple documents `ModelActor` as serializing work on its model context. An
+implementation SHOULD use `@ModelActor` or an equally official SwiftData
+isolation primitive. It MUST NOT infer undocumented cross-context, sidecar, or
+rollback guarantees; those behaviors require tests. See
+[`ModelActor`](https://developer.apple.com/documentation/swiftdata/modelactor),
+[`ModelContainer`](https://developer.apple.com/documentation/swiftdata/modelcontainer),
+and [`SchemaMigrationPlan`](https://developer.apple.com/documentation/swiftdata/schemamigrationplan).
+
+## Schema and transaction rules
+
+- Every schema version and migration stage MUST be explicit and testable.
+- Query paths for session chronology, session elapsed time, event kind/time,
+  source/sample identity, and analysis version MUST have measured index support.
+- Uniqueness MUST use real stable identity. Missing identity MUST NOT be replaced
+  by fuzzy matching or lossy deduplication.
+- The schema MUST use separate conceptual records from the
+  [data contract](data-contract.md), not a universal nullable table.
+- Static configuration MUST be stored once per immutable snapshot and referenced,
+  not repeated in every frame.
+- The background writer's incidental autosave MUST be disabled. Batches MUST use
+  explicit save/transaction boundaries and expose success/failure accounting.
+- Previously committed batches MUST survive an interrupted session. Recovery
+  MUST mark an incomplete tail honestly; it MUST NOT invent completion.
+
+Apple's `ModelContext.transaction(block:)` performs the block and saves pending
+changes, but this specification does not assume undocumented ACID rollback
+semantics. Failure and reopen behavior MUST be verified with the concrete schema
+and store. See
+[`transaction(block:)`](https://developer.apple.com/documentation/swiftdata/modelcontext/transaction(block:)).
+
+## Store location, protection, and backup
+
+The production store MUST live in an application-owned support directory, not a
+temporary/export location. The selected policy is:
+
+- `completeUntilFirstUserAuthentication` file protection for the SQLite store
+  and every discovered WAL/SHM/sidecar file;
+- exclusion from device/cloud backup for the store and every discovered sidecar,
+  preserving the product's local-only boundary;
+- reapplication and verification after create, write, close, reopen, migration,
+  replacement, and other file operations that can change resource attributes.
+
+`completeUntilFirstUserAuthentication` keeps a protected file unavailable until
+the first unlock after boot and available after subsequent locks. Backup
+exclusion and protection are per-resource properties; coverage of SQLite
+sidecars MUST be measured rather than assumed. See
+[`URLFileProtection.completeUntilFirstUserAuthentication`](https://developer.apple.com/documentation/foundation/urlfileprotection/completeuntilfirstuserauthentication)
+and [`isExcludedFromBackupKey`](https://developer.apple.com/documentation/foundation/urlresourcekey/isexcludedfrombackupkey).
+
+Automated environments MAY report device-only lifecycle/protection checks as
+`UNVERIFIED_ON_DEVICE`. Each such item MUST be carried by name to gate #37 and
+MUST NOT be reported as passed.
+
+## Retention classes
+
+| Class | Examples | Retention rule |
+| --- | --- | --- |
+| training evidence | sessions, sources, native HR/treadmill samples, causal/lifecycle/safety events, frames, immutable configuration | MUST NOT be automatically deleted, sampled away for storage targets, or deleted by export |
+| derived analysis | versioned analyses and quality grades | MAY be recomputed or superseded only when evidence remains intact and analyzer/version provenance remains auditable |
+| diagnostic chatter | optional raw BLE traces, verbose debug payloads, benchmark detail | MUST be a separate explicitly bounded store/class; it MUST NOT share training-evidence retention semantics |
+| recorder health | pressure/loss/recovery counters and events without private payloads | MUST remain with the affected session when needed to interpret completeness |
+| transient ingress | bounded in-memory records awaiting persistence | MAY be discarded only under the explicit pressure policy, with loss accounting; it is not a durable store |
+| export artifacts | user-created CSV/archive/manifest projections | Are user-managed copies; creating or sharing one MUST NOT mutate the source store |
+
+There is no time-, count-, or size-based automatic deletion of training evidence.
+Deletion requires an explicit user action scoped to identified sessions/data, or
+a separately approved migration/retirement step that has proved the replacement
+contains the evidence. Destructive UI and debug actions MUST identify their
+scope, require confirmation where appropriate, and remain outside control paths.
+
+Diagnostic chatter MUST have a documented byte/count/age bound before it is
+enabled. Oldest-first deletion is permitted only inside that class. Raw BLE
+payloads MUST NOT be copied into training events, unified logging, MetricKit, or
+repository fixtures containing private data.
+
+## Failure behavior
+
+- Store construction, migration, save, protection, or reopen failure MUST fail
+  telemetry closed: record/report degraded telemetry health when possible,
+  preserve committed evidence, and keep control running independently.
+- Persistence MUST NOT block control, authorize motion, trigger a command, or
+  weaken start/stale-HR/speed/units/disconnect/cooldown/manual-stop/stop gates.
+- The buffer MUST remain bounded. Unavoidable loss MUST be classified and make
+  the session incomplete when critical evidence may be missing.
+- Read or export failure MUST surface an explicit error and MUST NOT silently
+  substitute legacy data after V2 read cutover.
+- Corrupt or unknown records MUST be quarantined/preserved for diagnosis when
+  safe; they MUST NOT be silently rewritten as valid facts.
+
+## SwiftData gate and Core Data fallback trigger
+
+Issue #26 MUST exercise the concrete schema at CI scale and at a configurable
+full profile of roughly 1,000 workout-hours/several million records. Results are
+classified `PASS`, `FAIL`, or `UNVERIFIED_ON_DEVICE` using the methodology in
+[performance-budget.md](performance-budget.md).
+
+A material failure in any of the following blocks later runtime integration:
+
+- isolation from the main/control path;
+- bounded insert/query/memory/storage behavior at the measured workload;
+- reopen after interruption and preservation of committed batches;
+- schema migration viability;
+- protection or backup-exclusion policy for the store and sidecars;
+- deterministic uniqueness, relationship, or deletion behavior.
+
+On a material failure, #26 MUST stop for PM decision with measured evidence and
+a narrow SwiftData-versus-Core Data recommendation. It MUST NOT silently
+downsample native evidence, add hidden stores, switch persistence technology, or
+weaken the contract. A Core Data fallback requires explicit PM approval and MUST
+still satisfy every semantic, isolation, privacy, retention, migration, and
+safety requirement in this specification.

--- a/docs/telemetry-v2/rollout-and-migration.md
+++ b/docs/telemetry-v2/rollout-and-migration.md
@@ -1,0 +1,191 @@
+# Telemetry V2 rollout and migration
+
+Status: normative sequential delivery, cutover, rollback, and deletion contract.
+
+## Sequential queue
+
+Implementation issues MUST run in this order. Each starts from the then-current
+exact GitHub `main` only after its predecessor has been PM-reviewed, merged, and
+closed. No implementation issue runs in parallel.
+
+| Stage | Issue | Required exit |
+| --- | --- | --- |
+| Contract | #23 | This repository-owned specification is accepted |
+| Typed domain | #24 | Persistence-independent types encode time, provenance, quality, and causality |
+| Store | #25 | Unwired versioned local SwiftData V1 store exists |
+| Architecture gate | #26 | Automated scale/recovery/protection evidence accepted; device-only items named |
+| Recorder | #27 | Constant-time ingress, bounded buffering, batching, and loss accounting |
+| HR truth | #28 | Native HR evidence normalized without changing controller arrival behavior |
+| Treadmill/command truth | #29 | Factual observations, estimates, desired values, and command lifecycle separated |
+| Session/dual-write | #30 | Session lifecycle and observed frames integrated; legacy remains product source |
+| Instrumentation | #31 | Privacy-safe metrics and soak harness |
+| Parity/replay | #32 | Deterministic V2/legacy comparison and control-output replay gate |
+| Analysis | #33 | Versioned timestamp-weighted analyzer and quality grading |
+| Import | #34 | Idempotent conservative import and reconciliation |
+| Read cutover | #35 | V2 is the only product read source; legacy writer remains shadow-only |
+| Physical evidence | #37 | PM/user-supplied real evidence yields `GO FOR LEGACY RETIREMENT` or named blockers |
+| Retirement | #36 | Legacy writers/reads/pruning are deleted only after #37 GO or explicit PM waiver |
+
+Issue #36 MUST NOT start merely because #35 merged or automated parity passed.
+
+## Write and read authority by phase
+
+| Phase | Canonical new evidence | Product reads | Legacy role |
+| --- | --- | --- | --- |
+| Before #30 | legacy paths | legacy paths | current source of truth |
+| #30 through #34 | V2 evidence is written and evaluated alongside legacy | legacy paths | compatibility/parity source while V2 is shadow-evaluated |
+| After #35, before #37/#36 | V2 | V2 only | isolated temporary shadow-write for real parity/rollback evidence; never a read fallback |
+| After #36 | V2 only | V2 only | no production writer/read/pruning/export-delete path; importer only for the documented compatibility window |
+
+Dual-write is a temporary migration mechanism, not two sources of truth. Both
+writes MUST consume the same immutable typed ingress record where architecture
+allows. Legacy conversion failure MUST NOT mutate V2 evidence. V2 failure MUST
+be recorded and MUST NOT block control or cause the legacy result to be labeled
+successful V2 persistence.
+
+The #30 V2 session MUST begin only after the existing production start gates
+authorize the current workout session. Telemetry session creation is an
+observation of that result, never an input to the authorization.
+
+## Parity and replay gate
+
+Before read cutover, issue #32 MUST prove with deterministic fixtures/replays:
+
+- native observations and exact events retain timestamps, provenance, units,
+  arrival order, and causal IDs;
+- no frame is backfilled across a gap;
+- factual speed is never replaced by desired, commanded, or estimated speed;
+- duplicate/out-of-order HR is preserved and quality-flagged;
+- timestamp-derived durations/integrals use explicit freshness/gap rules;
+- telemetry enabled/disabled produces identical control outputs for identical
+  replay inputs;
+- recorder loss, incomplete sessions, and unsupported legacy ambiguity are
+  visible rather than silently normalized.
+
+Automated parity is necessary but not sufficient authority to retire the legacy
+writer. Real-device facts remain for #37.
+
+## Deterministic legacy import and reconciliation
+
+Issue #34 owns import of legacy JSONL evidence and `workout_history_v1` summaries.
+The importer MUST be versioned, idempotent, non-destructive, and auditable.
+
+### Source identity
+
+Each source item MUST receive an import identity derived from an immutable source
+namespace plus a stable source identifier when one exists. Suitable identifiers
+include an explicit session ID, HealthKit workout UUID, or a content fingerprint
+used to identify the exact source item. The importer MUST record source kind,
+locator/fingerprint, importer version, and result.
+
+Repeating the same importer version on the same exact source item MUST NOT create
+another V2 record. A content fingerprint proves identity of that source artifact;
+it does not by itself prove that a JSONL session and a `workout_history_v1` row
+describe the same real workout.
+
+### Cross-source reconciliation
+
+JSONL and `workout_history_v1` reconciliation MUST attempt exact stable identity
+in this order:
+
+1. exact JSONL `workout_saved.workout_id` to `workout_history_v1` entry ID;
+2. exact HealthKit workout UUID when both sources carry it;
+3. exact stable legacy session ID or explicit cross-reference.
+
+Sources MAY be joined into one session only when an identity above matches and
+does not conflict. Timestamp proximity, similar duration, BPM, distance, or speed
+MUST NOT be used as a destructive fuzzy merge key.
+
+JSONL native/event evidence is authoritative for observations and events it
+explicitly contains. `workout_history_v1` MAY fill missing session-summary
+metadata but MUST NOT overwrite more specific timestamped evidence. Conflicting
+values MUST retain both provenance/conflict facts and prefer the more specific
+factual source for applicable projections rather than silently choosing a
+number.
+
+When stable cross-source identity is unavailable or conflicting:
+
+- preserve the raw evidence import and legacy summary as separately provenanced
+  records/candidates;
+- mark reconciliation `ambiguous` or `conflict` with the compared fields;
+- do not overwrite factual values or delete either source;
+- exclude unresolved duplicates from automatic aggregate double-counting using
+  an explicit query/quality policy;
+- require a deterministic later rule or explicit user/PM resolution before
+  collapsing records.
+
+Incomplete or malformed tails MUST retain all parseable evidence, record the
+failure boundary, and mark the session incomplete. Import success MUST never
+delete or modify the legacy source. Ambiguous legacy `speed_actual_kmh` MUST be
+imported as legacy-estimated/unknown rather than factual, and random/synthetic
+steps MUST be excluded from scientific evidence with an optional warning count.
+
+## Read cutover (#35)
+
+Read cutover requires accepted SwiftData, recorder, replay/parity, analyzer, and
+import gates. At its completion:
+
+- V2 is the only user-visible source for history, statistics, charts, and export;
+- new training evidence is canonical in V2;
+- raw CSV and summary CSV are V2 projections, not independent stores;
+- product failure is explicit and MUST NOT silently fall back to legacy values;
+- export is non-destructive;
+- the existing legacy writer remains isolated as a temporary shadow only for
+  real-session comparison through #37.
+
+The shadow writer MUST NOT gain product fields or features, drive UI/analysis,
+delete V2 evidence, or become a permanent fallback.
+
+## Physical real-evidence gate (#37)
+
+Gate #37 consumes ordinary real workout evidence supplied by the user/PM for
+read-only analysis. Codex MUST NOT install or launch the app, connect to a
+treadmill, or send BLE/controller commands under this rollout. Any non-ordinary
+physical experiment requires its own explicit hardware-experiment contract.
+
+The gate MUST report `PASS`, `FAIL`, or `UNVERIFIED` for HR fidelity, treadmill
+facts, causal command correlation, phase/cooldown/stop fidelity, recorder
+completeness, timestamp-derived analysis, and carried device-only persistence
+and performance items. A failure affecting safety, provenance, causality,
+control parity, or unexplained critical loss blocks retirement. Every
+`UNVERIFIED` item requires an explicit PM decision.
+
+Issue #36 requires `GO FOR LEGACY RETIREMENT`, or a separate PM waiver naming
+each remaining `UNVERIFIED` item and why retirement is acceptable.
+
+## Rollback contract
+
+- Before read cutover, V2 integration MAY be disabled without changing control;
+  collected V2 evidence MUST be preserved for diagnosis.
+- After read cutover and before retirement, rollback MAY restore the last
+  compatible release only through an explicit release/PM decision. It MUST
+  preserve V2 evidence and document whether temporary legacy shadow data is
+  complete. Runtime read errors MUST NOT trigger an automatic legacy fallback.
+- Schema migration failure MUST stop the V2 read/write transition, preserve the
+  original store, and expose recovery status. It MUST NOT create an empty store
+  and present it as successful migration.
+- After legacy retirement, rollback MUST use a build that reads the accepted V2
+  schema or an explicitly approved forward/backward migration. It MUST NOT
+  resurrect obsolete pruning, export deletion, or a hidden dual-write path.
+
+Every migration/cutover PR MUST document the last compatible app/schema version,
+backup/evidence preservation, observable failure state, and bounded recovery
+procedure.
+
+## Deletion plan
+
+Only issue #36, after its dependency gate, may remove production legacy paths:
+
+- JSONL canonical writes and count-based pruning;
+- export-triggered deletion;
+- wide nullable training snapshots/CSV as runtime architecture;
+- whole-file production history parsers;
+- capped `workout_history_v1` persistence after accepted import/cutover;
+- synthetic factual metrics and sample-count-as-seconds summaries;
+- obsolete legacy-only debug actions.
+
+Deletion MUST be proven by a complete cumulative Epic diff and integrated checks.
+The compatibility importer MAY remain only for a documented window and MUST be
+separate from production writes. No private evidence is committed. A failed
+gate, ambiguous destructive migration, base drift, or unresolved material
+finding stops the rollout for PM decision.

--- a/docs/telemetry-v2/safety-boundary.md
+++ b/docs/telemetry-v2/safety-boundary.md
@@ -1,0 +1,132 @@
+# Telemetry V2 safety boundary
+
+Status: normative safety and future-adaptation separation contract.
+
+Telemetry V2 observes and records the existing system. It does not own motion,
+speed, stop, HR control, or safety authority.
+
+## Immutable invariants
+
+Throughout this Epic:
+
+1. Control and safety MAY emit telemetry; telemetry MUST never authorize motion
+   or block the control path.
+2. No persistence, serialization, file synchronization, export, or analysis work
+   may execute synchronously in a control or sensor callback.
+3. Start, stale-HR, speed-bound, controller-unit, disconnect, cooldown,
+   manual-stop, and stop-confirmation behavior MUST remain unchanged unless a
+   later issue carries its own explicit PM-approved behavior contract.
+4. Stop confirmation requires fresh factual device evidence. Desired/commanded
+   speed, an ACK, a frame, an estimate, missing telemetry, or stale last-known
+   state MUST NOT prove that the treadmill stopped.
+5. Unknown or unconfirmed controller-unit semantics MUST NOT enable HR control
+   or silent physical-unit conversion.
+6. Missing, stale, ambiguous, dropped, estimated, or derived evidence MUST NOT be
+   promoted to a safe factual state.
+7. Debug, replay, preview, benchmark, simulator, and mock paths MUST NOT bypass
+   production gates or reach production transport.
+8. Telemetry, persistence, export, and analyzer failure MUST be fail-independent:
+   they may degrade evidence health, never motion safety.
+
+These are safety boundaries, not learnable parameters.
+
+## One-way authority
+
+```text
+provider facts -> control/safety -> command service
+       |              |                 |
+       +--------------+-----------------+
+                      v
+                   telemetry
+                      v
+             persistence / analysis
+```
+
+There is no production arrow back from telemetry, persistence, frames, analysis,
+history, export, or diagnostics to control in this Epic. A database record or
+analyzer result MUST NOT satisfy a runtime safety predicate.
+
+Telemetry emission MUST occur after or alongside the owning action without
+becoming a precondition for it. Queue pressure, store locks, migration, export,
+or analysis MUST NOT delay, reorder, retry, suppress, or synthesize a control
+command.
+
+## Evidence boundaries used by safety review
+
+- Native HR observations preserve controller-facing arrival order. V2 MAY flag
+  duplicates, out-of-order measurement times, stale values, and unknown source,
+  but normalization MUST NOT reorder or filter what the current controller sees.
+- A `usedForControl` fact records the actual existing decision. Analysis MUST
+  NOT infer that fact from proximity or freshness after the event.
+- Factual treadmill observations remain distinct from desired, commanded,
+  controller-reported target, estimated, and derived speed.
+- ACK means only the protocol outcome actually evidenced by the transport. It
+  is not observed motion and not stop confirmation.
+- A canonical frame is a query projection. It cannot upgrade the authority or
+  freshness of the evidence it references.
+- Missing frames across a gap remain missing. Backfill MUST NOT create apparent
+  continuous device evidence.
+
+## Safety policy versus future learnable parameters
+
+Every session MUST snapshot the algorithm, safety-policy, workout-protocol, and
+immutable configuration versions that produced its decisions. Safety policy
+includes hard start/stop conditions, stale-signal limits, physical speed bounds,
+unit confirmation, disconnect behavior, cooldown/manual-stop behavior, and stop
+confirmation requirements.
+
+Future research MAY calculate a recommendation from retained evidence only
+outside this Epic. Any such recommendation:
+
+- is derived data, not evidence;
+- MUST be versioned and explain its evidence/quality inputs;
+- MUST remain shadow/read-only until a separate behavior contract authorizes a
+  bounded runtime consumer;
+- MUST NOT learn, widen, disable, or bypass a safety invariant;
+- MUST NOT be applied when required evidence is missing, stale, ambiguous, or
+  low quality;
+- MUST remain distinguishable from current user configuration and controller
+  desire.
+
+No interval engine or automatic adaptation is implemented in issues #23-#36.
+
+## Provider and transport neutrality
+
+The HR contract MUST support unknown, HealthKit-selected, Watch-mediated,
+phone-local, and future provider identities without assuming Apple Watch is the
+only physical source. Provider/source metadata is evidence; it does not change
+the existing HR safety gates or controller acceptance order.
+
+Replacing the current Watch transport with HealthKit workout mirroring is a
+separate future change. This Epic MUST NOT couple the data model to that design
+or use HealthKit metadata to authorize motion.
+
+## Allowed and prohibited effects
+
+| Telemetry operation | Allowed | Prohibited |
+| --- | --- | --- |
+| emit record | constant-time immutable value emission | waiting for disk/network or changing the owning decision |
+| recorder overflow | bounded loss policy and explicit health/incomplete state | blocking control or presenting dropped evidence as complete |
+| persistence failure | preserve committed data, report degraded evidence health | fallback that changes control or silently fabricates records |
+| frame materialization | carry referenced last-known evidence with freshness | fabricate a native sample or backfill runtime gaps |
+| analysis | deterministic timestamp-weighted post-workout result | sample-count-as-seconds or live command authority |
+| replay | compare deterministic outputs in an isolated harness | connecting to production transport or weakening gates |
+| export | privacy-conscious non-destructive projection | deleting source evidence or logging private payloads |
+
+## Validation boundary
+
+Hosted tests, replay, benchmarks, and unsigned builds are the automated validation
+layer. They MUST report device-only facts as `UNVERIFIED_ON_DEVICE`, not infer
+them.
+
+Issue #37 is the mandatory real-evidence layer after V2 read cutover and before
+legacy writer retirement. It uses ordinary user/PM-supplied workouts for
+read-only analysis. Codex MUST NOT install/launch on a device, connect to a
+treadmill, or send controller commands under that gate. Any special physical
+experiment requires a separate fixed-whitelist, PM-approved hardware-experiment
+contract.
+
+A failure involving safety, factual provenance, causal correlation, unexplained
+critical loss, or control divergence blocks legacy retirement. An unverified
+item requires explicit PM disposition; simulation alone is not authority to
+delete the comparison path.


### PR DESCRIPTION
## Summary

Adds the repository-owned Telemetry V2 normative specification: architecture and dependency direction, evidence and timestamp semantics, persistence/retention policy, gated rollout and migration, measurable performance budgets, and the immutable safety boundary.

Updates only `ROADMAP.md` to link the specification. No runtime, project-setting, package, BLE, HealthKit/Watch, persistence implementation, UI, or test files change.

## Why

Issues #24-#36 and real-evidence gate #37 need one binding contract for factual provenance, causal correlation, observed-only frames, timestamp-weighted analysis, local retention, SwiftData validation, and legacy cutover rather than re-deciding those semantics in each PR.

## Verification

- [x] `python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py`
- [x] `cd ios/WalkingPadRemote/WalkingPadRemote && swift test` (141 tests passed)
- [ ] `xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` (not run locally; this is docs-only and exact-head hosted CI owns the app-build gate)
- [x] Relative Markdown link checker (7 files; no broken local links)
- [x] `git diff --check`
- [x] Independent final review: `GO`, no P0/P1/material P2 findings on exact head `83714929cf335fe1ed8f08cbdc220c1376ce0ee4`

## Hardware / environment

- Treadmill model: not applicable; no hardware access
- Protocol: not applicable; no BLE/controller commands
- iPhone / iOS: not applicable; no install or launch
- Apple Watch / watchOS: not applicable; no device activity

## Screenshots or logs

Not applicable; documentation-only change.

## Risks / Notes

- Risk is limited to contract ambiguity or inconsistency; the full docs-only diff received a scope/safety challenge `GO` and a fresh independent final-review `GO` after one privacy wording correction.
- SwiftData remains provisional until the explicit automated benchmark/protection/recovery gate.
- Device-only facts remain `UNVERIFIED_ON_DEVICE` until the separate #37 real-evidence gate.
- Legacy writer retirement remains blocked until #37 returns `GO FOR LEGACY RETIREMENT` or PM explicitly waives named unverified items.
- No deployment, rollback action, migration, configuration change, or production behavior change is included.

Closes #23
