### PR TITLE
Telemetry V2 foundation: typed domain and unwired SwiftData store

### DIFF
--- a/docs/telemetry-v2/architecture.md
+++ b/docs/telemetry-v2/architecture.md
@@ -31,10 +31,10 @@ This specification does not implement or authorize:
 
 ## Platform boundary
 
-The core product baseline for this Epic is iOS 26. Issue #24 MUST express that
+The core product baseline for this Epic is iOS 26. Issue #39 MUST express that
 package platform floor without silently changing the repository's
 `swift-tools-version: 5.10`, Swift language mode, or macOS test-host floor. If
-the actual toolchain cannot express and build the iOS 26 floor compatibly, #24
+the actual toolchain cannot express and build the iOS 26 floor compatibly, #39
 MUST stop for PM decision with the exact compiler/package error.
 
 ## Component graph
@@ -175,9 +175,8 @@ exports.
 
 | Issue | Contract-owned output |
 | --- | --- |
-| #24 | Pure typed domain, identifiers, timestamps, provenance, quality, events, and frames |
-| #25 | Versioned V1 schema and isolated local store |
-| #26 | Automated SwiftData scale, recovery, protection, and fallback gate |
+| #39 | Combined Foundation: pure typed domain first, then a versioned V1 schema and isolated local store after the domain checkpoint passes |
+| #26 | Automated SwiftData scale, recovery, protection, and fallback gate after #39 |
 | #27 | Constant-time ingress, bounded buffering, batching, and loss accounting |
 | #28 | HR normalization with unchanged controller arrival behavior |
 | #29 | Factual treadmill truth and command/estimate separation |

--- a/docs/telemetry-v2/data-contract.md
+++ b/docs/telemetry-v2/data-contract.md
@@ -53,6 +53,16 @@ missing, or earlier than a previously received sample. Sorting for display or
 analysis MUST NOT rewrite evidence order. Clock regressions, impossible ordering,
 and excessive receive delay MUST be quality-flagged.
 
+An exact provider redelivery is idempotent at the persistence boundary only when
+the provider supplies a non-empty stable native sample identifier. That identity
+MUST be scoped by the signal source's stable provider/local identity. A repeated
+native identity MUST NOT create a second scientific sample, even when recorder-
+local record and observation IDs differ. Provider sequence, BPM, timestamps, or
+value similarity MUST NOT substitute for native identity. When native identity
+is absent, otherwise identical observations remain separate evidence. This
+storage rule MUST NOT reorder, filter, or deduplicate the controller-facing HR
+stream.
+
 Analysis MUST integrate over timestamp intervals for which evidence is fresh.
 It MUST define gap and boundary behavior and MUST NOT treat a sample count as a
 duration in seconds.
@@ -104,6 +114,9 @@ observation(s) used -> decision -> command enqueue/send
   applicable.
 - ACK, timeout, cancellation, retry, and transport failure MUST be separate
   events referencing the command attempt they describe.
+- A retry-scheduled event's queryable primary attempt ID is the next scheduled
+  attempt; its typed payload MUST also retain the previous attempt ID so the
+  retry edge is not lost.
 - A later treadmill observation MAY reference the command as a candidate causal
   response only when the implementation has real correlation evidence. Mere
   temporal proximity MUST NOT be recorded as proven causation.
@@ -152,10 +165,12 @@ domain MUST represent at least:
 - recorder loss before the record;
 - estimated/derived provenance where applicable.
 
-Duplicate and out-of-order HR observations MUST be preserved and flagged. The
-controller-facing ordering and acceptance decision remain unchanged during V2
-normalization. A record MUST separately state whether it was accepted/used for
-control; quality flags alone MUST NOT reconstruct that decision.
+Duplicate-value, duplicate-sequence, and out-of-order HR observations MUST be
+preserved and flagged unless they are an exact provider redelivery proven by the
+same stable native sample identity described above. The controller-facing
+ordering and acceptance decision remain unchanged during V2 normalization. A
+record MUST separately state whether it was accepted/used for control; quality
+flags alone MUST NOT reconstruct that decision.
 
 Freshness MUST be evaluated from the original observation time role and the
 policy/version that consumed it. A stale value carried into a frame remains

