### PR TITLE
Add Telemetry V2 SwiftData architecture gate evidence

### DIFF
--- a/docs/telemetry-v2/swiftdata-gate.md
+++ b/docs/telemetry-v2/swiftdata-gate.md
@@ -4,7 +4,7 @@ Status: issue #26 hosted evidence report.
 
 ## Verdict
 
-`BLOCKED FOR PM DECISION`
+`PASS` for the automated/hosted architecture gate.
 
 The actual V1 SwiftData Foundation completed the deterministic hosted fast and
 full profiles without semantic, corruption, recovery, migration, or isolation
@@ -14,20 +14,25 @@ substantially, but measured throughput, bounded late-scale behavior, sub-200-ms
 representative queries, bounded memory, and successful reopen do not expose a
 material scale defect.
 
-The gate is nevertheless blocked because one repository-wide run observed the
-actual WAL and SHM sidecars with `isExcludedFromBackup = false` immediately
-after a subsequent write. Later repetitions passed, so the failure is
-nondeterministic rather than a consistently broken helper. An observed failure
-of required automatic sidecar policy cannot be classified `PASS`, and changing
-production persistence lifecycle behavior is outside issue #26. PM must decide
-the narrow Foundation correction/investigation and require this host gate to be
-rerun. The other target misses remain product-planning evidence, not permission
-to weaken retention or scientific semantics.
+The first gate was correctly blocked by contradictory hosted backup-exclusion
+evidence. PM retained SwiftData and authorized one narrow correction: the
+dedicated `TelemetryV2` directory is now created, marked
+`isExcludedFromBackup = true`, and read-verified before `ModelContainer` opens
+or migrates its store. Discovered primary/WAL/SHM files continue to receive the
+existing protection and backup attributes as defense in depth, but transient
+child-file xattrs are no longer the sole semantic boundary.
+
+The corrected hosted tests deterministically preserve the directory exclusion
+through creation, writes, subsequent writes, reopen, child reset/recreation,
+and synthetic migration. No sleep, polling, retry, checkpoint, raw SQLite,
+private API, or background-timer workaround was introduced. The significant
+performance/storage target misses remain product-planning evidence, not
+permission to weaken retention or scientific semantics.
 
 This gate evaluates the concrete, unwired Telemetry V2 Foundation merged by
 issue #39. It does not implement the recorder or authorize issue #27. Product
-work must not proceed until the automated host-policy failure is corrected and
-this gate is rerun; PM must then also accept every device-only carry-over item.
+work remains blocked until PM accepts this corrected automated gate and every
+explicit device-only carry-over item.
 
 ## Tested revision and environment
 
@@ -36,8 +41,10 @@ this gate is rerun; PM must then also accept every device-only carry-over item.
 | Canonical base | `4c59ae0257d40c9e86df386ca9c56713e88f3270` |
 | Measured full-profile harness head | `c67f991d4568c776d9776f6100b03c15279c642b` |
 | Corrected recovery head | `6a0d8b2a57d1486a0312ab8861e2e38834b08311` |
+| Directory-policy correction code/test head | `aca3a1ff36a0a920fd9a0f2ee972b130274f5d94` |
 | Schema | actual production `TelemetrySchemaV1` (`1.0.0`) |
-| Harness | `swiftdata-gate-v1` |
+| Full-scale harness | `swiftdata-gate-v1` |
+| Correction fast harness | `swiftdata-gate-v2-directory-boundary` |
 | Deterministic seed | `0x26_39_40_2026` (`164169261094`) |
 | Machine | Apple M5, arm64, 10 logical CPUs, 16 GB RAM |
 | Host OS | macOS 27.0, build `26A5406e` |