--- a/docs/telemetry-v2/persistence-and-retention.md
+++ b/docs/telemetry-v2/persistence-and-retention.md
@@ -32,6 +32,9 @@ and [`SchemaMigrationPlan`](https://developer.apple.com/documentation/swiftdata/
   source/sample identity, and analysis version MUST have measured index support.
 - Uniqueness MUST use real stable identity. Missing identity MUST NOT be replaced
   by fuzzy matching or lossy deduplication.
+- Exact native HR sample replay detection MUST use a bounded indexed lookup of
+  the optional source-scoped native identity. A missing identity remains `nil`
+  and MUST NOT be replaced by a sentinel uniqueness key.
 - The schema MUST use separate conceptual records from the
   [data contract](data-contract.md), not a universal nullable table.
 - Static configuration MUST be stored once per immutable snapshot and referenced,

--- a/docs/telemetry-v2/rollout-and-migration.md
+++ b/docs/telemetry-v2/rollout-and-migration.md
@@ -11,9 +11,8 @@ closed. No implementation issue runs in parallel.
 | Stage | Issue | Required exit |
 | --- | --- | --- |
 | Contract | #23 | This repository-owned specification is accepted |
-| Typed domain | #24 | Persistence-independent types encode time, provenance, quality, and causality |
-| Store | #25 | Unwired versioned local SwiftData V1 store exists |
-| Architecture gate | #26 | Automated scale/recovery/protection evidence accepted; device-only items named |
+| Foundation | #39 | Phase A checkpoint proves the persistence-independent typed domain; Phase B then adds the unwired versioned local SwiftData V1 store in the same Draft PR |
+| Architecture gate | #26 | After #39, automated scale/recovery/protection evidence is accepted and device-only items are named |
 | Recorder | #27 | Constant-time ingress, bounded buffering, batching, and loss accounting |
 | HR truth | #28 | Native HR evidence normalized without changing controller arrival behavior |
 | Treadmill/command truth | #29 | Factual observations, estimates, desired values, and command lifecycle separated |

--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -4,16 +4,31 @@ import PackageDescription
 let package = Package(
     name: "WalkingPadRemoteCoreLogic",
     platforms: [
-        .iOS(.v16),
-        .macOS(.v13)
+        .iOS("26.0"),
+        .macOS("15.0")
     ],
     products: [
         .library(
             name: "WalkingPadCoreLogic",
             targets: ["WalkingPadCoreLogic"]
+        ),
+        .library(
+            name: "TelemetryDomain",
+            targets: ["TelemetryDomain"]
+        ),
+        .library(
+            name: "TelemetryPersistence",
+            targets: ["TelemetryPersistence"]
         )
     ],
     targets: [
+        .target(
+            name: "TelemetryDomain"
+        ),
+        .target(
+            name: "TelemetryPersistence",
+            dependencies: ["TelemetryDomain"]
+        ),
         .target(
             name: "WalkingPadCoreLogic",
             path: "WalkingPadRemote",
@@ -59,6 +74,14 @@ let package = Package(
             name: "WalkingPadCoreLogicTests",
             dependencies: ["WalkingPadCoreLogic"],
             path: "WalkingPadRemoteCoreTests"
+        ),
+        .testTarget(
+            name: "TelemetryDomainTests",
+            dependencies: ["TelemetryDomain"]
+        ),
+        .testTarget(
+            name: "TelemetryPersistenceTests",
+            dependencies: ["TelemetryDomain", "TelemetryPersistence"]
         )
     ]
 )

--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "WalkingPadRemoteCoreLogic",
+    // SwiftData #Index requires macOS 15; tools and language mode remain unchanged.
     platforms: [
         .iOS("26.0"),
         .macOS("15.0")

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/CanonicalFrame.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/CanonicalFrame.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+public enum CanonicalGapKind: String, Codable, Hashable, Sendable {
+    case noObservation
+    case runtimeSuspensionOrStall
+    case recorderOutageOrLoss
+    case unknown
+}
+public struct CanonicalGapBoundary: Codable, Hashable, Sendable {
+    public let missingSinceElapsedSecond: Int64
+    public let kind: CanonicalGapKind
+
+    public init(missingSinceElapsedSecond: Int64, kind: CanonicalGapKind) {
+        self.missingSinceElapsedSecond = missingSinceElapsedSecond
+        self.kind = kind
+    }
+}
+
+public struct HeartRateFrameEvidence: Codable, Hashable, Sendable {
+    public let observationID: ObservationID
+    public let recordID: RecordID
+    public let sourceID: SourceID
+    public let beatsPerMinute: UInt16
+    public let measuredAt: Date?
+    public let receivedAt: Date
+    public let evidenceElapsed: ElapsedDuration
+    public let ageAtMaterialization: ElapsedDuration
+    public let freshness: FreshnessState
+    public let provenance: EvidenceProvenance
+
+    public init(
+        observationID: ObservationID,
+        recordID: RecordID,
+        sourceID: SourceID,
+        beatsPerMinute: UInt16,
+        measuredAt: Date?,
+        receivedAt: Date,
+        evidenceElapsed: ElapsedDuration,
+        ageAtMaterialization: ElapsedDuration,
+        freshness: FreshnessState,
+        provenance: EvidenceProvenance
+    ) {
+        self.observationID = observationID
+        self.recordID = recordID
+        self.sourceID = sourceID
+        self.beatsPerMinute = beatsPerMinute
+        self.measuredAt = measuredAt
+        self.receivedAt = receivedAt
+        self.evidenceElapsed = evidenceElapsed
+        self.ageAtMaterialization = ageAtMaterialization
+        self.freshness = freshness
+        self.provenance = provenance
+    }
+}
+
+public struct TreadmillFrameEvidence: Codable, Hashable, Sendable {
+    public let observationID: ObservationID
+    public let recordID: RecordID
+    public let sourceID: SourceID
+    public let nativeSpeed: NativeTreadmillSpeed
+    public let factualSpeed: FactualSpeedKilometresPerHour?
+    public let deviceState: TreadmillDeviceState
+    public let measuredAt: Date?
+    public let receivedAt: Date
+    public let evidenceElapsed: ElapsedDuration
+    public let ageAtMaterialization: ElapsedDuration
+    public let freshness: FreshnessState
+    public let provenance: EvidenceProvenance
+
+    public init(
+        observationID: ObservationID,
+        recordID: RecordID,
+        sourceID: SourceID,
+        nativeSpeed: NativeTreadmillSpeed,
+        factualSpeed: FactualSpeedKilometresPerHour?,
+        deviceState: TreadmillDeviceState,
+        measuredAt: Date?,
+        receivedAt: Date,
+        evidenceElapsed: ElapsedDuration,
+        ageAtMaterialization: ElapsedDuration,
+        freshness: FreshnessState,
+        provenance: EvidenceProvenance
+    ) {
+        self.observationID = observationID
+        self.recordID = recordID
+        self.sourceID = sourceID
+        self.nativeSpeed = nativeSpeed
+        self.factualSpeed = factualSpeed
+        self.deviceState = deviceState
+        self.measuredAt = measuredAt
+        self.receivedAt = receivedAt
+        self.evidenceElapsed = evidenceElapsed
+        self.ageAtMaterialization = ageAtMaterialization
+        self.freshness = freshness
+        self.provenance = provenance
+    }
+}
+
+public struct CanonicalFrame: Codable, Hashable, Sendable {
+    public let frameID: FrameID
+    public let recordID: RecordID
+    public let sessionID: SessionID
+    public let canonicalElapsedSecond: Int64
+    public let materializedAt: RecordTimestamp
+    public let heartRateEvidence: HeartRateFrameEvidence?
+    public let treadmillEvidence: TreadmillFrameEvidence?
+    public let precedingGap: CanonicalGapBoundary?
+
+    public init(
+        frameID: FrameID,
+        recordID: RecordID,
+        sessionID: SessionID,
+        canonicalElapsedSecond: Int64,
+        materializedAt: RecordTimestamp,
+        heartRateEvidence: HeartRateFrameEvidence?,
+        treadmillEvidence: TreadmillFrameEvidence?,
+        precedingGap: CanonicalGapBoundary? = nil
+    ) {
+        self.frameID = frameID
+        self.recordID = recordID
+        self.sessionID = sessionID
+        self.canonicalElapsedSecond = canonicalElapsedSecond
+        self.materializedAt = materializedAt
+        self.heartRateEvidence = heartRateEvidence
+        self.treadmillEvidence = treadmillEvidence
+        self.precedingGap = precedingGap
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/CanonicalFrame.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/CanonicalFrame.swift
@@ -6,6 +6,7 @@ public enum CanonicalGapKind: String, Codable, Hashable, Sendable {
     case recorderOutageOrLoss
     case unknown
 }
+
 public struct CanonicalGapBoundary: Codable, Hashable, Sendable {
     public let missingSinceElapsedSecond: Int64
     public let kind: CanonicalGapKind

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Configuration.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Configuration.swift
@@ -13,6 +13,7 @@ public struct VersionValue<Tag>: RawRepresentable, Codable, Hashable, Sendable,
         rawValue
     }
 }
+
 public enum TelemetrySchemaVersionTag: Sendable {}
 public enum AlgorithmVersionTag: Sendable {}
 public enum SafetyPolicyVersionTag: Sendable {}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Configuration.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Configuration.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+public struct VersionValue<Tag>: RawRepresentable, Codable, Hashable, Sendable,
+    CustomStringConvertible
+{
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String {
+        rawValue
+    }
+}
+public enum TelemetrySchemaVersionTag: Sendable {}
+public enum AlgorithmVersionTag: Sendable {}
+public enum SafetyPolicyVersionTag: Sendable {}
+public enum WorkoutProtocolVersionTag: Sendable {}
+public enum AnalyzerVersionTag: Sendable {}
+
+public typealias TelemetrySchemaVersion = VersionValue<TelemetrySchemaVersionTag>
+public typealias AlgorithmVersion = VersionValue<AlgorithmVersionTag>
+public typealias SafetyPolicyVersion = VersionValue<SafetyPolicyVersionTag>
+public typealias WorkoutProtocolVersion = VersionValue<WorkoutProtocolVersionTag>
+public typealias AnalyzerVersion = VersionValue<AnalyzerVersionTag>
+
+public struct RuntimeVersionContext: Codable, Hashable, Sendable {
+    public let telemetrySchema: TelemetrySchemaVersion
+    public let algorithm: AlgorithmVersion
+    public let safetyPolicy: SafetyPolicyVersion
+    public let workoutProtocol: WorkoutProtocolVersion
+
+    public init(
+        telemetrySchema: TelemetrySchemaVersion,
+        algorithm: AlgorithmVersion,
+        safetyPolicy: SafetyPolicyVersion,
+        workoutProtocol: WorkoutProtocolVersion
+    ) {
+        self.telemetrySchema = telemetrySchema
+        self.algorithm = algorithm
+        self.safetyPolicy = safetyPolicy
+        self.workoutProtocol = workoutProtocol
+    }
+}
+
+public struct AppRuntimeContext: Codable, Hashable, Sendable {
+    public let appVersion: String
+    public let buildNumber: String
+    public let operatingSystemVersion: String
+    public let deviceModel: String?
+
+    public init(
+        appVersion: String,
+        buildNumber: String,
+        operatingSystemVersion: String,
+        deviceModel: String? = nil
+    ) {
+        self.appVersion = appVersion
+        self.buildNumber = buildNumber
+        self.operatingSystemVersion = operatingSystemVersion
+        self.deviceModel = deviceModel
+    }
+}
+
+public enum ConfigurationPayloadFormat: String, Codable, Hashable, Sendable {
+    case canonicalJSON
+}
+
+public enum ContentHashAlgorithm: String, Codable, Hashable, Sendable {
+    case sha256
+}
+
+public struct ContentHash: Codable, Hashable, Sendable {
+    public let algorithm: ContentHashAlgorithm
+    public let lowercaseHexDigest: String
+
+    public init(algorithm: ContentHashAlgorithm, lowercaseHexDigest: String) {
+        self.algorithm = algorithm
+        self.lowercaseHexDigest = lowercaseHexDigest
+    }
+}
+
+public struct ImmutableConfigurationSnapshot: Codable, Hashable, Sendable {
+    public let id: ConfigurationSnapshotID
+    public let formatVersion: UInt16
+    public let format: ConfigurationPayloadFormat
+    public let canonicalPayload: Data
+    public let contentHash: ContentHash
+
+    public init(
+        id: ConfigurationSnapshotID,
+        formatVersion: UInt16,
+        format: ConfigurationPayloadFormat,
+        canonicalPayload: Data,
+        contentHash: ContentHash
+    ) {
+        self.id = id
+        self.formatVersion = formatVersion
+        self.format = format
+        self.canonicalPayload = canonicalPayload
+        self.contentHash = contentHash
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Events.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Events.swift
@@ -1,0 +1,373 @@
+import Foundation
+
+public enum WorkoutMode: Codable, Hashable, Sendable {
+    case heartRateControlled
+    case manual
+    case other(String)
+}
+
+public enum WorkoutPhase: Codable, Hashable, Sendable {
+    case warmup
+    case main
+    case cooldown
+    case finished
+    case unknown
+    case other(String)
+}
+
+public enum SessionLifecycleState: String, Codable, Hashable, Sendable {
+    case created
+    case running
+    case paused
+    case completed
+    case incomplete
+    case cancelled
+}
+
+public enum ObservationReference: Codable, Hashable, Sendable {
+    case heartRate(ObservationID)
+    case treadmill(ObservationID)
+}
+
+public enum ControlTarget: Codable, Hashable, Sendable {
+    case none
+    case heartRate(beatsPerMinute: UInt16)
+    case desiredSpeed(DesiredSpeedKilometresPerHour)
+    case stop
+}
+
+public enum ControlAction: Codable, Hashable, Sendable {
+    case noCommand
+    case enqueueSpeed(DesiredSpeedKilometresPerHour)
+    case enqueueStop
+}
+
+public enum ControlDecisionReason: Codable, Hashable, Sendable {
+    case withinTarget
+    case belowTarget
+    case aboveTarget
+    case safetyGate(String)
+    case manual
+    case other(String)
+}
+
+public struct ControlDecision: Codable, Hashable, Sendable {
+    public let decisionID: DecisionID
+    public let observationsUsed: [ObservationReference]
+    public let target: ControlTarget
+    public let action: ControlAction
+    public let reason: ControlDecisionReason
+    public let versions: RuntimeVersionContext
+    public let configurationSnapshotID: ConfigurationSnapshotID
+
+    public init(
+        decisionID: DecisionID,
+        observationsUsed: [ObservationReference],
+        target: ControlTarget,
+        action: ControlAction,
+        reason: ControlDecisionReason,
+        versions: RuntimeVersionContext,
+        configurationSnapshotID: ConfigurationSnapshotID
+    ) {
+        self.decisionID = decisionID
+        self.observationsUsed = observationsUsed
+        self.target = target
+        self.action = action
+        self.reason = reason
+        self.versions = versions
+        self.configurationSnapshotID = configurationSnapshotID
+    }
+}
+
+public enum CommandKind: Codable, Hashable, Sendable {
+    case setSpeed(CommandedSpeed)
+    case stop
+    case other(String)
+}
+
+public enum CommandCancellationReason: Codable, Hashable, Sendable {
+    case superseded
+    case sessionEnded
+    case safetyGate(String)
+    case other(String)
+}
+
+public enum CommandFailureReason: Codable, Hashable, Sendable {
+    case transportUnavailable
+    case encodingFailed
+    case rejected
+    case other(String)
+}
+
+public enum CommandLifecycle: Codable, Hashable, Sendable {
+    case enqueued(kind: CommandKind)
+    case sendAttempt(attemptID: CommandAttemptID, attemptNumber: UInt16)
+    case acknowledged(attemptID: CommandAttemptID)
+    case timedOut(attemptID: CommandAttemptID)
+    case retryScheduled(
+        previousAttemptID: CommandAttemptID,
+        nextAttemptID: CommandAttemptID,
+        nextAttemptNumber: UInt16
+    )
+    case cancelled(reason: CommandCancellationReason)
+    case failed(attemptID: CommandAttemptID?, reason: CommandFailureReason)
+}
+
+public struct CommandLifecycleRecord: Codable, Hashable, Sendable {
+    public let commandID: CommandID
+    public let decisionID: DecisionID?
+    public let lifecycle: CommandLifecycle
+
+    public init(commandID: CommandID, decisionID: DecisionID?, lifecycle: CommandLifecycle) {
+        self.commandID = commandID
+        self.decisionID = decisionID
+        self.lifecycle = lifecycle
+    }
+}
+
+public struct SessionLifecycleEvent: Codable, Hashable, Sendable {
+    public let previous: SessionLifecycleState?
+    public let current: SessionLifecycleState
+    public let incompleteReason: String?
+
+    public init(
+        previous: SessionLifecycleState?,
+        current: SessionLifecycleState,
+        incompleteReason: String? = nil
+    ) {
+        self.previous = previous
+        self.current = current
+        self.incompleteReason = incompleteReason
+    }
+}
+
+public struct WorkoutPhaseTransition: Codable, Hashable, Sendable {
+    public let previous: WorkoutPhase?
+    public let current: WorkoutPhase
+
+    public init(previous: WorkoutPhase?, current: WorkoutPhase) {
+        self.previous = previous
+        self.current = current
+    }
+}
+
+public struct SourceTransition: Codable, Hashable, Sendable {
+    public let previousSourceID: SourceID?
+    public let currentSourceID: SourceID?
+    public let reason: String
+
+    public init(previousSourceID: SourceID?, currentSourceID: SourceID?, reason: String) {
+        self.previousSourceID = previousSourceID
+        self.currentSourceID = currentSourceID
+        self.reason = reason
+    }
+}
+
+public enum ConnectionState: String, Codable, Hashable, Sendable {
+    case disconnected
+    case connecting
+    case connected
+    case degraded
+}
+
+public struct ConnectionTransition: Codable, Hashable, Sendable {
+    public let previous: ConnectionState
+    public let current: ConnectionState
+    public let reason: String?
+
+    public init(previous: ConnectionState, current: ConnectionState, reason: String? = nil) {
+        self.previous = previous
+        self.current = current
+        self.reason = reason
+    }
+}
+
+public enum CooldownLifecycle: String, Codable, Hashable, Sendable {
+    case started
+    case targetChanged
+    case completed
+    case insufficient
+    case cancelled
+}
+
+public struct CooldownEvent: Codable, Hashable, Sendable {
+    public let lifecycle: CooldownLifecycle
+    public let targetHeartRate: UInt16?
+
+    public init(lifecycle: CooldownLifecycle, targetHeartRate: UInt16? = nil) {
+        self.lifecycle = lifecycle
+        self.targetHeartRate = targetHeartRate
+    }
+}
+
+public struct ManualStopEvent: Codable, Hashable, Sendable {
+    public let reason: String?
+
+    public init(reason: String? = nil) {
+        self.reason = reason
+    }
+}
+
+public enum SafetyEventOutcome: String, Codable, Hashable, Sendable {
+    case allowed
+    case blocked
+    case failedClosed
+}
+
+public struct SafetyEvent: Codable, Hashable, Sendable {
+    public let policy: SafetyPolicyVersion
+    public let gate: String
+    public let outcome: SafetyEventOutcome
+    public let evidence: [ObservationReference]
+
+    public init(
+        policy: SafetyPolicyVersion,
+        gate: String,
+        outcome: SafetyEventOutcome,
+        evidence: [ObservationReference]
+    ) {
+        self.policy = policy
+        self.gate = gate
+        self.outcome = outcome
+        self.evidence = evidence
+    }
+}
+
+public enum StopEvidenceConclusion: Codable, Hashable, Sendable {
+    case confirmedByFreshFactualObservation(ObservationID)
+    case unconfirmed(reason: String)
+    case contradictory(reason: String)
+}
+
+public struct StopEvidenceEvent: Codable, Hashable, Sendable {
+    public let conclusion: StopEvidenceConclusion
+    public let freshness: EvidenceFreshness?
+    public let deviceState: TreadmillDeviceState?
+    public let factualSpeed: FactualSpeedKilometresPerHour?
+
+    public init(
+        conclusion: StopEvidenceConclusion,
+        freshness: EvidenceFreshness?,
+        deviceState: TreadmillDeviceState?,
+        factualSpeed: FactualSpeedKilometresPerHour?
+    ) {
+        self.conclusion = conclusion
+        self.freshness = freshness
+        self.deviceState = deviceState
+        self.factualSpeed = factualSpeed
+    }
+}
+
+public enum RecorderHealthKind: String, Codable, Hashable, Sendable {
+    case pressure
+    case loss
+    case drain
+    case persistence
+    case recovery
+}
+
+public struct RecorderHealthEvent: Codable, Hashable, Sendable {
+    public let kind: RecorderHealthKind
+    public let affectedRecordClass: String?
+    public let count: UInt64?
+    public let detailCode: String?
+
+    public init(
+        kind: RecorderHealthKind,
+        affectedRecordClass: String? = nil,
+        count: UInt64? = nil,
+        detailCode: String? = nil
+    ) {
+        self.kind = kind
+        self.affectedRecordClass = affectedRecordClass
+        self.count = count
+        self.detailCode = detailCode
+    }
+}
+
+public enum WorkoutEventPayload: Codable, Hashable, Sendable {
+    case sessionLifecycle(SessionLifecycleEvent)
+    case workoutPhase(WorkoutPhaseTransition)
+    case sourceTransition(SourceTransition)
+    case connectionTransition(ConnectionTransition)
+    case controlDecision(ControlDecision)
+    case commandLifecycle(CommandLifecycleRecord)
+    case cooldown(CooldownEvent)
+    case manualStop(ManualStopEvent)
+    case safety(SafetyEvent)
+    case stopEvidence(StopEvidenceEvent)
+    case recorderHealth(RecorderHealthEvent)
+
+    public var kind: WorkoutEventKind {
+        switch self {
+        case .sessionLifecycle: .sessionLifecycle
+        case .workoutPhase: .workoutPhase
+        case .sourceTransition: .sourceTransition
+        case .connectionTransition: .connectionTransition
+        case .controlDecision: .controlDecision
+        case .commandLifecycle: .commandLifecycle
+        case .cooldown: .cooldown
+        case .manualStop: .manualStop
+        case .safety: .safety
+        case .stopEvidence: .stopEvidence
+        case .recorderHealth: .recorderHealth
+        }
+    }
+}
+
+public enum WorkoutEventKind: String, Codable, Hashable, Sendable {
+    case sessionLifecycle
+    case workoutPhase
+    case sourceTransition
+    case connectionTransition
+    case controlDecision
+    case commandLifecycle
+    case cooldown
+    case manualStop
+    case safety
+    case stopEvidence
+    case recorderHealth
+}
+
+public struct EventPayloadEnvelope: Codable, Hashable, Sendable {
+    public let schemaVersion: UInt16
+    public let payload: WorkoutEventPayload
+
+    public init(schemaVersion: UInt16, payload: WorkoutEventPayload) {
+        self.schemaVersion = schemaVersion
+        self.payload = payload
+    }
+}
+
+public struct WorkoutEvent: Codable, Hashable, Sendable {
+    public let recordID: RecordID
+    public let sessionID: SessionID
+    public let kind: WorkoutEventKind
+    public let timestamp: EventTimestamp
+    public let sourceID: SourceID?
+    public let decisionID: DecisionID?
+    public let commandID: CommandID?
+    public let attemptID: CommandAttemptID?
+    public let payload: EventPayloadEnvelope
+
+    public init(
+        recordID: RecordID,
+        sessionID: SessionID,
+        timestamp: EventTimestamp,
+        sourceID: SourceID? = nil,
+        decisionID: DecisionID? = nil,
+        commandID: CommandID? = nil,
+        attemptID: CommandAttemptID? = nil,
+        payload: EventPayloadEnvelope
+    ) {
+        self.recordID = recordID
+        self.sessionID = sessionID
+        self.kind = payload.payload.kind
+        self.timestamp = timestamp
+        self.sourceID = sourceID
+        self.decisionID = decisionID
+        self.commandID = commandID
+        self.attemptID = attemptID
+        self.payload = payload
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Events.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Events.swift
@@ -313,6 +313,58 @@ public enum WorkoutEventPayload: Codable, Hashable, Sendable {
         case .recorderHealth: .recorderHealth
         }
     }
+
+    public var causalIDs: WorkoutEventCausalIDs {
+        switch self {
+        case let .controlDecision(decision):
+            WorkoutEventCausalIDs(
+                decisionID: decision.decisionID,
+                commandID: nil,
+                attemptID: nil
+            )
+        case let .commandLifecycle(record):
+            WorkoutEventCausalIDs(
+                decisionID: record.decisionID,
+                commandID: record.commandID,
+                attemptID: record.lifecycle.primaryAttemptID
+            )
+        default:
+            WorkoutEventCausalIDs(decisionID: nil, commandID: nil, attemptID: nil)
+        }
+    }
+}
+
+private extension CommandLifecycle {
+    var primaryAttemptID: CommandAttemptID? {
+        switch self {
+        case .enqueued, .cancelled:
+            nil
+        case let .sendAttempt(attemptID, _),
+             let .acknowledged(attemptID),
+             let .timedOut(attemptID):
+            attemptID
+        case let .retryScheduled(_, nextAttemptID, _):
+            nextAttemptID
+        case let .failed(attemptID, _):
+            attemptID
+        }
+    }
+}
+
+public struct WorkoutEventCausalIDs: Codable, Hashable, Sendable {
+    public let decisionID: DecisionID?
+    public let commandID: CommandID?
+    public let attemptID: CommandAttemptID?
+
+    public init(
+        decisionID: DecisionID?,
+        commandID: CommandID?,
+        attemptID: CommandAttemptID?
+    ) {
+        self.decisionID = decisionID
+        self.commandID = commandID
+        self.attemptID = attemptID
+    }
 }
 
 public enum WorkoutEventKind: String, Codable, Hashable, Sendable {
@@ -350,24 +402,71 @@ public struct WorkoutEvent: Codable, Hashable, Sendable {
     public let attemptID: CommandAttemptID?
     public let payload: EventPayloadEnvelope
 
+    private struct CodingRepresentation: Codable {
+        let recordID: RecordID
+        let sessionID: SessionID
+        let kind: WorkoutEventKind
+        let timestamp: EventTimestamp
+        let sourceID: SourceID?
+        let decisionID: DecisionID?
+        let commandID: CommandID?
+        let attemptID: CommandAttemptID?
+        let payload: EventPayloadEnvelope
+    }
+
     public init(
         recordID: RecordID,
         sessionID: SessionID,
         timestamp: EventTimestamp,
         sourceID: SourceID? = nil,
-        decisionID: DecisionID? = nil,
-        commandID: CommandID? = nil,
-        attemptID: CommandAttemptID? = nil,
         payload: EventPayloadEnvelope
     ) {
+        let causalIDs = payload.payload.causalIDs
         self.recordID = recordID
         self.sessionID = sessionID
         self.kind = payload.payload.kind
         self.timestamp = timestamp
         self.sourceID = sourceID
-        self.decisionID = decisionID
-        self.commandID = commandID
-        self.attemptID = attemptID
+        self.decisionID = causalIDs.decisionID
+        self.commandID = causalIDs.commandID
+        self.attemptID = causalIDs.attemptID
         self.payload = payload
+    }
+
+    public init(from decoder: Decoder) throws {
+        let representation = try CodingRepresentation(from: decoder)
+        self.init(
+            recordID: representation.recordID,
+            sessionID: representation.sessionID,
+            timestamp: representation.timestamp,
+            sourceID: representation.sourceID,
+            payload: representation.payload
+        )
+        guard representation.kind == kind,
+              representation.decisionID == decisionID,
+              representation.commandID == commandID,
+              representation.attemptID == attemptID
+        else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Workout event envelope contradicts its typed payload."
+                )
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        try CodingRepresentation(
+            recordID: recordID,
+            sessionID: sessionID,
+            kind: kind,
+            timestamp: timestamp,
+            sourceID: sourceID,
+            decisionID: decisionID,
+            commandID: commandID,
+            attemptID: attemptID,
+            payload: payload
+        ).encode(to: encoder)
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Identifiers.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Identifiers.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public struct TelemetryIdentifier<Tag>: RawRepresentable, Codable, Hashable, Sendable,
+    CustomStringConvertible
+{
+    public let rawValue: UUID
+
+    public init(rawValue: UUID) {
+        self.rawValue = rawValue
+    }
+
+    public init() {
+        self.init(rawValue: UUID())
+    }
+
+    public var description: String {
+        rawValue.uuidString.lowercased()
+    }
+}
+
+public enum SessionIDTag: Sendable {}
+public enum RecordIDTag: Sendable {}
+public enum SourceIDTag: Sendable {}
+public enum ObservationIDTag: Sendable {}
+public enum DecisionIDTag: Sendable {}
+public enum CommandIDTag: Sendable {}
+public enum CommandAttemptIDTag: Sendable {}
+public enum FrameIDTag: Sendable {}
+public enum AnalysisIDTag: Sendable {}
+public enum ConfigurationSnapshotIDTag: Sendable {}
+
+public typealias SessionID = TelemetryIdentifier<SessionIDTag>
+public typealias RecordID = TelemetryIdentifier<RecordIDTag>
+public typealias SourceID = TelemetryIdentifier<SourceIDTag>
+public typealias ObservationID = TelemetryIdentifier<ObservationIDTag>
+public typealias DecisionID = TelemetryIdentifier<DecisionIDTag>
+public typealias CommandID = TelemetryIdentifier<CommandIDTag>
+public typealias CommandAttemptID = TelemetryIdentifier<CommandAttemptIDTag>
+public typealias FrameID = TelemetryIdentifier<FrameIDTag>
+public typealias AnalysisID = TelemetryIdentifier<AnalysisIDTag>
+public typealias ConfigurationSnapshotID = TelemetryIdentifier<ConfigurationSnapshotIDTag>

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Observations.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Observations.swift
@@ -14,6 +14,34 @@ public enum ControlUseState: String, Codable, Hashable, Sendable {
     }
 }
 
+public struct ProviderNativeSampleIdentity: Codable, Hashable, Sendable {
+    public let identifier: String
+
+    public init?(identifier: String) {
+        guard !identifier.isEmpty else {
+            return nil
+        }
+        self.identifier = identifier
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let identifier = try container.decode(String.self)
+        guard !identifier.isEmpty else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "A provider-native sample identity must not be empty."
+            )
+        }
+        self.identifier = identifier
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(identifier)
+    }
+}
+
 public struct HeartRateObservation: Codable, Hashable, Sendable {
     public let recordID: RecordID
     public let observationID: ObservationID
@@ -22,7 +50,7 @@ public struct HeartRateObservation: Codable, Hashable, Sendable {
     public let beatsPerMinute: UInt16
     public let arrivalOrder: UInt64
     public let providerSequence: Int64?
-    public let providerSampleIdentifier: String?
+    public let providerSampleIdentity: ProviderNativeSampleIdentity?
     public let timestamp: ObservationTimestamp
     public let provenance: EvidenceProvenance
     public let freshness: EvidenceFreshness
@@ -37,7 +65,7 @@ public struct HeartRateObservation: Codable, Hashable, Sendable {
         beatsPerMinute: UInt16,
         arrivalOrder: UInt64,
         providerSequence: Int64?,
-        providerSampleIdentifier: String?,
+        providerSampleIdentity: ProviderNativeSampleIdentity?,
         timestamp: ObservationTimestamp,
         provenance: EvidenceProvenance,
         freshness: EvidenceFreshness,
@@ -51,7 +79,7 @@ public struct HeartRateObservation: Codable, Hashable, Sendable {
         self.beatsPerMinute = beatsPerMinute
         self.arrivalOrder = arrivalOrder
         self.providerSequence = providerSequence
-        self.providerSampleIdentifier = providerSampleIdentifier
+        self.providerSampleIdentity = providerSampleIdentity
         self.timestamp = timestamp
         self.provenance = provenance
         self.freshness = freshness

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Observations.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Observations.swift
@@ -214,6 +214,21 @@ public struct TreadmillObservation: Codable, Hashable, Sendable {
     public let freshness: EvidenceFreshness
     public let quality: QualityFlags
 
+    private struct CodingRepresentation: Codable {
+        let recordID: RecordID
+        let observationID: ObservationID
+        let sessionID: SessionID
+        let source: SignalSourceIdentity
+        let nativeSpeed: NativeTreadmillSpeed
+        let factualSpeed: FactualSpeedKilometresPerHour?
+        let deviceState: TreadmillDeviceState
+        let arrivalOrder: UInt64
+        let timestamp: ObservationTimestamp
+        let provenance: EvidenceProvenance
+        let freshness: EvidenceFreshness
+        let quality: QualityFlags
+    }
+
     public init(
         recordID: RecordID,
         observationID: ObservationID,
@@ -244,5 +259,49 @@ public struct TreadmillObservation: Codable, Hashable, Sendable {
         self.provenance = provenance
         self.freshness = freshness
         self.quality = quality
+    }
+
+    public init(from decoder: Decoder) throws {
+        let decoded = try CodingRepresentation(from: decoder)
+        self.init(
+            recordID: decoded.recordID,
+            observationID: decoded.observationID,
+            sessionID: decoded.sessionID,
+            source: decoded.source,
+            nativeSpeed: decoded.nativeSpeed,
+            deviceState: decoded.deviceState,
+            arrivalOrder: decoded.arrivalOrder,
+            timestamp: decoded.timestamp,
+            provenance: decoded.provenance,
+            freshness: decoded.freshness,
+            quality: decoded.quality,
+            normalizationRule: decoded.factualSpeed?.normalizationRule
+                ?? .nativeToKilometresPerHourV1
+        )
+        guard factualSpeed == decoded.factualSpeed else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Factual treadmill speed contradicts native evidence."
+                )
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        try CodingRepresentation(
+            recordID: recordID,
+            observationID: observationID,
+            sessionID: sessionID,
+            source: source,
+            nativeSpeed: nativeSpeed,
+            factualSpeed: factualSpeed,
+            deviceState: deviceState,
+            arrivalOrder: arrivalOrder,
+            timestamp: timestamp,
+            provenance: provenance,
+            freshness: freshness,
+            quality: quality
+        ).encode(to: encoder)
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Observations.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Observations.swift
@@ -1,0 +1,218 @@
+import Foundation
+
+public enum ControlUseState: String, Codable, Hashable, Sendable {
+    case rejected
+    case acceptedNotUsed
+    case acceptedAndUsed
+
+    public var acceptedForControl: Bool {
+        self != .rejected
+    }
+
+    public var usedForControl: Bool {
+        self == .acceptedAndUsed
+    }
+}
+
+public struct HeartRateObservation: Codable, Hashable, Sendable {
+    public let recordID: RecordID
+    public let observationID: ObservationID
+    public let sessionID: SessionID
+    public let source: SignalSourceIdentity
+    public let beatsPerMinute: UInt16
+    public let arrivalOrder: UInt64
+    public let providerSequence: Int64?
+    public let providerSampleIdentifier: String?
+    public let timestamp: ObservationTimestamp
+    public let provenance: EvidenceProvenance
+    public let freshness: EvidenceFreshness
+    public let quality: QualityFlags
+    public let controlUse: ControlUseState
+
+    public init(
+        recordID: RecordID,
+        observationID: ObservationID,
+        sessionID: SessionID,
+        source: SignalSourceIdentity,
+        beatsPerMinute: UInt16,
+        arrivalOrder: UInt64,
+        providerSequence: Int64?,
+        providerSampleIdentifier: String?,
+        timestamp: ObservationTimestamp,
+        provenance: EvidenceProvenance,
+        freshness: EvidenceFreshness,
+        quality: QualityFlags,
+        controlUse: ControlUseState
+    ) {
+        self.recordID = recordID
+        self.observationID = observationID
+        self.sessionID = sessionID
+        self.source = source
+        self.beatsPerMinute = beatsPerMinute
+        self.arrivalOrder = arrivalOrder
+        self.providerSequence = providerSequence
+        self.providerSampleIdentifier = providerSampleIdentifier
+        self.timestamp = timestamp
+        self.provenance = provenance
+        self.freshness = freshness
+        self.quality = quality
+        self.controlUse = controlUse
+    }
+}
+
+public enum TreadmillNativeSpeedUnit: Codable, Hashable, Sendable {
+    case kilometresPerHour
+    case milesPerHour
+    case controllerNative(code: String?)
+    case unknown
+}
+
+public struct NativeTreadmillSpeed: Codable, Hashable, Sendable {
+    public let value: Double
+    public let unit: TreadmillNativeSpeedUnit
+
+    public init(value: Double, unit: TreadmillNativeSpeedUnit) {
+        self.value = value
+        self.unit = unit
+    }
+}
+
+public struct FactualSpeedKilometresPerHour: Codable, Hashable, Sendable {
+    public let value: Double
+    public let provenance: EvidenceProvenance
+
+    private init(value: Double, provenance: EvidenceProvenance) {
+        self.value = value
+        self.provenance = provenance
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case value
+        case provenance
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let value = try container.decode(Double.self, forKey: .value)
+        guard value.isFinite, value >= 0 else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .value,
+                in: container,
+                debugDescription: "Factual treadmill speed must be finite and non-negative."
+            )
+        }
+
+        self.init(
+            value: value,
+            provenance: try container.decode(EvidenceProvenance.self, forKey: .provenance)
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(value, forKey: .value)
+        try container.encode(provenance, forKey: .provenance)
+    }
+
+    public static func normalized(
+        from native: NativeTreadmillSpeed,
+        provenance: EvidenceProvenance
+    ) -> Self? {
+        guard native.value.isFinite, native.value >= 0 else {
+            return nil
+        }
+
+        switch native.unit {
+        case .kilometresPerHour:
+            return Self(value: native.value, provenance: provenance)
+        case .milesPerHour:
+            return Self(value: native.value * 1.609_344, provenance: provenance)
+        case .controllerNative, .unknown:
+            return nil
+        }
+    }
+}
+
+public struct DesiredSpeedKilometresPerHour: Codable, Hashable, Sendable {
+    public let value: Double
+
+    public init(value: Double) {
+        self.value = value
+    }
+}
+
+public struct CommandedSpeed: Codable, Hashable, Sendable {
+    public let nativeValue: Double
+    public let nativeUnit: TreadmillNativeSpeedUnit
+
+    public init(nativeValue: Double, nativeUnit: TreadmillNativeSpeedUnit) {
+        self.nativeValue = nativeValue
+        self.nativeUnit = nativeUnit
+    }
+}
+
+public struct EstimatedSpeedKilometresPerHour: Codable, Hashable, Sendable {
+    public let value: Double
+    public let method: String
+    public let version: String
+
+    public init(value: Double, method: String, version: String) {
+        self.value = value
+        self.method = method
+        self.version = version
+    }
+}
+
+public enum TreadmillDeviceState: String, Codable, Hashable, Sendable {
+    case unknown
+    case stopped
+    case moving
+    case paused
+    case disconnected
+    case fault
+}
+
+public struct TreadmillObservation: Codable, Hashable, Sendable {
+    public let recordID: RecordID
+    public let observationID: ObservationID
+    public let sessionID: SessionID
+    public let source: SignalSourceIdentity
+    public let nativeSpeed: NativeTreadmillSpeed
+    public let factualSpeed: FactualSpeedKilometresPerHour?
+    public let deviceState: TreadmillDeviceState
+    public let arrivalOrder: UInt64
+    public let timestamp: ObservationTimestamp
+    public let provenance: EvidenceProvenance
+    public let freshness: EvidenceFreshness
+    public let quality: QualityFlags
+
+    public init(
+        recordID: RecordID,
+        observationID: ObservationID,
+        sessionID: SessionID,
+        source: SignalSourceIdentity,
+        nativeSpeed: NativeTreadmillSpeed,
+        deviceState: TreadmillDeviceState,
+        arrivalOrder: UInt64,
+        timestamp: ObservationTimestamp,
+        provenance: EvidenceProvenance,
+        freshness: EvidenceFreshness,
+        quality: QualityFlags
+    ) {
+        self.recordID = recordID
+        self.observationID = observationID
+        self.sessionID = sessionID
+        self.source = source
+        self.nativeSpeed = nativeSpeed
+        self.factualSpeed = FactualSpeedKilometresPerHour.normalized(
+            from: nativeSpeed,
+            provenance: provenance
+        )
+        self.deviceState = deviceState
+        self.arrivalOrder = arrivalOrder
+        self.timestamp = timestamp
+        self.provenance = provenance
+        self.freshness = freshness
+        self.quality = quality
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Observations.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Observations.swift
@@ -77,18 +77,29 @@ public struct NativeTreadmillSpeed: Codable, Hashable, Sendable {
     }
 }
 
+public enum FactualSpeedNormalizationRule: String, Codable, Hashable, Sendable {
+    case nativeToKilometresPerHourV1
+}
+
 public struct FactualSpeedKilometresPerHour: Codable, Hashable, Sendable {
     public let value: Double
     public let provenance: EvidenceProvenance
+    public let normalizationRule: FactualSpeedNormalizationRule
 
-    private init(value: Double, provenance: EvidenceProvenance) {
+    private init(
+        value: Double,
+        provenance: EvidenceProvenance,
+        normalizationRule: FactualSpeedNormalizationRule
+    ) {
         self.value = value
         self.provenance = provenance
+        self.normalizationRule = normalizationRule
     }
 
     private enum CodingKeys: String, CodingKey {
         case value
         case provenance
+        case normalizationRule
     }
 
     public init(from decoder: Decoder) throws {
@@ -104,7 +115,11 @@ public struct FactualSpeedKilometresPerHour: Codable, Hashable, Sendable {
 
         self.init(
             value: value,
-            provenance: try container.decode(EvidenceProvenance.self, forKey: .provenance)
+            provenance: try container.decode(EvidenceProvenance.self, forKey: .provenance),
+            normalizationRule: try container.decode(
+                FactualSpeedNormalizationRule.self,
+                forKey: .normalizationRule
+            )
         )
     }
 
@@ -112,23 +127,36 @@ public struct FactualSpeedKilometresPerHour: Codable, Hashable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(value, forKey: .value)
         try container.encode(provenance, forKey: .provenance)
+        try container.encode(normalizationRule, forKey: .normalizationRule)
     }
 
     public static func normalized(
         from native: NativeTreadmillSpeed,
-        provenance: EvidenceProvenance
+        provenance: EvidenceProvenance,
+        normalizationRule: FactualSpeedNormalizationRule = .nativeToKilometresPerHourV1
     ) -> Self? {
         guard native.value.isFinite, native.value >= 0 else {
             return nil
         }
 
-        switch native.unit {
-        case .kilometresPerHour:
-            return Self(value: native.value, provenance: provenance)
-        case .milesPerHour:
-            return Self(value: native.value * 1.609_344, provenance: provenance)
-        case .controllerNative, .unknown:
-            return nil
+        switch normalizationRule {
+        case .nativeToKilometresPerHourV1:
+            switch native.unit {
+            case .kilometresPerHour:
+                return Self(
+                    value: native.value,
+                    provenance: provenance,
+                    normalizationRule: normalizationRule
+                )
+            case .milesPerHour:
+                return Self(
+                    value: native.value * 1.609_344,
+                    provenance: provenance,
+                    normalizationRule: normalizationRule
+                )
+            case .controllerNative, .unknown:
+                return nil
+            }
         }
     }
 }
@@ -197,7 +225,8 @@ public struct TreadmillObservation: Codable, Hashable, Sendable {
         timestamp: ObservationTimestamp,
         provenance: EvidenceProvenance,
         freshness: EvidenceFreshness,
-        quality: QualityFlags
+        quality: QualityFlags,
+        normalizationRule: FactualSpeedNormalizationRule = .nativeToKilometresPerHourV1
     ) {
         self.recordID = recordID
         self.observationID = observationID
@@ -206,7 +235,8 @@ public struct TreadmillObservation: Codable, Hashable, Sendable {
         self.nativeSpeed = nativeSpeed
         self.factualSpeed = FactualSpeedKilometresPerHour.normalized(
             from: nativeSpeed,
-            provenance: provenance
+            provenance: provenance,
+            normalizationRule: normalizationRule
         )
         self.deviceState = deviceState
         self.arrivalOrder = arrivalOrder

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Provenance.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Provenance.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+public enum SignalProviderKind: Codable, Hashable, Sendable {
+    case unknown
+    case healthKitSelected
+    case watchMediated
+    case phoneLocal
+    case bluetooth
+    case treadmillProtocol
+    case other(String)
+}
+public struct ProviderSavingSource: Codable, Hashable, Sendable {
+    public let bundleIdentifier: String?
+    public let productType: String?
+    public let softwareVersion: String?
+
+    public init(
+        bundleIdentifier: String? = nil,
+        productType: String? = nil,
+        softwareVersion: String? = nil
+    ) {
+        self.bundleIdentifier = bundleIdentifier
+        self.productType = productType
+        self.softwareVersion = softwareVersion
+    }
+}
+
+public struct KnownDeviceMetadata: Codable, Hashable, Sendable {
+    public let manufacturer: String?
+    public let model: String?
+    public let hardwareVersion: String?
+
+    public init(
+        manufacturer: String? = nil,
+        model: String? = nil,
+        hardwareVersion: String? = nil
+    ) {
+        self.manufacturer = manufacturer
+        self.model = model
+        self.hardwareVersion = hardwareVersion
+    }
+}
+
+public struct SignalSourceIdentity: Codable, Hashable, Sendable {
+    public let id: SourceID
+    public let providerKind: SignalProviderKind
+    public let stableLocalKey: String
+    public let savingSource: ProviderSavingSource?
+    public let knownDevice: KnownDeviceMetadata?
+
+    public init(
+        id: SourceID,
+        providerKind: SignalProviderKind,
+        stableLocalKey: String,
+        savingSource: ProviderSavingSource? = nil,
+        knownDevice: KnownDeviceMetadata? = nil
+    ) {
+        self.id = id
+        self.providerKind = providerKind
+        self.stableLocalKey = stableLocalKey
+        self.savingSource = savingSource
+        self.knownDevice = knownDevice
+    }
+}
+
+public enum EvidenceProvenance: String, Codable, Hashable, Sendable {
+    case measuredByProvider
+    case reportedByProvider
+    case decodedDeviceReport
+}
+
+public enum QualityFlag: String, Codable, Hashable, Sendable, CaseIterable {
+    case missingSource
+    case missingMeasurementTime
+    case duplicateProviderIdentity
+    case duplicateProviderSequence
+    case measurementOutOfArrivalOrder
+    case invalidNativeValue
+    case nativeValueOutOfDomain
+    case staleAtUse
+    case unknownFreshness
+    case clockRegression
+    case implausibleReceiveLatency
+    case gapBeforeRecord
+    case recorderLossBeforeRecord
+    case estimatedProvenance
+    case derivedProvenance
+}
+
+public struct QualityFlags: Codable, Hashable, Sendable, ExpressibleByArrayLiteral {
+    public private(set) var values: Set<QualityFlag>
+
+    public init(_ values: Set<QualityFlag> = []) {
+        self.values = values
+    }
+
+    public init(arrayLiteral elements: QualityFlag...) {
+        self.init(Set(elements))
+    }
+
+    public func contains(_ flag: QualityFlag) -> Bool {
+        values.contains(flag)
+    }
+
+    public mutating func insert(_ flag: QualityFlag) {
+        values.insert(flag)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(Set(try container.decode([QualityFlag].self)))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(values.sorted { $0.rawValue < $1.rawValue })
+    }
+}
+
+public enum FreshnessState: String, Codable, Hashable, Sendable {
+    case fresh
+    case stale
+    case unknown
+}
+
+public struct EvidenceFreshness: Codable, Hashable, Sendable {
+    public let state: FreshnessState
+    public let evaluatedAt: RecordTimestamp
+    public let age: ElapsedDuration?
+    public let policyVersion: SafetyPolicyVersion?
+
+    public init(
+        state: FreshnessState,
+        evaluatedAt: RecordTimestamp,
+        age: ElapsedDuration?,
+        policyVersion: SafetyPolicyVersion?
+    ) {
+        self.state = state
+        self.evaluatedAt = evaluatedAt
+        self.age = age
+        self.policyVersion = policyVersion
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Provenance.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Provenance.swift
@@ -9,6 +9,7 @@ public enum SignalProviderKind: Codable, Hashable, Sendable {
     case treadmillProtocol
     case other(String)
 }
+
 public struct ProviderSavingSource: Codable, Hashable, Sendable {
     public let bundleIdentifier: String?
     public let productType: String?

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/SessionAndAnalysis.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/SessionAndAnalysis.swift
@@ -18,6 +18,7 @@ public struct RecorderHealthSummary: Codable, Hashable, Sendable {
         self.lastPersistedElapsed = lastPersistedElapsed
     }
 }
+
 public struct KnownTreadmillMetadata: Codable, Hashable, Sendable {
     public let stableLocalIdentifier: String?
     public let model: String?

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/SessionAndAnalysis.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/SessionAndAnalysis.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+public struct RecorderHealthSummary: Codable, Hashable, Sendable {
+    public let isComplete: Bool
+    public let lostCriticalRecordCount: UInt64
+    public let lostNativeRecordCount: UInt64
+    public let lastPersistedElapsed: ElapsedDuration?
+
+    public init(
+        isComplete: Bool,
+        lostCriticalRecordCount: UInt64,
+        lostNativeRecordCount: UInt64,
+        lastPersistedElapsed: ElapsedDuration?
+    ) {
+        self.isComplete = isComplete
+        self.lostCriticalRecordCount = lostCriticalRecordCount
+        self.lostNativeRecordCount = lostNativeRecordCount
+        self.lastPersistedElapsed = lastPersistedElapsed
+    }
+}
+public struct KnownTreadmillMetadata: Codable, Hashable, Sendable {
+    public let stableLocalIdentifier: String?
+    public let model: String?
+    public let protocolName: String?
+    public let protocolVersion: String?
+
+    public init(
+        stableLocalIdentifier: String? = nil,
+        model: String? = nil,
+        protocolName: String? = nil,
+        protocolVersion: String? = nil
+    ) {
+        self.stableLocalIdentifier = stableLocalIdentifier
+        self.model = model
+        self.protocolName = protocolName
+        self.protocolVersion = protocolVersion
+    }
+}
+
+public struct WorkoutSessionRecord: Codable, Hashable, Sendable {
+    public let recordID: RecordID
+    public let sessionID: SessionID
+    public let profileLocalIdentifier: String
+    public let lifecycleState: SessionLifecycleState
+    public let workoutMode: WorkoutMode
+    public let startedAt: Date
+    public let endedAt: Date?
+    public let endedElapsed: ElapsedDuration?
+    public let incompleteReason: String?
+    public let appContext: AppRuntimeContext
+    public let versions: RuntimeVersionContext
+    public let configuration: ImmutableConfigurationSnapshot
+    public let healthKitWorkoutIdentifier: UUID?
+    public let treadmill: KnownTreadmillMetadata?
+    public let recorderHealth: RecorderHealthSummary
+
+    public init(
+        recordID: RecordID,
+        sessionID: SessionID,
+        profileLocalIdentifier: String,
+        lifecycleState: SessionLifecycleState,
+        workoutMode: WorkoutMode,
+        startedAt: Date,
+        endedAt: Date?,
+        endedElapsed: ElapsedDuration?,
+        incompleteReason: String?,
+        appContext: AppRuntimeContext,
+        versions: RuntimeVersionContext,
+        configuration: ImmutableConfigurationSnapshot,
+        healthKitWorkoutIdentifier: UUID?,
+        treadmill: KnownTreadmillMetadata?,
+        recorderHealth: RecorderHealthSummary
+    ) {
+        self.recordID = recordID
+        self.sessionID = sessionID
+        self.profileLocalIdentifier = profileLocalIdentifier
+        self.lifecycleState = lifecycleState
+        self.workoutMode = workoutMode
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.endedElapsed = endedElapsed
+        self.incompleteReason = incompleteReason
+        self.appContext = appContext
+        self.versions = versions
+        self.configuration = configuration
+        self.healthKitWorkoutIdentifier = healthKitWorkoutIdentifier
+        self.treadmill = treadmill
+        self.recorderHealth = recorderHealth
+    }
+}
+
+public enum AnalysisQualityGrade: String, Codable, Hashable, Sendable {
+    case high
+    case medium
+    case low
+    case unusable
+}
+
+public struct AnalysisExclusion: Codable, Hashable, Sendable {
+    public let code: String
+    public let detail: String?
+
+    public init(code: String, detail: String? = nil) {
+        self.code = code
+        self.detail = detail
+    }
+}
+
+public struct AnalysisKeyMetrics: Codable, Hashable, Sendable {
+    public let coveredDuration: ElapsedDuration
+    public let averageHeartRate: Double?
+    public let maximumHeartRate: UInt16?
+    public let averageFactualSpeedKilometresPerHour: Double?
+
+    public init(
+        coveredDuration: ElapsedDuration,
+        averageHeartRate: Double?,
+        maximumHeartRate: UInt16?,
+        averageFactualSpeedKilometresPerHour: Double?
+    ) {
+        self.coveredDuration = coveredDuration
+        self.averageHeartRate = averageHeartRate
+        self.maximumHeartRate = maximumHeartRate
+        self.averageFactualSpeedKilometresPerHour = averageFactualSpeedKilometresPerHour
+    }
+}
+
+public struct WorkoutAnalysisResult: Codable, Hashable, Sendable {
+    public let analysisID: AnalysisID
+    public let recordID: RecordID
+    public let sessionID: SessionID
+    public let analyzerVersion: AnalyzerVersion
+    public let evidenceHash: ContentHash
+    public let generatedAt: Date
+    public let qualityGrade: AnalysisQualityGrade
+    public let exclusions: [AnalysisExclusion]
+    public let keyMetrics: AnalysisKeyMetrics
+    public let detailSchemaVersion: UInt16
+    public let versionedDetailPayload: Data
+
+    public init(
+        analysisID: AnalysisID,
+        recordID: RecordID,
+        sessionID: SessionID,
+        analyzerVersion: AnalyzerVersion,
+        evidenceHash: ContentHash,
+        generatedAt: Date,
+        qualityGrade: AnalysisQualityGrade,
+        exclusions: [AnalysisExclusion],
+        keyMetrics: AnalysisKeyMetrics,
+        detailSchemaVersion: UInt16,
+        versionedDetailPayload: Data
+    ) {
+        self.analysisID = analysisID
+        self.recordID = recordID
+        self.sessionID = sessionID
+        self.analyzerVersion = analyzerVersion
+        self.evidenceHash = evidenceHash
+        self.generatedAt = generatedAt
+        self.qualityGrade = qualityGrade
+        self.exclusions = exclusions
+        self.keyMetrics = keyMetrics
+        self.detailSchemaVersion = detailSchemaVersion
+        self.versionedDetailPayload = versionedDetailPayload
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Time.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Time.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+public struct ElapsedDuration: RawRepresentable, Codable, Hashable, Sendable, Comparable {
+    public let rawValue: Int64
+
+    public init(rawValue microseconds: Int64) {
+        self.rawValue = microseconds
+    }
+
+    public init(microseconds: Int64) {
+        self.init(rawValue: microseconds)
+    }
+
+    public init?(milliseconds: Int64) {
+        let conversion = milliseconds.multipliedReportingOverflow(by: 1_000)
+        guard !conversion.overflow else {
+            return nil
+        }
+
+        self.init(rawValue: conversion.partialValue)
+    }
+
+    public static let zero = ElapsedDuration(microseconds: 0)
+
+    public var microseconds: Int64 {
+        rawValue
+    }
+
+    public var seconds: Double {
+        Double(rawValue) / 1_000_000
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+public struct RecordTimestamp: Codable, Hashable, Sendable {
+    public let recordedAt: Date
+    public let elapsed: ElapsedDuration
+
+    public init(recordedAt: Date, elapsed: ElapsedDuration) {
+        self.recordedAt = recordedAt
+        self.elapsed = elapsed
+    }
+}
+
+public struct ObservationTimestamp: Codable, Hashable, Sendable {
+    public let measuredAt: Date?
+    public let receivedAt: Date
+    public let recordedAt: Date
+    public let measuredElapsed: ElapsedDuration?
+    public let receivedElapsed: ElapsedDuration
+    public let recordedElapsed: ElapsedDuration
+
+    public init(
+        measuredAt: Date?,
+        receivedAt: Date,
+        recordedAt: Date,
+        measuredElapsed: ElapsedDuration?,
+        receivedElapsed: ElapsedDuration,
+        recordedElapsed: ElapsedDuration
+    ) {
+        self.measuredAt = measuredAt
+        self.receivedAt = receivedAt
+        self.recordedAt = recordedAt
+        self.measuredElapsed = measuredElapsed
+        self.receivedElapsed = receivedElapsed
+        self.recordedElapsed = recordedElapsed
+    }
+
+    public var effectiveElapsed: ElapsedDuration {
+        measuredElapsed ?? receivedElapsed
+    }
+}
+
+public struct EventTimestamp: Codable, Hashable, Sendable {
+    public let occurredAt: Date
+    public let recordedAt: Date
+    public let occurredElapsed: ElapsedDuration
+    public let recordedElapsed: ElapsedDuration
+
+    public init(
+        occurredAt: Date,
+        recordedAt: Date,
+        occurredElapsed: ElapsedDuration,
+        recordedElapsed: ElapsedDuration
+    ) {
+        self.occurredAt = occurredAt
+        self.recordedAt = recordedAt
+        self.occurredElapsed = occurredElapsed
+        self.recordedElapsed = recordedElapsed
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetrySchemaV1.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetrySchemaV1.swift
@@ -278,6 +278,7 @@ final class TelemetryTreadmillSampleV1 {
     public var nativeUnitKey: String
     public var nativeUnitPayload: Data
     public var factualKilometresPerHour: Double?
+    public var factualSpeedNormalizationRuleKey: String?
     public var deviceStateKey: String
     public var arrivalOrder: Int64
     public var measuredAt: Date?
@@ -301,6 +302,7 @@ final class TelemetryTreadmillSampleV1 {
         nativeUnitKey: String,
         nativeUnitPayload: Data,
         factualKilometresPerHour: Double?,
+        factualSpeedNormalizationRuleKey: String?,
         deviceStateKey: String,
         arrivalOrder: Int64,
         measuredAt: Date?,
@@ -323,6 +325,7 @@ final class TelemetryTreadmillSampleV1 {
         self.nativeUnitKey = nativeUnitKey
         self.nativeUnitPayload = nativeUnitPayload
         self.factualKilometresPerHour = factualKilometresPerHour
+        self.factualSpeedNormalizationRuleKey = factualSpeedNormalizationRuleKey
         self.deviceStateKey = deviceStateKey
         self.arrivalOrder = arrivalOrder
         self.measuredAt = measuredAt

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetrySchemaV1.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetrySchemaV1.swift
@@ -194,7 +194,8 @@ final class TelemetrySignalSourceV1 {
 final class TelemetryHeartRateSampleV1 {
     #Index<TelemetryHeartRateSampleV1>(
         [\.sessionID, \.receivedElapsedMicroseconds],
-        [\.sourceID, \.arrivalOrder]
+        [\.sourceID, \.arrivalOrder],
+        [\.nativeSampleIdentityKey]
     )
 
     @Attribute(.unique) public var observationID: String
@@ -205,6 +206,7 @@ final class TelemetryHeartRateSampleV1 {
     public var arrivalOrder: Int64
     public var providerSequence: Int64?
     public var providerSampleIdentifier: String?
+    public var nativeSampleIdentityKey: String?
     public var measuredAt: Date?
     public var receivedAt: Date
     public var recordedAt: Date
@@ -227,6 +229,7 @@ final class TelemetryHeartRateSampleV1 {
         arrivalOrder: Int64,
         providerSequence: Int64?,
         providerSampleIdentifier: String?,
+        nativeSampleIdentityKey: String?,
         measuredAt: Date?,
         receivedAt: Date,
         recordedAt: Date,
@@ -248,6 +251,7 @@ final class TelemetryHeartRateSampleV1 {
         self.arrivalOrder = arrivalOrder
         self.providerSequence = providerSequence
         self.providerSampleIdentifier = providerSampleIdentifier
+        self.nativeSampleIdentityKey = nativeSampleIdentityKey
         self.measuredAt = measuredAt
         self.receivedAt = receivedAt
         self.recordedAt = recordedAt
@@ -344,7 +348,12 @@ final class TelemetryTreadmillSampleV1 {
 
 @Model
 final class TelemetryWorkoutEventV1 {
-    #Index<TelemetryWorkoutEventV1>([\.sessionID, \.kindKey, \.occurredElapsedMicroseconds])
+    #Index<TelemetryWorkoutEventV1>(
+        [\.sessionID, \.kindKey, \.occurredElapsedMicroseconds],
+        [\.decisionID],
+        [\.commandID],
+        [\.attemptID]
+    )
 
     @Attribute(.unique) public var recordID: String
     public var sessionID: String

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetrySchemaV1.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetrySchemaV1.swift
@@ -1,0 +1,499 @@
+import Foundation
+import SwiftData
+
+enum TelemetrySchemaV1: VersionedSchema {
+    public static let versionIdentifier = Schema.Version(1, 0, 0)
+
+    public static var models: [any PersistentModel.Type] {
+        [
+            TelemetryConfigurationSnapshotV1.self,
+            TelemetryWorkoutSessionV1.self,
+            TelemetrySignalSourceV1.self,
+            TelemetryHeartRateSampleV1.self,
+            TelemetryTreadmillSampleV1.self,
+            TelemetryWorkoutEventV1.self,
+            TelemetryWorkoutFrameV1.self,
+            TelemetryWorkoutAnalysisV1.self,
+        ]
+    }
+}
+
+enum TelemetryMigrationPlan: SchemaMigrationPlan {
+    public static var schemas: [any VersionedSchema.Type] {
+        [TelemetrySchemaV1.self]
+    }
+
+    public static var stages: [MigrationStage] {
+        []
+    }
+}
+
+@Model
+final class TelemetryConfigurationSnapshotV1 {
+    #Index<TelemetryConfigurationSnapshotV1>([\.contentHashDigest])
+
+    @Attribute(.unique) public var snapshotID: String
+    public var formatVersion: Int
+    public var formatKey: String
+    public var canonicalPayload: Data
+    public var hashAlgorithmKey: String
+    public var contentHashDigest: String
+
+    public init(
+        snapshotID: String,
+        formatVersion: Int,
+        formatKey: String,
+        canonicalPayload: Data,
+        hashAlgorithmKey: String,
+        contentHashDigest: String
+    ) {
+        self.snapshotID = snapshotID
+        self.formatVersion = formatVersion
+        self.formatKey = formatKey
+        self.canonicalPayload = canonicalPayload
+        self.hashAlgorithmKey = hashAlgorithmKey
+        self.contentHashDigest = contentHashDigest
+    }
+}
+
+@Model
+final class TelemetryWorkoutSessionV1 {
+    #Index<TelemetryWorkoutSessionV1>([\.startedAt], [\.profileLocalIdentifier, \.startedAt])
+
+    @Attribute(.unique) public var sessionID: String
+    @Attribute(.unique) public var recordID: String
+    public var profileLocalIdentifier: String
+    public var lifecycleStateKey: String
+    public var workoutModePayload: Data
+    public var startedAt: Date
+    public var endedAt: Date?
+    public var endedElapsedMicroseconds: Int64?
+    public var incompleteReason: String?
+    public var appVersion: String
+    public var buildNumber: String
+    public var operatingSystemVersion: String
+    public var deviceModel: String?
+    public var telemetrySchemaVersion: String
+    public var algorithmVersion: String
+    public var safetyPolicyVersion: String
+    public var workoutProtocolVersion: String
+    public var healthKitWorkoutIdentifier: String?
+    public var treadmillMetadataPayload: Data?
+    public var recorderIsComplete: Bool
+    public var lostCriticalRecordCount: Int64
+    public var lostNativeRecordCount: Int64
+    public var lastPersistedElapsedMicroseconds: Int64?
+    public var configuration: TelemetryConfigurationSnapshotV1?
+
+    @Relationship(deleteRule: .cascade, inverse: \TelemetryHeartRateSampleV1.session)
+    public var heartRateSamples: [TelemetryHeartRateSampleV1] = []
+
+    @Relationship(deleteRule: .cascade, inverse: \TelemetryTreadmillSampleV1.session)
+    public var treadmillSamples: [TelemetryTreadmillSampleV1] = []
+
+    @Relationship(deleteRule: .cascade, inverse: \TelemetryWorkoutEventV1.session)
+    public var events: [TelemetryWorkoutEventV1] = []
+
+    @Relationship(deleteRule: .cascade, inverse: \TelemetryWorkoutFrameV1.session)
+    public var frames: [TelemetryWorkoutFrameV1] = []
+
+    @Relationship(deleteRule: .cascade, inverse: \TelemetryWorkoutAnalysisV1.session)
+    public var analyses: [TelemetryWorkoutAnalysisV1] = []
+
+    public init(
+        sessionID: String,
+        recordID: String,
+        profileLocalIdentifier: String,
+        lifecycleStateKey: String,
+        workoutModePayload: Data,
+        startedAt: Date,
+        endedAt: Date?,
+        endedElapsedMicroseconds: Int64?,
+        incompleteReason: String?,
+        appVersion: String,
+        buildNumber: String,
+        operatingSystemVersion: String,
+        deviceModel: String?,
+        telemetrySchemaVersion: String,
+        algorithmVersion: String,
+        safetyPolicyVersion: String,
+        workoutProtocolVersion: String,
+        healthKitWorkoutIdentifier: String?,
+        treadmillMetadataPayload: Data?,
+        recorderIsComplete: Bool,
+        lostCriticalRecordCount: Int64,
+        lostNativeRecordCount: Int64,
+        lastPersistedElapsedMicroseconds: Int64?,
+        configuration: TelemetryConfigurationSnapshotV1
+    ) {
+        self.sessionID = sessionID
+        self.recordID = recordID
+        self.profileLocalIdentifier = profileLocalIdentifier
+        self.lifecycleStateKey = lifecycleStateKey
+        self.workoutModePayload = workoutModePayload
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.endedElapsedMicroseconds = endedElapsedMicroseconds
+        self.incompleteReason = incompleteReason
+        self.appVersion = appVersion
+        self.buildNumber = buildNumber
+        self.operatingSystemVersion = operatingSystemVersion
+        self.deviceModel = deviceModel
+        self.telemetrySchemaVersion = telemetrySchemaVersion
+        self.algorithmVersion = algorithmVersion
+        self.safetyPolicyVersion = safetyPolicyVersion
+        self.workoutProtocolVersion = workoutProtocolVersion
+        self.healthKitWorkoutIdentifier = healthKitWorkoutIdentifier
+        self.treadmillMetadataPayload = treadmillMetadataPayload
+        self.recorderIsComplete = recorderIsComplete
+        self.lostCriticalRecordCount = lostCriticalRecordCount
+        self.lostNativeRecordCount = lostNativeRecordCount
+        self.lastPersistedElapsedMicroseconds = lastPersistedElapsedMicroseconds
+        self.configuration = configuration
+    }
+}
+
+@Model
+final class TelemetrySignalSourceV1 {
+    #Index<TelemetrySignalSourceV1>([\.providerKindKey, \.stableLocalKey], [\.lastSeen])
+
+    @Attribute(.unique) public var sourceID: String
+    @Attribute(.unique) public var stableIdentityKey: String
+    public var providerKindKey: String
+    public var providerKindPayload: Data
+    public var stableLocalKey: String
+    public var savingSourcePayload: Data?
+    public var knownDevicePayload: Data?
+    public var firstSeen: Date
+    public var lastSeen: Date
+
+    public init(
+        sourceID: String,
+        stableIdentityKey: String,
+        providerKindKey: String,
+        providerKindPayload: Data,
+        stableLocalKey: String,
+        savingSourcePayload: Data?,
+        knownDevicePayload: Data?,
+        firstSeen: Date,
+        lastSeen: Date
+    ) {
+        self.sourceID = sourceID
+        self.stableIdentityKey = stableIdentityKey
+        self.providerKindKey = providerKindKey
+        self.providerKindPayload = providerKindPayload
+        self.stableLocalKey = stableLocalKey
+        self.savingSourcePayload = savingSourcePayload
+        self.knownDevicePayload = knownDevicePayload
+        self.firstSeen = firstSeen
+        self.lastSeen = lastSeen
+    }
+}
+
+@Model
+final class TelemetryHeartRateSampleV1 {
+    #Index<TelemetryHeartRateSampleV1>(
+        [\.sessionID, \.receivedElapsedMicroseconds],
+        [\.sourceID, \.arrivalOrder]
+    )
+
+    @Attribute(.unique) public var observationID: String
+    @Attribute(.unique) public var recordID: String
+    public var sessionID: String
+    public var sourceID: String
+    public var beatsPerMinute: Int
+    public var arrivalOrder: Int64
+    public var providerSequence: Int64?
+    public var providerSampleIdentifier: String?
+    public var measuredAt: Date?
+    public var receivedAt: Date
+    public var recordedAt: Date
+    public var measuredElapsedMicroseconds: Int64?
+    public var receivedElapsedMicroseconds: Int64
+    public var recordedElapsedMicroseconds: Int64
+    public var provenanceKey: String
+    public var freshnessPayload: Data
+    public var qualityPayload: Data
+    public var controlUseKey: String
+    public var session: TelemetryWorkoutSessionV1?
+    public var source: TelemetrySignalSourceV1?
+
+    public init(
+        observationID: String,
+        recordID: String,
+        sessionID: String,
+        sourceID: String,
+        beatsPerMinute: Int,
+        arrivalOrder: Int64,
+        providerSequence: Int64?,
+        providerSampleIdentifier: String?,
+        measuredAt: Date?,
+        receivedAt: Date,
+        recordedAt: Date,
+        measuredElapsedMicroseconds: Int64?,
+        receivedElapsedMicroseconds: Int64,
+        recordedElapsedMicroseconds: Int64,
+        provenanceKey: String,
+        freshnessPayload: Data,
+        qualityPayload: Data,
+        controlUseKey: String,
+        session: TelemetryWorkoutSessionV1,
+        source: TelemetrySignalSourceV1
+    ) {
+        self.observationID = observationID
+        self.recordID = recordID
+        self.sessionID = sessionID
+        self.sourceID = sourceID
+        self.beatsPerMinute = beatsPerMinute
+        self.arrivalOrder = arrivalOrder
+        self.providerSequence = providerSequence
+        self.providerSampleIdentifier = providerSampleIdentifier
+        self.measuredAt = measuredAt
+        self.receivedAt = receivedAt
+        self.recordedAt = recordedAt
+        self.measuredElapsedMicroseconds = measuredElapsedMicroseconds
+        self.receivedElapsedMicroseconds = receivedElapsedMicroseconds
+        self.recordedElapsedMicroseconds = recordedElapsedMicroseconds
+        self.provenanceKey = provenanceKey
+        self.freshnessPayload = freshnessPayload
+        self.qualityPayload = qualityPayload
+        self.controlUseKey = controlUseKey
+        self.session = session
+        self.source = source
+    }
+}
+
+@Model
+final class TelemetryTreadmillSampleV1 {
+    #Index<TelemetryTreadmillSampleV1>(
+        [\.sessionID, \.receivedElapsedMicroseconds],
+        [\.sourceID, \.arrivalOrder]
+    )
+
+    @Attribute(.unique) public var observationID: String
+    @Attribute(.unique) public var recordID: String
+    public var sessionID: String
+    public var sourceID: String
+    public var nativeValue: Double
+    public var nativeUnitKey: String
+    public var nativeUnitPayload: Data
+    public var factualKilometresPerHour: Double?
+    public var deviceStateKey: String
+    public var arrivalOrder: Int64
+    public var measuredAt: Date?
+    public var receivedAt: Date
+    public var recordedAt: Date
+    public var measuredElapsedMicroseconds: Int64?
+    public var receivedElapsedMicroseconds: Int64
+    public var recordedElapsedMicroseconds: Int64
+    public var provenanceKey: String
+    public var freshnessPayload: Data
+    public var qualityPayload: Data
+    public var session: TelemetryWorkoutSessionV1?
+    public var source: TelemetrySignalSourceV1?
+
+    public init(
+        observationID: String,
+        recordID: String,
+        sessionID: String,
+        sourceID: String,
+        nativeValue: Double,
+        nativeUnitKey: String,
+        nativeUnitPayload: Data,
+        factualKilometresPerHour: Double?,
+        deviceStateKey: String,
+        arrivalOrder: Int64,
+        measuredAt: Date?,
+        receivedAt: Date,
+        recordedAt: Date,
+        measuredElapsedMicroseconds: Int64?,
+        receivedElapsedMicroseconds: Int64,
+        recordedElapsedMicroseconds: Int64,
+        provenanceKey: String,
+        freshnessPayload: Data,
+        qualityPayload: Data,
+        session: TelemetryWorkoutSessionV1,
+        source: TelemetrySignalSourceV1
+    ) {
+        self.observationID = observationID
+        self.recordID = recordID
+        self.sessionID = sessionID
+        self.sourceID = sourceID
+        self.nativeValue = nativeValue
+        self.nativeUnitKey = nativeUnitKey
+        self.nativeUnitPayload = nativeUnitPayload
+        self.factualKilometresPerHour = factualKilometresPerHour
+        self.deviceStateKey = deviceStateKey
+        self.arrivalOrder = arrivalOrder
+        self.measuredAt = measuredAt
+        self.receivedAt = receivedAt
+        self.recordedAt = recordedAt
+        self.measuredElapsedMicroseconds = measuredElapsedMicroseconds
+        self.receivedElapsedMicroseconds = receivedElapsedMicroseconds
+        self.recordedElapsedMicroseconds = recordedElapsedMicroseconds
+        self.provenanceKey = provenanceKey
+        self.freshnessPayload = freshnessPayload
+        self.qualityPayload = qualityPayload
+        self.session = session
+        self.source = source
+    }
+}
+
+@Model
+final class TelemetryWorkoutEventV1 {
+    #Index<TelemetryWorkoutEventV1>([\.sessionID, \.kindKey, \.occurredElapsedMicroseconds])
+
+    @Attribute(.unique) public var recordID: String
+    public var sessionID: String
+    public var kindKey: String
+    public var occurredAt: Date
+    public var recordedAt: Date
+    public var occurredElapsedMicroseconds: Int64
+    public var recordedElapsedMicroseconds: Int64
+    public var sourceID: String?
+    public var decisionID: String?
+    public var commandID: String?
+    public var attemptID: String?
+    public var payloadSchemaVersion: Int
+    public var payload: Data
+    public var session: TelemetryWorkoutSessionV1?
+    public var source: TelemetrySignalSourceV1?
+
+    public init(
+        recordID: String,
+        sessionID: String,
+        kindKey: String,
+        occurredAt: Date,
+        recordedAt: Date,
+        occurredElapsedMicroseconds: Int64,
+        recordedElapsedMicroseconds: Int64,
+        sourceID: String?,
+        decisionID: String?,
+        commandID: String?,
+        attemptID: String?,
+        payloadSchemaVersion: Int,
+        payload: Data,
+        session: TelemetryWorkoutSessionV1,
+        source: TelemetrySignalSourceV1?
+    ) {
+        self.recordID = recordID
+        self.sessionID = sessionID
+        self.kindKey = kindKey
+        self.occurredAt = occurredAt
+        self.recordedAt = recordedAt
+        self.occurredElapsedMicroseconds = occurredElapsedMicroseconds
+        self.recordedElapsedMicroseconds = recordedElapsedMicroseconds
+        self.sourceID = sourceID
+        self.decisionID = decisionID
+        self.commandID = commandID
+        self.attemptID = attemptID
+        self.payloadSchemaVersion = payloadSchemaVersion
+        self.payload = payload
+        self.session = session
+        self.source = source
+    }
+}
+
+@Model
+final class TelemetryWorkoutFrameV1 {
+    #Index<TelemetryWorkoutFrameV1>([\.sessionID, \.canonicalElapsedSecond])
+
+    @Attribute(.unique) public var frameID: String
+    @Attribute(.unique) public var recordID: String
+    @Attribute(.unique) public var canonicalIdentityKey: String
+    public var sessionID: String
+    public var canonicalElapsedSecond: Int64
+    public var materializedAt: Date
+    public var materializedElapsedMicroseconds: Int64
+    public var heartRateEvidencePayload: Data?
+    public var treadmillEvidencePayload: Data?
+    public var precedingGapPayload: Data?
+    public var session: TelemetryWorkoutSessionV1?
+
+    public init(
+        frameID: String,
+        recordID: String,
+        canonicalIdentityKey: String,
+        sessionID: String,
+        canonicalElapsedSecond: Int64,
+        materializedAt: Date,
+        materializedElapsedMicroseconds: Int64,
+        heartRateEvidencePayload: Data?,
+        treadmillEvidencePayload: Data?,
+        precedingGapPayload: Data?,
+        session: TelemetryWorkoutSessionV1
+    ) {
+        self.frameID = frameID
+        self.recordID = recordID
+        self.canonicalIdentityKey = canonicalIdentityKey
+        self.sessionID = sessionID
+        self.canonicalElapsedSecond = canonicalElapsedSecond
+        self.materializedAt = materializedAt
+        self.materializedElapsedMicroseconds = materializedElapsedMicroseconds
+        self.heartRateEvidencePayload = heartRateEvidencePayload
+        self.treadmillEvidencePayload = treadmillEvidencePayload
+        self.precedingGapPayload = precedingGapPayload
+        self.session = session
+    }
+}
+
+@Model
+final class TelemetryWorkoutAnalysisV1 {
+    #Index<TelemetryWorkoutAnalysisV1>([\.sessionID, \.analyzerVersion, \.generatedAt])
+
+    @Attribute(.unique) public var analysisID: String
+    @Attribute(.unique) public var recordID: String
+    @Attribute(.unique) public var analysisIdentityKey: String
+    public var sessionID: String
+    public var analyzerVersion: String
+    public var evidenceHashAlgorithm: String
+    public var evidenceHashDigest: String
+    public var generatedAt: Date
+    public var qualityGradeKey: String
+    public var exclusionsPayload: Data
+    public var coveredDurationMicroseconds: Int64
+    public var averageHeartRate: Double?
+    public var maximumHeartRate: Int?
+    public var averageFactualSpeedKilometresPerHour: Double?
+    public var detailSchemaVersion: Int
+    public var detailPayload: Data
+    public var session: TelemetryWorkoutSessionV1?
+
+    public init(
+        analysisID: String,
+        recordID: String,
+        analysisIdentityKey: String,
+        sessionID: String,
+        analyzerVersion: String,
+        evidenceHashAlgorithm: String,
+        evidenceHashDigest: String,
+        generatedAt: Date,
+        qualityGradeKey: String,
+        exclusionsPayload: Data,
+        coveredDurationMicroseconds: Int64,
+        averageHeartRate: Double?,
+        maximumHeartRate: Int?,
+        averageFactualSpeedKilometresPerHour: Double?,
+        detailSchemaVersion: Int,
+        detailPayload: Data,
+        session: TelemetryWorkoutSessionV1
+    ) {
+        self.analysisID = analysisID
+        self.recordID = recordID
+        self.analysisIdentityKey = analysisIdentityKey
+        self.sessionID = sessionID
+        self.analyzerVersion = analyzerVersion
+        self.evidenceHashAlgorithm = evidenceHashAlgorithm
+        self.evidenceHashDigest = evidenceHashDigest
+        self.generatedAt = generatedAt
+        self.qualityGradeKey = qualityGradeKey
+        self.exclusionsPayload = exclusionsPayload
+        self.coveredDurationMicroseconds = coveredDurationMicroseconds
+        self.averageHeartRate = averageHeartRate
+        self.maximumHeartRate = maximumHeartRate
+        self.averageFactualSpeedKilometresPerHour = averageFactualSpeedKilometresPerHour
+        self.detailSchemaVersion = detailSchemaVersion
+        self.detailPayload = detailPayload
+        self.session = session
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
@@ -1,0 +1,871 @@
+import Foundation
+import SwiftData
+import TelemetryDomain
+
+public enum TelemetryStoreConfiguration: Sendable, Equatable {
+    case inMemory
+    case onDisk(URL)
+}
+
+public enum TelemetryStoreError: Error, Equatable, Sendable {
+    case missingSession(SessionID)
+    case missingSource(SourceID)
+    case duplicateStableIdentity(String)
+    case conflictingStableIdentity(String)
+    case invalidNumericValue(String)
+    case corruptStoredRecord(String)
+}
+
+public struct StoredSignalSource: Codable, Hashable, Sendable {
+    public let identity: SignalSourceIdentity
+    public let firstSeen: Date
+    public let lastSeen: Date
+
+    public init(identity: SignalSourceIdentity, firstSeen: Date, lastSeen: Date) {
+        self.identity = identity
+        self.firstSeen = firstSeen
+        self.lastSeen = lastSeen
+    }
+}
+
+public struct TelemetryStoreCounts: Codable, Hashable, Sendable {
+    public let configurations: Int
+    public let sessions: Int
+    public let sources: Int
+    public let heartRateSamples: Int
+    public let treadmillSamples: Int
+    public let events: Int
+    public let frames: Int
+    public let analyses: Int
+
+    public init(
+        configurations: Int,
+        sessions: Int,
+        sources: Int,
+        heartRateSamples: Int,
+        treadmillSamples: Int,
+        events: Int,
+        frames: Int,
+        analyses: Int
+    ) {
+        self.configurations = configurations
+        self.sessions = sessions
+        self.sources = sources
+        self.heartRateSamples = heartRateSamples
+        self.treadmillSamples = treadmillSamples
+        self.events = events
+        self.frames = frames
+        self.analyses = analyses
+    }
+}
+
+public enum TelemetryStoreFactory {
+    public static func make(_ configuration: TelemetryStoreConfiguration) throws -> TelemetryStore {
+        let schema = Schema(versionedSchema: TelemetrySchemaV1.self)
+        let modelConfiguration: ModelConfiguration
+
+        switch configuration {
+        case .inMemory:
+            modelConfiguration = ModelConfiguration(
+                "TelemetryV2InMemory",
+                schema: schema,
+                isStoredInMemoryOnly: true,
+                cloudKitDatabase: .none
+            )
+        case let .onDisk(url):
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            modelConfiguration = ModelConfiguration(
+                "TelemetryV2",
+                schema: schema,
+                url: url,
+                cloudKitDatabase: .none
+            )
+        }
+
+        let container = try ModelContainer(
+            for: schema,
+            migrationPlan: TelemetryMigrationPlan.self,
+            configurations: [modelConfiguration]
+        )
+        return TelemetryStore(modelContainer: container)
+    }
+}
+
+@ModelActor
+public actor TelemetryStore {
+    public func insertSession(_ record: WorkoutSessionRecord) throws {
+        let sessionKey = record.sessionID.description
+        let recordKey = record.recordID.description
+        let configurationKey = record.configuration.id.description
+        let modePayload = try Self.encode(record.workoutMode)
+        let treadmillPayload = try record.treadmill.map(Self.encode)
+        let lostCritical = try Self.int64(record.recorderHealth.lostCriticalRecordCount, field: "lostCriticalRecordCount")
+        let lostNative = try Self.int64(record.recorderHealth.lostNativeRecordCount, field: "lostNativeRecordCount")
+
+        try explicitTransaction {
+            try requireAbsent(TelemetryWorkoutSessionV1.self, key: sessionKey) { model, value in
+                model.sessionID == value || model.recordID == recordKey
+            }
+
+            let configuration = try configurationModel(
+                snapshot: record.configuration,
+                configurationKey: configurationKey
+            )
+            let model = TelemetryWorkoutSessionV1(
+                sessionID: sessionKey,
+                recordID: recordKey,
+                profileLocalIdentifier: record.profileLocalIdentifier,
+                lifecycleStateKey: record.lifecycleState.rawValue,
+                workoutModePayload: modePayload,
+                startedAt: record.startedAt,
+                endedAt: record.endedAt,
+                endedElapsedMicroseconds: record.endedElapsed?.microseconds,
+                incompleteReason: record.incompleteReason,
+                appVersion: record.appContext.appVersion,
+                buildNumber: record.appContext.buildNumber,
+                operatingSystemVersion: record.appContext.operatingSystemVersion,
+                deviceModel: record.appContext.deviceModel,
+                telemetrySchemaVersion: record.versions.telemetrySchema.rawValue,
+                algorithmVersion: record.versions.algorithm.rawValue,
+                safetyPolicyVersion: record.versions.safetyPolicy.rawValue,
+                workoutProtocolVersion: record.versions.workoutProtocol.rawValue,
+                healthKitWorkoutIdentifier: record.healthKitWorkoutIdentifier?.uuidString.lowercased(),
+                treadmillMetadataPayload: treadmillPayload,
+                recorderIsComplete: record.recorderHealth.isComplete,
+                lostCriticalRecordCount: lostCritical,
+                lostNativeRecordCount: lostNative,
+                lastPersistedElapsedMicroseconds: record.recorderHealth.lastPersistedElapsed?.microseconds,
+                configuration: configuration
+            )
+            modelContext.insert(model)
+        }
+    }
+
+    public func insertSource(
+        _ source: SignalSourceIdentity,
+        firstSeen: Date,
+        lastSeen: Date
+    ) throws {
+        let sourceKey = source.id.description
+        let stableIdentityKey = try Self.sourceStableIdentityKey(source)
+        let providerKindPayload = try Self.encode(source.providerKind)
+        let savingSourcePayload = try source.savingSource.map(Self.encode)
+        let knownDevicePayload = try source.knownDevice.map(Self.encode)
+
+        try explicitTransaction {
+            try requireAbsent(TelemetrySignalSourceV1.self, key: sourceKey) { model, value in
+                model.sourceID == value || model.stableIdentityKey == stableIdentityKey
+            }
+            modelContext.insert(
+                TelemetrySignalSourceV1(
+                    sourceID: sourceKey,
+                    stableIdentityKey: stableIdentityKey,
+                    providerKindKey: Self.providerKindKey(source.providerKind),
+                    providerKindPayload: providerKindPayload,
+                    stableLocalKey: source.stableLocalKey,
+                    savingSourcePayload: savingSourcePayload,
+                    knownDevicePayload: knownDevicePayload,
+                    firstSeen: firstSeen,
+                    lastSeen: lastSeen
+                )
+            )
+        }
+    }
+
+    public func insertHeartRate(_ observation: HeartRateObservation) throws {
+        let observationKey = observation.observationID.description
+        let recordKey = observation.recordID.description
+        let session = try sessionModel(observation.sessionID)
+        let source = try sourceModel(observation.source.id)
+        let freshnessPayload = try Self.encode(observation.freshness)
+        let qualityPayload = try Self.encode(observation.quality)
+        let arrivalOrder = try Self.int64(observation.arrivalOrder, field: "arrivalOrder")
+
+        try explicitTransaction {
+            try requireAbsent(TelemetryHeartRateSampleV1.self, key: observationKey) { model, value in
+                model.observationID == value || model.recordID == recordKey
+            }
+            modelContext.insert(
+                TelemetryHeartRateSampleV1(
+                    observationID: observationKey,
+                    recordID: recordKey,
+                    sessionID: observation.sessionID.description,
+                    sourceID: observation.source.id.description,
+                    beatsPerMinute: Int(observation.beatsPerMinute),
+                    arrivalOrder: arrivalOrder,
+                    providerSequence: observation.providerSequence,
+                    providerSampleIdentifier: observation.providerSampleIdentifier,
+                    measuredAt: observation.timestamp.measuredAt,
+                    receivedAt: observation.timestamp.receivedAt,
+                    recordedAt: observation.timestamp.recordedAt,
+                    measuredElapsedMicroseconds: observation.timestamp.measuredElapsed?.microseconds,
+                    receivedElapsedMicroseconds: observation.timestamp.receivedElapsed.microseconds,
+                    recordedElapsedMicroseconds: observation.timestamp.recordedElapsed.microseconds,
+                    provenanceKey: observation.provenance.rawValue,
+                    freshnessPayload: freshnessPayload,
+                    qualityPayload: qualityPayload,
+                    controlUseKey: observation.controlUse.rawValue,
+                    session: session,
+                    source: source
+                )
+            )
+        }
+    }
+
+    public func insertTreadmill(_ observation: TreadmillObservation) throws {
+        let observationKey = observation.observationID.description
+        let recordKey = observation.recordID.description
+        let session = try sessionModel(observation.sessionID)
+        let source = try sourceModel(observation.source.id)
+        let nativeUnitPayload = try Self.encode(observation.nativeSpeed.unit)
+        let freshnessPayload = try Self.encode(observation.freshness)
+        let qualityPayload = try Self.encode(observation.quality)
+        let arrivalOrder = try Self.int64(observation.arrivalOrder, field: "arrivalOrder")
+
+        try explicitTransaction {
+            try requireAbsent(TelemetryTreadmillSampleV1.self, key: observationKey) { model, value in
+                model.observationID == value || model.recordID == recordKey
+            }
+            modelContext.insert(
+                TelemetryTreadmillSampleV1(
+                    observationID: observationKey,
+                    recordID: recordKey,
+                    sessionID: observation.sessionID.description,
+                    sourceID: observation.source.id.description,
+                    nativeValue: observation.nativeSpeed.value,
+                    nativeUnitKey: Self.nativeUnitKey(observation.nativeSpeed.unit),
+                    nativeUnitPayload: nativeUnitPayload,
+                    factualKilometresPerHour: observation.factualSpeed?.value,
+                    deviceStateKey: observation.deviceState.rawValue,
+                    arrivalOrder: arrivalOrder,
+                    measuredAt: observation.timestamp.measuredAt,
+                    receivedAt: observation.timestamp.receivedAt,
+                    recordedAt: observation.timestamp.recordedAt,
+                    measuredElapsedMicroseconds: observation.timestamp.measuredElapsed?.microseconds,
+                    receivedElapsedMicroseconds: observation.timestamp.receivedElapsed.microseconds,
+                    recordedElapsedMicroseconds: observation.timestamp.recordedElapsed.microseconds,
+                    provenanceKey: observation.provenance.rawValue,
+                    freshnessPayload: freshnessPayload,
+                    qualityPayload: qualityPayload,
+                    session: session,
+                    source: source
+                )
+            )
+        }
+    }
+
+    public func insertEvent(_ event: WorkoutEvent) throws {
+        let recordKey = event.recordID.description
+        let session = try sessionModel(event.sessionID)
+        let source = try event.sourceID.map(sourceModel)
+        let payload = try Self.encode(event.payload.payload)
+
+        try explicitTransaction {
+            try requireAbsent(TelemetryWorkoutEventV1.self, key: recordKey) { model, value in
+                model.recordID == value
+            }
+            modelContext.insert(
+                TelemetryWorkoutEventV1(
+                    recordID: recordKey,
+                    sessionID: event.sessionID.description,
+                    kindKey: event.kind.rawValue,
+                    occurredAt: event.timestamp.occurredAt,
+                    recordedAt: event.timestamp.recordedAt,
+                    occurredElapsedMicroseconds: event.timestamp.occurredElapsed.microseconds,
+                    recordedElapsedMicroseconds: event.timestamp.recordedElapsed.microseconds,
+                    sourceID: event.sourceID?.description,
+                    decisionID: event.decisionID?.description,
+                    commandID: event.commandID?.description,
+                    attemptID: event.attemptID?.description,
+                    payloadSchemaVersion: Int(event.payload.schemaVersion),
+                    payload: payload,
+                    session: session,
+                    source: source
+                )
+            )
+        }
+    }
+
+    public func insertFrame(_ frame: CanonicalFrame) throws {
+        guard frame.canonicalElapsedSecond >= 0 else {
+            throw TelemetryStoreError.invalidNumericValue("canonicalElapsedSecond")
+        }
+        let frameKey = frame.frameID.description
+        let recordKey = frame.recordID.description
+        let identityKey = Self.frameIdentityKey(
+            sessionID: frame.sessionID,
+            elapsedSecond: frame.canonicalElapsedSecond
+        )
+        let session = try sessionModel(frame.sessionID)
+        let heartRatePayload = try frame.heartRateEvidence.map(Self.encode)
+        let treadmillPayload = try frame.treadmillEvidence.map(Self.encode)
+        let gapPayload = try frame.precedingGap.map(Self.encode)
+
+        try explicitTransaction {
+            try requireAbsent(TelemetryWorkoutFrameV1.self, key: identityKey) { model, value in
+                model.canonicalIdentityKey == value || model.frameID == frameKey || model.recordID == recordKey
+            }
+            modelContext.insert(
+                TelemetryWorkoutFrameV1(
+                    frameID: frameKey,
+                    recordID: recordKey,
+                    canonicalIdentityKey: identityKey,
+                    sessionID: frame.sessionID.description,
+                    canonicalElapsedSecond: frame.canonicalElapsedSecond,
+                    materializedAt: frame.materializedAt.recordedAt,
+                    materializedElapsedMicroseconds: frame.materializedAt.elapsed.microseconds,
+                    heartRateEvidencePayload: heartRatePayload,
+                    treadmillEvidencePayload: treadmillPayload,
+                    precedingGapPayload: gapPayload,
+                    session: session
+                )
+            )
+        }
+    }
+
+    public func insertAnalysis(_ analysis: WorkoutAnalysisResult) throws {
+        let analysisKey = analysis.analysisID.description
+        let recordKey = analysis.recordID.description
+        let identityKey = try Self.analysisIdentityKey(analysis)
+        let session = try sessionModel(analysis.sessionID)
+        let exclusionsPayload = try Self.encode(analysis.exclusions)
+
+        try explicitTransaction {
+            try requireAbsent(TelemetryWorkoutAnalysisV1.self, key: identityKey) { model, value in
+                model.analysisIdentityKey == value || model.analysisID == analysisKey || model.recordID == recordKey
+            }
+            modelContext.insert(
+                TelemetryWorkoutAnalysisV1(
+                    analysisID: analysisKey,
+                    recordID: recordKey,
+                    analysisIdentityKey: identityKey,
+                    sessionID: analysis.sessionID.description,
+                    analyzerVersion: analysis.analyzerVersion.rawValue,
+                    evidenceHashAlgorithm: analysis.evidenceHash.algorithm.rawValue,
+                    evidenceHashDigest: analysis.evidenceHash.lowercaseHexDigest,
+                    generatedAt: analysis.generatedAt,
+                    qualityGradeKey: analysis.qualityGrade.rawValue,
+                    exclusionsPayload: exclusionsPayload,
+                    coveredDurationMicroseconds: analysis.keyMetrics.coveredDuration.microseconds,
+                    averageHeartRate: analysis.keyMetrics.averageHeartRate,
+                    maximumHeartRate: analysis.keyMetrics.maximumHeartRate.map(Int.init),
+                    averageFactualSpeedKilometresPerHour: analysis.keyMetrics.averageFactualSpeedKilometresPerHour,
+                    detailSchemaVersion: Int(analysis.detailSchemaVersion),
+                    detailPayload: analysis.versionedDetailPayload,
+                    session: session
+                )
+            )
+        }
+    }
+
+    public func fetchSessions(profileLocalIdentifier: String? = nil) throws -> [WorkoutSessionRecord] {
+        var descriptor = FetchDescriptor<TelemetryWorkoutSessionV1>(
+            sortBy: [SortDescriptor(\TelemetryWorkoutSessionV1.startedAt)]
+        )
+        if let profileLocalIdentifier {
+            descriptor.predicate = #Predicate { $0.profileLocalIdentifier == profileLocalIdentifier }
+        }
+        return try modelContext.fetch(descriptor).map(Self.domainSession)
+    }
+
+    public func fetchSources(providerKindKey: String? = nil) throws -> [StoredSignalSource] {
+        var descriptor = FetchDescriptor<TelemetrySignalSourceV1>(
+            sortBy: [SortDescriptor(\TelemetrySignalSourceV1.lastSeen)]
+        )
+        if let providerKindKey {
+            descriptor.predicate = #Predicate { $0.providerKindKey == providerKindKey }
+        }
+        return try modelContext.fetch(descriptor).map(Self.domainSource)
+    }
+
+    public func fetchHeartRate(sessionID: SessionID) throws -> [HeartRateObservation] {
+        let key = sessionID.description
+        let descriptor = FetchDescriptor<TelemetryHeartRateSampleV1>(
+            predicate: #Predicate { $0.sessionID == key },
+            sortBy: [SortDescriptor(\TelemetryHeartRateSampleV1.arrivalOrder)]
+        )
+        return try modelContext.fetch(descriptor).map(Self.domainHeartRate)
+    }
+
+    public func fetchTreadmill(sessionID: SessionID) throws -> [TreadmillObservation] {
+        let key = sessionID.description
+        let descriptor = FetchDescriptor<TelemetryTreadmillSampleV1>(
+            predicate: #Predicate { $0.sessionID == key },
+            sortBy: [SortDescriptor(\TelemetryTreadmillSampleV1.arrivalOrder)]
+        )
+        return try modelContext.fetch(descriptor).map(Self.domainTreadmill)
+    }
+
+    public func fetchEvents(
+        sessionID: SessionID,
+        kind: WorkoutEventKind? = nil
+    ) throws -> [WorkoutEvent] {
+        let sessionKey = sessionID.description
+        let descriptor: FetchDescriptor<TelemetryWorkoutEventV1>
+        if let kind {
+            let kindKey = kind.rawValue
+            descriptor = FetchDescriptor(
+                predicate: #Predicate { $0.sessionID == sessionKey && $0.kindKey == kindKey },
+                sortBy: [SortDescriptor(\TelemetryWorkoutEventV1.occurredElapsedMicroseconds)]
+            )
+        } else {
+            descriptor = FetchDescriptor(
+                predicate: #Predicate { $0.sessionID == sessionKey },
+                sortBy: [SortDescriptor(\TelemetryWorkoutEventV1.occurredElapsedMicroseconds)]
+            )
+        }
+        return try modelContext.fetch(descriptor).map(Self.domainEvent)
+    }
+
+    public func fetchFrames(sessionID: SessionID) throws -> [CanonicalFrame] {
+        let key = sessionID.description
+        let descriptor = FetchDescriptor<TelemetryWorkoutFrameV1>(
+            predicate: #Predicate { $0.sessionID == key },
+            sortBy: [SortDescriptor(\TelemetryWorkoutFrameV1.canonicalElapsedSecond)]
+        )
+        return try modelContext.fetch(descriptor).map(Self.domainFrame)
+    }
+
+    public func fetchAnalyses(
+        sessionID: SessionID,
+        analyzerVersion: AnalyzerVersion? = nil
+    ) throws -> [WorkoutAnalysisResult] {
+        let sessionKey = sessionID.description
+        let descriptor: FetchDescriptor<TelemetryWorkoutAnalysisV1>
+        if let analyzerVersion {
+            let versionKey = analyzerVersion.rawValue
+            descriptor = FetchDescriptor(
+                predicate: #Predicate { $0.sessionID == sessionKey && $0.analyzerVersion == versionKey },
+                sortBy: [SortDescriptor(\TelemetryWorkoutAnalysisV1.generatedAt)]
+            )
+        } else {
+            descriptor = FetchDescriptor(
+                predicate: #Predicate { $0.sessionID == sessionKey },
+                sortBy: [SortDescriptor(\TelemetryWorkoutAnalysisV1.generatedAt)]
+            )
+        }
+        return try modelContext.fetch(descriptor).map(Self.domainAnalysis)
+    }
+
+    public func deleteSession(_ sessionID: SessionID) throws {
+        let session = try sessionModel(sessionID)
+        try explicitTransaction {
+            modelContext.delete(session)
+        }
+    }
+
+    public func counts() throws -> TelemetryStoreCounts {
+        TelemetryStoreCounts(
+            configurations: try modelContext.fetchCount(FetchDescriptor<TelemetryConfigurationSnapshotV1>()),
+            sessions: try modelContext.fetchCount(FetchDescriptor<TelemetryWorkoutSessionV1>()),
+            sources: try modelContext.fetchCount(FetchDescriptor<TelemetrySignalSourceV1>()),
+            heartRateSamples: try modelContext.fetchCount(FetchDescriptor<TelemetryHeartRateSampleV1>()),
+            treadmillSamples: try modelContext.fetchCount(FetchDescriptor<TelemetryTreadmillSampleV1>()),
+            events: try modelContext.fetchCount(FetchDescriptor<TelemetryWorkoutEventV1>()),
+            frames: try modelContext.fetchCount(FetchDescriptor<TelemetryWorkoutFrameV1>()),
+            analyses: try modelContext.fetchCount(FetchDescriptor<TelemetryWorkoutAnalysisV1>())
+        )
+    }
+
+    public func isAutosaveEnabled() -> Bool {
+        modelContext.autosaveEnabled
+    }
+
+    private func explicitTransaction(_ operation: () throws -> Void) throws {
+        modelContext.autosaveEnabled = false
+        try modelContext.transaction(block: operation)
+    }
+
+    private func sessionModel(_ sessionID: SessionID) throws -> TelemetryWorkoutSessionV1 {
+        let key = sessionID.description
+        var descriptor = FetchDescriptor<TelemetryWorkoutSessionV1>(
+            predicate: #Predicate { $0.sessionID == key }
+        )
+        descriptor.fetchLimit = 1
+        guard let model = try modelContext.fetch(descriptor).first else {
+            throw TelemetryStoreError.missingSession(sessionID)
+        }
+        return model
+    }
+
+    private func sourceModel(_ sourceID: SourceID) throws -> TelemetrySignalSourceV1 {
+        let key = sourceID.description
+        var descriptor = FetchDescriptor<TelemetrySignalSourceV1>(
+            predicate: #Predicate { $0.sourceID == key }
+        )
+        descriptor.fetchLimit = 1
+        guard let model = try modelContext.fetch(descriptor).first else {
+            throw TelemetryStoreError.missingSource(sourceID)
+        }
+        return model
+    }
+
+    private func configurationModel(
+        snapshot: ImmutableConfigurationSnapshot,
+        configurationKey: String
+    ) throws -> TelemetryConfigurationSnapshotV1 {
+        var descriptor = FetchDescriptor<TelemetryConfigurationSnapshotV1>(
+            predicate: #Predicate { $0.snapshotID == configurationKey }
+        )
+        descriptor.fetchLimit = 1
+        if let existing = try modelContext.fetch(descriptor).first {
+            guard existing.formatVersion == Int(snapshot.formatVersion),
+                  existing.formatKey == snapshot.format.rawValue,
+                  existing.canonicalPayload == snapshot.canonicalPayload,
+                  existing.hashAlgorithmKey == snapshot.contentHash.algorithm.rawValue,
+                  existing.contentHashDigest == snapshot.contentHash.lowercaseHexDigest
+            else {
+                throw TelemetryStoreError.conflictingStableIdentity(configurationKey)
+            }
+            return existing
+        }
+
+        let created = TelemetryConfigurationSnapshotV1(
+            snapshotID: configurationKey,
+            formatVersion: Int(snapshot.formatVersion),
+            formatKey: snapshot.format.rawValue,
+            canonicalPayload: snapshot.canonicalPayload,
+            hashAlgorithmKey: snapshot.contentHash.algorithm.rawValue,
+            contentHashDigest: snapshot.contentHash.lowercaseHexDigest
+        )
+        modelContext.insert(created)
+        return created
+    }
+
+    private func requireAbsent<Model: PersistentModel>(
+        _ type: Model.Type,
+        key: String,
+        matches: (Model, String) -> Bool
+    ) throws {
+        let models = try modelContext.fetch(FetchDescriptor<Model>())
+        guard !models.contains(where: { matches($0, key) }) else {
+            throw TelemetryStoreError.duplicateStableIdentity(key)
+        }
+    }
+}
+
+private extension TelemetryStore {
+    static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
+    static let decoder = JSONDecoder()
+
+    static func encode<T: Encodable>(_ value: T) throws -> Data {
+        try encoder.encode(value)
+    }
+
+    static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        try decoder.decode(type, from: data)
+    }
+
+    static func int64(_ value: UInt64, field: String) throws -> Int64 {
+        guard let converted = Int64(exactly: value) else {
+            throw TelemetryStoreError.invalidNumericValue(field)
+        }
+        return converted
+    }
+
+    static func providerKindKey(_ kind: SignalProviderKind) -> String {
+        switch kind {
+        case .unknown: "unknown"
+        case .healthKitSelected: "healthKitSelected"
+        case .watchMediated: "watchMediated"
+        case .phoneLocal: "phoneLocal"
+        case .bluetooth: "bluetooth"
+        case .treadmillProtocol: "treadmillProtocol"
+        case .other: "other"
+        }
+    }
+
+    static func nativeUnitKey(_ unit: TreadmillNativeSpeedUnit) -> String {
+        switch unit {
+        case .kilometresPerHour: "kilometresPerHour"
+        case .milesPerHour: "milesPerHour"
+        case .controllerNative: "controllerNative"
+        case .unknown: "unknown"
+        }
+    }
+
+    static func sourceStableIdentityKey(_ source: SignalSourceIdentity) throws -> String {
+        let providerIdentity = try encode(source.providerKind).base64EncodedString()
+        return "\(providerIdentity)|\(source.stableLocalKey)"
+    }
+
+    static func frameIdentityKey(sessionID: SessionID, elapsedSecond: Int64) -> String {
+        "\(sessionID.description)|\(elapsedSecond)"
+    }
+
+    static func analysisIdentityKey(_ analysis: WorkoutAnalysisResult) throws -> String {
+        try encode([
+            analysis.sessionID.description,
+            analysis.analyzerVersion.rawValue,
+            analysis.evidenceHash.algorithm.rawValue,
+            analysis.evidenceHash.lowercaseHexDigest,
+        ]).base64EncodedString()
+    }
+
+    static func uuid<Tag>(_ string: String, as type: Tag.Type) throws -> TelemetryIdentifier<Tag> {
+        guard let value = UUID(uuidString: string) else {
+            throw TelemetryStoreError.corruptStoredRecord("invalid UUID: \(string)")
+        }
+        return TelemetryIdentifier<Tag>(rawValue: value)
+    }
+
+    static func domainSession(_ model: TelemetryWorkoutSessionV1) throws -> WorkoutSessionRecord {
+        guard let configuration = model.configuration,
+              let lifecycle = SessionLifecycleState(rawValue: model.lifecycleStateKey),
+              let lostCritical = UInt64(exactly: model.lostCriticalRecordCount),
+              let lostNative = UInt64(exactly: model.lostNativeRecordCount),
+              let configurationFormatVersion = UInt16(exactly: configuration.formatVersion),
+              let configurationFormat = ConfigurationPayloadFormat(rawValue: configuration.formatKey),
+              let configurationHashAlgorithm = ContentHashAlgorithm(
+                  rawValue: configuration.hashAlgorithmKey
+              )
+        else {
+            throw TelemetryStoreError.corruptStoredRecord(model.sessionID)
+        }
+        let healthKitWorkoutIdentifier: UUID?
+        if let storedIdentifier = model.healthKitWorkoutIdentifier {
+            guard let identifier = UUID(uuidString: storedIdentifier) else {
+                throw TelemetryStoreError.corruptStoredRecord(model.sessionID)
+            }
+            healthKitWorkoutIdentifier = identifier
+        } else {
+            healthKitWorkoutIdentifier = nil
+        }
+        let mode = try decode(WorkoutMode.self, from: model.workoutModePayload)
+        let treadmill = try model.treadmillMetadataPayload.map { try decode(KnownTreadmillMetadata.self, from: $0) }
+        let configurationSnapshot = ImmutableConfigurationSnapshot(
+            id: try uuid(configuration.snapshotID, as: ConfigurationSnapshotIDTag.self),
+            formatVersion: configurationFormatVersion,
+            format: configurationFormat,
+            canonicalPayload: configuration.canonicalPayload,
+            contentHash: ContentHash(
+                algorithm: configurationHashAlgorithm,
+                lowercaseHexDigest: configuration.contentHashDigest
+            )
+        )
+        return WorkoutSessionRecord(
+            recordID: try uuid(model.recordID, as: RecordIDTag.self),
+            sessionID: try uuid(model.sessionID, as: SessionIDTag.self),
+            profileLocalIdentifier: model.profileLocalIdentifier,
+            lifecycleState: lifecycle,
+            workoutMode: mode,
+            startedAt: model.startedAt,
+            endedAt: model.endedAt,
+            endedElapsed: model.endedElapsedMicroseconds.map(ElapsedDuration.init(microseconds:)),
+            incompleteReason: model.incompleteReason,
+            appContext: AppRuntimeContext(
+                appVersion: model.appVersion,
+                buildNumber: model.buildNumber,
+                operatingSystemVersion: model.operatingSystemVersion,
+                deviceModel: model.deviceModel
+            ),
+            versions: RuntimeVersionContext(
+                telemetrySchema: TelemetrySchemaVersion(rawValue: model.telemetrySchemaVersion),
+                algorithm: AlgorithmVersion(rawValue: model.algorithmVersion),
+                safetyPolicy: SafetyPolicyVersion(rawValue: model.safetyPolicyVersion),
+                workoutProtocol: WorkoutProtocolVersion(rawValue: model.workoutProtocolVersion)
+            ),
+            configuration: configurationSnapshot,
+            healthKitWorkoutIdentifier: healthKitWorkoutIdentifier,
+            treadmill: treadmill,
+            recorderHealth: RecorderHealthSummary(
+                isComplete: model.recorderIsComplete,
+                lostCriticalRecordCount: lostCritical,
+                lostNativeRecordCount: lostNative,
+                lastPersistedElapsed: model.lastPersistedElapsedMicroseconds.map(ElapsedDuration.init(microseconds:))
+            )
+        )
+    }
+
+    static func domainSource(_ model: TelemetrySignalSourceV1) throws -> StoredSignalSource {
+        let identity = SignalSourceIdentity(
+            id: try uuid(model.sourceID, as: SourceIDTag.self),
+            providerKind: try decode(SignalProviderKind.self, from: model.providerKindPayload),
+            stableLocalKey: model.stableLocalKey,
+            savingSource: try model.savingSourcePayload.map { try decode(ProviderSavingSource.self, from: $0) },
+            knownDevice: try model.knownDevicePayload.map { try decode(KnownDeviceMetadata.self, from: $0) }
+        )
+        return StoredSignalSource(identity: identity, firstSeen: model.firstSeen, lastSeen: model.lastSeen)
+    }
+
+    static func domainHeartRate(_ model: TelemetryHeartRateSampleV1) throws -> HeartRateObservation {
+        guard let bpm = UInt16(exactly: model.beatsPerMinute),
+              let arrivalOrder = UInt64(exactly: model.arrivalOrder),
+              let provenance = EvidenceProvenance(rawValue: model.provenanceKey),
+              let controlUse = ControlUseState(rawValue: model.controlUseKey),
+              let source = model.source
+        else {
+            throw TelemetryStoreError.corruptStoredRecord(model.observationID)
+        }
+        return HeartRateObservation(
+            recordID: try uuid(model.recordID, as: RecordIDTag.self),
+            observationID: try uuid(model.observationID, as: ObservationIDTag.self),
+            sessionID: try uuid(model.sessionID, as: SessionIDTag.self),
+            source: try domainSource(source).identity,
+            beatsPerMinute: bpm,
+            arrivalOrder: arrivalOrder,
+            providerSequence: model.providerSequence,
+            providerSampleIdentifier: model.providerSampleIdentifier,
+            timestamp: observationTimestamp(
+                measuredAt: model.measuredAt,
+                receivedAt: model.receivedAt,
+                recordedAt: model.recordedAt,
+                measuredElapsed: model.measuredElapsedMicroseconds,
+                receivedElapsed: model.receivedElapsedMicroseconds,
+                recordedElapsed: model.recordedElapsedMicroseconds
+            ),
+            provenance: provenance,
+            freshness: try decode(EvidenceFreshness.self, from: model.freshnessPayload),
+            quality: try decode(QualityFlags.self, from: model.qualityPayload),
+            controlUse: controlUse
+        )
+    }
+
+    static func domainTreadmill(_ model: TelemetryTreadmillSampleV1) throws -> TreadmillObservation {
+        guard let arrivalOrder = UInt64(exactly: model.arrivalOrder),
+              let provenance = EvidenceProvenance(rawValue: model.provenanceKey),
+              let deviceState = TreadmillDeviceState(rawValue: model.deviceStateKey),
+              let source = model.source
+        else {
+            throw TelemetryStoreError.corruptStoredRecord(model.observationID)
+        }
+        let observation = TreadmillObservation(
+            recordID: try uuid(model.recordID, as: RecordIDTag.self),
+            observationID: try uuid(model.observationID, as: ObservationIDTag.self),
+            sessionID: try uuid(model.sessionID, as: SessionIDTag.self),
+            source: try domainSource(source).identity,
+            nativeSpeed: NativeTreadmillSpeed(
+                value: model.nativeValue,
+                unit: try decode(TreadmillNativeSpeedUnit.self, from: model.nativeUnitPayload)
+            ),
+            deviceState: deviceState,
+            arrivalOrder: arrivalOrder,
+            timestamp: observationTimestamp(
+                measuredAt: model.measuredAt,
+                receivedAt: model.receivedAt,
+                recordedAt: model.recordedAt,
+                measuredElapsed: model.measuredElapsedMicroseconds,
+                receivedElapsed: model.receivedElapsedMicroseconds,
+                recordedElapsed: model.recordedElapsedMicroseconds
+            ),
+            provenance: provenance,
+            freshness: try decode(EvidenceFreshness.self, from: model.freshnessPayload),
+            quality: try decode(QualityFlags.self, from: model.qualityPayload)
+        )
+        guard observation.factualSpeed?.value == model.factualKilometresPerHour else {
+            throw TelemetryStoreError.corruptStoredRecord(model.observationID)
+        }
+        return observation
+    }
+
+    static func domainEvent(_ model: TelemetryWorkoutEventV1) throws -> WorkoutEvent {
+        guard let kind = WorkoutEventKind(rawValue: model.kindKey),
+              let payloadVersion = UInt16(exactly: model.payloadSchemaVersion)
+        else {
+            throw TelemetryStoreError.corruptStoredRecord(model.recordID)
+        }
+        let payload = try decode(WorkoutEventPayload.self, from: model.payload)
+        guard payload.kind == kind else {
+            throw TelemetryStoreError.corruptStoredRecord(model.recordID)
+        }
+        return WorkoutEvent(
+            recordID: try uuid(model.recordID, as: RecordIDTag.self),
+            sessionID: try uuid(model.sessionID, as: SessionIDTag.self),
+            timestamp: EventTimestamp(
+                occurredAt: model.occurredAt,
+                recordedAt: model.recordedAt,
+                occurredElapsed: ElapsedDuration(microseconds: model.occurredElapsedMicroseconds),
+                recordedElapsed: ElapsedDuration(microseconds: model.recordedElapsedMicroseconds)
+            ),
+            sourceID: try model.sourceID.map { try uuid($0, as: SourceIDTag.self) },
+            decisionID: try model.decisionID.map { try uuid($0, as: DecisionIDTag.self) },
+            commandID: try model.commandID.map { try uuid($0, as: CommandIDTag.self) },
+            attemptID: try model.attemptID.map { try uuid($0, as: CommandAttemptIDTag.self) },
+            payload: EventPayloadEnvelope(
+                schemaVersion: payloadVersion,
+                payload: payload
+            )
+        )
+    }
+
+    static func domainFrame(_ model: TelemetryWorkoutFrameV1) throws -> CanonicalFrame {
+        CanonicalFrame(
+            frameID: try uuid(model.frameID, as: FrameIDTag.self),
+            recordID: try uuid(model.recordID, as: RecordIDTag.self),
+            sessionID: try uuid(model.sessionID, as: SessionIDTag.self),
+            canonicalElapsedSecond: model.canonicalElapsedSecond,
+            materializedAt: RecordTimestamp(
+                recordedAt: model.materializedAt,
+                elapsed: ElapsedDuration(microseconds: model.materializedElapsedMicroseconds)
+            ),
+            heartRateEvidence: try model.heartRateEvidencePayload.map { try decode(HeartRateFrameEvidence.self, from: $0) },
+            treadmillEvidence: try model.treadmillEvidencePayload.map { try decode(TreadmillFrameEvidence.self, from: $0) },
+            precedingGap: try model.precedingGapPayload.map { try decode(CanonicalGapBoundary.self, from: $0) }
+        )
+    }
+
+    static func domainAnalysis(_ model: TelemetryWorkoutAnalysisV1) throws -> WorkoutAnalysisResult {
+        guard let hashAlgorithm = ContentHashAlgorithm(rawValue: model.evidenceHashAlgorithm),
+              let qualityGrade = AnalysisQualityGrade(rawValue: model.qualityGradeKey),
+              let detailSchemaVersion = UInt16(exactly: model.detailSchemaVersion)
+        else {
+            throw TelemetryStoreError.corruptStoredRecord(model.analysisID)
+        }
+        let maximumHeartRate: UInt16?
+        if let storedMaximum = model.maximumHeartRate {
+            guard let convertedMaximum = UInt16(exactly: storedMaximum) else {
+                throw TelemetryStoreError.corruptStoredRecord(model.analysisID)
+            }
+            maximumHeartRate = convertedMaximum
+        } else {
+            maximumHeartRate = nil
+        }
+        return WorkoutAnalysisResult(
+            analysisID: try uuid(model.analysisID, as: AnalysisIDTag.self),
+            recordID: try uuid(model.recordID, as: RecordIDTag.self),
+            sessionID: try uuid(model.sessionID, as: SessionIDTag.self),
+            analyzerVersion: AnalyzerVersion(rawValue: model.analyzerVersion),
+            evidenceHash: ContentHash(
+                algorithm: hashAlgorithm,
+                lowercaseHexDigest: model.evidenceHashDigest
+            ),
+            generatedAt: model.generatedAt,
+            qualityGrade: qualityGrade,
+            exclusions: try decode([AnalysisExclusion].self, from: model.exclusionsPayload),
+            keyMetrics: AnalysisKeyMetrics(
+                coveredDuration: ElapsedDuration(microseconds: model.coveredDurationMicroseconds),
+                averageHeartRate: model.averageHeartRate,
+                maximumHeartRate: maximumHeartRate,
+                averageFactualSpeedKilometresPerHour: model.averageFactualSpeedKilometresPerHour
+            ),
+            detailSchemaVersion: detailSchemaVersion,
+            versionedDetailPayload: model.detailPayload
+        )
+    }
+
+    static func observationTimestamp(
+        measuredAt: Date?,
+        receivedAt: Date,
+        recordedAt: Date,
+        measuredElapsed: Int64?,
+        receivedElapsed: Int64,
+        recordedElapsed: Int64
+    ) -> ObservationTimestamp {
+        ObservationTimestamp(
+            measuredAt: measuredAt,
+            receivedAt: receivedAt,
+            recordedAt: recordedAt,
+            measuredElapsed: measuredElapsed.map(ElapsedDuration.init(microseconds:)),
+            receivedElapsed: ElapsedDuration(microseconds: receivedElapsed),
+            recordedElapsed: ElapsedDuration(microseconds: recordedElapsed)
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
@@ -63,9 +63,11 @@ public enum TelemetryStoreFactory {
     public static func make(_ configuration: TelemetryStoreConfiguration) throws -> TelemetryStore {
         let schema = Schema(versionedSchema: TelemetrySchemaV1.self)
         let modelConfiguration: ModelConfiguration
+        let onDiskStoreURL: URL?
 
         switch configuration {
         case .inMemory:
+            onDiskStoreURL = nil
             modelConfiguration = ModelConfiguration(
                 "TelemetryV2InMemory",
                 schema: schema,
@@ -73,6 +75,7 @@ public enum TelemetryStoreFactory {
                 cloudKitDatabase: .none
             )
         case let .onDisk(url):
+            onDiskStoreURL = url
             try FileManager.default.createDirectory(
                 at: url.deletingLastPathComponent(),
                 withIntermediateDirectories: true
@@ -90,12 +93,29 @@ public enum TelemetryStoreFactory {
             migrationPlan: TelemetryMigrationPlan.self,
             configurations: [modelConfiguration]
         )
-        return TelemetryStore(modelContainer: container)
+        if let onDiskStoreURL {
+            _ = try TelemetryStoreFilePolicy.applyRequiredAttributes(
+                primaryStoreURL: onDiskStoreURL
+            )
+        }
+        return TelemetryStore(
+            modelContainer: container,
+            onDiskStoreURL: onDiskStoreURL
+        )
     }
 }
 
 @ModelActor
 public actor TelemetryStore {
+    private var onDiskStoreURL: URL?
+
+    init(modelContainer: ModelContainer, onDiskStoreURL: URL?) {
+        let modelContext = ModelContext(modelContainer)
+        modelExecutor = DefaultSerialModelExecutor(modelContext: modelContext)
+        self.modelContainer = modelContainer
+        self.onDiskStoreURL = onDiskStoreURL
+    }
+
     public func insertSession(_ record: WorkoutSessionRecord) throws {
         let sessionKey = record.sessionID.description
         let recordKey = record.recordID.description
@@ -239,6 +259,8 @@ public actor TelemetryStore {
                     nativeUnitKey: Self.nativeUnitKey(observation.nativeSpeed.unit),
                     nativeUnitPayload: nativeUnitPayload,
                     factualKilometresPerHour: observation.factualSpeed?.value,
+                    factualSpeedNormalizationRuleKey: observation.factualSpeed?
+                        .normalizationRule.rawValue,
                     deviceStateKey: observation.deviceState.rawValue,
                     arrivalOrder: arrivalOrder,
                     measuredAt: observation.timestamp.measuredAt,
@@ -477,6 +499,11 @@ public actor TelemetryStore {
     private func explicitTransaction(_ operation: () throws -> Void) throws {
         modelContext.autosaveEnabled = false
         try modelContext.transaction(block: operation)
+        if let onDiskStoreURL {
+            _ = try TelemetryStoreFilePolicy.applyRequiredAttributes(
+                primaryStoreURL: onDiskStoreURL
+            )
+        }
     }
 
     private func sessionModel(_ sessionID: SessionID) throws -> TelemetryWorkoutSessionV1 {
@@ -701,7 +728,10 @@ private extension TelemetryStore {
               let arrivalOrder = UInt64(exactly: model.arrivalOrder),
               let provenance = EvidenceProvenance(rawValue: model.provenanceKey),
               let controlUse = ControlUseState(rawValue: model.controlUseKey),
-              let source = model.source
+              let session = model.session,
+              session.sessionID == model.sessionID,
+              let source = model.source,
+              source.sourceID == model.sourceID
         else {
             throw TelemetryStoreError.corruptStoredRecord(model.observationID)
         }
@@ -733,8 +763,23 @@ private extension TelemetryStore {
         guard let arrivalOrder = UInt64(exactly: model.arrivalOrder),
               let provenance = EvidenceProvenance(rawValue: model.provenanceKey),
               let deviceState = TreadmillDeviceState(rawValue: model.deviceStateKey),
-              let source = model.source
+              let session = model.session,
+              session.sessionID == model.sessionID,
+              let source = model.source,
+              source.sourceID == model.sourceID
         else {
+            throw TelemetryStoreError.corruptStoredRecord(model.observationID)
+        }
+        let normalizationRule: FactualSpeedNormalizationRule?
+        switch (model.factualKilometresPerHour, model.factualSpeedNormalizationRuleKey) {
+        case (nil, nil):
+            normalizationRule = nil
+        case (.some, let ruleKey?):
+            guard let rule = FactualSpeedNormalizationRule(rawValue: ruleKey) else {
+                throw TelemetryStoreError.corruptStoredRecord(model.observationID)
+            }
+            normalizationRule = rule
+        default:
             throw TelemetryStoreError.corruptStoredRecord(model.observationID)
         }
         let observation = TreadmillObservation(
@@ -758,9 +803,12 @@ private extension TelemetryStore {
             ),
             provenance: provenance,
             freshness: try decode(EvidenceFreshness.self, from: model.freshnessPayload),
-            quality: try decode(QualityFlags.self, from: model.qualityPayload)
+            quality: try decode(QualityFlags.self, from: model.qualityPayload),
+            normalizationRule: normalizationRule ?? .nativeToKilometresPerHourV1
         )
-        guard observation.factualSpeed?.value == model.factualKilometresPerHour else {
+        guard observation.factualSpeed?.value == model.factualKilometresPerHour,
+              observation.factualSpeed?.normalizationRule == normalizationRule
+        else {
             throw TelemetryStoreError.corruptStoredRecord(model.observationID)
         }
         return observation
@@ -768,8 +816,17 @@ private extension TelemetryStore {
 
     static func domainEvent(_ model: TelemetryWorkoutEventV1) throws -> WorkoutEvent {
         guard let kind = WorkoutEventKind(rawValue: model.kindKey),
-              let payloadVersion = UInt16(exactly: model.payloadSchemaVersion)
+              let payloadVersion = UInt16(exactly: model.payloadSchemaVersion),
+              let session = model.session,
+              session.sessionID == model.sessionID
         else {
+            throw TelemetryStoreError.corruptStoredRecord(model.recordID)
+        }
+        if let sourceID = model.sourceID {
+            guard let source = model.source, source.sourceID == sourceID else {
+                throw TelemetryStoreError.corruptStoredRecord(model.recordID)
+            }
+        } else if model.source != nil {
             throw TelemetryStoreError.corruptStoredRecord(model.recordID)
         }
         let payload = try decode(WorkoutEventPayload.self, from: model.payload)
@@ -797,7 +854,10 @@ private extension TelemetryStore {
     }
 
     static func domainFrame(_ model: TelemetryWorkoutFrameV1) throws -> CanonicalFrame {
-        CanonicalFrame(
+        guard let session = model.session, session.sessionID == model.sessionID else {
+            throw TelemetryStoreError.corruptStoredRecord(model.recordID)
+        }
+        return CanonicalFrame(
             frameID: try uuid(model.frameID, as: FrameIDTag.self),
             recordID: try uuid(model.recordID, as: RecordIDTag.self),
             sessionID: try uuid(model.sessionID, as: SessionIDTag.self),
@@ -815,7 +875,9 @@ private extension TelemetryStore {
     static func domainAnalysis(_ model: TelemetryWorkoutAnalysisV1) throws -> WorkoutAnalysisResult {
         guard let hashAlgorithm = ContentHashAlgorithm(rawValue: model.evidenceHashAlgorithm),
               let qualityGrade = AnalysisQualityGrade(rawValue: model.qualityGradeKey),
-              let detailSchemaVersion = UInt16(exactly: model.detailSchemaVersion)
+              let detailSchemaVersion = UInt16(exactly: model.detailSchemaVersion),
+              let session = model.session,
+              session.sessionID == model.sessionID
         else {
             throw TelemetryStoreError.corruptStoredRecord(model.analysisID)
         }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
@@ -126,9 +126,16 @@ public actor TelemetryStore {
         let lostNative = try Self.int64(record.recorderHealth.lostNativeRecordCount, field: "lostNativeRecordCount")
 
         try explicitTransaction {
-            try requireAbsent(TelemetryWorkoutSessionV1.self, key: sessionKey) { model, value in
-                model.sessionID == value || model.recordID == recordKey
-            }
+            try rejectDuplicate(
+                TelemetryWorkoutSessionV1.self,
+                key: sessionKey,
+                predicate: #Predicate { $0.sessionID == sessionKey }
+            )
+            try rejectDuplicate(
+                TelemetryWorkoutSessionV1.self,
+                key: recordKey,
+                predicate: #Predicate { $0.recordID == recordKey }
+            )
 
             let configuration = try configurationModel(
                 snapshot: record.configuration,
@@ -176,9 +183,16 @@ public actor TelemetryStore {
         let knownDevicePayload = try source.knownDevice.map(Self.encode)
 
         try explicitTransaction {
-            try requireAbsent(TelemetrySignalSourceV1.self, key: sourceKey) { model, value in
-                model.sourceID == value || model.stableIdentityKey == stableIdentityKey
-            }
+            try rejectDuplicate(
+                TelemetrySignalSourceV1.self,
+                key: sourceKey,
+                predicate: #Predicate { $0.sourceID == sourceKey }
+            )
+            try rejectDuplicate(
+                TelemetrySignalSourceV1.self,
+                key: stableIdentityKey,
+                predicate: #Predicate { $0.stableIdentityKey == stableIdentityKey }
+            )
             modelContext.insert(
                 TelemetrySignalSourceV1(
                     sourceID: sourceKey,
@@ -203,10 +217,32 @@ public actor TelemetryStore {
         let freshnessPayload = try Self.encode(observation.freshness)
         let qualityPayload = try Self.encode(observation.quality)
         let arrivalOrder = try Self.int64(observation.arrivalOrder, field: "arrivalOrder")
+        let nativeSampleIdentityKey = try observation.providerSampleIdentity.map {
+            try Self.heartRateNativeSampleIdentityKey(
+                sourceStableIdentityKey: source.stableIdentityKey,
+                providerSampleIdentity: $0
+            )
+        }
 
         try explicitTransaction {
-            try requireAbsent(TelemetryHeartRateSampleV1.self, key: observationKey) { model, value in
-                model.observationID == value || model.recordID == recordKey
+            try rejectDuplicate(
+                TelemetryHeartRateSampleV1.self,
+                key: observationKey,
+                predicate: #Predicate { $0.observationID == observationKey }
+            )
+            try rejectDuplicate(
+                TelemetryHeartRateSampleV1.self,
+                key: recordKey,
+                predicate: #Predicate { $0.recordID == recordKey }
+            )
+            if let nativeSampleIdentityKey {
+                try rejectDuplicate(
+                    TelemetryHeartRateSampleV1.self,
+                    key: nativeSampleIdentityKey,
+                    predicate: #Predicate {
+                        $0.nativeSampleIdentityKey == nativeSampleIdentityKey
+                    }
+                )
             }
             modelContext.insert(
                 TelemetryHeartRateSampleV1(
@@ -217,7 +253,8 @@ public actor TelemetryStore {
                     beatsPerMinute: Int(observation.beatsPerMinute),
                     arrivalOrder: arrivalOrder,
                     providerSequence: observation.providerSequence,
-                    providerSampleIdentifier: observation.providerSampleIdentifier,
+                    providerSampleIdentifier: observation.providerSampleIdentity?.identifier,
+                    nativeSampleIdentityKey: nativeSampleIdentityKey,
                     measuredAt: observation.timestamp.measuredAt,
                     receivedAt: observation.timestamp.receivedAt,
                     recordedAt: observation.timestamp.recordedAt,
@@ -246,9 +283,16 @@ public actor TelemetryStore {
         let arrivalOrder = try Self.int64(observation.arrivalOrder, field: "arrivalOrder")
 
         try explicitTransaction {
-            try requireAbsent(TelemetryTreadmillSampleV1.self, key: observationKey) { model, value in
-                model.observationID == value || model.recordID == recordKey
-            }
+            try rejectDuplicate(
+                TelemetryTreadmillSampleV1.self,
+                key: observationKey,
+                predicate: #Predicate { $0.observationID == observationKey }
+            )
+            try rejectDuplicate(
+                TelemetryTreadmillSampleV1.self,
+                key: recordKey,
+                predicate: #Predicate { $0.recordID == recordKey }
+            )
             modelContext.insert(
                 TelemetryTreadmillSampleV1(
                     observationID: observationKey,
@@ -286,9 +330,11 @@ public actor TelemetryStore {
         let payload = try Self.encode(event.payload.payload)
 
         try explicitTransaction {
-            try requireAbsent(TelemetryWorkoutEventV1.self, key: recordKey) { model, value in
-                model.recordID == value
-            }
+            try rejectDuplicate(
+                TelemetryWorkoutEventV1.self,
+                key: recordKey,
+                predicate: #Predicate { $0.recordID == recordKey }
+            )
             modelContext.insert(
                 TelemetryWorkoutEventV1(
                     recordID: recordKey,
@@ -327,9 +373,21 @@ public actor TelemetryStore {
         let gapPayload = try frame.precedingGap.map(Self.encode)
 
         try explicitTransaction {
-            try requireAbsent(TelemetryWorkoutFrameV1.self, key: identityKey) { model, value in
-                model.canonicalIdentityKey == value || model.frameID == frameKey || model.recordID == recordKey
-            }
+            try rejectDuplicate(
+                TelemetryWorkoutFrameV1.self,
+                key: identityKey,
+                predicate: #Predicate { $0.canonicalIdentityKey == identityKey }
+            )
+            try rejectDuplicate(
+                TelemetryWorkoutFrameV1.self,
+                key: frameKey,
+                predicate: #Predicate { $0.frameID == frameKey }
+            )
+            try rejectDuplicate(
+                TelemetryWorkoutFrameV1.self,
+                key: recordKey,
+                predicate: #Predicate { $0.recordID == recordKey }
+            )
             modelContext.insert(
                 TelemetryWorkoutFrameV1(
                     frameID: frameKey,
@@ -356,9 +414,21 @@ public actor TelemetryStore {
         let exclusionsPayload = try Self.encode(analysis.exclusions)
 
         try explicitTransaction {
-            try requireAbsent(TelemetryWorkoutAnalysisV1.self, key: identityKey) { model, value in
-                model.analysisIdentityKey == value || model.analysisID == analysisKey || model.recordID == recordKey
-            }
+            try rejectDuplicate(
+                TelemetryWorkoutAnalysisV1.self,
+                key: identityKey,
+                predicate: #Predicate { $0.analysisIdentityKey == identityKey }
+            )
+            try rejectDuplicate(
+                TelemetryWorkoutAnalysisV1.self,
+                key: analysisKey,
+                predicate: #Predicate { $0.analysisID == analysisKey }
+            )
+            try rejectDuplicate(
+                TelemetryWorkoutAnalysisV1.self,
+                key: recordKey,
+                predicate: #Predicate { $0.recordID == recordKey }
+            )
             modelContext.insert(
                 TelemetryWorkoutAnalysisV1(
                     analysisID: analysisKey,
@@ -562,13 +632,14 @@ public actor TelemetryStore {
         return created
     }
 
-    private func requireAbsent<Model: PersistentModel>(
-        _ type: Model.Type,
+    private func rejectDuplicate<Model: PersistentModel>(
+        _: Model.Type,
         key: String,
-        matches: (Model, String) -> Bool
+        predicate: Predicate<Model>
     ) throws {
-        let models = try modelContext.fetch(FetchDescriptor<Model>())
-        guard !models.contains(where: { matches($0, key) }) else {
+        var descriptor = FetchDescriptor<Model>(predicate: predicate)
+        descriptor.fetchLimit = 1
+        guard try modelContext.fetch(descriptor).isEmpty else {
             throw TelemetryStoreError.duplicateStableIdentity(key)
         }
     }
@@ -622,6 +693,16 @@ private extension TelemetryStore {
     static func sourceStableIdentityKey(_ source: SignalSourceIdentity) throws -> String {
         let providerIdentity = try encode(source.providerKind).base64EncodedString()
         return "\(providerIdentity)|\(source.stableLocalKey)"
+    }
+
+    static func heartRateNativeSampleIdentityKey(
+        sourceStableIdentityKey: String,
+        providerSampleIdentity: ProviderNativeSampleIdentity
+    ) throws -> String {
+        try encode([
+            sourceStableIdentityKey,
+            providerSampleIdentity.identifier,
+        ]).base64EncodedString()
     }
 
     static func frameIdentityKey(sessionID: SessionID, elapsedSecond: Int64) -> String {
@@ -735,6 +816,23 @@ private extension TelemetryStore {
         else {
             throw TelemetryStoreError.corruptStoredRecord(model.observationID)
         }
+        let providerSampleIdentity: ProviderNativeSampleIdentity?
+        if let identifier = model.providerSampleIdentifier {
+            guard let identity = ProviderNativeSampleIdentity(identifier: identifier),
+                  model.nativeSampleIdentityKey == (try heartRateNativeSampleIdentityKey(
+                      sourceStableIdentityKey: source.stableIdentityKey,
+                      providerSampleIdentity: identity
+                  ))
+            else {
+                throw TelemetryStoreError.corruptStoredRecord(model.observationID)
+            }
+            providerSampleIdentity = identity
+        } else {
+            guard model.nativeSampleIdentityKey == nil else {
+                throw TelemetryStoreError.corruptStoredRecord(model.observationID)
+            }
+            providerSampleIdentity = nil
+        }
         return HeartRateObservation(
             recordID: try uuid(model.recordID, as: RecordIDTag.self),
             observationID: try uuid(model.observationID, as: ObservationIDTag.self),
@@ -743,7 +841,7 @@ private extension TelemetryStore {
             beatsPerMinute: bpm,
             arrivalOrder: arrivalOrder,
             providerSequence: model.providerSequence,
-            providerSampleIdentifier: model.providerSampleIdentifier,
+            providerSampleIdentity: providerSampleIdentity,
             timestamp: observationTimestamp(
                 measuredAt: model.measuredAt,
                 receivedAt: model.receivedAt,
@@ -833,7 +931,7 @@ private extension TelemetryStore {
         guard payload.kind == kind else {
             throw TelemetryStoreError.corruptStoredRecord(model.recordID)
         }
-        return WorkoutEvent(
+        let event = WorkoutEvent(
             recordID: try uuid(model.recordID, as: RecordIDTag.self),
             sessionID: try uuid(model.sessionID, as: SessionIDTag.self),
             timestamp: EventTimestamp(
@@ -843,14 +941,18 @@ private extension TelemetryStore {
                 recordedElapsed: ElapsedDuration(microseconds: model.recordedElapsedMicroseconds)
             ),
             sourceID: try model.sourceID.map { try uuid($0, as: SourceIDTag.self) },
-            decisionID: try model.decisionID.map { try uuid($0, as: DecisionIDTag.self) },
-            commandID: try model.commandID.map { try uuid($0, as: CommandIDTag.self) },
-            attemptID: try model.attemptID.map { try uuid($0, as: CommandAttemptIDTag.self) },
             payload: EventPayloadEnvelope(
                 schemaVersion: payloadVersion,
                 payload: payload
             )
         )
+        guard model.decisionID == event.decisionID?.description,
+              model.commandID == event.commandID?.description,
+              model.attemptID == event.attemptID?.description
+        else {
+            throw TelemetryStoreError.corruptStoredRecord(model.recordID)
+        }
+        return event
     }
 
     static func domainFrame(_ model: TelemetryWorkoutFrameV1) throws -> CanonicalFrame {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStoreFilePolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStoreFilePolicy.swift
@@ -59,14 +59,15 @@ public enum TelemetryStoreFilePolicy {
             fileManager: fileManager
         )
         for url in discovered {
-            var values = URLResourceValues()
-            values.isExcludedFromBackup = true
-            var mutableURL = url
-            try mutableURL.setResourceValues(values)
             try fileManager.setAttributes(
                 [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
                 ofItemAtPath: url.path
             )
+            // Apply backup exclusion last because other file-attribute updates may reset it.
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            var mutableURL = url
+            try mutableURL.setResourceValues(values)
         }
         return TelemetryStoreFilePolicyResult(
             protectedURLs: discovered,

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStoreFilePolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStoreFilePolicy.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+public enum TelemetryStoreLocation {
+    public static func applicationSupportStoreURL(
+        appIdentifier: String,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        let applicationSupport = try fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        )
+        return applicationSupport
+            .appendingPathComponent(appIdentifier, isDirectory: true)
+            .appendingPathComponent("TelemetryV2", isDirectory: true)
+            .appendingPathComponent("TelemetryV2.store", isDirectory: false)
+    }
+}
+
+public struct TelemetryStoreFilePolicyResult: Sendable, Equatable {
+    public let protectedURLs: [URL]
+    public let deviceVerificationRequired: Bool
+
+    public init(protectedURLs: [URL], deviceVerificationRequired: Bool) {
+        self.protectedURLs = protectedURLs
+        self.deviceVerificationRequired = deviceVerificationRequired
+    }
+}
+
+public enum TelemetryStoreFilePolicy {
+    public static func discoveredStoreFiles(
+        primaryStoreURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> [URL] {
+        let directory = primaryStoreURL.deletingLastPathComponent()
+        let primaryName = primaryStoreURL.lastPathComponent
+        let contents = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+        return contents
+            .filter { url in
+                let name = url.lastPathComponent
+                return name == primaryName
+                    || name.hasPrefix(primaryName + "-")
+                    || name.hasPrefix(primaryName + ".")
+            }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    public static func applyRequiredAttributes(
+        primaryStoreURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> TelemetryStoreFilePolicyResult {
+        let discovered = try discoveredStoreFiles(
+            primaryStoreURL: primaryStoreURL,
+            fileManager: fileManager
+        )
+        for url in discovered {
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            var mutableURL = url
+            try mutableURL.setResourceValues(values)
+            try fileManager.setAttributes(
+                [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+                ofItemAtPath: url.path
+            )
+        }
+        return TelemetryStoreFilePolicyResult(
+            protectedURLs: discovered,
+            deviceVerificationRequired: true
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/EventSessionAndAnalysisTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/EventSessionAndAnalysisTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import TelemetryDomain
+import XCTest
+
+final class EventSessionAndAnalysisTests: XCTestCase {
+    func testControlDecisionPreservesActualObservationReferencesAndContext() throws {
+        let decision = makeDecision()
+
+        XCTAssertEqual(decision.observationsUsed, [.heartRate(TelemetryDomainFixtures.observationID)])
+        XCTAssertEqual(decision.configurationSnapshotID, TelemetryDomainFixtures.configurationID)
+        try assertCodableRoundTrip(decision)
+    }
+
+    func testEveryCommandLifecycleCaseRoundTripsWithCausalIDs() throws {
+        let commandID = CommandID()
+        let decisionID = DecisionID()
+        let firstAttempt = CommandAttemptID()
+        let secondAttempt = CommandAttemptID()
+        let cases: [CommandLifecycle] = [
+            .enqueued(kind: .setSpeed(CommandedSpeed(nativeValue: 50, nativeUnit: .controllerNative(code: "tenths")))),
+            .sendAttempt(attemptID: firstAttempt, attemptNumber: 1),
+            .acknowledged(attemptID: firstAttempt),
+            .timedOut(attemptID: firstAttempt),
+            .retryScheduled(
+                previousAttemptID: firstAttempt,
+                nextAttemptID: secondAttempt,
+                nextAttemptNumber: 2
+            ),
+            .cancelled(reason: .sessionEnded),
+            .failed(attemptID: secondAttempt, reason: .transportUnavailable),
+        ]
+
+        for lifecycle in cases {
+            try assertCodableRoundTrip(
+                CommandLifecycleRecord(
+                    commandID: commandID,
+                    decisionID: decisionID,
+                    lifecycle: lifecycle
+                )
+            )
+        }
+    }
+
+    func testTypedEventPayloadTaxonomyRoundTripsWithoutSparseUniversalFields() throws {
+        let payloads: [(WorkoutEventKind, WorkoutEventPayload)] = [
+            (.sessionLifecycle, .sessionLifecycle(SessionLifecycleEvent(previous: .created, current: .running))),
+            (.workoutPhase, .workoutPhase(WorkoutPhaseTransition(previous: .warmup, current: .main))),
+            (.sourceTransition, .sourceTransition(SourceTransition(previousSourceID: nil, currentSourceID: TelemetryDomainFixtures.sourceID, reason: "selected"))),
+            (.connectionTransition, .connectionTransition(ConnectionTransition(previous: .connecting, current: .connected))),
+            (.controlDecision, .controlDecision(makeDecision())),
+            (.commandLifecycle, .commandLifecycle(CommandLifecycleRecord(commandID: CommandID(), decisionID: nil, lifecycle: .enqueued(kind: .stop)))),
+            (.cooldown, .cooldown(CooldownEvent(lifecycle: .started, targetHeartRate: 100))),
+            (.manualStop, .manualStop(ManualStopEvent(reason: "user"))),
+            (.safety, .safety(SafetyEvent(policy: TelemetryDomainFixtures.versions.safetyPolicy, gate: "stale-hr", outcome: .blocked, evidence: []))),
+            (.stopEvidence, .stopEvidence(StopEvidenceEvent(conclusion: .unconfirmed(reason: "missing factual evidence"), freshness: nil, deviceState: nil, factualSpeed: nil))),
+            (.recorderHealth, .recorderHealth(RecorderHealthEvent(kind: .loss, affectedRecordClass: "native", count: 2))),
+        ]
+
+        for (offset, entry) in payloads.enumerated() {
+            let event = WorkoutEvent(
+                recordID: RecordID(),
+                sessionID: TelemetryDomainFixtures.sessionID,
+                timestamp: EventTimestamp(
+                    occurredAt: TelemetryDomainFixtures.baseDate.addingTimeInterval(Double(offset)),
+                    recordedAt: TelemetryDomainFixtures.baseDate.addingTimeInterval(Double(offset) + 0.01),
+                    occurredElapsed: ElapsedDuration(microseconds: Int64(offset) * 1_000_000),
+                    recordedElapsed: ElapsedDuration(microseconds: Int64(offset) * 1_000_000 + 10_000)
+                ),
+                payload: EventPayloadEnvelope(schemaVersion: 1, payload: entry.1)
+            )
+            XCTAssertEqual(event.kind, entry.0)
+            try assertCodableRoundTrip(event)
+        }
+    }
+
+    func testWorkoutSessionAndAnalysisRoundTrip() throws {
+        let session = WorkoutSessionRecord(
+            recordID: RecordID(),
+            sessionID: TelemetryDomainFixtures.sessionID,
+            profileLocalIdentifier: "profile-local-1",
+            lifecycleState: .completed,
+            workoutMode: .heartRateControlled,
+            startedAt: TelemetryDomainFixtures.baseDate,
+            endedAt: TelemetryDomainFixtures.baseDate.addingTimeInterval(1_800),
+            endedElapsed: ElapsedDuration(microseconds: 1_800_000_000),
+            incompleteReason: nil,
+            appContext: AppRuntimeContext(
+                appVersion: "1.0",
+                buildNumber: "42",
+                operatingSystemVersion: "iOS 26.0"
+            ),
+            versions: TelemetryDomainFixtures.versions,
+            configuration: TelemetryDomainFixtures.configuration,
+            healthKitWorkoutIdentifier: nil,
+            treadmill: KnownTreadmillMetadata(model: "known-model", protocolName: "known-protocol"),
+            recorderHealth: RecorderHealthSummary(
+                isComplete: true,
+                lostCriticalRecordCount: 0,
+                lostNativeRecordCount: 0,
+                lastPersistedElapsed: ElapsedDuration(microseconds: 1_800_000_000)
+            )
+        )
+        let analysis = WorkoutAnalysisResult(
+            analysisID: AnalysisID(),
+            recordID: RecordID(),
+            sessionID: session.sessionID,
+            analyzerVersion: AnalyzerVersion(rawValue: "analyzer-v1"),
+            evidenceHash: ContentHash(
+                algorithm: .sha256,
+                lowercaseHexDigest: String(repeating: "b", count: 64)
+            ),
+            generatedAt: TelemetryDomainFixtures.baseDate.addingTimeInterval(1_900),
+            qualityGrade: .high,
+            exclusions: [],
+            keyMetrics: AnalysisKeyMetrics(
+                coveredDuration: ElapsedDuration(microseconds: 1_700_000_000),
+                averageHeartRate: 122.4,
+                maximumHeartRate: 145,
+                averageFactualSpeedKilometresPerHour: 5.7
+            ),
+            detailSchemaVersion: 1,
+            versionedDetailPayload: Data(#"{"metric":"value"}"#.utf8)
+        )
+
+        try assertCodableRoundTrip(session)
+        try assertCodableRoundTrip(analysis)
+    }
+
+    private func makeDecision() -> ControlDecision {
+        ControlDecision(
+            decisionID: DecisionID(),
+            observationsUsed: [.heartRate(TelemetryDomainFixtures.observationID)],
+            target: .heartRate(beatsPerMinute: 120),
+            action: .enqueueSpeed(DesiredSpeedKilometresPerHour(value: 5.5)),
+            reason: .aboveTarget,
+            versions: TelemetryDomainFixtures.versions,
+            configurationSnapshotID: TelemetryDomainFixtures.configurationID
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/EventSessionAndAnalysisTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/EventSessionAndAnalysisTests.swift
@@ -16,28 +16,100 @@ final class EventSessionAndAnalysisTests: XCTestCase {
         let decisionID = DecisionID()
         let firstAttempt = CommandAttemptID()
         let secondAttempt = CommandAttemptID()
-        let cases: [CommandLifecycle] = [
-            .enqueued(kind: .setSpeed(CommandedSpeed(nativeValue: 50, nativeUnit: .controllerNative(code: "tenths")))),
-            .sendAttempt(attemptID: firstAttempt, attemptNumber: 1),
-            .acknowledged(attemptID: firstAttempt),
-            .timedOut(attemptID: firstAttempt),
-            .retryScheduled(
+        let cases: [(CommandLifecycle, CommandAttemptID?)] = [
+            (
+                .enqueued(kind: .setSpeed(CommandedSpeed(nativeValue: 50, nativeUnit: .controllerNative(code: "tenths")))),
+                nil
+            ),
+            (.sendAttempt(attemptID: firstAttempt, attemptNumber: 1), firstAttempt),
+            (.acknowledged(attemptID: firstAttempt), firstAttempt),
+            (.timedOut(attemptID: firstAttempt), firstAttempt),
+            (
+                .retryScheduled(
                 previousAttemptID: firstAttempt,
                 nextAttemptID: secondAttempt,
                 nextAttemptNumber: 2
+                ),
+                secondAttempt
             ),
-            .cancelled(reason: .sessionEnded),
-            .failed(attemptID: secondAttempt, reason: .transportUnavailable),
+            (.cancelled(reason: .sessionEnded), nil),
+            (.failed(attemptID: secondAttempt, reason: .transportUnavailable), secondAttempt),
+            (.failed(attemptID: nil, reason: .encodingFailed), nil),
         ]
 
-        for lifecycle in cases {
-            try assertCodableRoundTrip(
-                CommandLifecycleRecord(
+        for (offset, entry) in cases.enumerated() {
+            let event = makeEvent(
+                payload: .commandLifecycle(CommandLifecycleRecord(
                     commandID: commandID,
-                    decisionID: decisionID,
-                    lifecycle: lifecycle
-                )
+                    decisionID: offset == 0 ? nil : decisionID,
+                    lifecycle: entry.0
+                ))
             )
+            XCTAssertEqual(event.commandID, commandID)
+            XCTAssertEqual(event.decisionID, offset == 0 ? nil : decisionID)
+            XCTAssertEqual(event.attemptID, entry.1)
+            try assertCodableRoundTrip(event)
+        }
+    }
+
+    func testControlDecisionEventDerivesDecisionIDFromPayload() throws {
+        let decision = makeDecision()
+        let event = makeEvent(payload: .controlDecision(decision))
+
+        XCTAssertEqual(event.decisionID, decision.decisionID)
+        XCTAssertNil(event.commandID)
+        XCTAssertNil(event.attemptID)
+        try assertCodableRoundTrip(event)
+    }
+
+    func testWorkoutEventDecodingRejectsContradictoryCausalIDs() throws {
+        let decision = makeDecision()
+        let controlEvent = makeEvent(payload: .controlDecision(decision))
+        let commandID = CommandID()
+        let decisionID = DecisionID()
+        let previousAttemptID = CommandAttemptID()
+        let nextAttemptID = CommandAttemptID()
+        let retryEvent = makeEvent(
+            payload: .commandLifecycle(CommandLifecycleRecord(
+                commandID: commandID,
+                decisionID: decisionID,
+                lifecycle: .retryScheduled(
+                    previousAttemptID: previousAttemptID,
+                    nextAttemptID: nextAttemptID,
+                    nextAttemptNumber: 2
+                )
+            ))
+        )
+        let contradictions = [
+            WorkoutEventCodingFixture(
+                event: controlEvent,
+                decisionID: DecisionID(),
+                commandID: controlEvent.commandID,
+                attemptID: controlEvent.attemptID
+            ),
+            WorkoutEventCodingFixture(
+                event: retryEvent,
+                decisionID: retryEvent.decisionID,
+                commandID: CommandID(),
+                attemptID: retryEvent.attemptID
+            ),
+            WorkoutEventCodingFixture(
+                event: retryEvent,
+                decisionID: nil,
+                commandID: retryEvent.commandID,
+                attemptID: retryEvent.attemptID
+            ),
+            WorkoutEventCodingFixture(
+                event: retryEvent,
+                decisionID: retryEvent.decisionID,
+                commandID: retryEvent.commandID,
+                attemptID: previousAttemptID
+            ),
+        ]
+
+        for contradiction in contradictions {
+            let data = try JSONEncoder().encode(contradiction)
+            XCTAssertThrowsError(try JSONDecoder().decode(WorkoutEvent.self, from: data))
         }
     }
 
@@ -136,5 +208,48 @@ final class EventSessionAndAnalysisTests: XCTestCase {
             versions: TelemetryDomainFixtures.versions,
             configurationSnapshotID: TelemetryDomainFixtures.configurationID
         )
+    }
+
+    private func makeEvent(payload: WorkoutEventPayload) -> WorkoutEvent {
+        WorkoutEvent(
+            recordID: RecordID(),
+            sessionID: TelemetryDomainFixtures.sessionID,
+            timestamp: EventTimestamp(
+                occurredAt: TelemetryDomainFixtures.baseDate,
+                recordedAt: TelemetryDomainFixtures.baseDate.addingTimeInterval(0.01),
+                occurredElapsed: ElapsedDuration(microseconds: 1_000_000),
+                recordedElapsed: ElapsedDuration(microseconds: 1_010_000)
+            ),
+            payload: EventPayloadEnvelope(schemaVersion: 1, payload: payload)
+        )
+    }
+}
+
+private struct WorkoutEventCodingFixture: Encodable {
+    let recordID: RecordID
+    let sessionID: SessionID
+    let kind: WorkoutEventKind
+    let timestamp: EventTimestamp
+    let sourceID: SourceID?
+    let decisionID: DecisionID?
+    let commandID: CommandID?
+    let attemptID: CommandAttemptID?
+    let payload: EventPayloadEnvelope
+
+    init(
+        event: WorkoutEvent,
+        decisionID: DecisionID?,
+        commandID: CommandID?,
+        attemptID: CommandAttemptID?
+    ) {
+        recordID = event.recordID
+        sessionID = event.sessionID
+        kind = event.kind
+        timestamp = event.timestamp
+        sourceID = event.sourceID
+        self.decisionID = decisionID
+        self.commandID = commandID
+        self.attemptID = attemptID
+        payload = event.payload
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/IdentifiersTimeAndProvenanceTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/IdentifiersTimeAndProvenanceTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import TelemetryDomain
+import XCTest
+
+final class IdentifiersTimeAndProvenanceTests: XCTestCase {
+    func testTypedIdentifiersKeepDomainsDistinct() throws {
+        let raw = UUID(uuidString: "00000000-0000-0000-0000-000000000099")!
+        let session = SessionID(rawValue: raw)
+        let record = RecordID(rawValue: raw)
+
+        func acceptsOnlySession(_ value: SessionID) -> UUID { value.rawValue }
+        func acceptsOnlyRecord(_ value: RecordID) -> UUID { value.rawValue }
+
+        XCTAssertEqual(acceptsOnlySession(session), raw)
+        XCTAssertEqual(acceptsOnlyRecord(record), raw)
+        XCTAssertEqual(session.description, raw.uuidString.lowercased())
+        try assertCodableRoundTrip(session)
+        try assertCodableRoundTrip(record)
+    }
+
+    func testElapsedDurationPreservesSignedMicrosecondsAndOrdersExactly() throws {
+        let beforeOrigin = ElapsedDuration(microseconds: -1)
+        let received = ElapsedDuration(microseconds: 1_234_567)
+        let later = ElapsedDuration(microseconds: 1_234_568)
+
+        XCTAssertLessThan(beforeOrigin, received)
+        XCTAssertLessThan(received, later)
+        XCTAssertEqual(received.seconds, 1.234_567, accuracy: 0.000_000_1)
+        try assertCodableRoundTrip(received)
+    }
+
+    func testElapsedDurationRejectsOverflowingMillisecondConversion() {
+        XCTAssertEqual(ElapsedDuration(milliseconds: 1_234)?.microseconds, 1_234_000)
+        XCTAssertNil(ElapsedDuration(milliseconds: Int64.max))
+        XCTAssertNil(ElapsedDuration(milliseconds: Int64.min))
+    }
+
+    func testMeasuredReceivedAndRecordedRolesRemainDistinct() throws {
+        let timestamp = TelemetryDomainFixtures.observationTimestamp
+
+        XCTAssertEqual(timestamp.effectiveElapsed, timestamp.measuredElapsed)
+        XCTAssertLessThan(timestamp.measuredAt!, timestamp.receivedAt)
+        XCTAssertLessThan(timestamp.receivedAt, timestamp.recordedAt)
+        XCTAssertNotEqual(timestamp.receivedElapsed, timestamp.recordedElapsed)
+        try assertCodableRoundTrip(timestamp)
+
+        let receiveFallback = ObservationTimestamp(
+            measuredAt: nil,
+            receivedAt: TelemetryDomainFixtures.baseDate,
+            recordedAt: TelemetryDomainFixtures.baseDate,
+            measuredElapsed: nil,
+            receivedElapsed: ElapsedDuration(microseconds: 9),
+            recordedElapsed: ElapsedDuration(microseconds: 10)
+        )
+        XCTAssertEqual(receiveFallback.effectiveElapsed, receiveFallback.receivedElapsed)
+    }
+
+    func testQualityFlagsEncodeDeterministicallyAndRemainAdditive() throws {
+        let first: QualityFlags = [.staleAtUse, .missingSource, .clockRegression]
+        let second: QualityFlags = [.clockRegression, .staleAtUse, .missingSource]
+        let encoder = JSONEncoder()
+
+        XCTAssertEqual(first, second)
+        XCTAssertTrue(first.contains(.missingSource))
+        XCTAssertEqual(try encoder.encode(first), try encoder.encode(second))
+        try assertCodableRoundTrip(first)
+    }
+
+    func testUnknownSourceDoesNotInventPhysicalMetadata() throws {
+        let unknown = SignalSourceIdentity(
+            id: SourceID(),
+            providerKind: .unknown,
+            stableLocalKey: "unknown-provider",
+            savingSource: nil,
+            knownDevice: nil
+        )
+
+        XCTAssertNil(unknown.savingSource)
+        XCTAssertNil(unknown.knownDevice)
+        try assertCodableRoundTrip(unknown)
+    }
+
+    func testConfigurationAndVersionTypesRoundTrip() throws {
+        try assertCodableRoundTrip(TelemetryDomainFixtures.versions)
+        try assertCodableRoundTrip(TelemetryDomainFixtures.configuration)
+        try assertCodableRoundTrip(
+            AppRuntimeContext(
+                appVersion: "1.0",
+                buildNumber: "42",
+                operatingSystemVersion: "iOS 26.0",
+                deviceModel: nil
+            )
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/ObservationAndFrameTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/ObservationAndFrameTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import TelemetryDomain
+import XCTest
+
+final class ObservationAndFrameTests: XCTestCase {
+    func testHeartRateCarriesArrivalQualityAndActualControlUse() throws {
+        let observation = TelemetryDomainFixtures.heartRate
+
+        XCTAssertEqual(observation.arrivalOrder, 7)
+        XCTAssertTrue(observation.quality.contains(.measurementOutOfArrivalOrder))
+        XCTAssertTrue(observation.controlUse.acceptedForControl)
+        XCTAssertTrue(observation.controlUse.usedForControl)
+        try assertCodableRoundTrip(observation)
+    }
+
+    func testMissingFactualSpeedStaysUnavailableForUnknownNativeUnit() throws {
+        let native = NativeTreadmillSpeed(value: 8, unit: .unknown)
+        let factual = FactualSpeedKilometresPerHour.normalized(
+            from: native,
+            provenance: .reportedByProvider
+        )
+        let observation = makeTreadmill(native: native)
+
+        XCTAssertNil(factual)
+        XCTAssertNil(observation.factualSpeed)
+        try assertCodableRoundTrip(observation)
+    }
+
+    func testKnownNativeUnitProducesExplicitFactualConversion() {
+        let metric = FactualSpeedKilometresPerHour.normalized(
+            from: NativeTreadmillSpeed(value: 6.2, unit: .kilometresPerHour),
+            provenance: .decodedDeviceReport
+        )
+        let imperial = FactualSpeedKilometresPerHour.normalized(
+            from: NativeTreadmillSpeed(value: 4, unit: .milesPerHour),
+            provenance: .reportedByProvider
+        )
+
+        XCTAssertEqual(metric?.value, 6.2)
+        XCTAssertEqual(imperial?.value ?? 0, 6.437_376, accuracy: 0.000_001)
+    }
+
+    func testFactualSpeedDecodingRejectsInvalidValue() throws {
+        let invalid = Data(
+            #"{"value":-1,"provenance":"decodedDeviceReport"}"#.utf8
+        )
+
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(FactualSpeedKilometresPerHour.self, from: invalid)
+        )
+    }
+
+    func testDesiredCommandedAndEstimatedSpeedRemainSeparateTypes() throws {
+        let desired = DesiredSpeedKilometresPerHour(value: 5.5)
+        let commanded = CommandedSpeed(nativeValue: 55, nativeUnit: .controllerNative(code: "tenths"))
+        let estimated = EstimatedSpeedKilometresPerHour(
+            value: 5.4,
+            method: "last-command",
+            version: "1"
+        )
+
+        XCTAssertNil(
+            FactualSpeedKilometresPerHour.normalized(
+                from: NativeTreadmillSpeed(value: commanded.nativeValue, unit: commanded.nativeUnit),
+                provenance: .reportedByProvider
+            )
+        )
+        try assertCodableRoundTrip(desired)
+        try assertCodableRoundTrip(commanded)
+        try assertCodableRoundTrip(estimated)
+    }
+
+    func testCanonicalFrameReferencesEvidenceWithoutCreatingObservation() throws {
+        let observation = TelemetryDomainFixtures.heartRate
+        let evidence = HeartRateFrameEvidence(
+            observationID: observation.observationID,
+            recordID: observation.recordID,
+            sourceID: observation.source.id,
+            beatsPerMinute: observation.beatsPerMinute,
+            measuredAt: observation.timestamp.measuredAt,
+            receivedAt: observation.timestamp.receivedAt,
+            evidenceElapsed: observation.timestamp.effectiveElapsed,
+            ageAtMaterialization: ElapsedDuration(microseconds: 790_000),
+            freshness: .fresh,
+            provenance: observation.provenance
+        )
+        let frame = CanonicalFrame(
+            frameID: FrameID(),
+            recordID: RecordID(),
+            sessionID: observation.sessionID,
+            canonicalElapsedSecond: 2,
+            materializedAt: RecordTimestamp(
+                recordedAt: TelemetryDomainFixtures.baseDate.addingTimeInterval(2),
+                elapsed: ElapsedDuration(microseconds: 2_000_000)
+            ),
+            heartRateEvidence: evidence,
+            treadmillEvidence: nil,
+            precedingGap: CanonicalGapBoundary(
+                missingSinceElapsedSecond: 0,
+                kind: .runtimeSuspensionOrStall
+            )
+        )
+
+        XCTAssertEqual(frame.heartRateEvidence?.observationID, observation.observationID)
+        XCTAssertEqual(frame.heartRateEvidence?.receivedAt, observation.timestamp.receivedAt)
+        XCTAssertEqual(frame.precedingGap?.missingSinceElapsedSecond, 0)
+        XCTAssertEqual(frame.canonicalElapsedSecond, 2)
+        try assertCodableRoundTrip(frame)
+    }
+
+    private func makeTreadmill(native: NativeTreadmillSpeed) -> TreadmillObservation {
+        TreadmillObservation(
+            recordID: RecordID(),
+            observationID: ObservationID(),
+            sessionID: TelemetryDomainFixtures.sessionID,
+            source: SignalSourceIdentity(
+                id: SourceID(),
+                providerKind: .treadmillProtocol,
+                stableLocalKey: "test-treadmill"
+            ),
+            nativeSpeed: native,
+            deviceState: .unknown,
+            arrivalOrder: 1,
+            timestamp: TelemetryDomainFixtures.observationTimestamp,
+            provenance: .reportedByProvider,
+            freshness: TelemetryDomainFixtures.freshness,
+            quality: []
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/ObservationAndFrameTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/ObservationAndFrameTests.swift
@@ -52,6 +52,22 @@ final class ObservationAndFrameTests: XCTestCase {
         )
     }
 
+    func testTreadmillDecodingRejectsFactualSpeedForUnknownNativeUnit() throws {
+        let valid = makeTreadmill(
+            native: NativeTreadmillSpeed(value: 6.2, unit: .kilometresPerHour)
+        )
+        let encoded = try JSONEncoder().encode(valid)
+        let json = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertTrue(json.contains("kilometresPerHour"))
+        let contradictory = Data(
+            json.replacingOccurrences(of: "kilometresPerHour", with: "unknown").utf8
+        )
+
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(TreadmillObservation.self, from: contradictory)
+        )
+    }
+
     func testDesiredCommandedAndEstimatedSpeedRemainSeparateTypes() throws {
         let desired = DesiredSpeedKilometresPerHour(value: 5.5)
         let commanded = CommandedSpeed(nativeValue: 55, nativeUnit: .controllerNative(code: "tenths"))

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/ObservationAndFrameTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/ObservationAndFrameTests.swift
@@ -38,11 +38,13 @@ final class ObservationAndFrameTests: XCTestCase {
 
         XCTAssertEqual(metric?.value, 6.2)
         XCTAssertEqual(imperial?.value ?? 0, 6.437_376, accuracy: 0.000_001)
+        XCTAssertEqual(metric?.normalizationRule, .nativeToKilometresPerHourV1)
+        XCTAssertEqual(imperial?.normalizationRule, .nativeToKilometresPerHourV1)
     }
 
     func testFactualSpeedDecodingRejectsInvalidValue() throws {
         let invalid = Data(
-            #"{"value":-1,"provenance":"decodedDeviceReport"}"#.utf8
+            #"{"value":-1,"provenance":"decodedDeviceReport","normalizationRule":"nativeToKilometresPerHourV1"}"#.utf8
         )
 
         XCTAssertThrowsError(

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/ObservationAndFrameTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/ObservationAndFrameTests.swift
@@ -13,6 +13,20 @@ final class ObservationAndFrameTests: XCTestCase {
         try assertCodableRoundTrip(observation)
     }
 
+    func testProviderNativeSampleIdentityRequiresAnExactNonEmptyValue() throws {
+        XCTAssertNil(ProviderNativeSampleIdentity(identifier: ""))
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(
+                ProviderNativeSampleIdentity.self,
+                from: Data("\"\"".utf8)
+            )
+        )
+        let identity = try XCTUnwrap(
+            ProviderNativeSampleIdentity(identifier: "provider-native-sample-1")
+        )
+        try assertCodableRoundTrip(identity)
+    }
+
     func testMissingFactualSpeedStaysUnavailableForUnknownNativeUnit() throws {
         let native = NativeTreadmillSpeed(value: 8, unit: .unknown)
         let factual = FactualSpeedKilometresPerHour.normalized(

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/TelemetryDomainTestSupport.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/TelemetryDomainTestSupport.swift
@@ -1,0 +1,88 @@
+import Foundation
+import TelemetryDomain
+import XCTest
+
+enum TelemetryDomainFixtures {
+    static let baseDate = Date(timeIntervalSince1970: 1_800_000_000)
+    static let sessionID = SessionID(rawValue: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    static let sourceID = SourceID(rawValue: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    static let observationID = ObservationID(rawValue: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!)
+    static let recordID = RecordID(rawValue: UUID(uuidString: "00000000-0000-0000-0000-000000000004")!)
+    static let configurationID = ConfigurationSnapshotID(
+        rawValue: UUID(uuidString: "00000000-0000-0000-0000-000000000005")!
+    )
+
+    static let versions = RuntimeVersionContext(
+        telemetrySchema: TelemetrySchemaVersion(rawValue: "2.0"),
+        algorithm: AlgorithmVersion(rawValue: "algorithm-v1"),
+        safetyPolicy: SafetyPolicyVersion(rawValue: "safety-v1"),
+        workoutProtocol: WorkoutProtocolVersion(rawValue: "workout-v1")
+    )
+
+    static let source = SignalSourceIdentity(
+        id: sourceID,
+        providerKind: .healthKitSelected,
+        stableLocalKey: "healthkit-selected",
+        savingSource: ProviderSavingSource(bundleIdentifier: "test.provider"),
+        knownDevice: nil
+    )
+
+    static let observationTimestamp = ObservationTimestamp(
+        measuredAt: baseDate,
+        receivedAt: baseDate.addingTimeInterval(0.2),
+        recordedAt: baseDate.addingTimeInterval(0.21),
+        measuredElapsed: ElapsedDuration(microseconds: 1_000_000),
+        receivedElapsed: ElapsedDuration(microseconds: 1_200_000),
+        recordedElapsed: ElapsedDuration(microseconds: 1_210_000)
+    )
+
+    static let freshness = EvidenceFreshness(
+        state: .fresh,
+        evaluatedAt: RecordTimestamp(
+            recordedAt: baseDate.addingTimeInterval(0.21),
+            elapsed: ElapsedDuration(microseconds: 1_210_000)
+        ),
+        age: ElapsedDuration(microseconds: 210_000),
+        policyVersion: versions.safetyPolicy
+    )
+
+    static let configuration = ImmutableConfigurationSnapshot(
+        id: configurationID,
+        formatVersion: 1,
+        format: .canonicalJSON,
+        canonicalPayload: Data(#"{"mode":"test"}"#.utf8),
+        contentHash: ContentHash(
+            algorithm: .sha256,
+            lowercaseHexDigest: String(repeating: "a", count: 64)
+        )
+    )
+
+    static let heartRate = HeartRateObservation(
+        recordID: recordID,
+        observationID: observationID,
+        sessionID: sessionID,
+        source: source,
+        beatsPerMinute: 123,
+        arrivalOrder: 7,
+        providerSequence: 44,
+        providerSampleIdentifier: "provider-sample-44",
+        timestamp: observationTimestamp,
+        provenance: .reportedByProvider,
+        freshness: freshness,
+        quality: [.measurementOutOfArrivalOrder, .unknownFreshness],
+        controlUse: .acceptedAndUsed
+    )
+}
+extension XCTestCase {
+    func assertCodableRoundTrip<T: Codable & Equatable>(
+        _ value: T,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(value)
+        let decoded = try JSONDecoder().decode(T.self, from: data)
+        XCTAssertEqual(decoded, value, file: file, line: line)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/TelemetryDomainTestSupport.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/TelemetryDomainTestSupport.swift
@@ -65,7 +65,7 @@ enum TelemetryDomainFixtures {
         beatsPerMinute: 123,
         arrivalOrder: 7,
         providerSequence: 44,
-        providerSampleIdentifier: "provider-sample-44",
+        providerSampleIdentity: ProviderNativeSampleIdentity(identifier: "provider-sample-44"),
         timestamp: observationTimestamp,
         provenance: .reportedByProvider,
         freshness: freshness,

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/TelemetryDomainTestSupport.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/TelemetryDomainTestSupport.swift
@@ -73,6 +73,7 @@ enum TelemetryDomainFixtures {
         controlUse: .acceptedAndUsed
     )
 }
+
 extension XCTestCase {
     func assertCodableRoundTrip<T: Codable & Equatable>(
         _ value: T,

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryPersistenceFixtures.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryPersistenceFixtures.swift
@@ -145,7 +145,8 @@ enum TelemetryPersistenceFixtures {
         seed: UInt8,
         session: WorkoutSessionRecord,
         kind: WorkoutEventKind,
-        elapsed: Int64
+        elapsed: Int64,
+        sourceID: SourceID? = nil
     ) -> WorkoutEvent {
         let payload: WorkoutEventPayload = switch kind {
         case .sessionLifecycle:
@@ -162,6 +163,7 @@ enum TelemetryPersistenceFixtures {
                 occurredElapsed: ElapsedDuration(microseconds: elapsed),
                 recordedElapsed: ElapsedDuration(microseconds: elapsed + 10_000)
             ),
+            sourceID: sourceID,
             payload: EventPayloadEnvelope(schemaVersion: 1, payload: payload)
         )
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryPersistenceFixtures.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryPersistenceFixtures.swift
@@ -1,0 +1,240 @@
+import Foundation
+import TelemetryDomain
+
+enum TelemetryPersistenceFixtures {
+    static let baseDate = Date(timeIntervalSince1970: 1_810_000_000)
+
+    static func configuration(seed: UInt8 = 1) -> ImmutableConfigurationSnapshot {
+        ImmutableConfigurationSnapshot(
+            id: ConfigurationSnapshotID(rawValue: uuid(seed)),
+            formatVersion: 1,
+            format: .canonicalJSON,
+            canonicalPayload: Data("{\"seed\":\(seed)}".utf8),
+            contentHash: ContentHash(
+                algorithm: .sha256,
+                lowercaseHexDigest: String(repeating: String(format: "%02x", seed), count: 32)
+            )
+        )
+    }
+
+    static func versions() -> RuntimeVersionContext {
+        RuntimeVersionContext(
+            telemetrySchema: TelemetrySchemaVersion(rawValue: "2.0"),
+            algorithm: AlgorithmVersion(rawValue: "algorithm-v1"),
+            safetyPolicy: SafetyPolicyVersion(rawValue: "safety-v1"),
+            workoutProtocol: WorkoutProtocolVersion(rawValue: "workout-v1")
+        )
+    }
+
+    static func session(
+        seed: UInt8,
+        profile: String = "profile-a",
+        configuration: ImmutableConfigurationSnapshot? = nil,
+        startedOffset: TimeInterval = 0
+    ) -> WorkoutSessionRecord {
+        WorkoutSessionRecord(
+            recordID: RecordID(rawValue: uuid(seed &+ 40)),
+            sessionID: SessionID(rawValue: uuid(seed)),
+            profileLocalIdentifier: profile,
+            lifecycleState: .completed,
+            workoutMode: .heartRateControlled,
+            startedAt: baseDate.addingTimeInterval(startedOffset),
+            endedAt: baseDate.addingTimeInterval(startedOffset + 600),
+            endedElapsed: ElapsedDuration(microseconds: 600_000_000),
+            incompleteReason: nil,
+            appContext: AppRuntimeContext(
+                appVersion: "1.0",
+                buildNumber: "100",
+                operatingSystemVersion: "iOS 26.0"
+            ),
+            versions: versions(),
+            configuration: configuration ?? self.configuration(seed: seed),
+            healthKitWorkoutIdentifier: nil,
+            treadmill: KnownTreadmillMetadata(model: "test-model", protocolName: "test-protocol"),
+            recorderHealth: RecorderHealthSummary(
+                isComplete: true,
+                lostCriticalRecordCount: 0,
+                lostNativeRecordCount: 0,
+                lastPersistedElapsed: ElapsedDuration(microseconds: 600_000_000)
+            )
+        )
+    }
+
+    static func source(seed: UInt8, kind: SignalProviderKind = .healthKitSelected) -> SignalSourceIdentity {
+        SignalSourceIdentity(
+            id: SourceID(rawValue: uuid(seed &+ 10)),
+            providerKind: kind,
+            stableLocalKey: "source-\(seed)",
+            savingSource: kind == .unknown ? nil : ProviderSavingSource(bundleIdentifier: "test.source.\(seed)"),
+            knownDevice: nil
+        )
+    }
+
+    static func timestamp(elapsedMicroseconds: Int64) -> ObservationTimestamp {
+        ObservationTimestamp(
+            measuredAt: baseDate.addingTimeInterval(Double(elapsedMicroseconds) / 1_000_000),
+            receivedAt: baseDate.addingTimeInterval(Double(elapsedMicroseconds + 20_000) / 1_000_000),
+            recordedAt: baseDate.addingTimeInterval(Double(elapsedMicroseconds + 30_000) / 1_000_000),
+            measuredElapsed: ElapsedDuration(microseconds: elapsedMicroseconds),
+            receivedElapsed: ElapsedDuration(microseconds: elapsedMicroseconds + 20_000),
+            recordedElapsed: ElapsedDuration(microseconds: elapsedMicroseconds + 30_000)
+        )
+    }
+
+    static func freshness(elapsedMicroseconds: Int64) -> EvidenceFreshness {
+        EvidenceFreshness(
+            state: .fresh,
+            evaluatedAt: RecordTimestamp(
+                recordedAt: baseDate.addingTimeInterval(Double(elapsedMicroseconds + 30_000) / 1_000_000),
+                elapsed: ElapsedDuration(microseconds: elapsedMicroseconds + 30_000)
+            ),
+            age: ElapsedDuration(microseconds: 30_000),
+            policyVersion: versions().safetyPolicy
+        )
+    }
+
+    static func heartRate(
+        seed: UInt8,
+        session: WorkoutSessionRecord,
+        source: SignalSourceIdentity,
+        arrivalOrder: UInt64,
+        bpm: UInt16
+    ) -> HeartRateObservation {
+        let elapsed = Int64(arrivalOrder) * 1_000_000
+        return HeartRateObservation(
+            recordID: RecordID(rawValue: uuid(seed &+ 80)),
+            observationID: ObservationID(rawValue: uuid(seed &+ 60)),
+            sessionID: session.sessionID,
+            source: source,
+            beatsPerMinute: bpm,
+            arrivalOrder: arrivalOrder,
+            providerSequence: Int64(arrivalOrder),
+            providerSampleIdentifier: "hr-\(seed)",
+            timestamp: timestamp(elapsedMicroseconds: elapsed),
+            provenance: .reportedByProvider,
+            freshness: freshness(elapsedMicroseconds: elapsed),
+            quality: arrivalOrder == 1 ? [.measurementOutOfArrivalOrder] : [],
+            controlUse: arrivalOrder == 1 ? .acceptedAndUsed : .acceptedNotUsed
+        )
+    }
+
+    static func treadmill(
+        seed: UInt8,
+        session: WorkoutSessionRecord,
+        source: SignalSourceIdentity,
+        arrivalOrder: UInt64,
+        unit: TreadmillNativeSpeedUnit
+    ) -> TreadmillObservation {
+        let elapsed = Int64(arrivalOrder) * 1_000_000
+        return TreadmillObservation(
+            recordID: RecordID(rawValue: uuid(seed &+ 100)),
+            observationID: ObservationID(rawValue: uuid(seed &+ 90)),
+            sessionID: session.sessionID,
+            source: source,
+            nativeSpeed: NativeTreadmillSpeed(value: 5.5, unit: unit),
+            deviceState: .moving,
+            arrivalOrder: arrivalOrder,
+            timestamp: timestamp(elapsedMicroseconds: elapsed),
+            provenance: .decodedDeviceReport,
+            freshness: freshness(elapsedMicroseconds: elapsed),
+            quality: []
+        )
+    }
+
+    static func event(
+        seed: UInt8,
+        session: WorkoutSessionRecord,
+        kind: WorkoutEventKind,
+        elapsed: Int64
+    ) -> WorkoutEvent {
+        let payload: WorkoutEventPayload = switch kind {
+        case .sessionLifecycle:
+            .sessionLifecycle(SessionLifecycleEvent(previous: .created, current: .running))
+        default:
+            .manualStop(ManualStopEvent(reason: "test"))
+        }
+        return WorkoutEvent(
+            recordID: RecordID(rawValue: uuid(seed &+ 120)),
+            sessionID: session.sessionID,
+            timestamp: EventTimestamp(
+                occurredAt: baseDate.addingTimeInterval(Double(elapsed) / 1_000_000),
+                recordedAt: baseDate.addingTimeInterval(Double(elapsed + 10_000) / 1_000_000),
+                occurredElapsed: ElapsedDuration(microseconds: elapsed),
+                recordedElapsed: ElapsedDuration(microseconds: elapsed + 10_000)
+            ),
+            payload: EventPayloadEnvelope(schemaVersion: 1, payload: payload)
+        )
+    }
+
+    static func frame(
+        seed: UInt8,
+        session: WorkoutSessionRecord,
+        elapsedSecond: Int64,
+        heartRate: HeartRateObservation? = nil
+    ) -> CanonicalFrame {
+        let evidence = heartRate.map {
+            HeartRateFrameEvidence(
+                observationID: $0.observationID,
+                recordID: $0.recordID,
+                sourceID: $0.source.id,
+                beatsPerMinute: $0.beatsPerMinute,
+                measuredAt: $0.timestamp.measuredAt,
+                receivedAt: $0.timestamp.receivedAt,
+                evidenceElapsed: $0.timestamp.effectiveElapsed,
+                ageAtMaterialization: ElapsedDuration(microseconds: 100_000),
+                freshness: .fresh,
+                provenance: $0.provenance
+            )
+        }
+        return CanonicalFrame(
+            frameID: FrameID(rawValue: uuid(seed &+ 130)),
+            recordID: RecordID(rawValue: uuid(seed &+ 140)),
+            sessionID: session.sessionID,
+            canonicalElapsedSecond: elapsedSecond,
+            materializedAt: RecordTimestamp(
+                recordedAt: baseDate.addingTimeInterval(Double(elapsedSecond)),
+                elapsed: ElapsedDuration(microseconds: elapsedSecond * 1_000_000)
+            ),
+            heartRateEvidence: evidence,
+            treadmillEvidence: nil,
+            precedingGap: elapsedSecond > 1
+                ? CanonicalGapBoundary(missingSinceElapsedSecond: 1, kind: .recorderOutageOrLoss)
+                : nil
+        )
+    }
+
+    static func analysis(
+        seed: UInt8,
+        session: WorkoutSessionRecord,
+        version: String
+    ) -> WorkoutAnalysisResult {
+        WorkoutAnalysisResult(
+            analysisID: AnalysisID(rawValue: uuid(seed &+ 150)),
+            recordID: RecordID(rawValue: uuid(seed &+ 160)),
+            sessionID: session.sessionID,
+            analyzerVersion: AnalyzerVersion(rawValue: version),
+            evidenceHash: ContentHash(
+                algorithm: .sha256,
+                lowercaseHexDigest: String(repeating: String(format: "%02x", seed &+ 5), count: 32)
+            ),
+            generatedAt: baseDate.addingTimeInterval(Double(seed)),
+            qualityGrade: .high,
+            exclusions: [],
+            keyMetrics: AnalysisKeyMetrics(
+                coveredDuration: ElapsedDuration(microseconds: 500_000_000),
+                averageHeartRate: 121.5,
+                maximumHeartRate: 140,
+                averageFactualSpeedKilometresPerHour: 5.5
+            ),
+            detailSchemaVersion: 1,
+            versionedDetailPayload: Data(#"{"detail":true}"#.utf8)
+        )
+    }
+
+    private static func uuid(_ byte: UInt8) -> UUID {
+        UUID(uuid: (
+            byte, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, byte
+        ))
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryPersistenceFixtures.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryPersistenceFixtures.swift
@@ -98,7 +98,9 @@ enum TelemetryPersistenceFixtures {
         session: WorkoutSessionRecord,
         source: SignalSourceIdentity,
         arrivalOrder: UInt64,
-        bpm: UInt16
+        bpm: UInt16,
+        providerSampleIdentity: ProviderNativeSampleIdentity? = nil,
+        timestamp: ObservationTimestamp? = nil
     ) -> HeartRateObservation {
         let elapsed = Int64(arrivalOrder) * 1_000_000
         return HeartRateObservation(
@@ -109,8 +111,8 @@ enum TelemetryPersistenceFixtures {
             beatsPerMinute: bpm,
             arrivalOrder: arrivalOrder,
             providerSequence: Int64(arrivalOrder),
-            providerSampleIdentifier: "hr-\(seed)",
-            timestamp: timestamp(elapsedMicroseconds: elapsed),
+            providerSampleIdentity: providerSampleIdentity,
+            timestamp: timestamp ?? self.timestamp(elapsedMicroseconds: elapsed),
             provenance: .reportedByProvider,
             freshness: freshness(elapsedMicroseconds: elapsed),
             quality: arrivalOrder == 1 ? [.measurementOutOfArrivalOrder] : [],

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetrySchemaAndBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetrySchemaAndBoundaryTests.swift
@@ -31,6 +31,9 @@ final class TelemetrySchemaAndBoundaryTests: XCTestCase {
         XCTAssertTrue(
             events.indices.contains(["binary", "sessionID", "kindKey", "occurredElapsedMicroseconds"])
         )
+
+        let treadmill = try XCTUnwrap(schema.entitiesByName["TelemetryTreadmillSampleV1"])
+        XCTAssertNotNil(treadmill.attributesByName["factualSpeedNormalizationRuleKey"])
     }
 
     func testStoreBoundaryDisablesAutosaveAndProductionSourcesDoNotInstantiateV2() async throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetrySchemaAndBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetrySchemaAndBoundaryTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import SwiftData
+import TelemetryDomain
+@testable import TelemetryPersistence
+import XCTest
+
+final class TelemetrySchemaAndBoundaryTests: XCTestCase {
+    func testVersionedSchemaMigrationPlanIndicesAndUniquenessAreRegistered() throws {
+        XCTAssertEqual(TelemetrySchemaV1.versionIdentifier, Schema.Version(1, 0, 0))
+        XCTAssertEqual(TelemetryMigrationPlan.schemas.count, 1)
+        XCTAssertTrue(TelemetryMigrationPlan.schemas[0] == TelemetrySchemaV1.self)
+        XCTAssertTrue(TelemetryMigrationPlan.stages.isEmpty)
+
+        let schema = Schema(versionedSchema: TelemetrySchemaV1.self)
+        XCTAssertEqual(schema.entities.count, 8)
+
+        let sessions = try XCTUnwrap(schema.entitiesByName["TelemetryWorkoutSessionV1"])
+        XCTAssertTrue(sessions.attributesByName["sessionID"]?.isUnique == true)
+        XCTAssertTrue(sessions.indices.contains(["binary", "startedAt"]))
+        XCTAssertTrue(
+            sessions.indices.contains(["binary", "profileLocalIdentifier", "startedAt"])
+        )
+
+        let frames = try XCTUnwrap(schema.entitiesByName["TelemetryWorkoutFrameV1"])
+        XCTAssertTrue(frames.attributesByName["canonicalIdentityKey"]?.isUnique == true)
+        XCTAssertTrue(
+            frames.indices.contains(["binary", "sessionID", "canonicalElapsedSecond"])
+        )
+
+        let events = try XCTUnwrap(schema.entitiesByName["TelemetryWorkoutEventV1"])
+        XCTAssertTrue(
+            events.indices.contains(["binary", "sessionID", "kindKey", "occurredElapsedMicroseconds"])
+        )
+    }
+
+    func testStoreBoundaryDisablesAutosaveAndProductionSourcesDoNotInstantiateV2() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let autosaveEnabled = await store.isAutosaveEnabled()
+        XCTAssertFalse(autosaveEnabled)
+
+        let testFile = URL(fileURLWithPath: #filePath)
+        let packageRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let productionSourceRoot = packageRoot.appendingPathComponent("WalkingPadRemote")
+        let sourceURLs = try FileManager.default.contentsOfDirectory(
+            at: productionSourceRoot,
+            includingPropertiesForKeys: nil
+        ).filter { $0.pathExtension == "swift" }
+
+        for url in sourceURLs {
+            let source = try String(contentsOf: url, encoding: .utf8)
+            XCTAssertFalse(source.contains("TelemetryStoreFactory"), "Unexpected V2 store wiring in \(url.lastPathComponent)")
+            XCTAssertFalse(source.contains("TelemetryPersistence"), "Unexpected V2 import in \(url.lastPathComponent)")
+        }
+    }
+
+    func testFrameSchemaDoesNotRepeatConfigurationSnapshot() throws {
+        let schema = Schema(versionedSchema: TelemetrySchemaV1.self)
+        let frames = try XCTUnwrap(schema.entitiesByName["TelemetryWorkoutFrameV1"])
+        XCTAssertNil(frames.attributesByName["configurationSnapshot"])
+        XCTAssertNil(frames.relationshipsByName["configuration"])
+    }
+
+    func testApplicationSupportLocationAndSidecarDiscoveryAreExplicit() throws {
+        let url = try TelemetryStoreLocation.applicationSupportStoreURL(appIdentifier: "test.telemetry")
+        XCTAssertEqual(url.lastPathComponent, "TelemetryV2.store")
+        XCTAssertTrue(url.path.contains("Application Support/test.telemetry/TelemetryV2"))
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("telemetry-policy-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let primary = directory.appendingPathComponent("TelemetryV2.store")
+        let wal = directory.appendingPathComponent("TelemetryV2.store-wal")
+        let unrelated = directory.appendingPathComponent("other.store")
+        try Data().write(to: primary)
+        try Data().write(to: wal)
+        try Data().write(to: unrelated)
+
+        let discovered = try TelemetryStoreFilePolicy.discoveredStoreFiles(primaryStoreURL: primary)
+        XCTAssertEqual(discovered.map(\.lastPathComponent), ["TelemetryV2.store", "TelemetryV2.store-wal"])
+
+        let result = try TelemetryStoreFilePolicy.applyRequiredAttributes(primaryStoreURL: primary)
+        XCTAssertEqual(result.protectedURLs, discovered)
+        XCTAssertTrue(result.deviceVerificationRequired)
+        let resourceValues = try primary.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        XCTAssertEqual(resourceValues.isExcludedFromBackup, true)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetrySchemaAndBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetrySchemaAndBoundaryTests.swift
@@ -31,9 +31,38 @@ final class TelemetrySchemaAndBoundaryTests: XCTestCase {
         XCTAssertTrue(
             events.indices.contains(["binary", "sessionID", "kindKey", "occurredElapsedMicroseconds"])
         )
+        XCTAssertTrue(events.indices.contains(["binary", "decisionID"]))
+        XCTAssertTrue(events.indices.contains(["binary", "commandID"]))
+        XCTAssertTrue(events.indices.contains(["binary", "attemptID"]))
+
+        let heartRate = try XCTUnwrap(schema.entitiesByName["TelemetryHeartRateSampleV1"])
+        XCTAssertTrue(heartRate.indices.contains(["binary", "nativeSampleIdentityKey"]))
 
         let treadmill = try XCTUnwrap(schema.entitiesByName["TelemetryTreadmillSampleV1"])
         XCTAssertNotNil(treadmill.attributesByName["factualSpeedNormalizationRuleKey"])
+    }
+
+    func testInsertDuplicatePreflightsAreBoundedPredicates() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let packageRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let storeURL = packageRoot
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("TelemetryPersistence")
+            .appendingPathComponent("TelemetryStore.swift")
+        let source = try String(contentsOf: storeURL, encoding: .utf8)
+
+        XCTAssertFalse(source.contains("requireAbsent"))
+        XCTAssertFalse(source.contains("modelContext.fetch(FetchDescriptor<Model>())"))
+        XCTAssertTrue(source.contains("private func rejectDuplicate<Model: PersistentModel>"))
+        XCTAssertTrue(source.contains("descriptor.fetchLimit = 1"))
+        XCTAssertGreaterThanOrEqual(
+            source.components(separatedBy: "try rejectDuplicate(").count - 1,
+            15,
+            "Every insert identity must use the bounded duplicate preflight."
+        )
     }
 
     func testStoreBoundaryDisablesAutosaveAndProductionSourcesDoNotInstantiateV2() async throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreConfigurationTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreConfigurationTests.swift
@@ -43,25 +43,28 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
         )
         try await writer?.insertHeartRate(heartRate)
 
-        let protectedFiles = try TelemetryStoreFilePolicy.discoveredStoreFiles(
-            primaryStoreURL: storeURL
-        )
-        XCTAssertTrue(
-            protectedFiles.map { $0.resolvingSymlinksInPath().path }
-                .contains(storeURL.resolvingSymlinksInPath().path),
-            "Expected primary store at \(storeURL.path); discovered \(protectedFiles.map(\.path))"
+        let protectedFiles = try assertRequiredFilePolicy(
+            primaryStoreURL: storeURL,
+            phase: "initial writes"
         )
         for url in protectedFiles {
-            let resourceValues = try url.resourceValues(forKeys: [.isExcludedFromBackupKey])
-            XCTAssertEqual(resourceValues.isExcludedFromBackup, true)
-            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
-            XCTAssertNotNil(attributes[.protectionKey])
+            var resetValues = URLResourceValues()
+            resetValues.isExcludedFromBackup = false
+            var mutableURL = url
+            try mutableURL.setResourceValues(resetValues)
+            try FileManager.default.setAttributes(
+                [.protectionKey: FileProtectionType.none],
+                ofItemAtPath: url.path
+            )
         }
+        _ = try TelemetryStoreFilePolicy.applyRequiredAttributes(
+            primaryStoreURL: storeURL
+        )
+        _ = try assertRequiredFilePolicy(
+            primaryStoreURL: storeURL,
+            phase: "explicit reapplication after file-attribute mutation"
+        )
 
-        var resetValues = URLResourceValues()
-        resetValues.isExcludedFromBackup = false
-        var mutableStoreURL = storeURL
-        try mutableStoreURL.setResourceValues(resetValues)
         try await writer?.insertEvent(
             TelemetryPersistenceFixtures.event(
                 seed: 8,
@@ -70,13 +73,17 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
                 elapsed: 2_000_000
             )
         )
-        XCTAssertEqual(
-            try storeURL.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup,
-            true
+        _ = try assertRequiredFilePolicy(
+            primaryStoreURL: storeURL,
+            phase: "automatic policy after subsequent write"
         )
         writer = nil
 
         let reader = try TelemetryStoreFactory.make(.onDisk(storeURL))
+        _ = try assertRequiredFilePolicy(
+            primaryStoreURL: storeURL,
+            phase: "reopen"
+        )
         let sessions = try await reader.fetchSessions()
         let heartRates = try await reader.fetchHeartRate(sessionID: session.sessionID)
         let sources = try await reader.fetchSources()
@@ -242,5 +249,41 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
         let counts = try await store.counts()
         XCTAssertEqual(counts.heartRateSamples, 0)
         XCTAssertEqual(counts.sources, 0)
+    }
+
+    private func assertRequiredFilePolicy(
+        primaryStoreURL: URL,
+        phase: String
+    ) throws -> [URL] {
+        let discovered = try TelemetryStoreFilePolicy.discoveredStoreFiles(
+            primaryStoreURL: primaryStoreURL
+        )
+        let primaryName = primaryStoreURL.lastPathComponent
+        let requiredNames: Set<String> = [
+            primaryName,
+            primaryName + "-shm",
+            primaryName + "-wal",
+        ]
+        let discoveredNames = Set(discovered.map(\.lastPathComponent))
+        XCTAssertTrue(
+            requiredNames.isSubset(of: discoveredNames),
+            "\(phase): expected primary, SHM, and WAL files; discovered \(discoveredNames.sorted())"
+        )
+
+        for url in discovered {
+            let resourceValues = try url.resourceValues(forKeys: [.isExcludedFromBackupKey])
+            XCTAssertEqual(
+                resourceValues.isExcludedFromBackup,
+                true,
+                "\(phase): \(url.lastPathComponent)"
+            )
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            XCTAssertEqual(
+                attributes[.protectionKey] as? FileProtectionType,
+                .completeUntilFirstUserAuthentication,
+                "\(phase): \(url.lastPathComponent)"
+            )
+        }
+        return discovered
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreConfigurationTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreConfigurationTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import TelemetryDomain
+import TelemetryPersistence
+import XCTest
+
+final class TelemetryStoreConfigurationTests: XCTestCase {
+    func testInMemoryStoresAreIsolated() async throws {
+        let first = try TelemetryStoreFactory.make(.inMemory)
+        let second = try TelemetryStoreFactory.make(.inMemory)
+        let session = TelemetryPersistenceFixtures.session(seed: 7)
+
+        try await first.insertSession(session)
+
+        let firstSessions = try await first.fetchSessions()
+        let secondSessions = try await second.fetchSessions()
+        XCTAssertEqual(firstSessions, [session])
+        XCTAssertTrue(secondSessions.isEmpty)
+    }
+
+    func testOnDiskStoreReopensWithEquivalentEvidence() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("telemetry-reopen-\(UUID().uuidString)", isDirectory: true)
+        let storeURL = directory.appendingPathComponent("TelemetryV2.store")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let session = TelemetryPersistenceFixtures.session(seed: 8)
+        let source = TelemetryPersistenceFixtures.source(seed: 8, kind: .unknown)
+        let heartRate = TelemetryPersistenceFixtures.heartRate(
+            seed: 8,
+            session: session,
+            source: source,
+            arrivalOrder: 1,
+            bpm: 119
+        )
+
+        var writer: TelemetryStore? = try TelemetryStoreFactory.make(.onDisk(storeURL))
+        try await writer?.insertSession(session)
+        try await writer?.insertSource(
+            source,
+            firstSeen: TelemetryPersistenceFixtures.baseDate,
+            lastSeen: TelemetryPersistenceFixtures.baseDate
+        )
+        try await writer?.insertHeartRate(heartRate)
+        writer = nil
+
+        let reader = try TelemetryStoreFactory.make(.onDisk(storeURL))
+        let sessions = try await reader.fetchSessions()
+        let heartRates = try await reader.fetchHeartRate(sessionID: session.sessionID)
+        let sources = try await reader.fetchSources()
+        XCTAssertEqual(sessions, [session])
+        XCTAssertEqual(heartRates, [heartRate])
+        XCTAssertEqual(sources.map(\.identity), [source])
+    }
+
+    func testMissingRelationshipsFailWithoutCreatingFallbackRecords() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = TelemetryPersistenceFixtures.session(seed: 9)
+        let source = TelemetryPersistenceFixtures.source(seed: 9)
+        let observation = TelemetryPersistenceFixtures.heartRate(
+            seed: 9,
+            session: session,
+            source: source,
+            arrivalOrder: 1,
+            bpm: 118
+        )
+
+        do {
+            try await store.insertHeartRate(observation)
+            XCTFail("Expected missing-session failure")
+        } catch {
+            XCTAssertEqual(error as? TelemetryStoreError, .missingSession(session.sessionID))
+        }
+        let missingSessionCounts = try await store.counts()
+        XCTAssertEqual(missingSessionCounts.heartRateSamples, 0)
+
+        try await store.insertSession(session)
+        do {
+            try await store.insertHeartRate(observation)
+            XCTFail("Expected missing-source failure")
+        } catch {
+            XCTAssertEqual(error as? TelemetryStoreError, .missingSource(source.id))
+        }
+        let counts = try await store.counts()
+        XCTAssertEqual(counts.heartRateSamples, 0)
+        XCTAssertEqual(counts.sources, 0)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreConfigurationTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreConfigurationTests.swift
@@ -92,6 +92,57 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
         XCTAssertEqual(sources.map(\.identity), [source])
     }
 
+    func testStableNativeHeartRateIdentityRemainsDeduplicatedAfterReopen() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("telemetry-native-id-\(UUID().uuidString)", isDirectory: true)
+        let storeURL = directory.appendingPathComponent("TelemetryV2.store")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let session = TelemetryPersistenceFixtures.session(seed: 17)
+        let source = TelemetryPersistenceFixtures.source(seed: 17)
+        let nativeIdentity = try XCTUnwrap(
+            ProviderNativeSampleIdentity(identifier: "native-reopen-sample")
+        )
+        let first = TelemetryPersistenceFixtures.heartRate(
+            seed: 17,
+            session: session,
+            source: source,
+            arrivalOrder: 1,
+            bpm: 119,
+            providerSampleIdentity: nativeIdentity
+        )
+        let redelivery = TelemetryPersistenceFixtures.heartRate(
+            seed: 18,
+            session: session,
+            source: source,
+            arrivalOrder: 2,
+            bpm: 119,
+            providerSampleIdentity: nativeIdentity
+        )
+
+        var writer: TelemetryStore? = try TelemetryStoreFactory.make(.onDisk(storeURL))
+        try await writer?.insertSession(session)
+        try await writer?.insertSource(
+            source,
+            firstSeen: TelemetryPersistenceFixtures.baseDate,
+            lastSeen: TelemetryPersistenceFixtures.baseDate
+        )
+        try await writer?.insertHeartRate(first)
+        writer = nil
+
+        let reopened = try TelemetryStoreFactory.make(.onDisk(storeURL))
+        do {
+            try await reopened.insertHeartRate(redelivery)
+            XCTFail("Expected stable native identity rejection after reopen")
+        } catch {
+            guard case TelemetryStoreError.duplicateStableIdentity = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        let stored = try await reopened.fetchHeartRate(sessionID: session.sessionID)
+        XCTAssertEqual(stored, [first])
+    }
+
     func testCorruptPersistedRelationshipFailsClosed() async throws {
         let schema = Schema(versionedSchema: TelemetrySchemaV1.self)
         let configuration = ModelConfiguration(
@@ -218,6 +269,88 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
         }
     }
 
+    func testContradictoryPersistedEventCausalProjectionFailsClosed() async throws {
+        let schema = Schema(versionedSchema: TelemetrySchemaV1.self)
+        let configuration = ModelConfiguration(
+            "TelemetryCausalCorruptionTest",
+            schema: schema,
+            isStoredInMemoryOnly: true,
+            cloudKitDatabase: .none
+        )
+        let container = try ModelContainer(
+            for: schema,
+            migrationPlan: TelemetryMigrationPlan.self,
+            configurations: [configuration]
+        )
+        let writer = TelemetryStore(modelContainer: container, onDiskStoreURL: nil)
+        let session = TelemetryPersistenceFixtures.session(seed: 20)
+        let decisionID = DecisionID()
+        let commandID = CommandID()
+        let previousAttemptID = CommandAttemptID()
+        let nextAttemptID = CommandAttemptID()
+        let event = WorkoutEvent(
+            recordID: RecordID(),
+            sessionID: session.sessionID,
+            timestamp: EventTimestamp(
+                occurredAt: TelemetryPersistenceFixtures.baseDate,
+                recordedAt: TelemetryPersistenceFixtures.baseDate.addingTimeInterval(0.01),
+                occurredElapsed: ElapsedDuration(microseconds: 1_000_000),
+                recordedElapsed: ElapsedDuration(microseconds: 1_010_000)
+            ),
+            payload: EventPayloadEnvelope(
+                schemaVersion: 1,
+                payload: .commandLifecycle(CommandLifecycleRecord(
+                    commandID: commandID,
+                    decisionID: decisionID,
+                    lifecycle: .retryScheduled(
+                        previousAttemptID: previousAttemptID,
+                        nextAttemptID: nextAttemptID,
+                        nextAttemptNumber: 2
+                    )
+                ))
+            )
+        )
+        try await writer.insertSession(session)
+        try await writer.insertEvent(event)
+
+        let corruptingContext = ModelContext(container)
+        let model = try XCTUnwrap(
+            corruptingContext.fetch(FetchDescriptor<TelemetryWorkoutEventV1>()).first
+        )
+
+        model.decisionID = nil
+        try corruptingContext.save()
+        await assertCorruptEventRead(
+            container: container,
+            sessionID: session.sessionID,
+            recordID: event.recordID
+        )
+
+        model.decisionID = decisionID.description
+        model.commandID = CommandID().description
+        try corruptingContext.save()
+        await assertCorruptEventRead(
+            container: container,
+            sessionID: session.sessionID,
+            recordID: event.recordID
+        )
+
+        model.commandID = commandID.description
+        model.attemptID = previousAttemptID.description
+        try corruptingContext.save()
+        await assertCorruptEventRead(
+            container: container,
+            sessionID: session.sessionID,
+            recordID: event.recordID
+        )
+
+        model.attemptID = nextAttemptID.description
+        try corruptingContext.save()
+        let validReader = TelemetryStore(modelContainer: container, onDiskStoreURL: nil)
+        let stored = try await validReader.fetchEvents(sessionID: session.sessionID)
+        XCTAssertEqual(stored, [event])
+    }
+
     func testMissingRelationshipsFailWithoutCreatingFallbackRecords() async throws {
         let store = try TelemetryStoreFactory.make(.inMemory)
         let session = TelemetryPersistenceFixtures.session(seed: 9)
@@ -249,6 +382,23 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
         let counts = try await store.counts()
         XCTAssertEqual(counts.heartRateSamples, 0)
         XCTAssertEqual(counts.sources, 0)
+    }
+
+    private func assertCorruptEventRead(
+        container: ModelContainer,
+        sessionID: SessionID,
+        recordID: RecordID
+    ) async {
+        let reader = TelemetryStore(modelContainer: container, onDiskStoreURL: nil)
+        do {
+            _ = try await reader.fetchEvents(sessionID: sessionID)
+            XCTFail("Expected contradictory causal projection failure")
+        } catch {
+            XCTAssertEqual(
+                error as? TelemetryStoreError,
+                .corruptStoredRecord(recordID.description)
+            )
+        }
     }
 
     private func assertRequiredFilePolicy(

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreConfigurationTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreConfigurationTests.swift
@@ -1,6 +1,7 @@
 import Foundation
+import SwiftData
 import TelemetryDomain
-import TelemetryPersistence
+@testable import TelemetryPersistence
 import XCTest
 
 final class TelemetryStoreConfigurationTests: XCTestCase {
@@ -41,6 +42,38 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
             lastSeen: TelemetryPersistenceFixtures.baseDate
         )
         try await writer?.insertHeartRate(heartRate)
+
+        let protectedFiles = try TelemetryStoreFilePolicy.discoveredStoreFiles(
+            primaryStoreURL: storeURL
+        )
+        XCTAssertTrue(
+            protectedFiles.map { $0.resolvingSymlinksInPath().path }
+                .contains(storeURL.resolvingSymlinksInPath().path),
+            "Expected primary store at \(storeURL.path); discovered \(protectedFiles.map(\.path))"
+        )
+        for url in protectedFiles {
+            let resourceValues = try url.resourceValues(forKeys: [.isExcludedFromBackupKey])
+            XCTAssertEqual(resourceValues.isExcludedFromBackup, true)
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            XCTAssertNotNil(attributes[.protectionKey])
+        }
+
+        var resetValues = URLResourceValues()
+        resetValues.isExcludedFromBackup = false
+        var mutableStoreURL = storeURL
+        try mutableStoreURL.setResourceValues(resetValues)
+        try await writer?.insertEvent(
+            TelemetryPersistenceFixtures.event(
+                seed: 8,
+                session: session,
+                kind: .sessionLifecycle,
+                elapsed: 2_000_000
+            )
+        )
+        XCTAssertEqual(
+            try storeURL.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup,
+            true
+        )
         writer = nil
 
         let reader = try TelemetryStoreFactory.make(.onDisk(storeURL))
@@ -50,6 +83,132 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
         XCTAssertEqual(sessions, [session])
         XCTAssertEqual(heartRates, [heartRate])
         XCTAssertEqual(sources.map(\.identity), [source])
+    }
+
+    func testCorruptPersistedRelationshipFailsClosed() async throws {
+        let schema = Schema(versionedSchema: TelemetrySchemaV1.self)
+        let configuration = ModelConfiguration(
+            "TelemetryCorruptionTest",
+            schema: schema,
+            isStoredInMemoryOnly: true,
+            cloudKitDatabase: .none
+        )
+        let container = try ModelContainer(
+            for: schema,
+            migrationPlan: TelemetryMigrationPlan.self,
+            configurations: [configuration]
+        )
+        let writer = TelemetryStore(modelContainer: container, onDiskStoreURL: nil)
+        let session = TelemetryPersistenceFixtures.session(seed: 10)
+        let source = TelemetryPersistenceFixtures.source(seed: 10)
+        let heartRate = TelemetryPersistenceFixtures.heartRate(
+            seed: 10,
+            session: session,
+            source: source,
+            arrivalOrder: 1,
+            bpm: 122
+        )
+        let treadmill = TelemetryPersistenceFixtures.treadmill(
+            seed: 10,
+            session: session,
+            source: source,
+            arrivalOrder: 1,
+            unit: .kilometresPerHour
+        )
+        let event = TelemetryPersistenceFixtures.event(
+            seed: 10,
+            session: session,
+            kind: .sessionLifecycle,
+            elapsed: 2_000_000,
+            sourceID: source.id
+        )
+        let frame = TelemetryPersistenceFixtures.frame(
+            seed: 10,
+            session: session,
+            elapsedSecond: 2,
+            heartRate: heartRate
+        )
+        let analysis = TelemetryPersistenceFixtures.analysis(
+            seed: 10,
+            session: session,
+            version: "analysis-v1"
+        )
+        try await writer.insertSession(session)
+        try await writer.insertSource(
+            source,
+            firstSeen: TelemetryPersistenceFixtures.baseDate,
+            lastSeen: TelemetryPersistenceFixtures.baseDate
+        )
+        try await writer.insertHeartRate(heartRate)
+        try await writer.insertTreadmill(treadmill)
+        try await writer.insertEvent(event)
+        try await writer.insertFrame(frame)
+        try await writer.insertAnalysis(analysis)
+
+        let corruptingContext = ModelContext(container)
+        try XCTUnwrap(
+            corruptingContext.fetch(FetchDescriptor<TelemetryHeartRateSampleV1>()).first
+        ).session = nil
+        try XCTUnwrap(
+            corruptingContext.fetch(FetchDescriptor<TelemetryTreadmillSampleV1>()).first
+        ).source = nil
+        try XCTUnwrap(
+            corruptingContext.fetch(FetchDescriptor<TelemetryWorkoutEventV1>()).first
+        ).source = nil
+        try XCTUnwrap(
+            corruptingContext.fetch(FetchDescriptor<TelemetryWorkoutFrameV1>()).first
+        ).session = nil
+        try XCTUnwrap(
+            corruptingContext.fetch(FetchDescriptor<TelemetryWorkoutAnalysisV1>()).first
+        ).session = nil
+        try corruptingContext.save()
+
+        let reader = TelemetryStore(modelContainer: container, onDiskStoreURL: nil)
+        do {
+            _ = try await reader.fetchHeartRate(sessionID: session.sessionID)
+            XCTFail("Expected corrupt heart-rate relationship failure")
+        } catch {
+            XCTAssertEqual(
+                error as? TelemetryStoreError,
+                .corruptStoredRecord(heartRate.observationID.description)
+            )
+        }
+        do {
+            _ = try await reader.fetchTreadmill(sessionID: session.sessionID)
+            XCTFail("Expected corrupt treadmill relationship failure")
+        } catch {
+            XCTAssertEqual(
+                error as? TelemetryStoreError,
+                .corruptStoredRecord(treadmill.observationID.description)
+            )
+        }
+        do {
+            _ = try await reader.fetchEvents(sessionID: session.sessionID)
+            XCTFail("Expected corrupt event relationship failure")
+        } catch {
+            XCTAssertEqual(
+                error as? TelemetryStoreError,
+                .corruptStoredRecord(event.recordID.description)
+            )
+        }
+        do {
+            _ = try await reader.fetchFrames(sessionID: session.sessionID)
+            XCTFail("Expected corrupt frame relationship failure")
+        } catch {
+            XCTAssertEqual(
+                error as? TelemetryStoreError,
+                .corruptStoredRecord(frame.recordID.description)
+            )
+        }
+        do {
+            _ = try await reader.fetchAnalyses(sessionID: session.sessionID)
+            XCTFail("Expected corrupt analysis relationship failure")
+        } catch {
+            XCTAssertEqual(
+                error as? TelemetryStoreError,
+                .corruptStoredRecord(analysis.analysisID.description)
+            )
+        }
     }
 
     func testMissingRelationshipsFailWithoutCreatingFallbackRecords() async throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreRoundTripTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreRoundTripTests.swift
@@ -197,6 +197,220 @@ final class TelemetryStoreRoundTripTests: XCTestCase {
         XCTAssertEqual(counts.heartRateSamples, 1)
     }
 
+    func testStableNativeHeartRateIdentityRejectsRedeliveryWithNewV2IDs() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = TelemetryPersistenceFixtures.session(seed: 11)
+        let source = TelemetryPersistenceFixtures.source(seed: 11)
+        let nativeIdentity = try XCTUnwrap(
+            ProviderNativeSampleIdentity(identifier: "native-sample-11")
+        )
+        let first = TelemetryPersistenceFixtures.heartRate(
+            seed: 11,
+            session: session,
+            source: source,
+            arrivalOrder: 1,
+            bpm: 121,
+            providerSampleIdentity: nativeIdentity
+        )
+        let redelivery = TelemetryPersistenceFixtures.heartRate(
+            seed: 12,
+            session: session,
+            source: source,
+            arrivalOrder: 2,
+            bpm: 121,
+            providerSampleIdentity: nativeIdentity
+        )
+        try await store.insertSession(session)
+        try await store.insertSource(
+            source,
+            firstSeen: TelemetryPersistenceFixtures.baseDate,
+            lastSeen: TelemetryPersistenceFixtures.baseDate
+        )
+        try await store.insertHeartRate(first)
+
+        await XCTAssertThrowsErrorAsync(try await store.insertHeartRate(redelivery)) { error in
+            guard case TelemetryStoreError.duplicateStableIdentity = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        let stored = try await store.fetchHeartRate(sessionID: session.sessionID)
+        let counts = try await store.counts()
+        XCTAssertEqual(stored, [first])
+        XCTAssertEqual(counts.heartRateSamples, 1)
+    }
+
+    func testHeartRateWithoutNativeIdentityIsNotFuzzilyDeduplicated() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = TelemetryPersistenceFixtures.session(seed: 13)
+        let source = TelemetryPersistenceFixtures.source(seed: 13)
+        let timestamp = TelemetryPersistenceFixtures.timestamp(elapsedMicroseconds: 1_000_000)
+        let first = TelemetryPersistenceFixtures.heartRate(
+            seed: 13,
+            session: session,
+            source: source,
+            arrivalOrder: 1,
+            bpm: 120,
+            timestamp: timestamp
+        )
+        let second = TelemetryPersistenceFixtures.heartRate(
+            seed: 14,
+            session: session,
+            source: source,
+            arrivalOrder: 2,
+            bpm: 120,
+            timestamp: timestamp
+        )
+        try await store.insertSession(session)
+        try await store.insertSource(
+            source,
+            firstSeen: TelemetryPersistenceFixtures.baseDate,
+            lastSeen: TelemetryPersistenceFixtures.baseDate
+        )
+        try await store.insertHeartRate(first)
+        try await store.insertHeartRate(second)
+
+        let stored = try await store.fetchHeartRate(sessionID: session.sessionID)
+        XCTAssertEqual(stored, [first, second])
+    }
+
+    func testSameNativeHeartRateIdentifierDoesNotCollideAcrossSources() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = TelemetryPersistenceFixtures.session(seed: 15)
+        let healthKitSource = TelemetryPersistenceFixtures.source(
+            seed: 15,
+            kind: .healthKitSelected
+        )
+        let bluetoothSource = TelemetryPersistenceFixtures.source(
+            seed: 16,
+            kind: .bluetooth
+        )
+        let nativeIdentity = try XCTUnwrap(
+            ProviderNativeSampleIdentity(identifier: "provider-shared-value")
+        )
+        let healthKitSample = TelemetryPersistenceFixtures.heartRate(
+            seed: 15,
+            session: session,
+            source: healthKitSource,
+            arrivalOrder: 1,
+            bpm: 120,
+            providerSampleIdentity: nativeIdentity
+        )
+        let bluetoothSample = TelemetryPersistenceFixtures.heartRate(
+            seed: 16,
+            session: session,
+            source: bluetoothSource,
+            arrivalOrder: 2,
+            bpm: 120,
+            providerSampleIdentity: nativeIdentity
+        )
+        try await store.insertSession(session)
+        try await store.insertSource(
+            healthKitSource,
+            firstSeen: TelemetryPersistenceFixtures.baseDate,
+            lastSeen: TelemetryPersistenceFixtures.baseDate
+        )
+        try await store.insertSource(
+            bluetoothSource,
+            firstSeen: TelemetryPersistenceFixtures.baseDate,
+            lastSeen: TelemetryPersistenceFixtures.baseDate
+        )
+        try await store.insertHeartRate(healthKitSample)
+        try await store.insertHeartRate(bluetoothSample)
+
+        let stored = try await store.fetchHeartRate(sessionID: session.sessionID)
+        XCTAssertEqual(stored, [healthKitSample, bluetoothSample])
+    }
+
+    func testCausalEventEnvelopePersistsExactlyForEveryLifecycle() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = TelemetryPersistenceFixtures.session(seed: 19)
+        let decisionID = DecisionID()
+        let commandID = CommandID()
+        let firstAttemptID = CommandAttemptID()
+        let secondAttemptID = CommandAttemptID()
+        let decision = ControlDecision(
+            decisionID: decisionID,
+            observationsUsed: [],
+            target: .stop,
+            action: .enqueueStop,
+            reason: .manual,
+            versions: TelemetryPersistenceFixtures.versions(),
+            configurationSnapshotID: session.configuration.id
+        )
+        let lifecyclePayloads: [WorkoutEventPayload] = [
+            .controlDecision(decision),
+            .commandLifecycle(CommandLifecycleRecord(
+                commandID: commandID,
+                decisionID: nil,
+                lifecycle: .enqueued(kind: .stop)
+            )),
+            .commandLifecycle(CommandLifecycleRecord(
+                commandID: commandID,
+                decisionID: decisionID,
+                lifecycle: .sendAttempt(attemptID: firstAttemptID, attemptNumber: 1)
+            )),
+            .commandLifecycle(CommandLifecycleRecord(
+                commandID: commandID,
+                decisionID: decisionID,
+                lifecycle: .acknowledged(attemptID: firstAttemptID)
+            )),
+            .commandLifecycle(CommandLifecycleRecord(
+                commandID: commandID,
+                decisionID: decisionID,
+                lifecycle: .timedOut(attemptID: firstAttemptID)
+            )),
+            .commandLifecycle(CommandLifecycleRecord(
+                commandID: commandID,
+                decisionID: decisionID,
+                lifecycle: .retryScheduled(
+                    previousAttemptID: firstAttemptID,
+                    nextAttemptID: secondAttemptID,
+                    nextAttemptNumber: 2
+                )
+            )),
+            .commandLifecycle(CommandLifecycleRecord(
+                commandID: commandID,
+                decisionID: decisionID,
+                lifecycle: .cancelled(reason: .sessionEnded)
+            )),
+            .commandLifecycle(CommandLifecycleRecord(
+                commandID: commandID,
+                decisionID: decisionID,
+                lifecycle: .failed(attemptID: secondAttemptID, reason: .transportUnavailable)
+            )),
+        ]
+        let events = lifecyclePayloads.enumerated().map { offset, payload in
+            let elapsed = Int64(offset + 1) * 1_000_000
+            return WorkoutEvent(
+                recordID: RecordID(),
+                sessionID: session.sessionID,
+                timestamp: EventTimestamp(
+                    occurredAt: TelemetryPersistenceFixtures.baseDate.addingTimeInterval(
+                        Double(elapsed) / 1_000_000
+                    ),
+                    recordedAt: TelemetryPersistenceFixtures.baseDate.addingTimeInterval(
+                        Double(elapsed + 10_000) / 1_000_000
+                    ),
+                    occurredElapsed: ElapsedDuration(microseconds: elapsed),
+                    recordedElapsed: ElapsedDuration(microseconds: elapsed + 10_000)
+                ),
+                payload: EventPayloadEnvelope(schemaVersion: 1, payload: payload)
+            )
+        }
+        try await store.insertSession(session)
+        for event in events {
+            try await store.insertEvent(event)
+        }
+
+        let stored = try await store.fetchEvents(sessionID: session.sessionID)
+        XCTAssertEqual(stored, events)
+        XCTAssertEqual(events[0].decisionID, decisionID)
+        XCTAssertNil(events[1].decisionID)
+        XCTAssertEqual(events[5].attemptID, secondAttemptID)
+        XCTAssertNil(events[6].attemptID)
+    }
+
     func testSessionDeletionCascadesOwnedRecordsButPreservesSourceAndConfiguration() async throws {
         let store = try TelemetryStoreFactory.make(.inMemory)
         let session = TelemetryPersistenceFixtures.session(seed: 5)

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreRoundTripTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreRoundTripTests.swift
@@ -1,0 +1,259 @@
+import Foundation
+import TelemetryDomain
+import TelemetryPersistence
+import XCTest
+
+final class TelemetryStoreRoundTripTests: XCTestCase {
+    func testInsertFetchOrderAndFilterAllConceptualRecords() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let sharedConfiguration = TelemetryPersistenceFixtures.configuration(seed: 1)
+        let later = TelemetryPersistenceFixtures.session(
+            seed: 2,
+            profile: "profile-b",
+            configuration: sharedConfiguration,
+            startedOffset: 100
+        )
+        let earlier = TelemetryPersistenceFixtures.session(
+            seed: 1,
+            profile: "profile-a",
+            configuration: sharedConfiguration,
+            startedOffset: 0
+        )
+        try await store.insertSession(later)
+        try await store.insertSession(earlier)
+
+        let unknownSource = TelemetryPersistenceFixtures.source(seed: 1, kind: .unknown)
+        let treadmillSource = TelemetryPersistenceFixtures.source(seed: 2, kind: .treadmillProtocol)
+        try await store.insertSource(
+            treadmillSource,
+            firstSeen: TelemetryPersistenceFixtures.baseDate,
+            lastSeen: TelemetryPersistenceFixtures.baseDate.addingTimeInterval(2)
+        )
+        try await store.insertSource(
+            unknownSource,
+            firstSeen: TelemetryPersistenceFixtures.baseDate,
+            lastSeen: TelemetryPersistenceFixtures.baseDate.addingTimeInterval(1)
+        )
+
+        let laterHR = TelemetryPersistenceFixtures.heartRate(
+            seed: 1,
+            session: earlier,
+            source: unknownSource,
+            arrivalOrder: 2,
+            bpm: 122
+        )
+        let earlierHR = TelemetryPersistenceFixtures.heartRate(
+            seed: 2,
+            session: earlier,
+            source: unknownSource,
+            arrivalOrder: 1,
+            bpm: 121
+        )
+        try await store.insertHeartRate(laterHR)
+        try await store.insertHeartRate(earlierHR)
+
+        let factualTreadmill = TelemetryPersistenceFixtures.treadmill(
+            seed: 1,
+            session: earlier,
+            source: treadmillSource,
+            arrivalOrder: 2,
+            unit: .kilometresPerHour
+        )
+        let unknownTreadmill = TelemetryPersistenceFixtures.treadmill(
+            seed: 2,
+            session: earlier,
+            source: treadmillSource,
+            arrivalOrder: 1,
+            unit: .unknown
+        )
+        try await store.insertTreadmill(factualTreadmill)
+        try await store.insertTreadmill(unknownTreadmill)
+
+        let laterEvent = TelemetryPersistenceFixtures.event(
+            seed: 1,
+            session: earlier,
+            kind: .manualStop,
+            elapsed: 3_000_000
+        )
+        let earlierEvent = TelemetryPersistenceFixtures.event(
+            seed: 2,
+            session: earlier,
+            kind: .sessionLifecycle,
+            elapsed: 1_000_000
+        )
+        try await store.insertEvent(laterEvent)
+        try await store.insertEvent(earlierEvent)
+
+        let frameThree = TelemetryPersistenceFixtures.frame(
+            seed: 1,
+            session: earlier,
+            elapsedSecond: 3,
+            heartRate: laterHR
+        )
+        let frameOne = TelemetryPersistenceFixtures.frame(
+            seed: 2,
+            session: earlier,
+            elapsedSecond: 1,
+            heartRate: earlierHR
+        )
+        try await store.insertFrame(frameThree)
+        try await store.insertFrame(frameOne)
+
+        let analysisV2 = TelemetryPersistenceFixtures.analysis(seed: 1, session: earlier, version: "v2")
+        let analysisV1 = TelemetryPersistenceFixtures.analysis(seed: 2, session: earlier, version: "v1")
+        try await store.insertAnalysis(analysisV2)
+        try await store.insertAnalysis(analysisV1)
+
+        let allSessions = try await store.fetchSessions()
+        let profileSessions = try await store.fetchSessions(profileLocalIdentifier: "profile-b")
+        XCTAssertEqual(allSessions.map(\.sessionID), [earlier.sessionID, later.sessionID])
+        XCTAssertEqual(profileSessions, [later])
+
+        let unknownSources = try await store.fetchSources(providerKindKey: "unknown")
+        XCTAssertEqual(unknownSources.map(\.identity), [unknownSource])
+        XCTAssertNil(unknownSources.first?.identity.knownDevice)
+
+        let heartRates = try await store.fetchHeartRate(sessionID: earlier.sessionID)
+        XCTAssertEqual(heartRates, [earlierHR, laterHR])
+        let treadmill = try await store.fetchTreadmill(sessionID: earlier.sessionID)
+        XCTAssertEqual(treadmill, [unknownTreadmill, factualTreadmill])
+        XCTAssertNil(treadmill[0].factualSpeed)
+        XCTAssertEqual(treadmill[1].factualSpeed?.value, 5.5)
+
+        let allEvents = try await store.fetchEvents(sessionID: earlier.sessionID)
+        let manualStopEvents = try await store.fetchEvents(sessionID: earlier.sessionID, kind: .manualStop)
+        let frames = try await store.fetchFrames(sessionID: earlier.sessionID)
+        let v1Analyses = try await store.fetchAnalyses(
+            sessionID: earlier.sessionID,
+            analyzerVersion: AnalyzerVersion(rawValue: "v1")
+        )
+        XCTAssertEqual(allEvents, [earlierEvent, laterEvent])
+        XCTAssertEqual(
+            manualStopEvents,
+            [laterEvent]
+        )
+        XCTAssertEqual(frames, [frameOne, frameThree])
+        XCTAssertEqual(v1Analyses, [analysisV1])
+
+        let counts = try await store.counts()
+        XCTAssertEqual(counts.configurations, 1)
+        XCTAssertEqual(counts.sessions, 2)
+        XCTAssertEqual(counts.sources, 2)
+        XCTAssertEqual(counts.heartRateSamples, 2)
+        XCTAssertEqual(counts.treadmillSamples, 2)
+        XCTAssertEqual(counts.events, 2)
+        XCTAssertEqual(counts.frames, 2)
+        XCTAssertEqual(counts.analyses, 2)
+    }
+
+    func testStableIdentityRejectsDuplicateFrameAndSourceWithoutFuzzyMatching() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = TelemetryPersistenceFixtures.session(seed: 3)
+        let source = TelemetryPersistenceFixtures.source(seed: 3)
+        try await store.insertSession(session)
+        try await store.insertSource(
+            source,
+            firstSeen: TelemetryPersistenceFixtures.baseDate,
+            lastSeen: TelemetryPersistenceFixtures.baseDate
+        )
+
+        let frame = TelemetryPersistenceFixtures.frame(seed: 3, session: session, elapsedSecond: 7)
+        let sameCanonicalSecond = TelemetryPersistenceFixtures.frame(seed: 4, session: session, elapsedSecond: 7)
+        let heartRate = TelemetryPersistenceFixtures.heartRate(
+            seed: 3,
+            session: session,
+            source: source,
+            arrivalOrder: 1,
+            bpm: 120
+        )
+        try await store.insertFrame(frame)
+        try await store.insertHeartRate(heartRate)
+
+        await XCTAssertThrowsErrorAsync(try await store.insertFrame(sameCanonicalSecond)) { error in
+            guard case TelemetryStoreError.duplicateStableIdentity = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        await XCTAssertThrowsErrorAsync(
+            try await store.insertSource(
+                source,
+                firstSeen: TelemetryPersistenceFixtures.baseDate,
+                lastSeen: TelemetryPersistenceFixtures.baseDate
+            )
+        ) { error in
+            guard case TelemetryStoreError.duplicateStableIdentity = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        await XCTAssertThrowsErrorAsync(try await store.insertHeartRate(heartRate)) { error in
+            guard case TelemetryStoreError.duplicateStableIdentity = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        let frames = try await store.fetchFrames(sessionID: session.sessionID)
+        let counts = try await store.counts()
+        XCTAssertEqual(frames.map(\.canonicalElapsedSecond), [7])
+        XCTAssertEqual(counts.heartRateSamples, 1)
+    }
+
+    func testSessionDeletionCascadesOwnedRecordsButPreservesSourceAndConfiguration() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = TelemetryPersistenceFixtures.session(seed: 5)
+        let source = TelemetryPersistenceFixtures.source(seed: 5)
+        try await store.insertSession(session)
+        try await store.insertSource(source, firstSeen: TelemetryPersistenceFixtures.baseDate, lastSeen: TelemetryPersistenceFixtures.baseDate)
+        try await store.insertHeartRate(
+            TelemetryPersistenceFixtures.heartRate(
+                seed: 5,
+                session: session,
+                source: source,
+                arrivalOrder: 1,
+                bpm: 120
+            )
+        )
+        try await store.insertTreadmill(
+            TelemetryPersistenceFixtures.treadmill(
+                seed: 5,
+                session: session,
+                source: source,
+                arrivalOrder: 1,
+                unit: .unknown
+            )
+        )
+        try await store.insertEvent(
+            TelemetryPersistenceFixtures.event(seed: 5, session: session, kind: .manualStop, elapsed: 2_000_000)
+        )
+        try await store.insertFrame(
+            TelemetryPersistenceFixtures.frame(seed: 5, session: session, elapsedSecond: 2)
+        )
+        try await store.insertAnalysis(
+            TelemetryPersistenceFixtures.analysis(seed: 5, session: session, version: "v1")
+        )
+
+        try await store.deleteSession(session.sessionID)
+        let counts = try await store.counts()
+        XCTAssertEqual(counts.sessions, 0)
+        XCTAssertEqual(counts.heartRateSamples, 0)
+        XCTAssertEqual(counts.treadmillSamples, 0)
+        XCTAssertEqual(counts.events, 0)
+        XCTAssertEqual(counts.frames, 0)
+        XCTAssertEqual(counts.analyses, 0)
+        XCTAssertEqual(counts.sources, 1)
+        XCTAssertEqual(counts.configurations, 1)
+    }
+}
+
+private func XCTAssertThrowsErrorAsync<T>(
+    _ expression: @autoclosure () async throws -> T,
+    _ errorHandler: (Error) -> Void,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expected error", file: file, line: line)
+    } catch {
+        errorHandler(error)
+    }
+}


### PR DESCRIPTION
## Summary

- Add a Foundation-only `TelemetryDomain` target with typed identities, wall/elapsed time roles, provenance, quality, factual/desired/commanded/estimated speed separation, causal events, canonical frames, session records, and versioned analysis values.
- Add an unwired, local-only `TelemetryPersistence` target with an explicit SwiftData V1 schema/migration plan, isolated `@ModelActor` store, deterministic identities, indexed queries, explicit transactions, fail-closed reads, cascade semantics, and injectable in-memory/on-disk configurations.
- Apply backup exclusion and `completeUntilFirstUserAuthentication` to the real primary/WAL/SHM store files after open and writes; keep physical device verification explicitly outstanding.
- Update only the #39 delivery-sequence references in the Telemetry V2 contract docs.

Closes #39.

## Why

Issue #39 combines the former typed-domain and unwired-store foundation stages. This establishes an auditable data contract and a versioned local persistence boundary before later recorder/runtime issues, without changing current control, BLE, HR, UI, legacy JSONL, or workout behavior.

## Verification

- [x] `cd ios/WalkingPadRemote/WalkingPadRemote && swift test` — 170 passed: 141 existing core, 18 domain, 11 persistence.
- [x] `swift test --filter TelemetryDomainTests` and `swift test --filter TelemetryPersistenceTests`; the on-disk persistence target was repeated after the final sidecar-policy correction.
- [x] `PYTHONPYCACHEPREFIX=/private/tmp/walkingpad-issue-39-pycache python3 -m compileall -q scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py`.
- [x] `swift package dump-package` — tools 5.10, iOS 26.0, macOS 15.0, separate domain/persistence targets.
- [x] `xcodebuild -list -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj`.
- [x] `xcodebuild -quiet -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO -derivedDataPath /private/tmp/walkingpad-issue-39-derived-data build`.
- [x] Domain dependency-purity and production no-wiring scans; `git diff --check`; exact base-to-head name/status audit.
- [x] Fresh independent final review: `GO`, with no P0/P1/material P2 findings after two correction cycles.

## Hardware / environment

- Treadmill model: Not applicable; no hardware connection or commands.
- Protocol: No BLE/controller protocol changes.
- iPhone / iOS: Generic unsigned iOS/watchOS build only; no install or launch.
- Toolchain: Xcode 27 beta (`27A5194q`), Swift 6.4 in Swift 5 language mode, iOS/macOS SDK 27.0.

## Risks / Notes

- The V2 store is intentionally not instantiated by any production app path and cannot affect control or safety behavior. Legacy persistence remains the product source of truth.
- `swift-tools-version: 5.10` and Swift language mode are unchanged. The package iOS floor is now 26.0. The macOS test-host floor is 15.0 because compiler probes showed SwiftData requires macOS 14 and the selected `#Index` schema API requires macOS 15; string platform forms avoid newer PackageDescription constants.
- The schema starts at V1 with an explicit empty migration plan; there is no migration from or mutation of legacy persistence.
- Host tests verify primary/WAL/SHM discovery, exact backup-exclusion and protection attributes, reapplication, and reopen. Real-device protection lifecycle remains `UNVERIFIED_ON_DEVICE` and belongs to the later architecture/device gate.
- A non-gating `swift format lint` diagnostic exited successfully but reported default two-space-format warnings; the repository sources use four-space indentation and have no formatter configuration in this scope.
- No deployment, device install, launch, BLE experiment, or release action was performed. Rollback is a normal revert of this unwired foundation branch.