@@ -59,7 +66,12 @@ used by the methodology are
 [`VersionedSchema`](https://developer.apple.com/documentation/swiftdata/versionedschema),
 and
 [`SchemaMigrationPlan`](https://developer.apple.com/documentation/swiftdata/schemamigrationplan).
-No private SwiftData API is a correctness dependency.
+The corrected file-policy boundary follows Apple's public
+[`Optimizing Your App's Data for iCloud Backup`](https://developer.apple.com/documentation/foundation/optimizing-your-app-s-data-for-icloud-backup)
+guidance to exclude a directory containing related files and the documented
+[`isExcludedFromBackupKey`](https://developer.apple.com/documentation/foundation/urlresourcekey/isexcludedfrombackupkey)
+warning that common file operations can reset a file's value. No private
+SwiftData or Foundation API is a correctness dependency.
 
 ## Harness and fixture
 
@@ -120,7 +132,7 @@ and hash. Its hash was `1cd21e9585942c0f`; the full hash was
 
 | Profile | Drain | Persisted/s | Transactions | Full 128-record transactions | p50 | p95 | p99 | Maximum | Unexpected failures |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| Fast CI | 2.689 s | 1,134.5 | 32 | 22 | 113.110 ms | 124.442 ms | 128.693 ms | 128.693 ms | 0 |
+| Fast CI, corrected directory boundary | 2.689 s | 1,134.6 | 32 | 22 | 112.401 ms | 137.098 ms | 154.940 ms | 154.940 ms | 0 |
 | Full | 7,183.637 s | 629.5 | 36,323 | 35,319 | 196.478 ms | 298.440 ms | 391.737 ms | 2,895.726 ms | 0 |
 
 The full run attempted and rejected exactly 4,000 stable provider-native HR
@@ -200,10 +212,10 @@ context of 200 ms for a user-triggered history/filter operation.
 The conservative full-profile process high-water was 550,174,720 bytes
 (524.688 MiB). Because `ru_maxrss` is monotonic, generation, persistence, query,
 export, and final process endpoint fields all retain the same maximum and cannot
-attribute which earlier operation created it. The fast profile high-water was
-47,382,528 bytes (45.188 MiB). External progress observations during full
-persistence showed current RSS around 27-54 MiB; those observations are not
-treated as phase peaks or substituted for the in-harness high-water.
+attribute which earlier operation created it. The corrected fast profile
+high-water was 43,810,816 bytes (41.781 MiB). External progress observations
+during full persistence showed current RSS around 27-54 MiB; those observations
+are not treated as phase peaks or substituted for the in-harness high-water.
 
 The mechanism is `getrusage(RUSAGE_SELF).ru_maxrss`, which is a process-lifetime
 resident high-water mark on this macOS runner. It is sampled at generation,
@@ -297,19 +309,47 @@ fallback is introduced.
 
 ## File policy and device boundary
 
-`FAIL` for reliable host-level automatic policy. The full profile, focused
-reopen test, forced interruption, and migration usually report the primary
-store and all discovered WAL/SHM sidecars as
-`NSFileProtectionCompleteUntilFirstUserAuthentication` with
-`isExcludedFromBackup = true`; the helper re-discovers and reapplies policy.
-However, one actual complete-suite run observed both WAL and SHM backup
-exclusion values as `false` immediately after a subsequent write.
+`PASS` for the corrected hosted directory boundary and discovered-file defense.
+The two pre-correction failures remain part of the evidence and are distinct:
 
-The exact focused test then passed 20/20, and six consecutive complete suites
-passed without a code change. Those repetitions show that the helper often
-works; they do not erase the observed nondeterministic sidecar-lifecycle
-failure. This gate does not alter the accepted production file-policy mechanism
-to make it pass.
+- One earlier local complete-suite run observed
+  `TelemetryV2.store-wal` and `TelemetryV2.store-shm` with
+  `isExcludedFromBackup = false` after a subsequent write.
+- Exact-head CI run
+  [`31885551307`](https://github.com/tourvald/walkingpad-remote/actions/runs/31885551307)
+  observed `TelemetryV2.store` and `TelemetryV2.store-shm` with
+  `isExcludedFromBackup = false`. It did not report WAL+SHM.
+
+Those observations prove that a child-file xattr can be transient and cannot be
+the authoritative group boundary. They are not erased or relabeled. Under the
+PM-approved correction, factory setup marks and immediately read-verifies
+exactly `primaryStoreURL.deletingLastPathComponent()` before `ModelContainer`
+opens. The production transaction body and its existing post-transaction
+discovered-file policy call are unchanged.
+
+At correction code/test head
+`aca3a1ff36a0a920fd9a0f2ee972b130274f5d94`, deterministic regression coverage
+verified the directory through store creation, initial and subsequent writes,
+child-attribute reset, reopen, WAL removal/recreation, and synthetic V1-to-test
+V2 migration. The recreated child cannot remove its parent's exclusion.
+Discovered primary/WAL/SHM files still receive
+`NSFileProtectionCompleteUntilFirstUserAuthentication` and
+`isExcludedFromBackup = true` when the defense-in-depth helper applies them.
+
+Post-correction hosted verification included 20/20 fixed focused policy
+repetitions, two explicit fast-gate invocations, the complete Swift suite
+(187 tests reported across targets, one configured full-profile skip, zero
+failures), forced interruption/recovery, synthetic migration, boundary/isolation
+tests, Python entrypoint compilation, Xcode metadata, and an unsigned generic
+iOS/watchOS build. The corrected fast summary reported the directory exclusion
+as `true` after write and reopen, unchanged deterministic hash
+`1cd21e9585942c0f`, and `filePolicyHostPass = true`.
+
+The second 1,000-hour profile was not rerun. The correction adds one directory
+setup/readback before `ModelContainer`; it does not change `explicitTransaction`,
+record mapping, transaction boundaries, per-write child policy, or transaction
+timing. Per the binding PM decision, all full-scale results remain those
+measured on `c67f991d4568c776d9776f6100b03c15279c642b`.
 
 This does not prove physical iOS behavior. The following items are explicitly
 carried to issue #37 and each remains `UNVERIFIED_ON_DEVICE`:
@@ -357,7 +397,7 @@ Each category has exactly one primary classification.
 | Interruption/reopen | `PASS` | External `SIGKILL`, committed count/hash preserved, tail absent |
 | Incomplete-session recovery | `PASS` | Harness-only transaction plus second reopen; no fabricated completion |
 | Migration viability | `PASS` | Actual V1 to test-only synthetic V2 plus repeated reopen |
-| Host file-policy application | `FAIL` | One run observed WAL/SHM backup exclusion lost after a write; later repetitions do not erase it |
+| Host file-policy application | `PASS` | Dedicated directory excluded before open and stable through writes/reopen/migration/child recreation; discovered-file defense retained |
 | Real-device file protection | `UNVERIFIED_ON_DEVICE` | Requires physical iPhone lock/lifecycle evidence in #37 |
 | Real-device backup exclusion | `UNVERIFIED_ON_DEVICE` | Requires physical iOS backup/restore evidence in #37 |
 | Designated-device performance | `UNVERIFIED_ON_DEVICE` | Hosted Mac numbers are not extrapolated to iPhone |
@@ -379,19 +419,16 @@ Each category has exactly one primary classification.
   buffer, retry, priority, loss-accounting, or batching policy.
 - Physical file protection, backup, performance, and Instruments evidence remain
   explicitly deferred to #37.
-- One hosted suite observed WAL/SHM backup-exclusion loss after a write; 20
-  focused and six full-suite repetitions passed unchanged. The nondeterministic
-  lifecycle failure is the automated blocker, not merely a device carry-over.
+- Per-file backup exclusion may be reset by file operations, as both local and
+  exact-head CI evidence demonstrated. The dedicated directory is now the
+  authoritative hosted boundary; child-file attributes remain defense in depth.
 
 The scale, query, recovery, and migration evidence supports retaining SwiftData;
 no corruption, committed-data loss, identity/provenance/causal corruption,
 migration loss, MainActor/control-path coupling, or operationally unusable scale
 behavior was found. A persistence technology switch is not justified.
 
-Issue #27 is not technically supportable while the automated host file-policy
-category is `FAIL`. The narrow recommendation is to investigate when SwiftData
-recreates or mutates WAL/SHM after `ModelContext.transaction`, establish a
-deterministic post-write/reopen reapplication boundary without weakening
-protection or backup exclusion, and rerun #26. PM must also retain the
+The corrected automated evidence supports PM review while retaining SwiftData.
+Issue #27 remains blocked until PM accepts this gate. PM must also retain the
 substantial storage/latency target misses and all five `UNVERIFIED_ON_DEVICE`
-items. No recorder work is authorized by this blocked report.
+items. No recorder work is authorized by this report.

--- a/docs/telemetry-v2/swiftdata-gate.md
+++ b/docs/telemetry-v2/swiftdata-gate.md
@@ -1,0 +1,385 @@
+# Telemetry V2 SwiftData automated architecture gate
+
+Status: issue #26 hosted evidence report.
+
+## Verdict
+
+`GO — AUTOMATED GATE ACCEPTABLE; DEVICE-ONLY ITEMS REQUIRE PM CARRY-OVER
+ACCEPTANCE`
+
+The actual V1 SwiftData Foundation completed the deterministic hosted fast and
+full profiles without semantic, corruption, recovery, migration, isolation, or
+file-policy failure. The full profile persisted 4,522,003 records representing
+exactly 1,000 workout-hours. Hosted transaction and storage hypotheses were
+missed substantially, but measured throughput, bounded late-scale behavior,
+sub-200-ms representative queries, bounded memory, and successful reopen show
+no material architecture defect. The misses are product-planning evidence, not
+permission to weaken retention or scientific semantics.
+
+This gate evaluates the concrete, unwired Telemetry V2 Foundation merged by
+issue #39. It does not implement the recorder or authorize issue #27. Product
+work may proceed only after PM accepts both this automated evidence and every
+device-only carry-over item below.
+
+## Tested revision and environment
+
+| Item | Value |
+| --- | --- |
+| Canonical base | `4c59ae0257d40c9e86df386ca9c56713e88f3270` |
+| Measured harness head | `c67f991d4568c776d9776f6100b03c15279c642b` |
+| Schema | actual production `TelemetrySchemaV1` (`1.0.0`) |
+| Harness | `swiftdata-gate-v1` |
+| Deterministic seed | `0x26_39_40_2026` (`164169261094`) |
+| Machine | Apple M5, arm64, 10 logical CPUs, 16 GB RAM |
+| Host OS | macOS 27.0, build `26A5406e` |
+| Xcode | 27.0 beta, build `27A5194q` |
+| Swift | 6.4, package compiled in Swift 5 language mode |
+| SDK | macOS 27.0 |
+| Full command | `TELEMETRY_GATE_PROFILE=full TELEMETRY_GATE_STORE_DIRECTORY=<fresh-temp>/store TELEMETRY_GATE_OUTPUT=<fresh-temp>/full-summary.json swift test -c release --filter TelemetryGateBenchmarkTests/testConfiguredFullProfile` |
+
+The full store was created in a fresh temporary directory. No app was installed
+or launched, no physical device was used, and no BLE/treadmill connection or
+command was attempted.
+
+The implementation uses the existing `@ModelActor` store and its serial model
+executor. The gate constructs the store from a detached task and verifies that
+store work is not running on the main thread. Apple's public SwiftData contracts
+used by the methodology are
+[`ModelActor`](https://developer.apple.com/documentation/swiftdata/modelactor),
+[`ModelContainer`](https://developer.apple.com/documentation/swiftdata/modelcontainer),
+[`VersionedSchema`](https://developer.apple.com/documentation/swiftdata/versionedschema),
+and
+[`SchemaMigrationPlan`](https://developer.apple.com/documentation/swiftdata/schemamigrationplan).
+No private SwiftData API is a correctness dependency.
+
+## Harness and fixture
+
+The SwiftPM-only gate lives in `Tests/TelemetrySwiftDataGateTests`. A separate
+`TelemetryGateCrashWorker` executable exists solely to prove forced-process
+interruption. Neither target is part of the Xcode application project.
+
+The production persistence API remains unwired. The one benchmark testability
+seam is internal to `TelemetryPersistence`: it runs the existing insert
+validation and model mapping inside one actual `ModelContext.transaction`.
+Therefore a reported 128-record transaction is one transaction, not 128 calls
+to the public per-record save API. The seam does not define recorder buffering
+or batching policy and has no application/runtime caller.
+
+The causal and comparable-session query helpers are likewise internal,
+harness-only probes against the accepted schema. They validate the required
+future query shapes without adding a product read API. In particular, workout
+mode is stored as a versioned payload, so the comparable-session probe first
+uses the indexed profile/recent ordering and then decodes the mode payload.
+
+### Deterministic profiles
+
+| Profile | Sessions | Seconds/session | Hours | HR | Treadmill | Events | Frames | Analyses | Configurations | Sources | Total persisted |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Fast CI | 4 | 600 | 0.667 | 480 | 160 | 80 | 2,320 | 4 | 1 | 2 | 3,051 |
+| Full | 1,000 | 3,600 | 1,000 | 720,000 | 240,000 | 20,000 | 3,540,000 | 1,000 | 1 | 2 | 4,522,003 |
+
+The total includes sessions. Fifty full-profile sessions are deliberately
+incomplete. A single immutable configuration snapshot is reused by all 1,000
+sessions.
+
+Native HR is generated every five seconds and treadmill evidence every fifteen
+seconds. One quarter of HR observations have a source-scoped provider-native
+identity. The fixture retries 4,000 exact provider redeliveries and requires
+every one to be rejected by that exact stable identity. It also persists
+18,000 duplicate-value/duplicate-sequence pairs without stable identity as
+separate evidence; no fuzzy deduplication is allowed.
+
+Each session contains the same typed 20-event lifecycle mix: session and phase
+transitions, source and connection transitions, control decisions, command
+enqueue/send/ACK, timeout/retry/failure, safety, cooldown, stop evidence, manual
+stop, and recorder-health evidence. Envelope causal IDs are checked against the
+typed payload IDs.
+
+Canonical frames are generated at no more than 1 Hz and reference existing
+native observations. Every session has a deliberate 60-second frame gap with no
+backfill; the first post-gap frame contains an explicit gap boundary. Factual
+treadmill speed remains decoded-device-report evidence and is never replaced by
+desired, commanded, or estimated speed.
+
+The generator streams at most one pending transaction (128 records) rather than
+holding the full fixture in memory. Counts and a deterministic FNV-1a identity
+hash are checked. The fast profile is run twice and must produce the same counts
+and hash. Its hash was `1cd21e9585942c0f`; the full hash was
+`e8a131ce8251eb90`.
+
+## Insert and transaction results
+
+| Profile | Drain | Persisted/s | Transactions | Full 128-record transactions | p50 | p95 | p99 | Maximum | Unexpected failures |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Fast CI | 2.689 s | 1,134.5 | 32 | 22 | 113.110 ms | 124.442 ms | 128.693 ms | 128.693 ms | 0 |
+| Full | 7,183.637 s | 629.5 | 36,323 | 35,319 | 196.478 ms | 298.440 ms | 391.737 ms | 2,895.726 ms | 0 |
+
+The full run attempted and rejected exactly 4,000 stable provider-native HR
+redeliveries. They are expected idempotence checks, not retry/failure noise.
+
+| Full records already persisted | Samples | p50 | p95 | p99 | Maximum |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 0-452,200 | 3,525 | 128.881 ms | 150.952 ms | 158.453 ms | 490.130 ms |
+| 452,200-1,130,500 | 5,299 | 135.506 ms | 252.020 ms | 284.588 ms | 472.385 ms |
+| 1,130,500-2,261,001 | 8,832 | 211.505 ms | 287.865 ms | 313.418 ms | 659.598 ms |
+| 2,261,001-4,522,003 | 17,663 | 222.937 ms | 318.693 ms | 482.001 ms | 2,895.726 ms |
+
+The first two buckets mix record classes, so their absolute difference is not
+attributed solely to store size. The last two buckets are overwhelmingly the
+same canonical-frame model and double the populated range: p50 increases 5.4%
+and p95 10.7%. That is visible scale cost, but not a return to an O(N) duplicate
+scan. p99 is noisier and rises 53.8%; the 2.896-second maximum is a rare hosted
+checkpoint/outlier. Aggregate throughput remains about 501 times the fixture's
+steady-state evidence rate of roughly 1.3 records/s.
+
+The percentile method is nearest-rank over every complete 128-record
+transaction. Drain time covers deterministic generation plus persistence. The
+transaction count also includes bounded partial transactions and the 1,000
+session/configuration owner writes; those are not misreported as 128-record
+transactions. Expected duplicate-redelivery rejections are reported separately
+from unexpected failures.
+
+Every record insertion still executes the Foundation's bounded identity
+predicates with `fetchLimit = 1`. Full-transaction latency is grouped by records
+already persisted (0-10%, 10-25%, 25-50%, and 50-100%) so an obvious return to a
+full-table duplicate scan is visible rather than inferred from a source-string
+test alone.
+
+The original 50 ms p95 is a designated-device hypothesis. The hosted result is
+reported honestly but is not an iPhone pass/fail threshold and does not select
+the production batch policy for issue #27.
+
+## Query results
+
+Each latency below is warm-up followed by repeated hosted measurements against
+the final profile store. Fast uses five repetitions and full uses nine. The
+export traversal is a single complete-session measurement. Fast and full provide
+two dataset scales; each queried session contains the normal per-session record
+volume shown above.
+
+| Query shape | Exact definition | Fast p50 / p95, ms | Full p50 / p95, ms | Returned records |
+| --- | --- | ---: | ---: | ---: |
+| Recent history | Profile predicate, newest `startedAt`, limit 20 | 0.309 / 0.344 | 13.900 / 14.188 | 20 full |
+| HR series | One session, arrival order | 4.607 / 5.060 | 23.282 / 23.563 | 720 full |
+| Treadmill series | One session, arrival order | 1.742 / 1.800 | 8.681 / 8.742 | 240 full |
+| Canonical frames | One session, canonical second | 17.420 / 18.012 | 96.141 / 98.606 | 3,540 full |
+| Session events | One session, elapsed event order | 0.891 / 1.001 | 1.355 / 1.423 | 20 |
+| Event kind | One session plus `commandLifecycle` | 0.525 / 0.553 | 1.035 / 1.081 | 8 |
+| Decision causal lookup | Exact decision ID | 0.431 / 0.464 | 0.945 / 1.007 | 4 |
+| Command causal lookup | Exact command ID | 0.378 / 0.428 | 0.898 / 0.944 | 3 |
+| Attempt causal lookup | Exact attempt ID | 0.384 / 0.575 | 0.865 / 0.911 | 2 |
+| Analysis | Session plus analyzer version | 0.333 / 0.379 | 0.852 / 0.879 | 1 |
+| Comparable sessions | Indexed profile/recent fetch, decoded exact workout mode, limit 10 | 0.293 / 0.332 | 176.310 / 177.330 | 10 full |
+| Export traversal | Complete session across all evidence classes | 25.283 single | 132.253 single | 4,522 full |
+
+`sqlite3 EXPLAIN QUERY PLAN` is used only as supplementary inspection. It is not
+a correctness dependency and does not access private SwiftData APIs.
+Plans use the profile/started-at index for recent history, the
+session/canonical-second index for frames, the session/kind/elapsed index for
+kind-filtered events, the three individual causal-ID indexes, and the
+session/analyzer-version/generated-at index for analyses. HR and treadmill use
+their indexed session predicates but make a temporary per-session sort for
+`arrivalOrder`; the accepted composite index orders by received elapsed time.
+Unfiltered session events and causal results likewise perform a small result-set
+sort. The measured p95 values above include those sorts. Comparable-session mode
+decoding fetches the 250 sessions for one of four profiles; its 177.330-ms p95
+is the slowest ordinary full-store query and remains below the declared hosted
+context of 200 ms for a user-triggered history/filter operation.
+
+## Memory
+
+The conservative full-profile process high-water was 550,174,720 bytes
+(524.688 MiB). Because `ru_maxrss` is monotonic, generation, persistence, query,
+export, and final process endpoint fields all retain the same maximum and cannot
+attribute which earlier operation created it. The fast profile high-water was
+47,382,528 bytes (45.188 MiB). External progress observations during full
+persistence showed current RSS around 27-54 MiB; those observations are not
+treated as phase peaks or substituted for the in-harness high-water.
+
+The mechanism is `getrusage(RUSAGE_SELF).ru_maxrss`, which is a process-lifetime
+resident high-water mark on this macOS runner. It is sampled at generation,
+persistence, representative fetch, export, and post-reopen endpoints. It is not
+instantaneous private footprint, cannot attribute shared pages precisely, and
+later phase values cannot decrease. The fixture is streamed and the full data
+set is never materialized as an in-memory array. The synthetic migration fixture
+is intentionally small and did not justify a separate full-scale memory claim.
+
+## Storage growth and decomposition
+
+After write and after reopen were identical:
+
+| File | Bytes | MiB |
+| --- | ---: | ---: |
+| Primary store | 7,150,436,352 | 6,819.188 |
+| WAL | 3,815,152 | 3.638 |
+| SHM | 65,536 | 0.063 |
+| Total | 7,154,317,040 | 6,822.888 |
+
+Total growth is 7,154,317 bytes/hour (6.823 MiB/hour): 7.15 times the
+1 MB/hour hypothesis and 3.58 times the 2 MB/hour hypothesis. At one workout
+hour per day, this is about 2.43 GiB/year. The miss is operationally significant
+and issue #27 must expose capacity/pressure evidence, but it is bounded, close
+to linear, and not by itself a material failure under this gate contract.
+
+Direct measurements include the primary SQLite store, every discovered WAL/SHM
+sidecar, their sum, and host file attributes at staged lifecycle points. Growth
+per hour is total bytes divided by exactly 1,000 represented workout-hours.
+
+The contribution table is a controlled staged delta: sessions/schema/sources,
+then HR, treadmill, events, frames, and analyses. Each delta includes that
+stage's rows, indexes, page allocation, and the contemporaneous WAL state. It is
+therefore a pressure estimate, not an exact per-table attribution. Remaining
+schema/index overhead is inferred from the initial stage and SQLite page/index
+inspection. WAL/SHM write amplification is reported separately from retained
+primary-store bytes.
+
+Staged total deltas were approximately 545.478 MiB for HR, 185.596 MiB for
+treadmill, 9.899 MiB for events, and 6,080.259 MiB for canonical frames. The
+analysis stage changed total by -0.318 MiB because its small write coincided
+with a WAL checkpoint, demonstrating why staged deltas are only estimates.
+
+Read-only SQLite `dbstat` page attribution after reopen gives a stronger direct
+breakdown of the retained primary store:
+
+| SQLite objects | MiB | Primary-store share |
+| --- | ---: | ---: |
+| Canonical frame table and indexes | 5,941.664 | 87.13% |
+| HR table and indexes | 518.102 | 7.60% |
+| Treadmill table and indexes | 175.199 | 2.57% |
+| SwiftData/Core Data history and metadata | 162.293 | 2.38% |
+| Event table and indexes | 13.090 | 0.19% |
+| Analysis table and indexes | 0.953 | 0.01% |
+| Sessions/configuration/sources and indexes | 0.551 | 0.01% |
+| Other objects plus unallocated pages | 7.336 | 0.11% |
+
+Frame payloads plus four frame identity/session indexes dominate the retained
+footprint. This is not WAL retention: WAL+SHM after reopen are only 3.701 MiB.
+
+The 1 MB/hour and 2 MB/hour values are hypotheses, not permission to remove or
+coalesce scientific evidence. Any miss above is retained and assessed without
+changing cadence, gaps, indexes, events, or retention semantics.
+
+## Forced interruption and incomplete-session recovery
+
+`PASS` — a separate worker creates an on-disk V1 store, persists a known session,
+source, and 256 HR records, writes the committed-prefix count and deterministic
+identity hash, then creates an uncommitted in-memory tail and waits. The parent
+sends `SIGKILL`; this is not a graceful close.
+
+Reopen retains exactly the 256 committed records and the same identity hash, and
+does not contain the uncommitted tail. The session remains `running`, has no end
+timestamp, and has incomplete recorder health; no fabricated completion or
+silent empty-store replacement occurs. A harness-only recovery transaction marks
+that existing session `incomplete` with reason `forced-process-interruption`.
+A second reopen retains the same evidence/count/hash and the honest incomplete
+state. This proves the schema/transaction mechanism; issue #27 still owns the
+production recovery orchestration.
+
+## Synthetic migration
+
+`PASS` — the test first writes actual `TelemetrySchemaV1` evidence, then opens
+the same file with a test-only `2.0.0` schema that adds one synthetic marker and
+a public SwiftData lightweight migration plan. Counts and the ordered HR
+identity hash remain identical, the marker is present, and a second reopen
+produces the same result. No production V2 schema, legacy import, or empty-store
+fallback is introduced.
+
+## File policy and device boundary
+
+`PASS` for the host-level helper: after write, reopen, forced interruption, and
+migration, the primary store and all discovered WAL/SHM sidecars report
+`NSFileProtectionCompleteUntilFirstUserAuthentication` and
+`isExcludedFromBackup = true` where macOS exposes those resource attributes.
+The helper re-discovers and reapplies policy to recreated sidecars.
+
+One initial repository-wide test run transiently observed backup exclusion as
+`false` on WAL/SHM immediately after a subsequent write. The exact focused test
+then passed 20/20, and six consecutive complete suites passed without a code
+change; the full profile, migration, recovery, and reopen snapshots also passed.
+This did not establish a repeatable Foundation defect, but it remains a host
+sidecar-lifecycle race risk for PM/device follow-up rather than being omitted.
+
+This does not prove physical iOS behavior. The following items are explicitly
+carried to issue #37 and each remains `UNVERIFIED_ON_DEVICE`:
+
+1. Protection of the real iPhone store and every SQLite sidecar after first
+   unlock, subsequent screen lock, process suspension/termination, and reopen.
+2. Real iOS backup exclusion for the store and recreated sidecars across device
+   backup and restore lifecycle.
+3. The provisional 128-record transaction p50/p95/p99 and throughput on the
+   designated physical target iPhone.
+4. Full-profile representative query latency on the designated target iPhone.
+5. On-device Instruments memory/footprint and app-lifecycle pressure behavior.
+
+No physical device installation, launch, screen-lock action, BLE connection, or
+treadmill command was performed by this gate.
+
+## Isolation and scope
+
+`PASS` — the Foundation store remains a `@ModelActor` backed by its serial model
+executor, autosave is disabled, the gate confirms persistence execution is not
+on the main thread, and static boundary tests confirm that neither gate target
+nor `TelemetryStoreFactory.make` appears in application runtime sources. The
+Xcode application project does not include the gate targets. No production
+control, sensor, HR, BLE, UI, history/export, legacy telemetry, or safety path
+acquired a database dependency.
+
+## Classification matrix
+
+Each category has exactly one primary classification.
+
+| Category | Classification | Evidence |
+| --- | --- | --- |
+| Fixture semantic correctness | `PASS` | Deterministic counts/hash, native/frame/gap/provenance checks |
+| Schema/identity correctness | `PASS` | Exact native redelivery rejected; identity-absent duplicates retained |
+| Insert scaling | `PASS` | Same-model late p50/p95 rise 5.4%/10.7% across doubled range; no full-table scan signature |
+| Transaction latency/throughput | `PASS` | Hosted p50/p95/p99 196/298/392 ms and 629.5 records/s; 50-ms hypothesis missed |
+| History queries | `PASS` | Full p95 14.188 ms |
+| Single-session time-series queries | `PASS` | Full HR/treadmill/frame p95 23.563/8.742/98.606 ms |
+| Causal queries | `PASS` | Indexed harness-only decision/command/attempt p95 at or below 1.007 ms |
+| Export traversal | `PASS` | Complete 4,522-record session in 132.253 ms |
+| Comparable-session queries | `PASS` | Indexed recent-profile plus decoded mode p95 177.330 ms |
+| Memory | `PASS` | Streamed fixture, no runaway/OOM; conservative host high-water 524.688 MiB |
+| Store growth | `PASS` | Bounded 6.823 MiB/hour; significant non-blocking target miss documented |
+| WAL/SHM behavior | `PASS` | 3.701 MiB combined after write/reopen; attributes retained |
+| Interruption/reopen | `PASS` | External `SIGKILL`, committed count/hash preserved, tail absent |
+| Incomplete-session recovery | `PASS` | Harness-only transaction plus second reopen; no fabricated completion |
+| Migration viability | `PASS` | Actual V1 to test-only synthetic V2 plus repeated reopen |
+| Host file-policy application | `PASS` | Primary/WAL/SHM attributes at relevant hosted lifecycles |
+| Real-device file protection | `UNVERIFIED_ON_DEVICE` | Requires physical iPhone lock/lifecycle evidence in #37 |
+| Real-device backup exclusion | `UNVERIFIED_ON_DEVICE` | Requires physical iOS backup/restore evidence in #37 |
+| Designated-device performance | `UNVERIFIED_ON_DEVICE` | Hosted Mac numbers are not extrapolated to iPhone |
+| Real-device query performance | `UNVERIFIED_ON_DEVICE` | Requires full-store query evidence on the target iPhone |
+| On-device memory/pressure | `UNVERIFIED_ON_DEVICE` | Requires Instruments and physical app-lifecycle evidence |
+| Main-actor/control-path isolation | `PASS` | Model actor/thread/runtime-coupling boundary checks |
+
+## Limitations and recommendation
+
+- Hosted latency and memory are runner-specific and do not predict an iPhone.
+- Absolute microbenchmark thresholds are intentionally not CI correctness gates;
+  semantic counts, identities, recovery, migration, policy, and boundaries are.
+- Storage staged deltas include page allocation, indexes, and current WAL state;
+  they are useful estimates, not exact table accounting.
+- Comparable mode filtering decodes the accepted payload in the harness because
+  V1 has no indexed scalar workout-mode projection. This is measured honestly
+  and is not redesigned here.
+- The gate batch seam proves transaction behavior but does not choose #27's
+  buffer, retry, priority, loss-accounting, or batching policy.
+- Physical file protection, backup, performance, and Instruments evidence remain
+  explicitly deferred to #37.
+- One hosted suite transiently observed WAL/SHM backup-exclusion loss after a
+  write; 20 focused and six full-suite repetitions passed unchanged. Treat this
+  as an unresolved lifecycle-race risk, especially in the real-device checks.
+
+The hosted evidence supports continuing with SwiftData and designing issue #27
+against measured drain/storage pressure. No corruption, committed-data loss,
+identity/provenance/causal corruption, migration loss, MainActor/control-path
+coupling, or operationally unusable scale behavior was found. A persistence
+technology switch is not justified by this evidence.
+
+Issue #27 is technically supportable, but it is not authorized by this report.
+PM must first accept the gate, the substantial storage/latency hypothesis misses,
+and all five `UNVERIFIED_ON_DEVICE` carry-over items. Recorder design should
+remain bounded and observable, treat 128 as a provisional measured point rather
+than policy, and plan product capacity UX/metrics without reducing native or
+canonical evidence.

--- a/docs/telemetry-v2/swiftdata-gate.md
+++ b/docs/telemetry-v2/swiftdata-gate.md
@@ -4,29 +4,38 @@ Status: issue #26 hosted evidence report.
 
 ## Verdict
 
-`GO — AUTOMATED GATE ACCEPTABLE; DEVICE-ONLY ITEMS REQUIRE PM CARRY-OVER
-ACCEPTANCE`
+`BLOCKED FOR PM DECISION`
 
 The actual V1 SwiftData Foundation completed the deterministic hosted fast and
-full profiles without semantic, corruption, recovery, migration, isolation, or
-file-policy failure. The full profile persisted 4,522,003 records representing
-exactly 1,000 workout-hours. Hosted transaction and storage hypotheses were
-missed substantially, but measured throughput, bounded late-scale behavior,
-sub-200-ms representative queries, bounded memory, and successful reopen show
-no material architecture defect. The misses are product-planning evidence, not
-permission to weaken retention or scientific semantics.
+full profiles without semantic, corruption, recovery, migration, or isolation
+failure. The full profile persisted 4,522,003 records representing exactly
+1,000 workout-hours. Hosted transaction and storage hypotheses were missed
+substantially, but measured throughput, bounded late-scale behavior, sub-200-ms
+representative queries, bounded memory, and successful reopen do not expose a
+material scale defect.
+
+The gate is nevertheless blocked because one repository-wide run observed the
+actual WAL and SHM sidecars with `isExcludedFromBackup = false` immediately
+after a subsequent write. Later repetitions passed, so the failure is
+nondeterministic rather than a consistently broken helper. An observed failure
+of required automatic sidecar policy cannot be classified `PASS`, and changing
+production persistence lifecycle behavior is outside issue #26. PM must decide
+the narrow Foundation correction/investigation and require this host gate to be
+rerun. The other target misses remain product-planning evidence, not permission
+to weaken retention or scientific semantics.
 
 This gate evaluates the concrete, unwired Telemetry V2 Foundation merged by
 issue #39. It does not implement the recorder or authorize issue #27. Product
-work may proceed only after PM accepts both this automated evidence and every
-device-only carry-over item below.
+work must not proceed until the automated host-policy failure is corrected and
+this gate is rerun; PM must then also accept every device-only carry-over item.
 
 ## Tested revision and environment
 
 | Item | Value |
 | --- | --- |
 | Canonical base | `4c59ae0257d40c9e86df386ca9c56713e88f3270` |
-| Measured harness head | `c67f991d4568c776d9776f6100b03c15279c642b` |
+| Measured full-profile harness head | `c67f991d4568c776d9776f6100b03c15279c642b` |
+| Corrected recovery head | `6a0d8b2a57d1486a0312ab8861e2e38834b08311` |
 | Schema | actual production `TelemetrySchemaV1` (`1.0.0`) |
 | Harness | `swiftdata-gate-v1` |
 | Deterministic seed | `0x26_39_40_2026` (`164169261094`) |
@@ -169,7 +178,7 @@ volume shown above.
 | Command causal lookup | Exact command ID | 0.378 / 0.428 | 0.898 / 0.944 | 3 |
 | Attempt causal lookup | Exact attempt ID | 0.384 / 0.575 | 0.865 / 0.911 | 2 |
 | Analysis | Session plus analyzer version | 0.333 / 0.379 | 0.852 / 0.879 | 1 |
-| Comparable sessions | Indexed profile/recent fetch, decoded exact workout mode, limit 10 | 0.293 / 0.332 | 176.310 / 177.330 | 10 full |
+| Comparable sessions | Unbounded profile/recent fetch (250 full rows), decoded exact workout mode, output limit 10 | 0.293 / 0.332 | 176.310 / 177.330 | 10 full |
 | Export traversal | Complete session across all evidence classes | 25.283 single | 132.253 single | 4,522 full |
 
 `sqlite3 EXPLAIN QUERY PLAN` is used only as supplementary inspection. It is not
@@ -262,9 +271,11 @@ changing cadence, gaps, indexes, events, or retention semantics.
 ## Forced interruption and incomplete-session recovery
 
 `PASS` — a separate worker creates an on-disk V1 store, persists a known session,
-source, and 256 HR records, writes the committed-prefix count and deterministic
-identity hash, then creates an uncommitted in-memory tail and waits. The parent
-sends `SIGKILL`; this is not a graceful close.
+source, and 256 HR records, then stages one additional HR model in the actual
+autosave-disabled `ModelContext` without a transaction/save. Only after that
+real uncommitted tail exists does it write the committed-prefix count and
+deterministic identity hash marker and wait. The parent sends `SIGKILL`; this is
+not a graceful close.
 
 Reopen retains exactly the 256 committed records and the same identity hash, and
 does not contain the uncommitted tail. The session remains `running`, has no end
@@ -286,18 +297,19 @@ fallback is introduced.
 
 ## File policy and device boundary
 
-`PASS` for the host-level helper: after write, reopen, forced interruption, and
-migration, the primary store and all discovered WAL/SHM sidecars report
-`NSFileProtectionCompleteUntilFirstUserAuthentication` and
-`isExcludedFromBackup = true` where macOS exposes those resource attributes.
-The helper re-discovers and reapplies policy to recreated sidecars.
+`FAIL` for reliable host-level automatic policy. The full profile, focused
+reopen test, forced interruption, and migration usually report the primary
+store and all discovered WAL/SHM sidecars as
+`NSFileProtectionCompleteUntilFirstUserAuthentication` with
+`isExcludedFromBackup = true`; the helper re-discovers and reapplies policy.
+However, one actual complete-suite run observed both WAL and SHM backup
+exclusion values as `false` immediately after a subsequent write.
 
-One initial repository-wide test run transiently observed backup exclusion as
-`false` on WAL/SHM immediately after a subsequent write. The exact focused test
-then passed 20/20, and six consecutive complete suites passed without a code
-change; the full profile, migration, recovery, and reopen snapshots also passed.
-This did not establish a repeatable Foundation defect, but it remains a host
-sidecar-lifecycle race risk for PM/device follow-up rather than being omitted.
+The exact focused test then passed 20/20, and six consecutive complete suites
+passed without a code change. Those repetitions show that the helper often
+works; they do not erase the observed nondeterministic sidecar-lifecycle
+failure. This gate does not alter the accepted production file-policy mechanism
+to make it pass.
 
 This does not prove physical iOS behavior. The following items are explicitly
 carried to issue #37 and each remains `UNVERIFIED_ON_DEVICE`:
@@ -341,11 +353,11 @@ Each category has exactly one primary classification.
 | Comparable-session queries | `PASS` | Indexed recent-profile plus decoded mode p95 177.330 ms |
 | Memory | `PASS` | Streamed fixture, no runaway/OOM; conservative host high-water 524.688 MiB |
 | Store growth | `PASS` | Bounded 6.823 MiB/hour; significant non-blocking target miss documented |
-| WAL/SHM behavior | `PASS` | 3.701 MiB combined after write/reopen; attributes retained |
+| WAL/SHM size/checkpoint behavior | `PASS` | 3.701 MiB combined after write/reopen; file-policy reliability classified separately |
 | Interruption/reopen | `PASS` | External `SIGKILL`, committed count/hash preserved, tail absent |
 | Incomplete-session recovery | `PASS` | Harness-only transaction plus second reopen; no fabricated completion |
 | Migration viability | `PASS` | Actual V1 to test-only synthetic V2 plus repeated reopen |
-| Host file-policy application | `PASS` | Primary/WAL/SHM attributes at relevant hosted lifecycles |
+| Host file-policy application | `FAIL` | One run observed WAL/SHM backup exclusion lost after a write; later repetitions do not erase it |
 | Real-device file protection | `UNVERIFIED_ON_DEVICE` | Requires physical iPhone lock/lifecycle evidence in #37 |
 | Real-device backup exclusion | `UNVERIFIED_ON_DEVICE` | Requires physical iOS backup/restore evidence in #37 |
 | Designated-device performance | `UNVERIFIED_ON_DEVICE` | Hosted Mac numbers are not extrapolated to iPhone |
@@ -367,19 +379,19 @@ Each category has exactly one primary classification.
   buffer, retry, priority, loss-accounting, or batching policy.
 - Physical file protection, backup, performance, and Instruments evidence remain
   explicitly deferred to #37.
-- One hosted suite transiently observed WAL/SHM backup-exclusion loss after a
-  write; 20 focused and six full-suite repetitions passed unchanged. Treat this
-  as an unresolved lifecycle-race risk, especially in the real-device checks.
+- One hosted suite observed WAL/SHM backup-exclusion loss after a write; 20
+  focused and six full-suite repetitions passed unchanged. The nondeterministic
+  lifecycle failure is the automated blocker, not merely a device carry-over.
 
-The hosted evidence supports continuing with SwiftData and designing issue #27
-against measured drain/storage pressure. No corruption, committed-data loss,
-identity/provenance/causal corruption, migration loss, MainActor/control-path
-coupling, or operationally unusable scale behavior was found. A persistence
-technology switch is not justified by this evidence.
+The scale, query, recovery, and migration evidence supports retaining SwiftData;
+no corruption, committed-data loss, identity/provenance/causal corruption,
+migration loss, MainActor/control-path coupling, or operationally unusable scale
+behavior was found. A persistence technology switch is not justified.
 
-Issue #27 is technically supportable, but it is not authorized by this report.
-PM must first accept the gate, the substantial storage/latency hypothesis misses,
-and all five `UNVERIFIED_ON_DEVICE` carry-over items. Recorder design should
-remain bounded and observable, treat 128 as a provisional measured point rather
-than policy, and plan product capacity UX/metrics without reducing native or
-canonical evidence.
+Issue #27 is not technically supportable while the automated host file-policy
+category is `FAIL`. The narrow recommendation is to investigate when SwiftData
+recreates or mutates WAL/SHM after `ModelContext.transaction`, establish a
+deterministic post-write/reopen reapplication boundary without weakening
+protection or backup exclusion, and rerun #26. PM must also retain the
+substantial storage/latency target misses and all five `UNVERIFIED_ON_DEVICE`
+items. No recorder work is authorized by this blocked report.

--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -30,6 +30,10 @@ let package = Package(
             name: "TelemetryPersistence",
             dependencies: ["TelemetryDomain"]
         ),
+        .executableTarget(
+            name: "TelemetryGateCrashWorker",
+            dependencies: ["TelemetryDomain", "TelemetryPersistence"]
+        ),
         .target(
             name: "WalkingPadCoreLogic",
             path: "WalkingPadRemote",
@@ -83,6 +87,14 @@ let package = Package(
         .testTarget(
             name: "TelemetryPersistenceTests",
             dependencies: ["TelemetryDomain", "TelemetryPersistence"]
+        ),
+        .testTarget(
+            name: "TelemetrySwiftDataGateTests",
+            dependencies: [
+                "TelemetryDomain",
+                "TelemetryPersistence",
+                "TelemetryGateCrashWorker",
+            ]
         )
     ]
 )

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryGateCrashWorker/main.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryGateCrashWorker/main.swift
@@ -1,0 +1,210 @@
+import Foundation
+import TelemetryDomain
+import TelemetryPersistence
+
+private struct WorkerArguments {
+    let storeURL: URL
+    let markerURL: URL
+    let committedHeartRateCount: Int
+
+    init(arguments: [String]) throws {
+        func value(after flag: String) -> String? {
+            guard let index = arguments.firstIndex(of: flag), arguments.indices.contains(index + 1) else {
+                return nil
+            }
+            return arguments[index + 1]
+        }
+
+        guard let storePath = value(after: "--store"),
+              let markerPath = value(after: "--marker"),
+              let countText = value(after: "--committed-heart-rate-count"),
+              let count = Int(countText),
+              count > 0
+        else {
+            throw WorkerError.invalidArguments
+        }
+
+        storeURL = URL(fileURLWithPath: storePath)
+        markerURL = URL(fileURLWithPath: markerPath)
+        committedHeartRateCount = count
+    }
+}
+
+private enum WorkerError: Error {
+    case invalidArguments
+}
+
+private struct RecoveryMarker: Codable {
+    let sessionID: String
+    let committedHeartRateCount: Int
+    let committedIdentityHash: String
+}
+
+private enum RecoveryFixture {
+    static let seed: UInt64 = 0x26_39_40
+    static let baseDate = Date(timeIntervalSince1970: 1_820_000_000)
+
+    static let sessionID = SessionID(rawValue: uuid(kind: 1, counter: 1))
+    static let source = SignalSourceIdentity(
+        id: SourceID(rawValue: uuid(kind: 2, counter: 1)),
+        providerKind: .healthKitSelected,
+        stableLocalKey: "gate-recovery-hr",
+        savingSource: ProviderSavingSource(bundleIdentifier: "gate.synthetic.hr"),
+        knownDevice: nil
+    )
+
+    static var versions: RuntimeVersionContext {
+        RuntimeVersionContext(
+            telemetrySchema: TelemetrySchemaVersion(rawValue: "v1"),
+            algorithm: AlgorithmVersion(rawValue: "gate-algorithm-v1"),
+            safetyPolicy: SafetyPolicyVersion(rawValue: "gate-safety-v1"),
+            workoutProtocol: WorkoutProtocolVersion(rawValue: "gate-workout-v1")
+        )
+    }
+
+    static var session: WorkoutSessionRecord {
+        WorkoutSessionRecord(
+            recordID: RecordID(rawValue: uuid(kind: 3, counter: 1)),
+            sessionID: sessionID,
+            profileLocalIdentifier: "gate-recovery-profile",
+            lifecycleState: .running,
+            workoutMode: .heartRateControlled,
+            startedAt: baseDate,
+            endedAt: nil,
+            endedElapsed: nil,
+            incompleteReason: nil,
+            appContext: AppRuntimeContext(
+                appVersion: "gate",
+                buildNumber: "26",
+                operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersionString
+            ),
+            versions: versions,
+            configuration: ImmutableConfigurationSnapshot(
+                id: ConfigurationSnapshotID(rawValue: uuid(kind: 4, counter: 1)),
+                formatVersion: 1,
+                format: .canonicalJSON,
+                canonicalPayload: Data(#"{"fixture":"recovery"}"#.utf8),
+                contentHash: ContentHash(
+                    algorithm: .sha256,
+                    lowercaseHexDigest: String(repeating: "26", count: 32)
+                )
+            ),
+            healthKitWorkoutIdentifier: nil,
+            treadmill: nil,
+            recorderHealth: RecorderHealthSummary(
+                isComplete: false,
+                lostCriticalRecordCount: 0,
+                lostNativeRecordCount: 0,
+                lastPersistedElapsed: nil
+            )
+        )
+    }
+
+    static func heartRate(index: Int) -> HeartRateObservation {
+        let elapsed = Int64(index) * 1_000_000
+        let measured = baseDate.addingTimeInterval(Double(index))
+        return HeartRateObservation(
+            recordID: RecordID(rawValue: uuid(kind: 5, counter: UInt64(index))),
+            observationID: ObservationID(rawValue: uuid(kind: 6, counter: UInt64(index))),
+            sessionID: sessionID,
+            source: source,
+            beatsPerMinute: UInt16(100 + index % 40),
+            arrivalOrder: UInt64(index),
+            providerSequence: Int64(index),
+            providerSampleIdentity: ProviderNativeSampleIdentity(identifier: "recovery-\(index)"),
+            timestamp: ObservationTimestamp(
+                measuredAt: measured,
+                receivedAt: measured.addingTimeInterval(0.02),
+                recordedAt: measured.addingTimeInterval(0.03),
+                measuredElapsed: ElapsedDuration(microseconds: elapsed),
+                receivedElapsed: ElapsedDuration(microseconds: elapsed + 20_000),
+                recordedElapsed: ElapsedDuration(microseconds: elapsed + 30_000)
+            ),
+            provenance: .reportedByProvider,
+            freshness: EvidenceFreshness(
+                state: .fresh,
+                evaluatedAt: RecordTimestamp(
+                    recordedAt: measured.addingTimeInterval(0.03),
+                    elapsed: ElapsedDuration(microseconds: elapsed + 30_000)
+                ),
+                age: ElapsedDuration(microseconds: 30_000),
+                policyVersion: versions.safetyPolicy
+            ),
+            quality: [],
+            controlUse: .acceptedNotUsed
+        )
+    }
+
+    static func committedIdentityHash(count: Int) -> String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for index in 0..<count {
+            for byte in heartRate(index: index).observationID.description.utf8 {
+                hash ^= UInt64(byte)
+                hash &*= 1_099_511_628_211
+            }
+        }
+        return String(format: "%016llx", hash)
+    }
+
+    private static func uuid(kind: UInt64, counter: UInt64) -> UUID {
+        var high = seed ^ (kind &* 0x9e37_79b9_7f4a_7c15) ^ counter
+        var low = high &+ 0x9e37_79b9_7f4a_7c15
+        high = mix(high)
+        low = mix(low)
+        let bytes = withUnsafeBytes(of: high.bigEndian) { Array($0) }
+            + withUnsafeBytes(of: low.bigEndian) { Array($0) }
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+
+    private static func mix(_ value: UInt64) -> UInt64 {
+        var mixed = value
+        mixed = (mixed ^ (mixed >> 30)) &* 0xbf58_476d_1ce4_e5b9
+        mixed = (mixed ^ (mixed >> 27)) &* 0x94d0_49bb_1331_11eb
+        return mixed ^ (mixed >> 31)
+    }
+}
+
+@main
+private enum TelemetryGateCrashWorker {
+    static func main() async throws {
+        let arguments = try WorkerArguments(arguments: CommandLine.arguments)
+        let store = try TelemetryStoreFactory.make(.onDisk(arguments.storeURL))
+
+        try await store.insertSession(RecoveryFixture.session)
+        try await store.insertSource(
+            RecoveryFixture.source,
+            firstSeen: RecoveryFixture.baseDate,
+            lastSeen: RecoveryFixture.baseDate.addingTimeInterval(
+                Double(arguments.committedHeartRateCount)
+            )
+        )
+        for index in 0..<arguments.committedHeartRateCount {
+            try await store.insertHeartRate(RecoveryFixture.heartRate(index: index))
+        }
+
+        // Allocate a deterministic uncommitted tail before telling the supervisor to kill us.
+        _ = RecoveryFixture.heartRate(index: arguments.committedHeartRateCount)
+        let marker = RecoveryMarker(
+            sessionID: RecoveryFixture.sessionID.description,
+            committedHeartRateCount: arguments.committedHeartRateCount,
+            committedIdentityHash: RecoveryFixture.committedIdentityHash(
+                count: arguments.committedHeartRateCount
+            )
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        try encoder.encode(marker).write(to: arguments.markerURL, options: .atomic)
+
+        // The supervisor uses SIGKILL during this interval. Reaching the tail insert is a failure.
+        try await Task.sleep(nanoseconds: 30_000_000_000)
+        try await store.insertHeartRate(
+            RecoveryFixture.heartRate(index: arguments.committedHeartRateCount)
+        )
+        throw WorkerError.invalidArguments
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryGateCrashWorker/main.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryGateCrashWorker/main.swift
@@ -187,8 +187,11 @@ private enum TelemetryGateCrashWorker {
             try await store.insertHeartRate(RecoveryFixture.heartRate(index: index))
         }
 
-        // Allocate a deterministic uncommitted tail before telling the supervisor to kill us.
-        _ = RecoveryFixture.heartRate(index: arguments.committedHeartRateCount)
+        // Stage a deterministic model-context tail without a transaction/save. Autosave is
+        // disabled by the store, so the supervisor's SIGKILL must discard this real tail.
+        try await store.gateStageUncommittedHeartRate(
+            RecoveryFixture.heartRate(index: arguments.committedHeartRateCount)
+        )
         let marker = RecoveryMarker(
             sessionID: RecoveryFixture.sessionID.description,
             committedHeartRateCount: arguments.committedHeartRateCount,

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
@@ -623,6 +623,14 @@ public actor TelemetryStore {
         }
     }
 
+    /// Issue #26 crash-worker seam. The package-only worker stages a real model-context
+    /// tail while autosave is disabled, then the supervisor interrupts the process.
+    package func gateStageUncommittedHeartRate(_ observation: HeartRateObservation) throws {
+        explicitTransactionDepth += 1
+        defer { explicitTransactionDepth -= 1 }
+        try insertHeartRate(observation)
+    }
+
     func gateFetchRecentSessions(
         profileLocalIdentifier: String,
         limit: Int

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
@@ -59,6 +59,29 @@ public struct TelemetryStoreCounts: Codable, Hashable, Sendable {
     }
 }
 
+enum TelemetryGateRecord: Sendable {
+    case session(WorkoutSessionRecord)
+    case source(StoredSignalSource)
+    case heartRate(HeartRateObservation)
+    case treadmill(TreadmillObservation)
+    case event(WorkoutEvent)
+    case frame(CanonicalFrame)
+    case analysis(WorkoutAnalysisResult)
+}
+
+struct TelemetryGateTraversalCounts: Codable, Hashable, Sendable {
+    let sessions: Int
+    let heartRateSamples: Int
+    let treadmillSamples: Int
+    let events: Int
+    let frames: Int
+    let analyses: Int
+
+    var total: Int {
+        sessions + heartRateSamples + treadmillSamples + events + frames + analyses
+    }
+}
+
 public enum TelemetryStoreFactory {
     public static func make(_ configuration: TelemetryStoreConfiguration) throws -> TelemetryStore {
         let schema = Schema(versionedSchema: TelemetrySchemaV1.self)
@@ -108,6 +131,7 @@ public enum TelemetryStoreFactory {
 @ModelActor
 public actor TelemetryStore {
     private var onDiskStoreURL: URL?
+    private var explicitTransactionDepth = 0
 
     init(modelContainer: ModelContainer, onDiskStoreURL: URL?) {
         let modelContext = ModelContext(modelContainer)
@@ -566,7 +590,153 @@ public actor TelemetryStore {
         modelContext.autosaveEnabled
     }
 
+    /// Issue #26 testability seam. It exercises the existing insert validation and model
+    /// mapping in one explicit transaction without defining a production recorder policy.
+    func insertGateBatch(_ records: [TelemetryGateRecord]) throws {
+        guard !records.isEmpty else {
+            return
+        }
+
+        try explicitTransaction {
+            for record in records {
+                switch record {
+                case let .session(session):
+                    try insertSession(session)
+                case let .source(source):
+                    try insertSource(
+                        source.identity,
+                        firstSeen: source.firstSeen,
+                        lastSeen: source.lastSeen
+                    )
+                case let .heartRate(observation):
+                    try insertHeartRate(observation)
+                case let .treadmill(observation):
+                    try insertTreadmill(observation)
+                case let .event(event):
+                    try insertEvent(event)
+                case let .frame(frame):
+                    try insertFrame(frame)
+                case let .analysis(analysis):
+                    try insertAnalysis(analysis)
+                }
+            }
+        }
+    }
+
+    func gateFetchRecentSessions(
+        profileLocalIdentifier: String,
+        limit: Int
+    ) throws -> [WorkoutSessionRecord] {
+        guard limit > 0 else {
+            return []
+        }
+        var descriptor = FetchDescriptor<TelemetryWorkoutSessionV1>(
+            predicate: #Predicate { $0.profileLocalIdentifier == profileLocalIdentifier },
+            sortBy: [SortDescriptor(\TelemetryWorkoutSessionV1.startedAt, order: .reverse)]
+        )
+        descriptor.fetchLimit = limit
+        return try modelContext.fetch(descriptor).map(Self.domainSession)
+    }
+
+    func gateFetchComparableSessions(
+        profileLocalIdentifier: String,
+        workoutMode: WorkoutMode,
+        limit: Int
+    ) throws -> [WorkoutSessionRecord] {
+        guard limit > 0 else {
+            return []
+        }
+        let descriptor = FetchDescriptor<TelemetryWorkoutSessionV1>(
+            predicate: #Predicate { $0.profileLocalIdentifier == profileLocalIdentifier },
+            sortBy: [SortDescriptor(\TelemetryWorkoutSessionV1.startedAt, order: .reverse)]
+        )
+        var comparable: [WorkoutSessionRecord] = []
+        for model in try modelContext.fetch(descriptor) {
+            let session = try Self.domainSession(model)
+            if session.workoutMode == workoutMode {
+                comparable.append(session)
+                if comparable.count == limit {
+                    break
+                }
+            }
+        }
+        return comparable
+    }
+
+    func gateFetchEvents(decisionID: DecisionID) throws -> [WorkoutEvent] {
+        let key = decisionID.description
+        let descriptor = FetchDescriptor<TelemetryWorkoutEventV1>(
+            predicate: #Predicate { $0.decisionID == key },
+            sortBy: [SortDescriptor(\TelemetryWorkoutEventV1.occurredElapsedMicroseconds)]
+        )
+        return try modelContext.fetch(descriptor).map(Self.domainEvent)
+    }
+
+    func gateFetchEvents(commandID: CommandID) throws -> [WorkoutEvent] {
+        let key = commandID.description
+        let descriptor = FetchDescriptor<TelemetryWorkoutEventV1>(
+            predicate: #Predicate { $0.commandID == key },
+            sortBy: [SortDescriptor(\TelemetryWorkoutEventV1.occurredElapsedMicroseconds)]
+        )
+        return try modelContext.fetch(descriptor).map(Self.domainEvent)
+    }
+
+    func gateFetchEvents(attemptID: CommandAttemptID) throws -> [WorkoutEvent] {
+        let key = attemptID.description
+        let descriptor = FetchDescriptor<TelemetryWorkoutEventV1>(
+            predicate: #Predicate { $0.attemptID == key },
+            sortBy: [SortDescriptor(\TelemetryWorkoutEventV1.occurredElapsedMicroseconds)]
+        )
+        return try modelContext.fetch(descriptor).map(Self.domainEvent)
+    }
+
+    func gateTraverseSession(_ sessionID: SessionID) throws -> TelemetryGateTraversalCounts {
+        let sessionKey = sessionID.description
+        let sessionDescriptor = FetchDescriptor<TelemetryWorkoutSessionV1>(
+            predicate: #Predicate { $0.sessionID == sessionKey }
+        )
+        let sessions = try modelContext.fetchCount(sessionDescriptor)
+        let heartRateSamples = try fetchHeartRate(sessionID: sessionID).count
+        let treadmillSamples = try fetchTreadmill(sessionID: sessionID).count
+        let events = try fetchEvents(sessionID: sessionID).count
+        let frames = try fetchFrames(sessionID: sessionID).count
+        let analyses = try fetchAnalyses(sessionID: sessionID).count
+        return TelemetryGateTraversalCounts(
+            sessions: sessions,
+            heartRateSamples: heartRateSamples,
+            treadmillSamples: treadmillSamples,
+            events: events,
+            frames: frames,
+            analyses: analyses
+        )
+    }
+
+    func gateMarkInterruptedSessionIncomplete(
+        _ sessionID: SessionID,
+        reason: String
+    ) throws {
+        let session = try sessionModel(sessionID)
+        try explicitTransaction {
+            session.lifecycleStateKey = SessionLifecycleState.incomplete.rawValue
+            session.incompleteReason = reason
+            session.recorderIsComplete = false
+            session.endedAt = nil
+            session.endedElapsedMicroseconds = nil
+        }
+    }
+
+    func gateRunsOnMainThread() -> Bool {
+        Thread.isMainThread
+    }
+
     private func explicitTransaction(_ operation: () throws -> Void) throws {
+        if explicitTransactionDepth > 0 {
+            try operation()
+            return
+        }
+
+        explicitTransactionDepth += 1
+        defer { explicitTransactionDepth -= 1 }
         modelContext.autosaveEnabled = false
         try modelContext.transaction(block: operation)
         if let onDiskStoreURL {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
@@ -99,9 +99,8 @@ public enum TelemetryStoreFactory {
             )
         case let .onDisk(url):
             onDiskStoreURL = url
-            try FileManager.default.createDirectory(
-                at: url.deletingLastPathComponent(),
-                withIntermediateDirectories: true
+            _ = try TelemetryStoreFilePolicy.prepareStoreDirectory(
+                primaryStoreURL: url
             )
             modelConfiguration = ModelConfiguration(
                 "TelemetryV2",

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStoreFilePolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStoreFilePolicy.swift
@@ -29,6 +29,31 @@ public struct TelemetryStoreFilePolicyResult: Sendable, Equatable {
 }
 
 public enum TelemetryStoreFilePolicy {
+    static func prepareStoreDirectory(
+        primaryStoreURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        let directory = primaryStoreURL.deletingLastPathComponent()
+        try fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        var mutableDirectory = directory
+        try mutableDirectory.setResourceValues(values)
+
+        let applied = try directory.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        guard applied.isExcludedFromBackup == true else {
+            throw CocoaError(
+                .fileWriteUnknown,
+                userInfo: [NSFilePathErrorKey: directory.path]
+            )
+        }
+        return directory
+    }
+
     public static func discoveredStoreFiles(
         primaryStoreURL: URL,
         fileManager: FileManager = .default

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetrySchemaAndBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetrySchemaAndBoundaryTests.swift
@@ -120,4 +120,70 @@ final class TelemetrySchemaAndBoundaryTests: XCTestCase {
         let resourceValues = try primary.resourceValues(forKeys: [.isExcludedFromBackupKey])
         XCTAssertEqual(resourceValues.isExcludedFromBackup, true)
     }
+
+    func testDirectoryBackupBoundarySurvivesChildResetAndRecreation() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("telemetry-directory-policy-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let directory = root.appendingPathComponent("TelemetryV2", isDirectory: true)
+        let primary = directory.appendingPathComponent("TelemetryV2.store")
+        let wal = directory.appendingPathComponent("TelemetryV2.store-wal")
+
+        let preparedDirectory = try TelemetryStoreFilePolicy.prepareStoreDirectory(
+            primaryStoreURL: primary
+        )
+        XCTAssertEqual(preparedDirectory, directory)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: primary.path))
+        XCTAssertEqual(
+            try directory.resourceValues(forKeys: [.isExcludedFromBackupKey])
+                .isExcludedFromBackup,
+            true
+        )
+
+        try Data().write(to: primary)
+        try Data().write(to: wal)
+        for url in [primary, wal] {
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = false
+            var mutableURL = url
+            try mutableURL.setResourceValues(values)
+        }
+        XCTAssertEqual(
+            try directory.resourceValues(forKeys: [.isExcludedFromBackupKey])
+                .isExcludedFromBackup,
+            true
+        )
+
+        try FileManager.default.removeItem(at: wal)
+        try Data().write(to: wal)
+        var resetValues = URLResourceValues()
+        resetValues.isExcludedFromBackup = false
+        var mutableWAL = wal
+        try mutableWAL.setResourceValues(resetValues)
+        XCTAssertEqual(
+            try directory.resourceValues(forKeys: [.isExcludedFromBackupKey])
+                .isExcludedFromBackup,
+            true
+        )
+
+        let result = try TelemetryStoreFilePolicy.applyRequiredAttributes(
+            primaryStoreURL: primary
+        )
+        XCTAssertEqual(
+            result.protectedURLs.map(\.lastPathComponent),
+            [primary.lastPathComponent, wal.lastPathComponent]
+        )
+        for url in result.protectedURLs {
+            XCTAssertEqual(
+                try url.resourceValues(forKeys: [.isExcludedFromBackupKey])
+                    .isExcludedFromBackup,
+                true
+            )
+            XCTAssertEqual(
+                try FileManager.default.attributesOfItem(atPath: url.path)[.protectionKey]
+                    as? FileProtectionType,
+                .completeUntilFirstUserAuthentication
+            )
+        }
+    }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreConfigurationTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreConfigurationTests.swift
@@ -35,6 +35,10 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
         )
 
         var writer: TelemetryStore? = try TelemetryStoreFactory.make(.onDisk(storeURL))
+        try assertDirectoryBackupBoundary(
+            primaryStoreURL: storeURL,
+            phase: "store creation"
+        )
         try await writer?.insertSession(session)
         try await writer?.insertSource(
             source,
@@ -43,7 +47,11 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
         )
         try await writer?.insertHeartRate(heartRate)
 
-        let protectedFiles = try assertRequiredFilePolicy(
+        let protectedFiles = try assertDiscoveredFileProtection(
+            primaryStoreURL: storeURL,
+            phase: "initial writes"
+        )
+        try assertDirectoryBackupBoundary(
             primaryStoreURL: storeURL,
             phase: "initial writes"
         )
@@ -64,6 +72,25 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
             primaryStoreURL: storeURL,
             phase: "explicit reapplication after file-attribute mutation"
         )
+        try assertDirectoryBackupBoundary(
+            primaryStoreURL: storeURL,
+            phase: "explicit reapplication after file-attribute mutation"
+        )
+
+        for url in protectedFiles {
+            var resetValues = URLResourceValues()
+            resetValues.isExcludedFromBackup = false
+            var mutableURL = url
+            try mutableURL.setResourceValues(resetValues)
+            try FileManager.default.setAttributes(
+                [.protectionKey: FileProtectionType.none],
+                ofItemAtPath: url.path
+            )
+        }
+        try assertDirectoryBackupBoundary(
+            primaryStoreURL: storeURL,
+            phase: "child policy reset"
+        )
 
         try await writer?.insertEvent(
             TelemetryPersistenceFixtures.event(
@@ -73,14 +100,22 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
                 elapsed: 2_000_000
             )
         )
-        _ = try assertRequiredFilePolicy(
+        _ = try assertDiscoveredFileProtection(
+            primaryStoreURL: storeURL,
+            phase: "automatic policy after subsequent write"
+        )
+        try assertDirectoryBackupBoundary(
             primaryStoreURL: storeURL,
             phase: "automatic policy after subsequent write"
         )
         writer = nil
 
         let reader = try TelemetryStoreFactory.make(.onDisk(storeURL))
-        _ = try assertRequiredFilePolicy(
+        _ = try assertDiscoveredFileProtection(
+            primaryStoreURL: storeURL,
+            phase: "reopen"
+        )
+        try assertDirectoryBackupBoundary(
             primaryStoreURL: storeURL,
             phase: "reopen"
         )
@@ -405,6 +440,25 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
         primaryStoreURL: URL,
         phase: String
     ) throws -> [URL] {
+        let discovered = try assertDiscoveredFileProtection(
+            primaryStoreURL: primaryStoreURL,
+            phase: phase
+        )
+        for url in discovered {
+            let resourceValues = try url.resourceValues(forKeys: [.isExcludedFromBackupKey])
+            XCTAssertEqual(
+                resourceValues.isExcludedFromBackup,
+                true,
+                "\(phase): \(url.lastPathComponent)"
+            )
+        }
+        return discovered
+    }
+
+    private func assertDiscoveredFileProtection(
+        primaryStoreURL: URL,
+        phase: String
+    ) throws -> [URL] {
         let discovered = try TelemetryStoreFilePolicy.discoveredStoreFiles(
             primaryStoreURL: primaryStoreURL
         )
@@ -421,12 +475,6 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
         )
 
         for url in discovered {
-            let resourceValues = try url.resourceValues(forKeys: [.isExcludedFromBackupKey])
-            XCTAssertEqual(
-                resourceValues.isExcludedFromBackup,
-                true,
-                "\(phase): \(url.lastPathComponent)"
-            )
             let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
             XCTAssertEqual(
                 attributes[.protectionKey] as? FileProtectionType,
@@ -435,5 +483,18 @@ final class TelemetryStoreConfigurationTests: XCTestCase {
             )
         }
         return discovered
+    }
+
+    private func assertDirectoryBackupBoundary(
+        primaryStoreURL: URL,
+        phase: String
+    ) throws {
+        let directory = primaryStoreURL.deletingLastPathComponent()
+        XCTAssertEqual(
+            try directory.resourceValues(forKeys: [.isExcludedFromBackupKey])
+                .isExcludedFromBackup,
+            true,
+            phase
+        )
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateBenchmarkTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateBenchmarkTests.swift
@@ -40,6 +40,7 @@ private struct GateStorageFile: Codable, Equatable {
 
 private struct GateStorageSnapshot: Codable, Equatable {
     let lifecycle: String
+    let directoryExcludedFromBackup: Bool?
     let files: [GateStorageFile]
 
     var primaryBytes: UInt64 {
@@ -340,15 +341,18 @@ final class TelemetryGateBenchmarkTests: XCTestCase {
             transactionLatencies,
             totalRecords: expected.totalPersistedRecords
         )
-        let filePolicyHostPass = (afterWrite.files + afterReopen.files).allSatisfy {
-            $0.protection == FileProtectionType.completeUntilFirstUserAuthentication.rawValue
-                && $0.excludedFromBackup == true
+        let filePolicyHostPass = [afterWrite, afterReopen].allSatisfy { snapshot in
+            snapshot.directoryExcludedFromBackup == true
+                && snapshot.files.allSatisfy {
+                    $0.protection
+                        == FileProtectionType.completeUntilFirstUserAuthentication.rawValue
+                }
         }
         XCTAssertTrue(filePolicyHostPass)
         XCTAssertFalse(full128Latencies.isEmpty)
 
         let summary = GateBenchmarkSummary(
-            harnessVersion: "swiftdata-gate-v1",
+            harnessVersion: "swiftdata-gate-v2-directory-boundary",
             profile: profile,
             deterministicSeed: generator.seed,
             representedWorkoutHours: profile.representedWorkoutHours,
@@ -571,6 +575,8 @@ final class TelemetryGateBenchmarkTests: XCTestCase {
         primaryStoreURL: URL,
         lifecycle: String
     ) throws -> GateStorageSnapshot {
+        let directoryValues = try primaryStoreURL.deletingLastPathComponent()
+            .resourceValues(forKeys: [.isExcludedFromBackupKey])
         let files = try TelemetryStoreFilePolicy.discoveredStoreFiles(
             primaryStoreURL: primaryStoreURL
         )
@@ -584,7 +590,11 @@ final class TelemetryGateBenchmarkTests: XCTestCase {
                 excludedFromBackup: resourceValues.isExcludedFromBackup
             )
         }
-        return GateStorageSnapshot(lifecycle: lifecycle, files: values)
+        return GateStorageSnapshot(
+            lifecycle: lifecycle,
+            directoryExcludedFromBackup: directoryValues.isExcludedFromBackup,
+            files: values
+        )
     }
 
     private func benchmarkRunRoot(

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateBenchmarkTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateBenchmarkTests.swift
@@ -1,0 +1,646 @@
+import Darwin
+import Foundation
+import TelemetryDomain
+@testable import TelemetryPersistence
+import XCTest
+
+private struct GateLatencySummary: Codable, Equatable {
+    let samples: Int
+    let p50Milliseconds: Double
+    let p95Milliseconds: Double
+    let p99Milliseconds: Double
+    let minimumMilliseconds: Double
+    let maximumMilliseconds: Double
+
+    static func calculate(_ values: [Double]) -> GateLatencySummary {
+        precondition(!values.isEmpty)
+        let sorted = values.sorted()
+        return GateLatencySummary(
+            samples: sorted.count,
+            p50Milliseconds: percentile(sorted, percentile: 0.50),
+            p95Milliseconds: percentile(sorted, percentile: 0.95),
+            p99Milliseconds: percentile(sorted, percentile: 0.99),
+            minimumMilliseconds: sorted[0],
+            maximumMilliseconds: sorted[sorted.count - 1]
+        )
+    }
+
+    private static func percentile(_ sorted: [Double], percentile: Double) -> Double {
+        let rank = max(1, Int(ceil(percentile * Double(sorted.count))))
+        return sorted[min(rank - 1, sorted.count - 1)]
+    }
+}
+
+private struct GateStorageFile: Codable, Equatable {
+    let name: String
+    let bytes: UInt64
+    let protection: String?
+    let excludedFromBackup: Bool?
+}
+
+private struct GateStorageSnapshot: Codable, Equatable {
+    let lifecycle: String
+    let files: [GateStorageFile]
+
+    var primaryBytes: UInt64 {
+        files.first { !$0.name.contains("-wal") && !$0.name.contains("-shm") }?.bytes ?? 0
+    }
+
+    var walBytes: UInt64 {
+        files.first { $0.name.contains("-wal") }?.bytes ?? 0
+    }
+
+    var shmBytes: UInt64 {
+        files.first { $0.name.contains("-shm") }?.bytes ?? 0
+    }
+
+    var totalBytes: UInt64 {
+        files.reduce(0) { $0 + $1.bytes }
+    }
+}
+
+private struct GateMemorySummary: Codable, Equatable {
+    let mechanism: String
+    let generationEndpointPeakBytes: UInt64
+    let persistenceEndpointPeakBytes: UInt64
+    let queryEndpointPeakBytes: UInt64
+    let exportEndpointPeakBytes: UInt64
+    let processLifetimePeakBytes: UInt64
+}
+
+private struct GateQuerySummary: Codable, Equatable {
+    let shape: String
+    let returnedRecords: Int
+    let latency: GateLatencySummary
+}
+
+private struct GateInsertScaleSummary: Codable, Equatable {
+    let lowerBoundPersistedRecords: Int
+    let upperBoundPersistedRecords: Int
+    let transactionLatency: GateLatencySummary
+}
+
+private struct GateBenchmarkSummary: Codable, Equatable {
+    let harnessVersion: String
+    let profile: TelemetryGateProfile
+    let deterministicSeed: UInt64
+    let representedWorkoutHours: Double
+    let expectedCounts: TelemetryGateExpectedCounts
+    let actualCounts: TelemetryStoreCounts
+    let deterministicIdentityHash: String
+    let transactionCount: Int
+    let full128RecordTransactionCount: Int
+    let expectedNativeRedeliveryRejections: Int
+    let unexpectedFailureCount: Int
+    let totalDrainSeconds: Double
+    let persistedRecordsPerSecond: Double
+    let full128RecordTransactionLatency: GateLatencySummary
+    let insertScaling: [GateInsertScaleSummary]
+    let queries: [GateQuerySummary]
+    let memory: GateMemorySummary
+    let storageStages: [GateStorageSnapshot]
+    let afterWriteStorage: GateStorageSnapshot
+    let afterReopenStorage: GateStorageSnapshot
+    let bytesPerWorkoutHourAfterWrite: Double
+    let bytesPerWorkoutHourAfterReopen: Double
+    let filePolicyHostPass: Bool
+    let storeURL: String
+    let operatingSystem: String
+    let processorArchitecture: String
+}
+
+final class TelemetryGateBenchmarkTests: XCTestCase {
+    func testFastCIProfile() async throws {
+        let first = try await runProfile(.fast, preserveStore: false)
+        XCTAssertEqual(first.actualCounts, first.expectedCounts.storeCounts)
+        XCTAssertEqual(first.representedWorkoutHours, 2.0 / 3.0, accuracy: 0.000_001)
+        XCTAssertGreaterThan(first.full128RecordTransactionCount, 0)
+        XCTAssertEqual(first.unexpectedFailureCount, 0)
+        XCTAssertTrue(first.filePolicyHostPass)
+
+        let second = try await runProfile(.fast, preserveStore: false)
+        XCTAssertEqual(first.expectedCounts, second.expectedCounts)
+        XCTAssertEqual(first.deterministicIdentityHash, second.deterministicIdentityHash)
+    }
+
+    func testConfiguredFullProfile() async throws {
+        guard ProcessInfo.processInfo.environment["TELEMETRY_GATE_PROFILE"] == "full" else {
+            throw XCTSkip("Set TELEMETRY_GATE_PROFILE=full to run the required 1000-hour profile.")
+        }
+        let summary = try await runProfile(.full, preserveStore: true)
+        XCTAssertEqual(summary.representedWorkoutHours, 1_000, accuracy: 0.000_001)
+        XCTAssertGreaterThanOrEqual(summary.actualCounts.frames, 3_000_000)
+        XCTAssertGreaterThanOrEqual(summary.expectedCounts.totalPersistedRecords, 4_000_000)
+        XCTAssertEqual(summary.actualCounts, summary.expectedCounts.storeCounts)
+        XCTAssertEqual(summary.unexpectedFailureCount, 0)
+        XCTAssertTrue(summary.filePolicyHostPass)
+    }
+
+    private func runProfile(
+        _ profile: TelemetryGateProfile,
+        preserveStore: Bool
+    ) async throws -> GateBenchmarkSummary {
+        let generator = TelemetryGateFixtureGenerator(profile: profile)
+        let expected = generator.expectedCounts
+        let runRoot = try benchmarkRunRoot(profile: profile, preserveStore: preserveStore)
+        let storeURL = runRoot.appendingPathComponent("TelemetryV2.store")
+        let store = try await Task.detached {
+            try TelemetryStoreFactory.make(.onDisk(storeURL))
+        }.value
+        let autosaveEnabled = await store.isAutosaveEnabled()
+        let runsOnMainThread = await store.gateRunsOnMainThread()
+        XCTAssertFalse(autosaveEnabled)
+        XCTAssertFalse(runsOnMainThread)
+
+        var pending: [TelemetryGateRecord] = []
+        pending.reserveCapacity(profile.batchSize)
+        var transactionLatencies: [(recordsBefore: Int, batchSize: Int, milliseconds: Double)] = []
+        var full128Latencies: [Double] = []
+        var persistedRecordCount = 0
+        var transactionCount = 0
+        var unexpectedFailures = 0
+        var identityHasher = TelemetryGateIdentityHasher()
+        var generationPeak = GateMemoryProbe.currentPhysicalFootprintBytes()
+        var persistencePeak = generationPeak
+
+        func recordIdentity(_ record: TelemetryGateRecord) -> String {
+            switch record {
+            case let .session(value): value.recordID.description
+            case let .source(value): value.identity.id.description
+            case let .heartRate(value): value.recordID.description
+            case let .treadmill(value): value.recordID.description
+            case let .event(value): value.recordID.description
+            case let .frame(value): value.recordID.description
+            case let .analysis(value): value.recordID.description
+            }
+        }
+
+        func persistPending(force: Bool = false) async throws {
+            guard !pending.isEmpty, force || pending.count == profile.batchSize else {
+                return
+            }
+            generationPeak = max(
+                generationPeak,
+                GateMemoryProbe.currentPhysicalFootprintBytes()
+            )
+            let batch = pending
+            pending.removeAll(keepingCapacity: true)
+            let started = DispatchTime.now().uptimeNanoseconds
+            do {
+                try await store.insertGateBatch(batch)
+            } catch {
+                unexpectedFailures += 1
+                throw error
+            }
+            let elapsed = Double(DispatchTime.now().uptimeNanoseconds - started) / 1_000_000
+            transactionLatencies.append(
+                (recordsBefore: persistedRecordCount, batchSize: batch.count, milliseconds: elapsed)
+            )
+            if batch.count == 128 {
+                full128Latencies.append(elapsed)
+            }
+            persistedRecordCount += batch.count
+            transactionCount += 1
+            persistencePeak = max(
+                persistencePeak,
+                GateMemoryProbe.currentPhysicalFootprintBytes()
+            )
+        }
+
+        func append(_ record: TelemetryGateRecord) async throws {
+            identityHasher.update(recordIdentity(record))
+            pending.append(record)
+            try await persistPending()
+        }
+
+        let drainStarted = DispatchTime.now().uptimeNanoseconds
+        for source in generator.sources {
+            try await append(.source(source))
+        }
+        try await persistPending(force: true)
+
+        for sessionIndex in 0..<profile.sessionCount {
+            try await append(.session(generator.session(index: sessionIndex)))
+            // Save the configuration owner before another session reuses it. This keeps the
+            // benchmark on the Foundation's existing configuration lookup semantics.
+            try await persistPending(force: true)
+        }
+        var storageStages = [
+            try storageSnapshot(primaryStoreURL: storeURL, lifecycle: "schema-sources-sessions"),
+        ]
+
+        for sessionIndex in 0..<profile.sessionCount {
+            for sampleIndex in 0..<profile.heartRatePerSession {
+                try await append(
+                    .heartRate(
+                        generator.heartRate(
+                            sessionIndex: sessionIndex,
+                            sampleIndex: sampleIndex
+                        )
+                    )
+                )
+            }
+        }
+        try await persistPending(force: true)
+
+        var nativeRedeliveryRejections = 0
+        for sessionIndex in 0..<profile.sessionCount {
+            for sampleIndex in generator.redeliverySampleIndices() {
+                do {
+                    try await store.insertHeartRate(
+                        generator.heartRate(
+                            sessionIndex: sessionIndex,
+                            sampleIndex: sampleIndex,
+                            redelivery: true
+                        )
+                    )
+                    XCTFail("Stable provider-native redelivery unexpectedly persisted.")
+                } catch TelemetryStoreError.duplicateStableIdentity {
+                    nativeRedeliveryRejections += 1
+                } catch {
+                    unexpectedFailures += 1
+                    throw error
+                }
+            }
+        }
+        storageStages.append(
+            try storageSnapshot(primaryStoreURL: storeURL, lifecycle: "after-native-heart-rate")
+        )
+
+        for sessionIndex in 0..<profile.sessionCount {
+            for sampleIndex in 0..<profile.treadmillPerSession {
+                try await append(
+                    .treadmill(
+                        generator.treadmill(
+                            sessionIndex: sessionIndex,
+                            sampleIndex: sampleIndex
+                        )
+                    )
+                )
+            }
+        }
+        try await persistPending(force: true)
+        storageStages.append(
+            try storageSnapshot(primaryStoreURL: storeURL, lifecycle: "after-treadmill")
+        )
+
+        for sessionIndex in 0..<profile.sessionCount {
+            for event in generator.events(sessionIndex: sessionIndex) {
+                try await append(.event(event))
+            }
+        }
+        try await persistPending(force: true)
+        storageStages.append(
+            try storageSnapshot(primaryStoreURL: storeURL, lifecycle: "after-events")
+        )
+
+        for sessionIndex in 0..<profile.sessionCount {
+            for second in 0..<profile.secondsPerSession {
+                if let frame = generator.frame(sessionIndex: sessionIndex, elapsedSecond: second) {
+                    try await append(.frame(frame))
+                }
+            }
+        }
+        try await persistPending(force: true)
+        storageStages.append(
+            try storageSnapshot(primaryStoreURL: storeURL, lifecycle: "after-canonical-frames")
+        )
+
+        for sessionIndex in 0..<profile.sessionCount {
+            try await append(.analysis(generator.analysis(sessionIndex: sessionIndex)))
+        }
+        try await persistPending(force: true)
+        storageStages.append(
+            try storageSnapshot(primaryStoreURL: storeURL, lifecycle: "after-analyses")
+        )
+        let drainSeconds = Double(DispatchTime.now().uptimeNanoseconds - drainStarted)
+            / 1_000_000_000
+
+        let actualCounts = try await store.counts()
+        XCTAssertEqual(actualCounts, expected.storeCounts)
+        XCTAssertEqual(nativeRedeliveryRejections, expected.expectedNativeRedeliveryRejections)
+        try await validateSemantics(store: store, generator: generator)
+
+        let afterWrite = try storageSnapshot(
+            primaryStoreURL: storeURL,
+            lifecycle: "after-write"
+        )
+        let queryResult = try await benchmarkQueries(store: store, generator: generator)
+        let afterReopenStore = try await Task.detached {
+            try TelemetryStoreFactory.make(.onDisk(storeURL))
+        }.value
+        let afterReopenCounts = try await afterReopenStore.counts()
+        XCTAssertEqual(afterReopenCounts, expected.storeCounts)
+        let afterReopen = try storageSnapshot(
+            primaryStoreURL: storeURL,
+            lifecycle: "after-reopen"
+        )
+
+        let scaleSummaries = insertScaleSummaries(
+            transactionLatencies,
+            totalRecords: expected.totalPersistedRecords
+        )
+        let filePolicyHostPass = (afterWrite.files + afterReopen.files).allSatisfy {
+            $0.protection == FileProtectionType.completeUntilFirstUserAuthentication.rawValue
+                && $0.excludedFromBackup == true
+        }
+        XCTAssertTrue(filePolicyHostPass)
+        XCTAssertFalse(full128Latencies.isEmpty)
+
+        let summary = GateBenchmarkSummary(
+            harnessVersion: "swiftdata-gate-v1",
+            profile: profile,
+            deterministicSeed: generator.seed,
+            representedWorkoutHours: profile.representedWorkoutHours,
+            expectedCounts: expected,
+            actualCounts: actualCounts,
+            deterministicIdentityHash: identityHasher.lowercaseHexDigest,
+            transactionCount: transactionCount,
+            full128RecordTransactionCount: full128Latencies.count,
+            expectedNativeRedeliveryRejections: nativeRedeliveryRejections,
+            unexpectedFailureCount: unexpectedFailures,
+            totalDrainSeconds: drainSeconds,
+            persistedRecordsPerSecond: Double(expected.totalPersistedRecords) / drainSeconds,
+            full128RecordTransactionLatency: GateLatencySummary.calculate(full128Latencies),
+            insertScaling: scaleSummaries,
+            queries: queryResult.summaries,
+            memory: GateMemorySummary(
+                mechanism: "getrusage RUSAGE_SELF ru_maxrss process high-water sampled at batch/query endpoints",
+                generationEndpointPeakBytes: generationPeak,
+                persistenceEndpointPeakBytes: persistencePeak,
+                queryEndpointPeakBytes: queryResult.queryPeakBytes,
+                exportEndpointPeakBytes: queryResult.exportPeakBytes,
+                processLifetimePeakBytes: GateMemoryProbe.lifetimePeakPhysicalFootprintBytes()
+            ),
+            storageStages: storageStages,
+            afterWriteStorage: afterWrite,
+            afterReopenStorage: afterReopen,
+            bytesPerWorkoutHourAfterWrite: Double(afterWrite.totalBytes)
+                / profile.representedWorkoutHours,
+            bytesPerWorkoutHourAfterReopen: Double(afterReopen.totalBytes)
+                / profile.representedWorkoutHours,
+            filePolicyHostPass: filePolicyHostPass,
+            storeURL: storeURL.path,
+            operatingSystem: ProcessInfo.processInfo.operatingSystemVersionString,
+            processorArchitecture: machineArchitecture()
+        )
+        try writeSummaryIfRequested(summary)
+        if !preserveStore {
+            try? FileManager.default.removeItem(at: runRoot)
+        }
+        return summary
+    }
+
+    private func validateSemantics(
+        store: TelemetryStore,
+        generator: TelemetryGateFixtureGenerator
+    ) async throws {
+        let sessionIndex = generator.profile.sessionCount - 1
+        let probe = generator.causalProbe(sessionIndex: sessionIndex)
+        let heartRate = try await store.fetchHeartRate(sessionID: probe.sessionID)
+        let treadmill = try await store.fetchTreadmill(sessionID: probe.sessionID)
+        let frames = try await store.fetchFrames(sessionID: probe.sessionID)
+        let events = try await store.fetchEvents(sessionID: probe.sessionID)
+        let analyses = try await store.fetchAnalyses(sessionID: probe.sessionID)
+        XCTAssertEqual(heartRate.count, generator.profile.heartRatePerSession)
+        XCTAssertEqual(treadmill.count, generator.profile.treadmillPerSession)
+        XCTAssertEqual(frames.count, generator.profile.framesPerSession)
+        XCTAssertEqual(events.count, generator.profile.eventsPerSession)
+        XCTAssertEqual(analyses.count, 1)
+
+        let frameSeconds = Set(frames.map(\.canonicalElapsedSecond))
+        for second in generator.profile.frameGapStartSecond..<(
+            generator.profile.frameGapStartSecond + generator.profile.frameGapLengthSeconds
+        ) {
+            XCTAssertFalse(frameSeconds.contains(Int64(second)))
+        }
+        let postGapSecond = Int64(
+            generator.profile.frameGapStartSecond + generator.profile.frameGapLengthSeconds
+        )
+        XCTAssertEqual(
+            frames.first { $0.canonicalElapsedSecond == postGapSecond }?.precedingGap,
+            CanonicalGapBoundary(
+                missingSinceElapsedSecond: Int64(generator.profile.frameGapStartSecond),
+                kind: .runtimeSuspensionOrStall
+            )
+        )
+        XCTAssertTrue(frames.allSatisfy { $0.heartRateEvidence != nil && $0.treadmillEvidence != nil })
+
+        let firstDuplicatePair = 21...22
+        let pair = heartRate.filter { firstDuplicatePair.contains(Int($0.arrivalOrder)) }
+        XCTAssertEqual(pair.count, 2)
+        XCTAssertEqual(Set(pair.map(\.beatsPerMinute)).count, 1)
+        XCTAssertEqual(Set(pair.compactMap(\.providerSequence)).count, 1)
+        XCTAssertTrue(pair.allSatisfy { $0.providerSampleIdentity == nil })
+        let decisionEvents = try await store.gateFetchEvents(decisionID: probe.decisionID)
+        let commandEvents = try await store.gateFetchEvents(commandID: probe.commandID)
+        let attemptEvents = try await store.gateFetchEvents(attemptID: probe.attemptID)
+        XCTAssertEqual(decisionEvents.count, 4)
+        XCTAssertEqual(commandEvents.count, 3)
+        XCTAssertEqual(attemptEvents.count, 2)
+        XCTAssertTrue(events.allSatisfy {
+            $0.payload.payload.causalIDs
+                == WorkoutEventCausalIDs(
+                    decisionID: $0.decisionID,
+                    commandID: $0.commandID,
+                    attemptID: $0.attemptID
+                )
+        })
+        XCTAssertTrue(treadmill.allSatisfy {
+            $0.factualSpeed?.provenance == .decodedDeviceReport
+        })
+    }
+
+    private func benchmarkQueries(
+        store: TelemetryStore,
+        generator: TelemetryGateFixtureGenerator
+    ) async throws -> (summaries: [GateQuerySummary], queryPeakBytes: UInt64, exportPeakBytes: UInt64) {
+        let sessionIndex = generator.profile.sessionCount - 1
+        let probe = generator.causalProbe(sessionIndex: sessionIndex)
+        var summaries: [GateQuerySummary] = []
+        var queryPeak = GateMemoryProbe.currentPhysicalFootprintBytes()
+        var exportPeak: UInt64 = 0
+
+        func measure(
+            shape: String,
+            operation: () async throws -> Int
+        ) async throws {
+            _ = try await operation()
+            var values: [Double] = []
+            var count = 0
+            for _ in 0..<generator.profile.queryRepetitions {
+                let started = DispatchTime.now().uptimeNanoseconds
+                count = try await operation()
+                values.append(
+                    Double(DispatchTime.now().uptimeNanoseconds - started) / 1_000_000
+                )
+                queryPeak = max(queryPeak, GateMemoryProbe.currentPhysicalFootprintBytes())
+            }
+            summaries.append(
+                GateQuerySummary(
+                    shape: shape,
+                    returnedRecords: count,
+                    latency: GateLatencySummary.calculate(values)
+                )
+            )
+        }
+
+        try await measure(shape: "recent workout history by profile") {
+            try await store.gateFetchRecentSessions(
+                profileLocalIdentifier: probe.profileLocalIdentifier,
+                limit: 20
+            ).count
+        }
+        try await measure(shape: "single-session HR time series by arrival order") {
+            try await store.fetchHeartRate(sessionID: probe.sessionID).count
+        }
+        try await measure(shape: "single-session treadmill time series by arrival order") {
+            try await store.fetchTreadmill(sessionID: probe.sessionID).count
+        }
+        try await measure(shape: "canonical frames for chart and replay") {
+            try await store.fetchFrames(sessionID: probe.sessionID).count
+        }
+        try await measure(shape: "all events for a session") {
+            try await store.fetchEvents(sessionID: probe.sessionID).count
+        }
+        try await measure(shape: "events filtered by event kind") {
+            try await store.fetchEvents(
+                sessionID: probe.sessionID,
+                kind: .commandLifecycle
+            ).count
+        }
+        try await measure(shape: "causal event lookup by decision ID") {
+            try await store.gateFetchEvents(decisionID: probe.decisionID).count
+        }
+        try await measure(shape: "causal event lookup by command ID") {
+            try await store.gateFetchEvents(commandID: probe.commandID).count
+        }
+        try await measure(shape: "causal event lookup by attempt ID") {
+            try await store.gateFetchEvents(attemptID: probe.attemptID).count
+        }
+        try await measure(shape: "analyses by session and analyzer version") {
+            try await store.fetchAnalyses(
+                sessionID: probe.sessionID,
+                analyzerVersion: AnalyzerVersion(rawValue: "gate-analyzer-v1")
+            ).count
+        }
+        try await measure(shape: "last N comparable sessions by profile and decoded mode") {
+            try await store.gateFetchComparableSessions(
+                profileLocalIdentifier: probe.profileLocalIdentifier,
+                workoutMode: probe.workoutMode,
+                limit: 10
+            ).count
+        }
+
+        let exportStarted = DispatchTime.now().uptimeNanoseconds
+        let traversal = try await store.gateTraverseSession(probe.sessionID)
+        exportPeak = GateMemoryProbe.currentPhysicalFootprintBytes()
+        summaries.append(
+            GateQuerySummary(
+                shape: "export-style complete session evidence traversal",
+                returnedRecords: traversal.total,
+                latency: GateLatencySummary.calculate([
+                    Double(DispatchTime.now().uptimeNanoseconds - exportStarted) / 1_000_000,
+                ])
+            )
+        )
+        return (summaries, queryPeak, exportPeak)
+    }
+
+    private func insertScaleSummaries(
+        _ samples: [(recordsBefore: Int, batchSize: Int, milliseconds: Double)],
+        totalRecords: Int
+    ) -> [GateInsertScaleSummary] {
+        let bounds = [0, totalRecords / 10, totalRecords / 4, totalRecords / 2, totalRecords]
+        return zip(bounds, bounds.dropFirst()).compactMap { lower, upper in
+            let latencies = samples.filter {
+                $0.batchSize == 128 && $0.recordsBefore >= lower && $0.recordsBefore < upper
+            }.map(\.milliseconds)
+            guard !latencies.isEmpty else {
+                return nil
+            }
+            return GateInsertScaleSummary(
+                lowerBoundPersistedRecords: lower,
+                upperBoundPersistedRecords: upper,
+                transactionLatency: GateLatencySummary.calculate(latencies)
+            )
+        }
+    }
+
+    private func storageSnapshot(
+        primaryStoreURL: URL,
+        lifecycle: String
+    ) throws -> GateStorageSnapshot {
+        let files = try TelemetryStoreFilePolicy.discoveredStoreFiles(
+            primaryStoreURL: primaryStoreURL
+        )
+        let values = try files.map { url in
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            let resourceValues = try url.resourceValues(forKeys: [.isExcludedFromBackupKey])
+            return GateStorageFile(
+                name: url.lastPathComponent,
+                bytes: (attributes[.size] as? NSNumber)?.uint64Value ?? 0,
+                protection: (attributes[.protectionKey] as? FileProtectionType)?.rawValue,
+                excludedFromBackup: resourceValues.isExcludedFromBackup
+            )
+        }
+        return GateStorageSnapshot(lifecycle: lifecycle, files: values)
+    }
+
+    private func benchmarkRunRoot(
+        profile: TelemetryGateProfile,
+        preserveStore: Bool
+    ) throws -> URL {
+        if preserveStore,
+           let requested = ProcessInfo.processInfo.environment["TELEMETRY_GATE_STORE_DIRECTORY"]
+        {
+            let url = URL(fileURLWithPath: requested, isDirectory: true)
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+            return url
+        }
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "telemetry-swiftdata-gate-\(profile.name)-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func writeSummaryIfRequested(_ summary: GateBenchmarkSummary) throws {
+        guard let outputPath = ProcessInfo.processInfo.environment["TELEMETRY_GATE_OUTPUT"] else {
+            return
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(summary).write(
+            to: URL(fileURLWithPath: outputPath),
+            options: .atomic
+        )
+    }
+
+    private func machineArchitecture() -> String {
+        var system = utsname()
+        uname(&system)
+        return withUnsafePointer(to: &system.machine) {
+            $0.withMemoryRebound(to: CChar.self, capacity: 1) {
+                String(cString: $0)
+            }
+        }
+    }
+}
+
+private enum GateMemoryProbe {
+    static func currentPhysicalFootprintBytes() -> UInt64 {
+        highWaterResidentBytes()
+    }
+
+    static func lifetimePeakPhysicalFootprintBytes() -> UInt64 {
+        highWaterResidentBytes()
+    }
+
+    private static func highWaterResidentBytes() -> UInt64 {
+        var usage = rusage()
+        let result = getrusage(RUSAGE_SELF, &usage)
+        return result == 0 ? UInt64(max(0, usage.ru_maxrss)) : 0
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateBoundaryTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+@testable import TelemetryPersistence
+import XCTest
+
+final class TelemetryGateBoundaryTests: XCTestCase {
+    func testFullProfileCannotSilentlyDowngradeBelowRequiredScale() {
+        let profile = TelemetryGateProfile.full
+        let expected = TelemetryGateFixtureGenerator(profile: profile).expectedCounts
+        XCTAssertEqual(profile.representedWorkoutHours, 1_000)
+        XCTAssertEqual(profile.sessionCount, 1_000)
+        XCTAssertEqual(profile.secondsPerSession, 3_600)
+        XCTAssertEqual(profile.batchSize, 128)
+        XCTAssertGreaterThanOrEqual(expected.totalPersistedRecords, 4_000_000)
+        XCTAssertGreaterThanOrEqual(expected.frames, 3_000_000)
+        XCTAssertGreaterThan(expected.expectedNativeRedeliveryRejections, 0)
+        XCTAssertGreaterThan(expected.identityAbsentDuplicatePairs, 0)
+    }
+
+    func testGateHarnessRemainsInternalAndOutsideApplicationTargets() throws {
+        let packageRoot = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let storeSource = try String(
+            contentsOf: packageRoot.appendingPathComponent(
+                "Sources/TelemetryPersistence/TelemetryStore.swift"
+            ),
+            encoding: .utf8
+        )
+        XCTAssertTrue(storeSource.contains("func insertGateBatch"))
+        XCTAssertFalse(storeSource.contains("public func insertGateBatch"))
+
+        let project = try String(
+            contentsOf: packageRoot.appendingPathComponent(
+                "WalkingPadRemote.xcodeproj/project.pbxproj"
+            ),
+            encoding: .utf8
+        )
+        XCTAssertFalse(project.contains("TelemetryGateCrashWorker"))
+        XCTAssertFalse(project.contains("TelemetrySwiftDataGateTests"))
+
+        let runtimeDirectory = packageRoot.appendingPathComponent("WalkingPadRemote")
+        let enumerator = FileManager.default.enumerator(
+            at: runtimeDirectory,
+            includingPropertiesForKeys: [.isRegularFileKey]
+        )
+        var runtimeSources = ""
+        while let url = enumerator?.nextObject() as? URL {
+            guard url.pathExtension == "swift" else {
+                continue
+            }
+            runtimeSources += try String(contentsOf: url, encoding: .utf8)
+        }
+        XCTAssertFalse(runtimeSources.contains("TelemetryGateCrashWorker"))
+        XCTAssertFalse(runtimeSources.contains("insertGateBatch"))
+        XCTAssertFalse(runtimeSources.contains("TelemetryStoreFactory.make"))
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateBoundaryTests.swift
@@ -26,6 +26,8 @@ final class TelemetryGateBoundaryTests: XCTestCase {
         )
         XCTAssertTrue(storeSource.contains("func insertGateBatch"))
         XCTAssertFalse(storeSource.contains("public func insertGateBatch"))
+        XCTAssertTrue(storeSource.contains("package func gateStageUncommittedHeartRate"))
+        XCTAssertFalse(storeSource.contains("public func gateStageUncommittedHeartRate"))
 
         let project = try String(
             contentsOf: packageRoot.appendingPathComponent(
@@ -50,6 +52,7 @@ final class TelemetryGateBoundaryTests: XCTestCase {
         }
         XCTAssertFalse(runtimeSources.contains("TelemetryGateCrashWorker"))
         XCTAssertFalse(runtimeSources.contains("insertGateBatch"))
+        XCTAssertFalse(runtimeSources.contains("gateStageUncommittedHeartRate"))
         XCTAssertFalse(runtimeSources.contains("TelemetryStoreFactory.make"))
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateFixture.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateFixture.swift
@@ -1,0 +1,698 @@
+import Foundation
+import TelemetryDomain
+@testable import TelemetryPersistence
+
+struct TelemetryGateProfile: Codable, Equatable, Sendable {
+    let name: String
+    let sessionCount: Int
+    let secondsPerSession: Int
+    let frameGapStartSecond: Int
+    let frameGapLengthSeconds: Int
+    let heartRateIntervalSeconds: Int
+    let treadmillIntervalSeconds: Int
+    let eventsPerSession: Int
+    let batchSize: Int
+    let queryRepetitions: Int
+
+    static let fast = TelemetryGateProfile(
+        name: "fast-ci",
+        sessionCount: 4,
+        secondsPerSession: 600,
+        frameGapStartSecond: 240,
+        frameGapLengthSeconds: 20,
+        heartRateIntervalSeconds: 5,
+        treadmillIntervalSeconds: 15,
+        eventsPerSession: 20,
+        batchSize: 128,
+        queryRepetitions: 5
+    )
+
+    static let full = TelemetryGateProfile(
+        name: "full-1000-hours",
+        sessionCount: 1_000,
+        secondsPerSession: 3_600,
+        frameGapStartSecond: 1_200,
+        frameGapLengthSeconds: 60,
+        heartRateIntervalSeconds: 5,
+        treadmillIntervalSeconds: 15,
+        eventsPerSession: 20,
+        batchSize: 128,
+        queryRepetitions: 9
+    )
+
+    var representedWorkoutHours: Double {
+        Double(sessionCount * secondsPerSession) / 3_600
+    }
+
+    var heartRatePerSession: Int {
+        (secondsPerSession + heartRateIntervalSeconds - 1) / heartRateIntervalSeconds
+    }
+
+    var treadmillPerSession: Int {
+        (secondsPerSession + treadmillIntervalSeconds - 1) / treadmillIntervalSeconds
+    }
+
+    var framesPerSession: Int {
+        secondsPerSession - frameGapLengthSeconds
+    }
+}
+
+struct TelemetryGateExpectedCounts: Codable, Equatable, Sendable {
+    let configurations: Int
+    let sessions: Int
+    let sources: Int
+    let heartRateSamples: Int
+    let treadmillSamples: Int
+    let events: Int
+    let frames: Int
+    let analyses: Int
+    let expectedNativeRedeliveryRejections: Int
+    let identityAbsentDuplicatePairs: Int
+
+    var totalPersistedRecords: Int {
+        configurations + sessions + sources + heartRateSamples + treadmillSamples
+            + events + frames + analyses
+    }
+
+    var storeCounts: TelemetryStoreCounts {
+        TelemetryStoreCounts(
+            configurations: configurations,
+            sessions: sessions,
+            sources: sources,
+            heartRateSamples: heartRateSamples,
+            treadmillSamples: treadmillSamples,
+            events: events,
+            frames: frames,
+            analyses: analyses
+        )
+    }
+}
+
+struct TelemetryGateCausalProbe: Sendable {
+    let sessionID: SessionID
+    let decisionID: DecisionID
+    let commandID: CommandID
+    let attemptID: CommandAttemptID
+    let profileLocalIdentifier: String
+    let workoutMode: WorkoutMode
+}
+
+struct TelemetryGateFixtureGenerator: Sendable {
+    static let documentedSeed: UInt64 = 0x26_39_40_2026
+    static let baseDate = Date(timeIntervalSince1970: 1_820_100_000)
+
+    let profile: TelemetryGateProfile
+    let seed: UInt64
+
+    init(profile: TelemetryGateProfile, seed: UInt64 = documentedSeed) {
+        self.profile = profile
+        self.seed = seed
+        precondition(profile.eventsPerSession == 20)
+    }
+
+    var configuration: ImmutableConfigurationSnapshot {
+        ImmutableConfigurationSnapshot(
+            id: ConfigurationSnapshotID(rawValue: uuid(kind: 1, counter: 1)),
+            formatVersion: 1,
+            format: .canonicalJSON,
+            canonicalPayload: Data(#"{"fixture":"swiftdata-gate","version":1}"#.utf8),
+            contentHash: ContentHash(
+                algorithm: .sha256,
+                lowercaseHexDigest: String(format: "%064llx", seed)
+            )
+        )
+    }
+
+    var versions: RuntimeVersionContext {
+        RuntimeVersionContext(
+            telemetrySchema: TelemetrySchemaVersion(rawValue: "v1"),
+            algorithm: AlgorithmVersion(rawValue: "gate-algorithm-v1"),
+            safetyPolicy: SafetyPolicyVersion(rawValue: "gate-safety-v1"),
+            workoutProtocol: WorkoutProtocolVersion(rawValue: "gate-workout-v1")
+        )
+    }
+
+    var heartRateSource: SignalSourceIdentity {
+        SignalSourceIdentity(
+            id: SourceID(rawValue: uuid(kind: 2, counter: 1)),
+            providerKind: .healthKitSelected,
+            stableLocalKey: "gate-health-provider",
+            savingSource: ProviderSavingSource(
+                bundleIdentifier: "gate.synthetic.health-provider",
+                productType: "hosted-fixture",
+                softwareVersion: "1"
+            ),
+            knownDevice: nil
+        )
+    }
+
+    var treadmillSource: SignalSourceIdentity {
+        SignalSourceIdentity(
+            id: SourceID(rawValue: uuid(kind: 2, counter: 2)),
+            providerKind: .treadmillProtocol,
+            stableLocalKey: "gate-treadmill-protocol",
+            savingSource: nil,
+            knownDevice: nil
+        )
+    }
+
+    var sources: [StoredSignalSource] {
+        let lastSeen = Self.baseDate.addingTimeInterval(
+            Double(profile.sessionCount * (profile.secondsPerSession + 60))
+        )
+        return [heartRateSource, treadmillSource].map {
+            StoredSignalSource(identity: $0, firstSeen: Self.baseDate, lastSeen: lastSeen)
+        }
+    }
+
+    var expectedCounts: TelemetryGateExpectedCounts {
+        let redeliveriesPerSession = (profile.heartRatePerSession + 199) / 200
+        let duplicatePairsPerSession = profile.heartRatePerSession > 22
+            ? ((profile.heartRatePerSession - 23) / 40) + 1
+            : 0
+        return TelemetryGateExpectedCounts(
+            configurations: 1,
+            sessions: profile.sessionCount,
+            sources: sources.count,
+            heartRateSamples: profile.sessionCount * profile.heartRatePerSession,
+            treadmillSamples: profile.sessionCount * profile.treadmillPerSession,
+            events: profile.sessionCount * profile.eventsPerSession,
+            frames: profile.sessionCount * profile.framesPerSession,
+            analyses: profile.sessionCount,
+            expectedNativeRedeliveryRejections: profile.sessionCount * redeliveriesPerSession,
+            identityAbsentDuplicatePairs: profile.sessionCount * duplicatePairsPerSession
+        )
+    }
+
+    func session(index: Int) -> WorkoutSessionRecord {
+        let start = sessionStart(index: index)
+        let isIncomplete = index % 20 == 19
+        let elapsed = ElapsedDuration(microseconds: Int64(profile.secondsPerSession) * 1_000_000)
+        return WorkoutSessionRecord(
+            recordID: RecordID(rawValue: uuid(kind: 3, counter: UInt64(index))),
+            sessionID: sessionID(index: index),
+            profileLocalIdentifier: profileIdentifier(sessionIndex: index),
+            lifecycleState: isIncomplete ? .incomplete : .completed,
+            workoutMode: workoutMode(sessionIndex: index),
+            startedAt: start,
+            endedAt: isIncomplete ? nil : start.addingTimeInterval(Double(profile.secondsPerSession)),
+            endedElapsed: isIncomplete ? nil : elapsed,
+            incompleteReason: isIncomplete ? "synthetic-hosted-interruption" : nil,
+            appContext: AppRuntimeContext(
+                appVersion: "gate",
+                buildNumber: "26",
+                operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+                deviceModel: "hosted-mac"
+            ),
+            versions: versions,
+            configuration: configuration,
+            healthKitWorkoutIdentifier: nil,
+            treadmill: KnownTreadmillMetadata(
+                stableLocalIdentifier: nil,
+                model: nil,
+                protocolName: "synthetic-v1",
+                protocolVersion: "1"
+            ),
+            recorderHealth: RecorderHealthSummary(
+                isComplete: !isIncomplete,
+                lostCriticalRecordCount: 0,
+                lostNativeRecordCount: 0,
+                lastPersistedElapsed: elapsed
+            )
+        )
+    }
+
+    func heartRate(sessionIndex: Int, sampleIndex: Int, redelivery: Bool = false)
+        -> HeartRateObservation
+    {
+        let sampleSecond = sampleIndex * profile.heartRateIntervalSeconds
+        let elapsed = Int64(sampleSecond) * 1_000_000
+        let measured = sessionStart(index: sessionIndex).addingTimeInterval(Double(sampleSecond))
+        let stableIdentity = sampleIndex % 4 == 0
+            ? ProviderNativeSampleIdentity(identifier: "hr-\(sessionIndex)-\(sampleIndex)")
+            : nil
+        let providerSequence = sampleIndex % 40 == 22
+            ? Int64(sampleIndex - 1)
+            : Int64(sampleIndex)
+        let bpmIndex = sampleIndex % 40 == 22 ? sampleIndex - 1 : sampleIndex
+        return HeartRateObservation(
+            recordID: RecordID(
+                rawValue: uuid(
+                    kind: redelivery ? 31 : 4,
+                    counter: recordCounter(sessionIndex: sessionIndex, localIndex: sampleIndex)
+                )
+            ),
+            observationID: ObservationID(
+                rawValue: uuid(
+                    kind: redelivery ? 32 : 5,
+                    counter: recordCounter(sessionIndex: sessionIndex, localIndex: sampleIndex)
+                )
+            ),
+            sessionID: sessionID(index: sessionIndex),
+            source: heartRateSource,
+            beatsPerMinute: UInt16(105 + (bpmIndex / 2) % 55),
+            arrivalOrder: UInt64(sampleIndex),
+            providerSequence: providerSequence,
+            providerSampleIdentity: stableIdentity,
+            timestamp: observationTimestamp(measured: measured, elapsedMicroseconds: elapsed),
+            provenance: .reportedByProvider,
+            freshness: freshness(at: measured, elapsedMicroseconds: elapsed),
+            quality: sampleIndex % 40 == 22 ? [.duplicateProviderSequence] : [],
+            controlUse: sampleIndex % 12 == 0 ? .acceptedAndUsed : .acceptedNotUsed
+        )
+    }
+
+    func treadmill(sessionIndex: Int, sampleIndex: Int) -> TreadmillObservation {
+        let sampleSecond = sampleIndex * profile.treadmillIntervalSeconds
+        let elapsed = Int64(sampleSecond) * 1_000_000
+        let measured = sessionStart(index: sessionIndex).addingTimeInterval(Double(sampleSecond))
+        return TreadmillObservation(
+            recordID: RecordID(
+                rawValue: uuid(
+                    kind: 6,
+                    counter: recordCounter(sessionIndex: sessionIndex, localIndex: sampleIndex)
+                )
+            ),
+            observationID: ObservationID(
+                rawValue: uuid(
+                    kind: 7,
+                    counter: recordCounter(sessionIndex: sessionIndex, localIndex: sampleIndex)
+                )
+            ),
+            sessionID: sessionID(index: sessionIndex),
+            source: treadmillSource,
+            nativeSpeed: NativeTreadmillSpeed(
+                value: 4.5 + Double(sampleIndex % 10) / 10,
+                unit: .kilometresPerHour
+            ),
+            deviceState: .moving,
+            arrivalOrder: UInt64(sampleIndex),
+            timestamp: observationTimestamp(measured: measured, elapsedMicroseconds: elapsed),
+            provenance: .decodedDeviceReport,
+            freshness: freshness(at: measured, elapsedMicroseconds: elapsed),
+            quality: []
+        )
+    }
+
+    func frame(sessionIndex: Int, elapsedSecond: Int) -> CanonicalFrame? {
+        let gapEnd = profile.frameGapStartSecond + profile.frameGapLengthSeconds
+        guard elapsedSecond < profile.frameGapStartSecond || elapsedSecond >= gapEnd else {
+            return nil
+        }
+
+        let heartRateIndex = elapsedSecond / profile.heartRateIntervalSeconds
+        let treadmillIndex = elapsedSecond / profile.treadmillIntervalSeconds
+        let heartRate = self.heartRate(sessionIndex: sessionIndex, sampleIndex: heartRateIndex)
+        let treadmill = self.treadmill(sessionIndex: sessionIndex, sampleIndex: treadmillIndex)
+        let materialized = sessionStart(index: sessionIndex).addingTimeInterval(Double(elapsedSecond))
+        let elapsed = Int64(elapsedSecond) * 1_000_000
+        let heartRateAge = Int64(elapsedSecond % profile.heartRateIntervalSeconds) * 1_000_000
+        let treadmillAge = Int64(elapsedSecond % profile.treadmillIntervalSeconds) * 1_000_000
+        return CanonicalFrame(
+            frameID: FrameID(
+                rawValue: uuid(
+                    kind: 8,
+                    counter: recordCounter(sessionIndex: sessionIndex, localIndex: elapsedSecond)
+                )
+            ),
+            recordID: RecordID(
+                rawValue: uuid(
+                    kind: 9,
+                    counter: recordCounter(sessionIndex: sessionIndex, localIndex: elapsedSecond)
+                )
+            ),
+            sessionID: sessionID(index: sessionIndex),
+            canonicalElapsedSecond: Int64(elapsedSecond),
+            materializedAt: RecordTimestamp(
+                recordedAt: materialized,
+                elapsed: ElapsedDuration(microseconds: elapsed)
+            ),
+            heartRateEvidence: HeartRateFrameEvidence(
+                observationID: heartRate.observationID,
+                recordID: heartRate.recordID,
+                sourceID: heartRate.source.id,
+                beatsPerMinute: heartRate.beatsPerMinute,
+                measuredAt: heartRate.timestamp.measuredAt,
+                receivedAt: heartRate.timestamp.receivedAt,
+                evidenceElapsed: heartRate.timestamp.effectiveElapsed,
+                ageAtMaterialization: ElapsedDuration(microseconds: heartRateAge),
+                freshness: .fresh,
+                provenance: heartRate.provenance
+            ),
+            treadmillEvidence: TreadmillFrameEvidence(
+                observationID: treadmill.observationID,
+                recordID: treadmill.recordID,
+                sourceID: treadmill.source.id,
+                nativeSpeed: treadmill.nativeSpeed,
+                factualSpeed: treadmill.factualSpeed,
+                deviceState: treadmill.deviceState,
+                measuredAt: treadmill.timestamp.measuredAt,
+                receivedAt: treadmill.timestamp.receivedAt,
+                evidenceElapsed: treadmill.timestamp.effectiveElapsed,
+                ageAtMaterialization: ElapsedDuration(microseconds: treadmillAge),
+                freshness: .fresh,
+                provenance: treadmill.provenance
+            ),
+            precedingGap: elapsedSecond == gapEnd
+                ? CanonicalGapBoundary(
+                    missingSinceElapsedSecond: Int64(profile.frameGapStartSecond),
+                    kind: .runtimeSuspensionOrStall
+                )
+                : nil
+        )
+    }
+
+    func events(sessionIndex: Int) -> [WorkoutEvent] {
+        let session = session(index: sessionIndex)
+        let decision1 = decisionID(sessionIndex: sessionIndex, localIndex: 1)
+        let decision2 = decisionID(sessionIndex: sessionIndex, localIndex: 2)
+        let command1 = commandID(sessionIndex: sessionIndex, localIndex: 1)
+        let command2 = commandID(sessionIndex: sessionIndex, localIndex: 2)
+        let attempt1 = attemptID(sessionIndex: sessionIndex, localIndex: 1)
+        let attempt2 = attemptID(sessionIndex: sessionIndex, localIndex: 2)
+        let attempt3 = attemptID(sessionIndex: sessionIndex, localIndex: 3)
+        let referenceHR = heartRate(sessionIndex: sessionIndex, sampleIndex: 0)
+        let referenceTreadmill = treadmill(sessionIndex: sessionIndex, sampleIndex: 0)
+        let control1 = ControlDecision(
+            decisionID: decision1,
+            observationsUsed: [
+                .heartRate(referenceHR.observationID),
+                .treadmill(referenceTreadmill.observationID),
+            ],
+            target: .heartRate(beatsPerMinute: 125),
+            action: .enqueueSpeed(DesiredSpeedKilometresPerHour(value: 5.0)),
+            reason: .belowTarget,
+            versions: versions,
+            configurationSnapshotID: configuration.id
+        )
+        let control2 = ControlDecision(
+            decisionID: decision2,
+            observationsUsed: [.heartRate(referenceHR.observationID)],
+            target: .stop,
+            action: .enqueueStop,
+            reason: .safetyGate("synthetic-timeout"),
+            versions: versions,
+            configurationSnapshotID: configuration.id
+        )
+        let payloads: [WorkoutEventPayload] = [
+            .sessionLifecycle(SessionLifecycleEvent(previous: .created, current: .running)),
+            .workoutPhase(WorkoutPhaseTransition(previous: nil, current: .warmup)),
+            .workoutPhase(WorkoutPhaseTransition(previous: .warmup, current: .main)),
+            .sourceTransition(
+                SourceTransition(
+                    previousSourceID: nil,
+                    currentSourceID: heartRateSource.id,
+                    reason: "synthetic-provider-selected"
+                )
+            ),
+            .connectionTransition(
+                ConnectionTransition(previous: .connecting, current: .connected)
+            ),
+            .controlDecision(control1),
+            .commandLifecycle(
+                CommandLifecycleRecord(
+                    commandID: command1,
+                    decisionID: decision1,
+                    lifecycle: .enqueued(
+                        kind: .setSpeed(
+                            CommandedSpeed(
+                                nativeValue: 5.0,
+                                nativeUnit: .kilometresPerHour
+                            )
+                        )
+                    )
+                )
+            ),
+            .commandLifecycle(
+                CommandLifecycleRecord(
+                    commandID: command1,
+                    decisionID: decision1,
+                    lifecycle: .sendAttempt(attemptID: attempt1, attemptNumber: 1)
+                )
+            ),
+            .commandLifecycle(
+                CommandLifecycleRecord(
+                    commandID: command1,
+                    decisionID: decision1,
+                    lifecycle: .acknowledged(attemptID: attempt1)
+                )
+            ),
+            .controlDecision(control2),
+            .commandLifecycle(
+                CommandLifecycleRecord(
+                    commandID: command2,
+                    decisionID: decision2,
+                    lifecycle: .enqueued(kind: .stop)
+                )
+            ),
+            .commandLifecycle(
+                CommandLifecycleRecord(
+                    commandID: command2,
+                    decisionID: decision2,
+                    lifecycle: .sendAttempt(attemptID: attempt2, attemptNumber: 1)
+                )
+            ),
+            .commandLifecycle(
+                CommandLifecycleRecord(
+                    commandID: command2,
+                    decisionID: decision2,
+                    lifecycle: .timedOut(attemptID: attempt2)
+                )
+            ),
+            .commandLifecycle(
+                CommandLifecycleRecord(
+                    commandID: command2,
+                    decisionID: decision2,
+                    lifecycle: .retryScheduled(
+                        previousAttemptID: attempt2,
+                        nextAttemptID: attempt3,
+                        nextAttemptNumber: 2
+                    )
+                )
+            ),
+            .commandLifecycle(
+                CommandLifecycleRecord(
+                    commandID: command2,
+                    decisionID: decision2,
+                    lifecycle: .failed(
+                        attemptID: attempt3,
+                        reason: .transportUnavailable
+                    )
+                )
+            ),
+            .safety(
+                SafetyEvent(
+                    policy: versions.safetyPolicy,
+                    gate: "synthetic-stale-hr",
+                    outcome: .failedClosed,
+                    evidence: [.heartRate(referenceHR.observationID)]
+                )
+            ),
+            .cooldown(CooldownEvent(lifecycle: .started, targetHeartRate: 110)),
+            .stopEvidence(
+                StopEvidenceEvent(
+                    conclusion: .unconfirmed(reason: "no-fresh-factual-stop-evidence"),
+                    freshness: nil,
+                    deviceState: nil,
+                    factualSpeed: nil
+                )
+            ),
+            .manualStop(ManualStopEvent(reason: "synthetic-user-request")),
+            .recorderHealth(
+                RecorderHealthEvent(kind: .drain, affectedRecordClass: "all", count: 0)
+            ),
+        ]
+        precondition(payloads.count == profile.eventsPerSession)
+        return payloads.enumerated().map { eventIndex, payload in
+            let elapsedSecond = min(eventIndex * 30, profile.secondsPerSession - 1)
+            let occurred = session.startedAt.addingTimeInterval(Double(elapsedSecond))
+            return WorkoutEvent(
+                recordID: RecordID(
+                    rawValue: uuid(
+                        kind: 10,
+                        counter: recordCounter(
+                            sessionIndex: sessionIndex,
+                            localIndex: eventIndex
+                        )
+                    )
+                ),
+                sessionID: session.sessionID,
+                timestamp: EventTimestamp(
+                    occurredAt: occurred,
+                    recordedAt: occurred.addingTimeInterval(0.01),
+                    occurredElapsed: ElapsedDuration(
+                        microseconds: Int64(elapsedSecond) * 1_000_000
+                    ),
+                    recordedElapsed: ElapsedDuration(
+                        microseconds: Int64(elapsedSecond) * 1_000_000 + 10_000
+                    )
+                ),
+                sourceID: payload.kind == .sourceTransition ? heartRateSource.id : nil,
+                payload: EventPayloadEnvelope(schemaVersion: 1, payload: payload)
+            )
+        }
+    }
+
+    func analysis(sessionIndex: Int) -> WorkoutAnalysisResult {
+        WorkoutAnalysisResult(
+            analysisID: AnalysisID(rawValue: uuid(kind: 11, counter: UInt64(sessionIndex))),
+            recordID: RecordID(rawValue: uuid(kind: 12, counter: UInt64(sessionIndex))),
+            sessionID: sessionID(index: sessionIndex),
+            analyzerVersion: AnalyzerVersion(rawValue: "gate-analyzer-v1"),
+            evidenceHash: ContentHash(
+                algorithm: .sha256,
+                lowercaseHexDigest: String(format: "%064llx", UInt64(sessionIndex) ^ seed)
+            ),
+            generatedAt: sessionStart(index: sessionIndex).addingTimeInterval(
+                Double(profile.secondsPerSession + 1)
+            ),
+            qualityGrade: sessionIndex % 20 == 19 ? .low : .high,
+            exclusions: sessionIndex % 20 == 19
+                ? [AnalysisExclusion(code: "incomplete-session")]
+                : [],
+            keyMetrics: AnalysisKeyMetrics(
+                coveredDuration: ElapsedDuration(
+                    microseconds: Int64(profile.secondsPerSession - profile.frameGapLengthSeconds)
+                        * 1_000_000
+                ),
+                averageHeartRate: 126,
+                maximumHeartRate: 159,
+                averageFactualSpeedKilometresPerHour: 4.95
+            ),
+            detailSchemaVersion: 1,
+            versionedDetailPayload: Data(#"{"method":"timestamp-aware-synthetic"}"#.utf8)
+        )
+    }
+
+    func causalProbe(sessionIndex: Int) -> TelemetryGateCausalProbe {
+        TelemetryGateCausalProbe(
+            sessionID: sessionID(index: sessionIndex),
+            decisionID: decisionID(sessionIndex: sessionIndex, localIndex: 1),
+            commandID: commandID(sessionIndex: sessionIndex, localIndex: 1),
+            attemptID: attemptID(sessionIndex: sessionIndex, localIndex: 1),
+            profileLocalIdentifier: profileIdentifier(sessionIndex: sessionIndex),
+            workoutMode: workoutMode(sessionIndex: sessionIndex)
+        )
+    }
+
+    func isFrameGapSecond(_ second: Int) -> Bool {
+        second >= profile.frameGapStartSecond
+            && second < profile.frameGapStartSecond + profile.frameGapLengthSeconds
+    }
+
+    func redeliverySampleIndices() -> StrideTo<Int> {
+        stride(from: 0, to: profile.heartRatePerSession, by: 200)
+    }
+
+    private func sessionID(index: Int) -> SessionID {
+        SessionID(rawValue: uuid(kind: 13, counter: UInt64(index)))
+    }
+
+    private func decisionID(sessionIndex: Int, localIndex: Int) -> DecisionID {
+        DecisionID(
+            rawValue: uuid(
+                kind: 14,
+                counter: recordCounter(sessionIndex: sessionIndex, localIndex: localIndex)
+            )
+        )
+    }
+
+    private func commandID(sessionIndex: Int, localIndex: Int) -> CommandID {
+        CommandID(
+            rawValue: uuid(
+                kind: 15,
+                counter: recordCounter(sessionIndex: sessionIndex, localIndex: localIndex)
+            )
+        )
+    }
+
+    private func attemptID(sessionIndex: Int, localIndex: Int) -> CommandAttemptID {
+        CommandAttemptID(
+            rawValue: uuid(
+                kind: 16,
+                counter: recordCounter(sessionIndex: sessionIndex, localIndex: localIndex)
+            )
+        )
+    }
+
+    private func sessionStart(index: Int) -> Date {
+        Self.baseDate.addingTimeInterval(
+            Double(index * (profile.secondsPerSession + 60))
+        )
+    }
+
+    private func profileIdentifier(sessionIndex: Int) -> String {
+        "profile-\(sessionIndex % 4)"
+    }
+
+    private func workoutMode(sessionIndex: Int) -> WorkoutMode {
+        sessionIndex % 3 == 0 ? .manual : .heartRateControlled
+    }
+
+    private func observationTimestamp(
+        measured: Date,
+        elapsedMicroseconds: Int64
+    ) -> ObservationTimestamp {
+        ObservationTimestamp(
+            measuredAt: measured,
+            receivedAt: measured.addingTimeInterval(0.02),
+            recordedAt: measured.addingTimeInterval(0.03),
+            measuredElapsed: ElapsedDuration(microseconds: elapsedMicroseconds),
+            receivedElapsed: ElapsedDuration(microseconds: elapsedMicroseconds + 20_000),
+            recordedElapsed: ElapsedDuration(microseconds: elapsedMicroseconds + 30_000)
+        )
+    }
+
+    private func freshness(at measured: Date, elapsedMicroseconds: Int64) -> EvidenceFreshness {
+        EvidenceFreshness(
+            state: .fresh,
+            evaluatedAt: RecordTimestamp(
+                recordedAt: measured.addingTimeInterval(0.03),
+                elapsed: ElapsedDuration(microseconds: elapsedMicroseconds + 30_000)
+            ),
+            age: ElapsedDuration(microseconds: 30_000),
+            policyVersion: versions.safetyPolicy
+        )
+    }
+
+    private func recordCounter(sessionIndex: Int, localIndex: Int) -> UInt64 {
+        UInt64(sessionIndex) * 10_000_000 + UInt64(localIndex)
+    }
+
+    private func uuid(kind: UInt64, counter: UInt64) -> UUID {
+        var high = seed ^ (kind &* 0x9e37_79b9_7f4a_7c15) ^ counter
+        var low = high &+ 0x9e37_79b9_7f4a_7c15
+        high = Self.mix(high)
+        low = Self.mix(low)
+        let bytes = withUnsafeBytes(of: high.bigEndian) { Array($0) }
+            + withUnsafeBytes(of: low.bigEndian) { Array($0) }
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+
+    private static func mix(_ value: UInt64) -> UInt64 {
+        var mixed = value
+        mixed = (mixed ^ (mixed >> 30)) &* 0xbf58_476d_1ce4_e5b9
+        mixed = (mixed ^ (mixed >> 27)) &* 0x94d0_49bb_1331_11eb
+        return mixed ^ (mixed >> 31)
+    }
+}
+
+struct TelemetryGateIdentityHasher {
+    private(set) var value: UInt64 = 14_695_981_039_346_656_037
+
+    mutating func update(_ text: String) {
+        for byte in text.utf8 {
+            value ^= UInt64(byte)
+            value &*= 1_099_511_628_211
+        }
+    }
+
+    var lowercaseHexDigest: String {
+        String(format: "%016llx", value)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateMigrationTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateMigrationTests.swift
@@ -54,14 +54,17 @@ final class TelemetryGateMigrationTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: root) }
         let storeURL = root.appendingPathComponent("TelemetryV2.store")
         let expected = try await createV1Fixture(at: storeURL)
+        try assertDirectoryBackupBoundary(primaryStoreURL: storeURL, phase: "V1 fixture")
 
         let migrated = try migrateAndRead(at: storeURL, addMarker: true)
         XCTAssertEqual(migrated.counts, expected.counts)
         XCTAssertEqual(migrated.heartRateIdentityHash, expected.heartRateIdentityHash)
         XCTAssertEqual(migrated.markerCount, 1)
+        try assertDirectoryBackupBoundary(primaryStoreURL: storeURL, phase: "migration")
 
         let repeatedReopen = try migrateAndRead(at: storeURL, addMarker: false)
         XCTAssertEqual(repeatedReopen, migrated)
+        try assertDirectoryBackupBoundary(primaryStoreURL: storeURL, phase: "migration reopen")
 
         let policy = try TelemetryStoreFilePolicy.applyRequiredAttributes(
             primaryStoreURL: storeURL
@@ -129,6 +132,13 @@ final class TelemetryGateMigrationTests: XCTestCase {
         at storeURL: URL,
         addMarker: Bool
     ) throws -> TelemetrySyntheticMigrationEvidence {
+        _ = try TelemetryStoreFilePolicy.prepareStoreDirectory(
+            primaryStoreURL: storeURL
+        )
+        try assertDirectoryBackupBoundary(
+            primaryStoreURL: storeURL,
+            phase: "before migration open"
+        )
         let schema = Schema(versionedSchema: TelemetrySyntheticSchemaV2.self)
         let configuration = ModelConfiguration(
             "TelemetryV2SyntheticMigration",
@@ -153,6 +163,10 @@ final class TelemetryGateMigrationTests: XCTestCase {
                 )
             }
         }
+        try assertDirectoryBackupBoundary(
+            primaryStoreURL: storeURL,
+            phase: "after migration write"
+        )
         _ = try TelemetryStoreFilePolicy.applyRequiredAttributes(
             primaryStoreURL: storeURL
         )
@@ -192,5 +206,18 @@ final class TelemetryGateMigrationTests: XCTestCase {
             hasher.update(observation.observationID.description)
         }
         return hasher.lowercaseHexDigest
+    }
+
+    private func assertDirectoryBackupBoundary(
+        primaryStoreURL: URL,
+        phase: String
+    ) throws {
+        XCTAssertEqual(
+            try primaryStoreURL.deletingLastPathComponent()
+                .resourceValues(forKeys: [.isExcludedFromBackupKey])
+                .isExcludedFromBackup,
+            true,
+            phase
+        )
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateMigrationTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateMigrationTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import SwiftData
+import TelemetryDomain
+@testable import TelemetryPersistence
+import XCTest
+
+@Model
+private final class TelemetrySyntheticMigrationMarkerV2 {
+    @Attribute(.unique) var key: String
+    var createdAt: Date
+
+    init(key: String, createdAt: Date) {
+        self.key = key
+        self.createdAt = createdAt
+    }
+}
+
+private enum TelemetrySyntheticSchemaV2: VersionedSchema {
+    static let versionIdentifier = Schema.Version(2, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        TelemetrySchemaV1.models + [TelemetrySyntheticMigrationMarkerV2.self]
+    }
+}
+
+private enum TelemetrySyntheticMigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any VersionedSchema.Type] {
+        [TelemetrySchemaV1.self, TelemetrySyntheticSchemaV2.self]
+    }
+
+    static var stages: [MigrationStage] {
+        [
+            .lightweight(
+                fromVersion: TelemetrySchemaV1.self,
+                toVersion: TelemetrySyntheticSchemaV2.self
+            ),
+        ]
+    }
+}
+
+private struct TelemetrySyntheticMigrationEvidence: Equatable {
+    let counts: TelemetryStoreCounts
+    let heartRateIdentityHash: String
+    let markerCount: Int
+}
+
+final class TelemetryGateMigrationTests: XCTestCase {
+    func testV1ToSyntheticV2MigrationRetainsEvidenceAcrossRepeatedReopen() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "telemetry-gate-migration-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let storeURL = root.appendingPathComponent("TelemetryV2.store")
+        let expected = try await createV1Fixture(at: storeURL)
+
+        let migrated = try migrateAndRead(at: storeURL, addMarker: true)
+        XCTAssertEqual(migrated.counts, expected.counts)
+        XCTAssertEqual(migrated.heartRateIdentityHash, expected.heartRateIdentityHash)
+        XCTAssertEqual(migrated.markerCount, 1)
+
+        let repeatedReopen = try migrateAndRead(at: storeURL, addMarker: false)
+        XCTAssertEqual(repeatedReopen, migrated)
+
+        let policy = try TelemetryStoreFilePolicy.applyRequiredAttributes(
+            primaryStoreURL: storeURL
+        )
+        XCTAssertFalse(policy.protectedURLs.isEmpty)
+        for url in policy.protectedURLs {
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            XCTAssertEqual(
+                attributes[.protectionKey] as? FileProtectionType,
+                .completeUntilFirstUserAuthentication
+            )
+            XCTAssertEqual(
+                try url.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup,
+                true
+            )
+        }
+    }
+
+    private func createV1Fixture(at storeURL: URL) async throws
+        -> TelemetrySyntheticMigrationEvidence
+    {
+        let profile = TelemetryGateProfile(
+            name: "migration-v1",
+            sessionCount: 1,
+            secondsPerSession: 60,
+            frameGapStartSecond: 20,
+            frameGapLengthSeconds: 5,
+            heartRateIntervalSeconds: 5,
+            treadmillIntervalSeconds: 15,
+            eventsPerSession: 20,
+            batchSize: 128,
+            queryRepetitions: 1
+        )
+        let generator = TelemetryGateFixtureGenerator(profile: profile)
+        let store = try TelemetryStoreFactory.make(.onDisk(storeURL))
+        try await store.insertGateBatch(generator.sources.map(TelemetryGateRecord.source))
+        try await store.insertSession(generator.session(index: 0))
+        var records: [TelemetryGateRecord] = []
+        for index in 0..<profile.heartRatePerSession {
+            records.append(.heartRate(generator.heartRate(sessionIndex: 0, sampleIndex: index)))
+        }
+        for index in 0..<profile.treadmillPerSession {
+            records.append(.treadmill(generator.treadmill(sessionIndex: 0, sampleIndex: index)))
+        }
+        records.append(contentsOf: generator.events(sessionIndex: 0).map(TelemetryGateRecord.event))
+        for second in 0..<profile.secondsPerSession {
+            if let frame = generator.frame(sessionIndex: 0, elapsedSecond: second) {
+                records.append(.frame(frame))
+            }
+        }
+        records.append(.analysis(generator.analysis(sessionIndex: 0)))
+        try await store.insertGateBatch(records)
+        let counts = try await store.counts()
+        let heartRate = try await store.fetchHeartRate(
+            sessionID: generator.causalProbe(sessionIndex: 0).sessionID
+        )
+        return TelemetrySyntheticMigrationEvidence(
+            counts: counts,
+            heartRateIdentityHash: identityHash(heartRate),
+            markerCount: 0
+        )
+    }
+
+    private func migrateAndRead(
+        at storeURL: URL,
+        addMarker: Bool
+    ) throws -> TelemetrySyntheticMigrationEvidence {
+        let schema = Schema(versionedSchema: TelemetrySyntheticSchemaV2.self)
+        let configuration = ModelConfiguration(
+            "TelemetryV2SyntheticMigration",
+            schema: schema,
+            url: storeURL,
+            cloudKitDatabase: .none
+        )
+        let container = try ModelContainer(
+            for: schema,
+            migrationPlan: TelemetrySyntheticMigrationPlan.self,
+            configurations: [configuration]
+        )
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+        if addMarker {
+            try context.transaction {
+                context.insert(
+                    TelemetrySyntheticMigrationMarkerV2(
+                        key: "synthetic-successor-v2",
+                        createdAt: TelemetryGateFixtureGenerator.baseDate
+                    )
+                )
+            }
+        }
+        _ = try TelemetryStoreFilePolicy.applyRequiredAttributes(
+            primaryStoreURL: storeURL
+        )
+        let heartRateDescriptor = FetchDescriptor<TelemetryHeartRateSampleV1>(
+            sortBy: [SortDescriptor(\TelemetryHeartRateSampleV1.arrivalOrder)]
+        )
+        let heartRateModels = try context.fetch(heartRateDescriptor)
+        var hasher = TelemetryGateIdentityHasher()
+        for model in heartRateModels {
+            hasher.update(model.observationID)
+        }
+        return TelemetrySyntheticMigrationEvidence(
+            counts: TelemetryStoreCounts(
+                configurations: try context.fetchCount(
+                    FetchDescriptor<TelemetryConfigurationSnapshotV1>()
+                ),
+                sessions: try context.fetchCount(FetchDescriptor<TelemetryWorkoutSessionV1>()),
+                sources: try context.fetchCount(FetchDescriptor<TelemetrySignalSourceV1>()),
+                heartRateSamples: heartRateModels.count,
+                treadmillSamples: try context.fetchCount(
+                    FetchDescriptor<TelemetryTreadmillSampleV1>()
+                ),
+                events: try context.fetchCount(FetchDescriptor<TelemetryWorkoutEventV1>()),
+                frames: try context.fetchCount(FetchDescriptor<TelemetryWorkoutFrameV1>()),
+                analyses: try context.fetchCount(FetchDescriptor<TelemetryWorkoutAnalysisV1>())
+            ),
+            heartRateIdentityHash: hasher.lowercaseHexDigest,
+            markerCount: try context.fetchCount(
+                FetchDescriptor<TelemetrySyntheticMigrationMarkerV2>()
+            )
+        )
+    }
+
+    private func identityHash(_ observations: [HeartRateObservation]) -> String {
+        var hasher = TelemetryGateIdentityHasher()
+        for observation in observations {
+            hasher.update(observation.observationID.description)
+        }
+        return hasher.lowercaseHexDigest
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateRecoveryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateRecoveryTests.swift
@@ -1,0 +1,141 @@
+import Darwin
+import Foundation
+import TelemetryDomain
+@testable import TelemetryPersistence
+import XCTest
+
+private struct TelemetryGateRecoveryMarker: Codable {
+    let sessionID: String
+    let committedHeartRateCount: Int
+    let committedIdentityHash: String
+}
+
+final class TelemetryGateRecoveryTests: XCTestCase {
+    func testForcedProcessInterruptionPreservesCommittedPrefixAndMarksIncomplete() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "telemetry-gate-recovery-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let storeURL = root.appendingPathComponent("TelemetryV2.store")
+        let markerURL = root.appendingPathComponent("committed-prefix.json")
+        let committedCount = 256
+
+        let worker = Process()
+        worker.executableURL = try crashWorkerExecutableURL()
+        worker.arguments = [
+            "--store", storeURL.path,
+            "--marker", markerURL.path,
+            "--committed-heart-rate-count", String(committedCount),
+        ]
+        worker.standardOutput = FileHandle.nullDevice
+        worker.standardError = FileHandle.nullDevice
+        try worker.run()
+
+        let deadline = Date().addingTimeInterval(30)
+        while !FileManager.default.fileExists(atPath: markerURL.path), Date() < deadline {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        guard FileManager.default.fileExists(atPath: markerURL.path) else {
+            if worker.isRunning {
+                kill(worker.processIdentifier, SIGKILL)
+                worker.waitUntilExit()
+            }
+            XCTFail("Crash worker did not publish the committed-prefix marker.")
+            return
+        }
+        let marker = try JSONDecoder().decode(
+            TelemetryGateRecoveryMarker.self,
+            from: Data(contentsOf: markerURL)
+        )
+        XCTAssertEqual(marker.committedHeartRateCount, committedCount)
+        XCTAssertTrue(worker.isRunning)
+
+        XCTAssertEqual(kill(worker.processIdentifier, SIGKILL), 0)
+        worker.waitUntilExit()
+        XCTAssertEqual(worker.terminationReason, .uncaughtSignal)
+        XCTAssertEqual(worker.terminationStatus, SIGKILL)
+
+        guard let rawSessionID = UUID(uuidString: marker.sessionID) else {
+            XCTFail("Worker emitted an invalid session identifier.")
+            return
+        }
+        let sessionID = SessionID(rawValue: rawSessionID)
+        let reopened = try TelemetryStoreFactory.make(.onDisk(storeURL))
+        let counts = try await reopened.counts()
+        XCTAssertEqual(counts.sessions, 1)
+        XCTAssertEqual(counts.sources, 1)
+        XCTAssertEqual(counts.heartRateSamples, committedCount)
+        let heartRate = try await reopened.fetchHeartRate(sessionID: sessionID)
+        XCTAssertEqual(heartRate.count, committedCount)
+        XCTAssertEqual(identityHash(heartRate), marker.committedIdentityHash)
+        let beforeRecovery = try await reopened.fetchSessions()
+        XCTAssertEqual(beforeRecovery.count, 1)
+        XCTAssertEqual(beforeRecovery[0].lifecycleState, .running)
+        XCTAssertFalse(beforeRecovery[0].recorderHealth.isComplete)
+        XCTAssertNil(beforeRecovery[0].endedAt)
+
+        try await reopened.gateMarkInterruptedSessionIncomplete(
+            sessionID,
+            reason: "forced-process-interruption"
+        )
+        let verifiedReopen = try TelemetryStoreFactory.make(.onDisk(storeURL))
+        let recoveredSessions = try await verifiedReopen.fetchSessions()
+        XCTAssertEqual(recoveredSessions.count, 1)
+        XCTAssertEqual(recoveredSessions[0].lifecycleState, .incomplete)
+        XCTAssertEqual(recoveredSessions[0].incompleteReason, "forced-process-interruption")
+        XCTAssertFalse(recoveredSessions[0].recorderHealth.isComplete)
+        XCTAssertNil(recoveredSessions[0].endedAt)
+        let verifiedCounts = try await verifiedReopen.counts()
+        XCTAssertEqual(verifiedCounts.heartRateSamples, committedCount)
+        let verifiedHeartRate = try await verifiedReopen.fetchHeartRate(sessionID: sessionID)
+        XCTAssertEqual(
+            identityHash(verifiedHeartRate),
+            marker.committedIdentityHash
+        )
+
+        let policy = try TelemetryStoreFilePolicy.applyRequiredAttributes(
+            primaryStoreURL: storeURL
+        )
+        XCTAssertFalse(policy.protectedURLs.isEmpty)
+        for url in policy.protectedURLs {
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            XCTAssertEqual(
+                attributes[.protectionKey] as? FileProtectionType,
+                .completeUntilFirstUserAuthentication
+            )
+            XCTAssertEqual(
+                try url.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup,
+                true
+            )
+        }
+    }
+
+    private func crashWorkerExecutableURL() throws -> URL {
+        let buildRoot = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(".build", isDirectory: true)
+        guard let enumerator = FileManager.default.enumerator(
+            at: buildRoot,
+            includingPropertiesForKeys: [.isRegularFileKey, .isExecutableKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        for case let url as URL in enumerator where url.lastPathComponent == "TelemetryGateCrashWorker" {
+            let values = try url.resourceValues(forKeys: [.isRegularFileKey, .isExecutableKey])
+            if values.isRegularFile == true, values.isExecutable == true {
+                return url
+            }
+        }
+        throw CocoaError(.fileNoSuchFile)
+    }
+
+    private func identityHash(_ observations: [HeartRateObservation]) -> String {
+        var hasher = TelemetryGateIdentityHasher()
+        for observation in observations {
+            hasher.update(observation.observationID.description)
+        }
+        return hasher.lowercaseHexDigest
+    }
+}


### PR DESCRIPTION
## Summary

- add deterministic fast and configurable full SwiftData gate profiles against the accepted Telemetry V1 schema;
- add a package-only crash worker, real unsaved-tail `SIGKILL` recovery test, and test-only synthetic V1-to-V2 migration;
- make the dedicated `TelemetryV2` parent directory the authoritative backup-exclusion boundary before `ModelContainer` opens or migrates, with immediate readback verification;
- retain primary/WAL/SHM file protection and backup attributes as defense in depth;
- document the actual 1,000-hour / 4,522,003-record hosted results and the corrected PASS / UNVERIFIED_ON_DEVICE matrix.

No production runtime wiring, recorder batching policy, schema/index semantics, telemetry cadence/retention, BLE/HR/UI/control behavior, legacy telemetry, device installation, app launch, or hardware activity is included.

Closes #26

## Verification

- `swift test --filter 'Telemetry(StoreConfigurationTests|SchemaAndBoundaryTests|GateMigrationTests)'` — 12 policy/persistence tests plus synthetic migration passed.
- Fixed 20-invocation focused repeat of directory lifecycle and child recreation tests — 20/20 passed without sleeps or retries.
- `swift test --filter TelemetryGateBenchmarkTests/testFastCIProfile` — passed twice explicitly; corrected summary: deterministic hash `1cd21e9585942c0f`, directory exclusion true after write/reopen, 22 full 128-record transactions, p50/p95/p99 112.401/137.098/154.940 ms, 1,134.6 records/s.
- `swift test --filter 'TelemetryGate(RecoveryTests|MigrationTests|BoundaryTests)'` — forced interruption/recovery, synthetic migration, and isolation passed.
- `swift test` — passed; 187 tests reported across targets, one configured full-profile skip, zero failures.
- Prior full-scale run on measured harness head `c67f991d4568c776d9776f6100b03c15279c642b` passed: exactly 1,000 workout-hours, 4,522,003 records, 35,319 true 128-record transactions, zero unexpected failures. It was not rerun because the correction is one pre-open directory setup/readback and does not change `explicitTransaction`, per-write persistence behavior, or transaction timing.
- `PYTHONPYCACHEPREFIX=<temp> python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py` — passed.
- `xcodebuild -list -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj` — passed.
- `xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` — unsigned generic iOS/watchOS build passed.
- `git diff --check 4c59ae0257d40c9e86df386ca9c56713e88f3270...HEAD` — passed.
- Fresh independent review of exact head `3ccfef7b6c853c60c53c0678e0ba25646d19ef9d` — GO; no P0-P3 findings.
- Exact-head CI run `31888178193` — all required jobs SUCCESS: Python Checks, Swift Package Tests, Xcode Project Metadata, and unsigned iOS/watchOS App Build.

## Risks / Notes

- Earlier evidence remains explicit: one local suite observed WAL+SHM backup exclusion false; CI run `31885551307` observed primary store+SHM false. Child-file xattrs are transient, so the dedicated directory is now authoritative while child attributes remain defense in depth.
- Hosted 128-record full-profile p95 was 298.440 ms versus the 50 ms designated-device hypothesis. Full throughput was 629.5 records/s.
- Retained growth was 7,154,317 bytes/hour (6.823 MiB/hour), dominated by canonical frame rows and indexes. Scientific evidence was not downsampled or coalesced.
- The comparable-session harness query fetches 250 sessions for one profile before decoding the mode and limiting output to 10; no production projection/index was added.
- `UNVERIFIED_ON_DEVICE`: real iPhone protection after first unlock and subsequent lock/lifecycle; real iOS backup/restore exclusion; designated-iPhone transaction performance; designated-iPhone full-store query latency; on-device Instruments memory/app-lifecycle pressure. These remain carried to #37.
- No schema migration, deployment, or backward-compatibility break is introduced. Existing stores reopen in the same location; rollback is reverting the two directory-policy correction commits, although the already-applied directory xattr may harmlessly remain.
- This PR must remain Draft and must not be merged or used to start #27 until PM accepts the corrected gate.
