### PR TITLE
Implement bounded Telemetry V2 recorder

### DIFF
--- a/docs/telemetry-v2/architecture.md
+++ b/docs/telemetry-v2/architecture.md
@@ -5,7 +5,9 @@ Status: normative contract for the Telemetry V2 implementation queue.
 This document defines component ownership and dependency direction. The related
 [data contract](data-contract.md), [persistence and retention policy](persistence-and-retention.md),
 [rollout plan](rollout-and-migration.md), [performance budget](performance-budget.md),
-and [safety boundary](safety-boundary.md) are equally normative.
+[safety boundary](safety-boundary.md), and the Issue #27
+[recorder implementation note](recorder-ingress.md) describe the corresponding
+normative and concrete boundaries.
 
 `MUST`, `MUST NOT`, `SHOULD`, `SHOULD NOT`, and `MAY` express requirement
 strength. A later issue MAY refine names and internal representation, but it

--- a/docs/telemetry-v2/recorder-ingress.md
+++ b/docs/telemetry-v2/recorder-ingress.md
@@ -105,17 +105,23 @@ persistence succeeded. Explicit failure, retry exhaustion, ambiguous commit,
 catastrophic pressure, and discarded or uncertain tail evidence cannot become a
 complete session. A persistence adapter must resolve an ambiguous final-state
 commit by reading back exact stored state; the SwiftData adapter does so. If an
-unresolved completion update still fails, the recorder makes one fail-closed,
-best-effort incomplete update and reports failure rather than success.
+unresolved completion update still fails, the recorder makes a fail-closed,
+best-effort terminal update and reports failure rather than success.
+Failure or cancellation accepted while completion finalization is in flight
+changes terminal intent under the recorder lock. A possibly committed completion
+is followed by an idempotent fail-closed incomplete or cancelled finalization;
+the recorder does not claim that the earlier transaction was rolled back.
 Cancellation accounts the queued or in-flight uncertain tail, persists the
 terminal `cancelled` lifecycle, does not fabricate success, and terminates the
 consumer.
 
-`unfinishedSessions()` exposes persisted sessions that never reached completed
-or cancelled state. `recoverUnfinishedSessions(using:)` marks them incomplete
-without inventing an end time, end elapsed value, or successful completion. The
-method is deliberately not connected to app launch in #27 and is not a claim of
-crash-proof delivery.
+`unfinishedSessions()` exposes only persisted `created`, `running`, or `paused`
+sessions. Persisted `completed`, `cancelled`, and `incomplete` states are terminal
+and excluded. `recoverUnfinishedSessions(using:)` marks genuinely unfinished
+sessions incomplete without inventing an end time, end elapsed value, or
+successful completion. Repeated recovery therefore preserves an existing
+incomplete reason and recorder-health summary. The method is deliberately not
+connected to app launch in #27 and is not a claim of crash-proof delivery.
 
 ## Privacy-safe operational state
 

--- a/docs/telemetry-v2/recorder-ingress.md
+++ b/docs/telemetry-v2/recorder-ingress.md
@@ -1,0 +1,126 @@
+# Telemetry V2 recorder ingress
+
+Status: Issue #27 implementation note. The normative contracts in this directory
+remain authoritative.
+
+Issue #27 provides an unwired recorder pipeline. It does not connect any current
+sensor, engine, application-lifecycle, BLE, controller, UI, history, or export
+producer. Issues #28 through #30 own production integration.
+
+## Dependency direction
+
+```text
+TelemetryDomain
+      ^
+      |
+TelemetryRecorder       (no SwiftData dependency)
+      ^
+      |
+TelemetryPersistence    (TelemetryStore adapter and SwiftData transaction)
+```
+
+`TelemetryRecorder` owns ingress, buffering, sequencing, scheduling, batching,
+and recorder lifecycle. `TelemetryPersistence` implements the recorder-facing
+protocol on the existing `TelemetryStore`. The application and
+`WalkingPadCoreLogic` do not depend on or instantiate the recorder in #27.
+
+## Producer contract and recorder ordering
+
+`TelemetryIngress.yield(_:)` is synchronous and non-throwing. It assigns a
+recorder-local monotonic sequence while holding a short lock, applies bounded
+admission, optionally wakes the single consumer, and returns an admission
+receipt. It performs no actor hop, await, task creation, persistence, filesystem
+access, JSON work, analysis, export, or network work.
+
+The sequence is an operational total order after concurrent calls are
+linearized. It does not replace provider arrival sequence, native identity,
+measurement time, receipt time, or causal identifiers. It is passed to the
+persistence boundary to preserve batch order but is not a new durable cross-table
+scientific ordering field.
+
+The buffer reserves its slot arena and exact-frame identity index at recorder
+creation. Global FIFO links, a bulk-frame eviction list, and exact-identity hash
+lookup keep normal enqueue, coalescing, and permitted eviction bounded without
+buffer scans or `Array.removeFirst()`.
+
+## Record classes and pressure rules
+
+The initial injected buffer policy is 2,048 total slots, including 256 slots
+reserved from non-critical use and 512 additional slots reserved from bulk
+frames for native evidence. This represents 16 provisional 128-record batches,
+with two batches protected for critical evidence and four for native evidence.
+It is a conservative integration starting point, not a permanent product
+constant; #31 owns tuning with integrated soak evidence.
+
+Records are classified as follows:
+
+- Critical: source/connection identity transitions and typed workout events.
+  Normal bulk pressure cannot consume the critical reserve. If the arena is full,
+  a critical record evicts the oldest queued frame. Critical loss occurs only
+  when no frame is available to evict.
+- Native: HR and treadmill observations. They are never value-, timestamp-, or
+  similarity-coalesced. Native admission may evict the oldest frame, but it
+  cannot consume the critical reserve.
+- Bulk: canonical frames. A queued frame may be replaced only by a later
+  candidate with the exact same session and canonical-second identity. The new
+  candidate moves to the global sequence tail. Otherwise excess frames are
+  dropped before native or critical evidence.
+
+Every coalesced or dropped frame and every unavoidable native or critical loss
+is counted. Any drop or loss makes the session incomplete. The recorder never
+fabricates or backfills frames, alters native observations, or affects treadmill,
+speed, HR selection, cooldown, command, or safety behavior.
+
+## Consumer, batching, and persistence
+
+Each recorder owns one long-lived utility-priority consumer. An `AsyncStream`
+with a one-element wake buffer coalesces wake notifications. At most one
+monotonic scheduler operation is armed for a batch deadline or retry; ingress
+does not create timers or tasks per record.
+
+The initial injected batch policy flushes at 128 records or five seconds from
+the oldest queued record, whichever occurs first. Explicit and lifecycle flush
+reasons use the same recorder control plane. They are not wired to application
+lifecycle callbacks in #27.
+
+The session header is submitted first by the asynchronous consumer. Body batches
+do not pass that boundary until the header succeeds. A body batch is delivered
+to `TelemetryRecorderPersistence.persistBatch(_:)` in strictly increasing
+recorder sequence. `TelemetryStore` validates that order and maps the entire
+batch through one explicit SwiftData transaction; it does not loop over
+independently saving public calls.
+
+## Retry, failure, completion, and recovery
+
+The initial injected retry policy permits one retry after 250 milliseconds, only
+when the persistence implementation explicitly reports a failure known to have
+happened before commit. Terminal failures and unknown commit outcomes are never
+retried because replay could duplicate an already committed batch. #31 may tune
+the conservative retry default from integrated evidence without changing this
+safety distinction.
+
+Normal `finish` stops admission, drains the accepted prefix, finalizes the
+session, and reports complete only when no record is known lost and all required
+persistence succeeded. Explicit failure, retry exhaustion, ambiguous commit,
+catastrophic pressure, and discarded or uncertain tail evidence cannot become a
+complete session. Cancellation accounts the queued or in-flight uncertain tail,
+does not fabricate success, and terminates the consumer.
+
+`unfinishedSessions()` exposes persisted sessions that never reached completed
+or cancelled state. `recoverUnfinishedSessions(using:)` marks them incomplete
+without inventing an end time, end elapsed value, or successful completion. The
+method is deliberately not connected to app launch in #27 and is not a claim of
+crash-proof delivery.
+
+## Privacy-safe operational state
+
+The recorder exposes queue depth and peak, coalesced and dropped frame counts,
+lost native and critical counts, writer failures, retries, successful flushes,
+last committed recorder sequence, latest flush duration, lifecycle state, and
+completeness. These counters contain no BPM, samples, source identifiers, raw
+BLE payloads, or exports and are not a user-facing UI contract.
+
+Issue #31 is expected to retune buffer capacities, reserves, batch count/time,
+and the conservative pre-commit retry parameters from integrated soak evidence.
+It must not use tuning to weaken native evidence, causal fidelity, safety
+boundaries, or completion semantics.

--- a/docs/telemetry-v2/recorder-ingress.md
+++ b/docs/telemetry-v2/recorder-ingress.md
@@ -103,8 +103,13 @@ Normal `finish` stops admission, drains the accepted prefix, finalizes the
 session, and reports complete only when no record is known lost and all required
 persistence succeeded. Explicit failure, retry exhaustion, ambiguous commit,
 catastrophic pressure, and discarded or uncertain tail evidence cannot become a
-complete session. Cancellation accounts the queued or in-flight uncertain tail,
-does not fabricate success, and terminates the consumer.
+complete session. A persistence adapter must resolve an ambiguous final-state
+commit by reading back exact stored state; the SwiftData adapter does so. If an
+unresolved completion update still fails, the recorder makes one fail-closed,
+best-effort incomplete update and reports failure rather than success.
+Cancellation accounts the queued or in-flight uncertain tail, persists the
+terminal `cancelled` lifecycle, does not fabricate success, and terminates the
+consumer.
 
 `unfinishedSessions()` exposes persisted sessions that never reached completed
 or cancelled state. `recoverUnfinishedSessions(using:)` marks them incomplete

--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -18,6 +18,10 @@ let package = Package(
             targets: ["TelemetryDomain"]
         ),
         .library(
+            name: "TelemetryRecorder",
+            targets: ["TelemetryRecorder"]
+        ),
+        .library(
             name: "TelemetryPersistence",
             targets: ["TelemetryPersistence"]
         )
@@ -27,8 +31,12 @@ let package = Package(
             name: "TelemetryDomain"
         ),
         .target(
-            name: "TelemetryPersistence",
+            name: "TelemetryRecorder",
             dependencies: ["TelemetryDomain"]
+        ),
+        .target(
+            name: "TelemetryPersistence",
+            dependencies: ["TelemetryDomain", "TelemetryRecorder"]
         ),
         .executableTarget(
             name: "TelemetryGateCrashWorker",
@@ -85,8 +93,12 @@ let package = Package(
             dependencies: ["TelemetryDomain"]
         ),
         .testTarget(
+            name: "TelemetryRecorderTests",
+            dependencies: ["TelemetryDomain", "TelemetryRecorder"]
+        ),
+        .testTarget(
             name: "TelemetryPersistenceTests",
-            dependencies: ["TelemetryDomain", "TelemetryPersistence"]
+            dependencies: ["TelemetryDomain", "TelemetryRecorder", "TelemetryPersistence"]
         ),
         .testTarget(
             name: "TelemetrySwiftDataGateTests",

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
@@ -653,9 +653,12 @@ public actor TelemetryStore {
     public func fetchUnfinishedRecorderSessions() throws -> [WorkoutSessionRecord] {
         let completed = SessionLifecycleState.completed.rawValue
         let cancelled = SessionLifecycleState.cancelled.rawValue
+        let incomplete = SessionLifecycleState.incomplete.rawValue
         let descriptor = FetchDescriptor<TelemetryWorkoutSessionV1>(
             predicate: #Predicate {
-                $0.lifecycleStateKey != completed && $0.lifecycleStateKey != cancelled
+                $0.lifecycleStateKey != completed
+                    && $0.lifecycleStateKey != cancelled
+                    && $0.lifecycleStateKey != incomplete
             },
             sortBy: [SortDescriptor(\TelemetryWorkoutSessionV1.startedAt)]
         )

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftData
 import TelemetryDomain
+import TelemetryRecorder
 
 public enum TelemetryStoreConfiguration: Sendable, Equatable {
     case inMemory
@@ -14,6 +15,7 @@ public enum TelemetryStoreError: Error, Equatable, Sendable {
     case conflictingStableIdentity(String)
     case invalidNumericValue(String)
     case corruptStoredRecord(String)
+    case nonMonotonicRecorderSequence
 }
 
 public struct StoredSignalSource: Codable, Hashable, Sendable {
@@ -587,6 +589,77 @@ public actor TelemetryStore {
 
     public func isAutosaveEnabled() -> Bool {
         modelContext.autosaveEnabled
+    }
+
+    public func insertRecorderBatch(_ records: [SequencedTelemetryRecord]) throws {
+        guard !records.isEmpty else {
+            return
+        }
+        var previousSequence: UInt64?
+        for record in records {
+            if let previousSequence,
+               record.recorderSequence <= previousSequence
+            {
+                throw TelemetryStoreError.nonMonotonicRecorderSequence
+            }
+            previousSequence = record.recorderSequence
+        }
+
+        try explicitTransaction {
+            for sequenced in records {
+                switch sequenced.record {
+                case let .source(source):
+                    try insertSource(
+                        source.identity,
+                        firstSeen: source.firstSeen,
+                        lastSeen: source.lastSeen
+                    )
+                case let .heartRate(observation):
+                    try insertHeartRate(observation)
+                case let .treadmill(observation):
+                    try insertTreadmill(observation)
+                case let .event(event):
+                    try insertEvent(event)
+                case let .frame(frame):
+                    try insertFrame(frame)
+                }
+            }
+        }
+    }
+
+    public func finalizeRecorderSession(_ finalization: TelemetrySessionFinalization) throws {
+        let session = try sessionModel(finalization.sessionID)
+        let lostCritical = try Self.int64(
+            finalization.recorderHealth.lostCriticalRecordCount,
+            field: "lostCriticalRecordCount"
+        )
+        let lostNative = try Self.int64(
+            finalization.recorderHealth.lostNativeRecordCount,
+            field: "lostNativeRecordCount"
+        )
+        try explicitTransaction {
+            session.lifecycleStateKey = finalization.lifecycleState.rawValue
+            session.endedAt = finalization.endedAt
+            session.endedElapsedMicroseconds = finalization.endedElapsed?.microseconds
+            session.incompleteReason = finalization.incompleteReason
+            session.recorderIsComplete = finalization.recorderHealth.isComplete
+            session.lostCriticalRecordCount = lostCritical
+            session.lostNativeRecordCount = lostNative
+            session.lastPersistedElapsedMicroseconds = finalization.recorderHealth
+                .lastPersistedElapsed?.microseconds
+        }
+    }
+
+    public func fetchUnfinishedRecorderSessions() throws -> [WorkoutSessionRecord] {
+        let completed = SessionLifecycleState.completed.rawValue
+        let cancelled = SessionLifecycleState.cancelled.rawValue
+        let descriptor = FetchDescriptor<TelemetryWorkoutSessionV1>(
+            predicate: #Predicate {
+                $0.lifecycleStateKey != completed && $0.lifecycleStateKey != cancelled
+            },
+            sortBy: [SortDescriptor(\TelemetryWorkoutSessionV1.startedAt)]
+        )
+        return try modelContext.fetch(descriptor).map(Self.domainSession)
     }
 
     /// Issue #26 testability seam. It exercises the existing insert validation and model
@@ -1208,5 +1281,63 @@ private extension TelemetryStore {
             receivedElapsed: ElapsedDuration(microseconds: receivedElapsed),
             recordedElapsed: ElapsedDuration(microseconds: recordedElapsed)
         )
+    }
+}
+
+extension TelemetryStore: TelemetryRecorderPersistence {
+    public func beginSession(_ header: WorkoutSessionRecord) async throws {
+        do {
+            try insertSession(header)
+        } catch {
+            throw TelemetryPersistenceOperationError.commitOutcomeUnknown(
+                code: "swiftdata-begin-session"
+            )
+        }
+    }
+
+    public func persistBatch(_ records: [SequencedTelemetryRecord]) async throws {
+        do {
+            try insertRecorderBatch(records)
+        } catch {
+            throw TelemetryPersistenceOperationError.commitOutcomeUnknown(
+                code: "swiftdata-batch"
+            )
+        }
+    }
+
+    public func finalizeSession(_ finalization: TelemetrySessionFinalization) async throws {
+        do {
+            try finalizeRecorderSession(finalization)
+        } catch {
+            if recorderFinalizationMatchesStoredState(finalization) {
+                return
+            }
+            throw TelemetryPersistenceOperationError.commitOutcomeUnknown(
+                code: "swiftdata-finalize-session"
+            )
+        }
+    }
+
+    public func unfinishedSessions() async throws -> [WorkoutSessionRecord] {
+        do {
+            return try fetchUnfinishedRecorderSessions()
+        } catch {
+            throw TelemetryPersistenceOperationError.terminal(
+                code: "swiftdata-unfinished-session-query"
+            )
+        }
+    }
+
+    private func recorderFinalizationMatchesStoredState(
+        _ finalization: TelemetrySessionFinalization
+    ) -> Bool {
+        guard let stored = try? Self.domainSession(sessionModel(finalization.sessionID)) else {
+            return false
+        }
+        return stored.lifecycleState == finalization.lifecycleState
+            && stored.endedAt == finalization.endedAt
+            && stored.endedElapsed == finalization.endedElapsed
+            && stored.incompleteReason == finalization.incompleteReason
+            && stored.recorderHealth == finalization.recorderHealth
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/BoundedTelemetryBuffer.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/BoundedTelemetryBuffer.swift
@@ -1,0 +1,302 @@
+import Foundation
+
+struct BufferedTelemetryRecord: Sendable {
+    let sequenced: SequencedTelemetryRecord
+    let enqueuedAt: Duration
+}
+
+struct TelemetryDiscardCounts: Equatable, Sendable {
+    var critical = 0
+    var native = 0
+    var bulkFrame = 0
+
+    var total: Int {
+        critical + native + bulkFrame
+    }
+}
+
+struct BufferEnqueueResult: Sendable {
+    let disposition: TelemetryYieldDisposition
+    let evictedBulkFrame: Bool
+}
+
+struct BoundedTelemetryBuffer: Sendable {
+    private struct Slot: Sendable {
+        var value: BufferedTelemetryRecord?
+        var previous: Int?
+        var next: Int?
+        var previousBulk: Int?
+        var nextBulk: Int?
+        var nextFree: Int?
+    }
+
+    let policy: TelemetryBufferPolicy
+
+    private var slots: [Slot]
+    private var freeHead: Int?
+    private var head: Int?
+    private var tail: Int?
+    private var bulkHead: Int?
+    private var bulkTail: Int?
+    private var frameSlots: [CanonicalFrameIdentity: Int] = [:]
+    private(set) var count = 0
+    private(set) var criticalCount = 0
+    private(set) var nativeCount = 0
+    private(set) var bulkFrameCount = 0
+
+    init(policy: TelemetryBufferPolicy) {
+        self.policy = policy
+        slots = (0..<policy.capacity).map { index in
+            Slot(
+                value: nil,
+                previous: nil,
+                next: nil,
+                previousBulk: nil,
+                nextBulk: nil,
+                nextFree: index + 1 < policy.capacity ? index + 1 : nil
+            )
+        }
+        freeHead = slots.isEmpty ? nil : 0
+        frameSlots.reserveCapacity(policy.bulkFrameCapacity)
+    }
+
+    var isEmpty: Bool {
+        count == 0
+    }
+
+    var oldestEnqueueTime: Duration? {
+        guard let head else {
+            return nil
+        }
+        return slots[head].value?.enqueuedAt
+    }
+
+    mutating func enqueue(
+        _ record: SequencedTelemetryRecord,
+        at enqueueTime: Duration
+    ) -> BufferEnqueueResult {
+        switch record.record.recordClass {
+        case .bulkFrame:
+            return enqueueFrame(record, at: enqueueTime)
+        case .native:
+            return enqueueNative(record, at: enqueueTime)
+        case .critical:
+            return enqueueCritical(record, at: enqueueTime)
+        }
+    }
+
+    mutating func drain(maximumCount: Int) -> [SequencedTelemetryRecord] {
+        guard maximumCount > 0 else {
+            return []
+        }
+        var drained: [SequencedTelemetryRecord] = []
+        drained.reserveCapacity(Swift.min(maximumCount, count))
+        while drained.count < maximumCount, let head {
+            guard let value = remove(at: head) else {
+                preconditionFailure("A linked telemetry slot must contain a value.")
+            }
+            drained.append(value.sequenced)
+        }
+        return drained
+    }
+
+    mutating func discardAll() -> TelemetryDiscardCounts {
+        var discarded = TelemetryDiscardCounts()
+        while let head, let removed = remove(at: head) {
+            switch removed.sequenced.record.recordClass {
+            case .critical:
+                discarded.critical += 1
+            case .native:
+                discarded.native += 1
+            case .bulkFrame:
+                discarded.bulkFrame += 1
+            }
+        }
+        return discarded
+    }
+
+    private mutating func enqueueFrame(
+        _ record: SequencedTelemetryRecord,
+        at enqueueTime: Duration
+    ) -> BufferEnqueueResult {
+        guard case let .frame(frame) = record.record else {
+            preconditionFailure("Bulk telemetry must be a canonical frame.")
+        }
+        let identity = CanonicalFrameIdentity(frame)
+        if let existing = frameSlots[identity] {
+            _ = remove(at: existing)
+            append(record, at: enqueueTime, frameIdentity: identity)
+            return BufferEnqueueResult(
+                disposition: .coalescedFrame,
+                evictedBulkFrame: false
+            )
+        }
+
+        guard bulkFrameCount < policy.bulkFrameCapacity,
+              nativeCount + bulkFrameCount < policy.nonCriticalCapacity,
+              count < policy.capacity
+        else {
+            return BufferEnqueueResult(disposition: .droppedFrame, evictedBulkFrame: false)
+        }
+
+        append(record, at: enqueueTime, frameIdentity: identity)
+        return BufferEnqueueResult(disposition: .enqueued, evictedBulkFrame: false)
+    }
+
+    private mutating func enqueueNative(
+        _ record: SequencedTelemetryRecord,
+        at enqueueTime: Duration
+    ) -> BufferEnqueueResult {
+        let nonCriticalCount = nativeCount + bulkFrameCount
+        var evictedBulkFrame = false
+        if nonCriticalCount >= policy.nonCriticalCapacity || count >= policy.capacity {
+            guard evictOldestBulkFrame() else {
+                return BufferEnqueueResult(disposition: .lostNative, evictedBulkFrame: false)
+            }
+            evictedBulkFrame = true
+        }
+        append(record, at: enqueueTime, frameIdentity: nil)
+        return BufferEnqueueResult(
+            disposition: .enqueued,
+            evictedBulkFrame: evictedBulkFrame
+        )
+    }
+
+    private mutating func enqueueCritical(
+        _ record: SequencedTelemetryRecord,
+        at enqueueTime: Duration
+    ) -> BufferEnqueueResult {
+        var evictedBulkFrame = false
+        if count >= policy.capacity {
+            guard evictOldestBulkFrame() else {
+                return BufferEnqueueResult(disposition: .lostCritical, evictedBulkFrame: false)
+            }
+            evictedBulkFrame = true
+        }
+        append(record, at: enqueueTime, frameIdentity: nil)
+        return BufferEnqueueResult(
+            disposition: .enqueued,
+            evictedBulkFrame: evictedBulkFrame
+        )
+    }
+
+    private mutating func append(
+        _ record: SequencedTelemetryRecord,
+        at enqueueTime: Duration,
+        frameIdentity: CanonicalFrameIdentity?
+    ) {
+        guard let index = allocateSlot() else {
+            preconditionFailure("Telemetry admission must reserve a free slot.")
+        }
+        slots[index].value = BufferedTelemetryRecord(
+            sequenced: record,
+            enqueuedAt: enqueueTime
+        )
+        slots[index].previous = tail
+        slots[index].next = nil
+        if let tail {
+            slots[tail].next = index
+        } else {
+            head = index
+        }
+        tail = index
+
+        switch record.record.recordClass {
+        case .critical:
+            criticalCount += 1
+        case .native:
+            nativeCount += 1
+        case .bulkFrame:
+            bulkFrameCount += 1
+            slots[index].previousBulk = bulkTail
+            slots[index].nextBulk = nil
+            if let bulkTail {
+                slots[bulkTail].nextBulk = index
+            } else {
+                bulkHead = index
+            }
+            bulkTail = index
+            if let frameIdentity {
+                frameSlots[frameIdentity] = index
+            }
+        }
+        count += 1
+    }
+
+    private mutating func evictOldestBulkFrame() -> Bool {
+        guard let bulkHead else {
+            return false
+        }
+        _ = remove(at: bulkHead)
+        return true
+    }
+
+    @discardableResult
+    private mutating func remove(at index: Int) -> BufferedTelemetryRecord? {
+        guard let removed = slots[index].value else {
+            return nil
+        }
+
+        let previous = slots[index].previous
+        let next = slots[index].next
+        if let previous {
+            slots[previous].next = next
+        } else {
+            head = next
+        }
+        if let next {
+            slots[next].previous = previous
+        } else {
+            tail = previous
+        }
+
+        switch removed.sequenced.record.recordClass {
+        case .critical:
+            criticalCount -= 1
+        case .native:
+            nativeCount -= 1
+        case .bulkFrame:
+            bulkFrameCount -= 1
+            let previousBulk = slots[index].previousBulk
+            let nextBulk = slots[index].nextBulk
+            if let previousBulk {
+                slots[previousBulk].nextBulk = nextBulk
+            } else {
+                bulkHead = nextBulk
+            }
+            if let nextBulk {
+                slots[nextBulk].previousBulk = previousBulk
+            } else {
+                bulkTail = previousBulk
+            }
+            if case let .frame(frame) = removed.sequenced.record {
+                let identity = CanonicalFrameIdentity(frame)
+                if frameSlots[identity] == index {
+                    frameSlots.removeValue(forKey: identity)
+                }
+            }
+        }
+        count -= 1
+        releaseSlot(index)
+        return removed
+    }
+
+    private mutating func allocateSlot() -> Int? {
+        guard let index = freeHead else {
+            return nil
+        }
+        freeHead = slots[index].nextFree
+        slots[index].nextFree = nil
+        return index
+    }
+
+    private mutating func releaseSlot(_ index: Int) {
+        slots[index].value = nil
+        slots[index].previous = nil
+        slots[index].next = nil
+        slots[index].previousBulk = nil
+        slots[index].nextBulk = nil
+        slots[index].nextFree = freeHead
+        freeHead = index
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecord.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecord.swift
@@ -165,6 +165,9 @@ public struct TelemetrySessionFinalization: Hashable, Sendable {
 public protocol TelemetryRecorderPersistence: Sendable {
     func beginSession(_ header: WorkoutSessionRecord) async throws
     func persistBatch(_ records: [SequencedTelemetryRecord]) async throws
+
+    /// Finalization must be idempotent. An adapter that observes an unknown commit
+    /// outcome must read back exact stored state before returning success or failure.
     func finalizeSession(_ finalization: TelemetrySessionFinalization) async throws
     func unfinishedSessions() async throws -> [WorkoutSessionRecord]
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecord.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecord.swift
@@ -1,0 +1,312 @@
+import Foundation
+import TelemetryDomain
+
+public struct TelemetrySourceRecord: Hashable, Sendable {
+    public let identity: SignalSourceIdentity
+    public let firstSeen: Date
+    public let lastSeen: Date
+
+    public init(identity: SignalSourceIdentity, firstSeen: Date, lastSeen: Date) {
+        self.identity = identity
+        self.firstSeen = firstSeen
+        self.lastSeen = lastSeen
+    }
+}
+
+public enum TelemetryPersistenceRecord: Hashable, Sendable {
+    case source(TelemetrySourceRecord)
+    case heartRate(HeartRateObservation)
+    case treadmill(TreadmillObservation)
+    case event(WorkoutEvent)
+    case frame(CanonicalFrame)
+}
+
+public struct SequencedTelemetryRecord: Hashable, Sendable {
+    public let recorderSequence: UInt64
+    public let record: TelemetryPersistenceRecord
+
+    public init(recorderSequence: UInt64, record: TelemetryPersistenceRecord) {
+        self.recorderSequence = recorderSequence
+        self.record = record
+    }
+}
+
+public enum TelemetryRecordClass: String, Hashable, Sendable {
+    case critical
+    case native
+    case bulkFrame
+}
+
+public enum TelemetryYieldDisposition: String, Hashable, Sendable {
+    case enqueued
+    case coalescedFrame
+    case droppedFrame
+    case lostNative
+    case lostCritical
+    case rejectedAfterFinish
+    case rejectedTerminal
+    case sequenceExhausted
+}
+
+public struct TelemetryYieldReceipt: Hashable, Sendable {
+    public let recorderSequence: UInt64?
+    public let disposition: TelemetryYieldDisposition
+
+    public init(recorderSequence: UInt64?, disposition: TelemetryYieldDisposition) {
+        self.recorderSequence = recorderSequence
+        self.disposition = disposition
+    }
+}
+
+public struct TelemetryBufferPolicy: Hashable, Sendable {
+    public static let initialDefault = TelemetryBufferPolicy(
+        capacity: 2_048,
+        reservedCriticalCapacity: 256,
+        reservedNativeCapacity: 512
+    )!
+
+    public let capacity: Int
+    public let reservedCriticalCapacity: Int
+    public let reservedNativeCapacity: Int
+
+    public init?(
+        capacity: Int,
+        reservedCriticalCapacity: Int,
+        reservedNativeCapacity: Int
+    ) {
+        guard capacity > 0,
+              reservedCriticalCapacity >= 0,
+              reservedNativeCapacity >= 0,
+              reservedCriticalCapacity + reservedNativeCapacity < capacity
+        else {
+            return nil
+        }
+        self.capacity = capacity
+        self.reservedCriticalCapacity = reservedCriticalCapacity
+        self.reservedNativeCapacity = reservedNativeCapacity
+    }
+
+    public var nonCriticalCapacity: Int {
+        capacity - reservedCriticalCapacity
+    }
+
+    public var bulkFrameCapacity: Int {
+        capacity - reservedCriticalCapacity - reservedNativeCapacity
+    }
+}
+
+public struct TelemetryBatchPolicy: Hashable, Sendable {
+    public static let initialDefault = TelemetryBatchPolicy(
+        maximumRecordCount: 128,
+        maximumInterval: .seconds(5)
+    )!
+
+    public let maximumRecordCount: Int
+    public let maximumInterval: Duration
+
+    public init?(maximumRecordCount: Int, maximumInterval: Duration) {
+        guard maximumRecordCount > 0, maximumInterval > .zero else {
+            return nil
+        }
+        self.maximumRecordCount = maximumRecordCount
+        self.maximumInterval = maximumInterval
+    }
+}
+
+public struct TelemetryRetryPolicy: Hashable, Sendable {
+    public static let initialDefault = TelemetryRetryPolicy(
+        maximumPrecommitRetries: 1,
+        delay: .milliseconds(250)
+    )!
+
+    public let maximumPrecommitRetries: Int
+    public let delay: Duration
+
+    public init?(maximumPrecommitRetries: Int, delay: Duration) {
+        guard maximumPrecommitRetries >= 0, delay >= .zero else {
+            return nil
+        }
+        self.maximumPrecommitRetries = maximumPrecommitRetries
+        self.delay = delay
+    }
+}
+
+public enum TelemetryPersistenceOperationError: Error, Equatable, Sendable {
+    case retryableBeforeCommit(code: String)
+    case terminal(code: String)
+    case commitOutcomeUnknown(code: String)
+}
+
+public struct TelemetrySessionFinalization: Hashable, Sendable {
+    public let sessionID: SessionID
+    public let lifecycleState: SessionLifecycleState
+    public let endedAt: Date?
+    public let endedElapsed: ElapsedDuration?
+    public let incompleteReason: String?
+    public let recorderHealth: RecorderHealthSummary
+
+    public init(
+        sessionID: SessionID,
+        lifecycleState: SessionLifecycleState,
+        endedAt: Date?,
+        endedElapsed: ElapsedDuration?,
+        incompleteReason: String?,
+        recorderHealth: RecorderHealthSummary
+    ) {
+        self.sessionID = sessionID
+        self.lifecycleState = lifecycleState
+        self.endedAt = endedAt
+        self.endedElapsed = endedElapsed
+        self.incompleteReason = incompleteReason
+        self.recorderHealth = recorderHealth
+    }
+}
+
+public protocol TelemetryRecorderPersistence: Sendable {
+    func beginSession(_ header: WorkoutSessionRecord) async throws
+    func persistBatch(_ records: [SequencedTelemetryRecord]) async throws
+    func finalizeSession(_ finalization: TelemetrySessionFinalization) async throws
+    func unfinishedSessions() async throws -> [WorkoutSessionRecord]
+}
+
+public protocol TelemetryRecorderScheduler: AnyObject, Sendable {
+    func now() -> Duration
+    func schedule(after delay: Duration, operation: @escaping @Sendable () -> Void)
+    func cancelScheduledOperation()
+}
+
+public enum TelemetryFlushReason: String, Hashable, Sendable {
+    case explicit
+    case applicationBackground
+    case applicationLifecycle
+    case sessionFinish
+}
+
+public enum TelemetryRecorderCompleteness: String, Hashable, Sendable {
+    case complete
+    case incomplete
+    case failed
+    case cancelled
+}
+
+public enum TelemetryRecorderLifecycleState: String, Hashable, Sendable {
+    case beginning
+    case active
+    case finishing
+    case failing
+    case cancelling
+    case complete
+    case incomplete
+    case failed
+    case cancelled
+}
+
+public struct TelemetryRecorderOperationalState: Equatable, Sendable {
+    public let queueDepth: Int
+    public let peakQueueDepth: Int
+    public let coalescedFrameCount: UInt64
+    public let droppedFrameCount: UInt64
+    public let lostNativeCount: UInt64
+    public let lostCriticalCount: UInt64
+    public let writerFailureCount: UInt64
+    public let retryCount: UInt64
+    public let successfulFlushCount: UInt64
+    public let lastCommittedRecorderSequence: UInt64?
+    public let mostRecentFlushDuration: Duration?
+    public let lifecycleState: TelemetryRecorderLifecycleState
+    public let completeness: TelemetryRecorderCompleteness
+
+    public init(
+        queueDepth: Int,
+        peakQueueDepth: Int,
+        coalescedFrameCount: UInt64,
+        droppedFrameCount: UInt64,
+        lostNativeCount: UInt64,
+        lostCriticalCount: UInt64,
+        writerFailureCount: UInt64,
+        retryCount: UInt64,
+        successfulFlushCount: UInt64,
+        lastCommittedRecorderSequence: UInt64?,
+        mostRecentFlushDuration: Duration?,
+        lifecycleState: TelemetryRecorderLifecycleState,
+        completeness: TelemetryRecorderCompleteness
+    ) {
+        self.queueDepth = queueDepth
+        self.peakQueueDepth = peakQueueDepth
+        self.coalescedFrameCount = coalescedFrameCount
+        self.droppedFrameCount = droppedFrameCount
+        self.lostNativeCount = lostNativeCount
+        self.lostCriticalCount = lostCriticalCount
+        self.writerFailureCount = writerFailureCount
+        self.retryCount = retryCount
+        self.successfulFlushCount = successfulFlushCount
+        self.lastCommittedRecorderSequence = lastCommittedRecorderSequence
+        self.mostRecentFlushDuration = mostRecentFlushDuration
+        self.lifecycleState = lifecycleState
+        self.completeness = completeness
+    }
+}
+
+public struct TelemetryFlushResult: Equatable, Sendable {
+    public let lastCommittedRecorderSequence: UInt64?
+    public let completeness: TelemetryRecorderCompleteness
+
+    public init(
+        lastCommittedRecorderSequence: UInt64?,
+        completeness: TelemetryRecorderCompleteness
+    ) {
+        self.lastCommittedRecorderSequence = lastCommittedRecorderSequence
+        self.completeness = completeness
+    }
+}
+
+public struct TelemetryFinishResult: Equatable, Sendable {
+    public let completeness: TelemetryRecorderCompleteness
+    public let lastCommittedRecorderSequence: UInt64?
+
+    public init(
+        completeness: TelemetryRecorderCompleteness,
+        lastCommittedRecorderSequence: UInt64?
+    ) {
+        self.completeness = completeness
+        self.lastCommittedRecorderSequence = lastCommittedRecorderSequence
+    }
+}
+
+extension TelemetryPersistenceRecord {
+    var recordClass: TelemetryRecordClass {
+        switch self {
+        case .source, .event:
+            .critical
+        case .heartRate, .treadmill:
+            .native
+        case .frame:
+            .bulkFrame
+        }
+    }
+
+    var persistedElapsed: ElapsedDuration? {
+        switch self {
+        case .source:
+            nil
+        case let .heartRate(observation):
+            observation.timestamp.recordedElapsed
+        case let .treadmill(observation):
+            observation.timestamp.recordedElapsed
+        case let .event(event):
+            event.timestamp.recordedElapsed
+        case let .frame(frame):
+            frame.materializedAt.elapsed
+        }
+    }
+}
+
+struct CanonicalFrameIdentity: Hashable, Sendable {
+    let sessionID: SessionID
+    let elapsedSecond: Int64
+
+    init(_ frame: CanonicalFrame) {
+        sessionID = frame.sessionID
+        elapsedSecond = frame.canonicalElapsedSecond
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorder.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorder.swift
@@ -1,0 +1,403 @@
+import Foundation
+import TelemetryDomain
+
+public final class TelemetryIngress: @unchecked Sendable {
+    private let core: TelemetryRecorderCore
+    private let scheduler: any TelemetryRecorderScheduler
+
+    fileprivate init(
+        core: TelemetryRecorderCore,
+        scheduler: any TelemetryRecorderScheduler
+    ) {
+        self.core = core
+        self.scheduler = scheduler
+    }
+
+    @discardableResult
+    public func yield(_ record: TelemetryPersistenceRecord) -> TelemetryYieldReceipt {
+        core.yield(record, at: scheduler.now())
+    }
+}
+
+public final class TelemetryRecorder: @unchecked Sendable {
+    public let ingress: TelemetryIngress
+
+    private let core: TelemetryRecorderCore
+    private let scheduler: any TelemetryRecorderScheduler
+    private let continuation: AsyncStream<Void>.Continuation
+    private let consumerTask: Task<Void, Never>
+
+    public init(
+        sessionHeader: WorkoutSessionRecord,
+        persistence: any TelemetryRecorderPersistence,
+        bufferPolicy: TelemetryBufferPolicy = .initialDefault,
+        batchPolicy: TelemetryBatchPolicy = .initialDefault,
+        retryPolicy: TelemetryRetryPolicy = .initialDefault,
+        scheduler: any TelemetryRecorderScheduler = ContinuousTelemetryRecorderScheduler()
+    ) {
+        var capturedContinuation: AsyncStream<Void>.Continuation?
+        let stream = AsyncStream<Void>(
+            Void.self,
+            bufferingPolicy: .bufferingNewest(1)
+        ) { streamContinuation in
+            capturedContinuation = streamContinuation
+        }
+        guard let streamContinuation = capturedContinuation else {
+            preconditionFailure("AsyncStream must synchronously provide its continuation.")
+        }
+
+        let core = TelemetryRecorderCore(
+            sessionHeader: sessionHeader,
+            bufferPolicy: bufferPolicy,
+            batchPolicy: batchPolicy,
+            retryPolicy: retryPolicy,
+            continuation: streamContinuation
+        )
+        self.core = core
+        self.scheduler = scheduler
+        continuation = streamContinuation
+        ingress = TelemetryIngress(core: core, scheduler: scheduler)
+        consumerTask = Task.detached(priority: .utility) {
+            await Self.consume(
+                core: core,
+                persistence: persistence,
+                scheduler: scheduler,
+                stream: stream,
+                continuation: streamContinuation
+            )
+        }
+    }
+
+    deinit {
+        core.requestCancellation(completion: nil)
+        core.wake()
+    }
+
+    public var operationalState: TelemetryRecorderOperationalState {
+        core.operationalState()
+    }
+
+    public func requestFlush(reason: TelemetryFlushReason) {
+        core.requestFlush(reason: reason)
+        core.wake()
+    }
+
+    public func flush(reason: TelemetryFlushReason) async -> TelemetryFlushResult {
+        await withCheckedContinuation { continuation in
+            if let immediate = core.requestFlush(reason: reason, completion: { result in
+                continuation.resume(returning: result)
+            }) {
+                continuation.resume(returning: immediate)
+            } else {
+                core.wake()
+            }
+        }
+    }
+
+    public func finish(
+        endedAt: Date,
+        endedElapsed: ElapsedDuration
+    ) async -> TelemetryFinishResult {
+        await withCheckedContinuation { continuation in
+            if let immediate = core.requestFinish(
+                endedAt: endedAt,
+                endedElapsed: endedElapsed,
+                completion: { result in continuation.resume(returning: result) }
+            ) {
+                continuation.resume(returning: immediate)
+            } else {
+                core.wake()
+            }
+        }
+    }
+
+    public func fail(reason: String) async -> TelemetryFinishResult {
+        await withCheckedContinuation { continuation in
+            if let immediate = core.requestFailure(
+                reason: reason,
+                completion: { result in continuation.resume(returning: result) }
+            ) {
+                continuation.resume(returning: immediate)
+            } else {
+                core.wake()
+            }
+        }
+    }
+
+    public func cancel() async -> TelemetryFinishResult {
+        await withCheckedContinuation { continuation in
+            if let immediate = core.requestCancellation(
+                completion: { result in continuation.resume(returning: result) }
+            ) {
+                continuation.resume(returning: immediate)
+            } else {
+                core.wake()
+            }
+        }
+    }
+
+    public static func recoverUnfinishedSessions(
+        using persistence: any TelemetryRecorderPersistence,
+        reason: String = "recorder-recovered-unfinished-session"
+    ) async throws -> [WorkoutSessionRecord] {
+        let unfinished = try await persistence.unfinishedSessions()
+        for session in unfinished {
+            let finalization = TelemetrySessionFinalization(
+                sessionID: session.sessionID,
+                lifecycleState: .incomplete,
+                endedAt: nil,
+                endedElapsed: nil,
+                incompleteReason: reason,
+                recorderHealth: RecorderHealthSummary(
+                    isComplete: false,
+                    lostCriticalRecordCount: session.recorderHealth.lostCriticalRecordCount,
+                    lostNativeRecordCount: session.recorderHealth.lostNativeRecordCount,
+                    lastPersistedElapsed: session.recorderHealth.lastPersistedElapsed
+                )
+            )
+            try await persistence.finalizeSession(finalization)
+        }
+        return unfinished
+    }
+}
+
+private extension TelemetryRecorder {
+    enum PersistenceAttemptResult {
+        case success
+        case aborted
+        case failure(Error)
+    }
+
+    static func consume(
+        core: TelemetryRecorderCore,
+        persistence: any TelemetryRecorderPersistence,
+        scheduler: any TelemetryRecorderScheduler,
+        stream: AsyncStream<Void>,
+        continuation: AsyncStream<Void>.Continuation
+    ) async {
+        var iterator = stream.makeAsyncIterator()
+
+        let beginResult = await attemptPersistence(
+            core: core,
+            scheduler: scheduler,
+            iterator: &iterator
+        ) {
+            try await persistence.beginSession(core.sessionHeader)
+        }
+        switch beginResult {
+        case .success:
+            core.headerPersisted()
+            core.resumeSatisfiedFlushes()
+        case .aborted:
+            await terminateRequestedRecorder(
+                core: core,
+                persistence: persistence
+            )
+            continuation.finish()
+            return
+        case let .failure(error):
+            core.persistenceBecameTerminal(error: error, uncertainRecords: [])
+            core.completeTerminal(.failed)
+            continuation.finish()
+            return
+        }
+
+        while true {
+            switch core.nextConsumerAction(now: scheduler.now()) {
+            case let .persist(batch):
+                cancelTimer(core: core, scheduler: scheduler)
+                let startedAt = scheduler.now()
+                let result = await attemptPersistence(
+                    core: core,
+                    scheduler: scheduler,
+                    iterator: &iterator
+                ) {
+                    try await persistence.persistBatch(batch)
+                }
+                switch result {
+                case .success:
+                    core.batchCommitted(
+                        batch,
+                        duration: nonnegativeDuration(from: startedAt, to: scheduler.now())
+                    )
+                    core.resumeSatisfiedFlushes()
+                case .aborted:
+                    core.restoreUncertainBatchForAccounting(batch)
+                case let .failure(error):
+                    core.persistenceBecameTerminal(error: error, uncertainRecords: batch)
+                    await bestEffortIncompleteFinalization(
+                        core: core,
+                        persistence: persistence
+                    )
+                    core.completeTerminal(.failed)
+                    continuation.finish()
+                    return
+                }
+
+            case let .scheduleFlush(after):
+                armTimer(
+                    core: core,
+                    scheduler: scheduler,
+                    purpose: .flush,
+                    delay: after
+                )
+
+            case .terminateRequested:
+                cancelTimer(core: core, scheduler: scheduler)
+                await terminateRequestedRecorder(
+                    core: core,
+                    persistence: persistence
+                )
+                continuation.finish()
+                return
+
+            case let .finalize(finalization, intendedCompleteness):
+                cancelTimer(core: core, scheduler: scheduler)
+                let result = await attemptPersistence(
+                    core: core,
+                    scheduler: scheduler,
+                    iterator: &iterator
+                ) {
+                    try await persistence.finalizeSession(finalization)
+                }
+                switch result {
+                case .success:
+                    core.completeTerminal(intendedCompleteness)
+                case .aborted:
+                    await terminateRequestedRecorder(
+                        core: core,
+                        persistence: persistence
+                    )
+                case let .failure(error):
+                    core.persistenceBecameTerminal(error: error, uncertainRecords: [])
+                    core.completeTerminal(.failed)
+                }
+                continuation.finish()
+                return
+
+            case .wait:
+                guard await iterator.next() != nil else {
+                    core.requestCancellation(completion: nil)
+                    continue
+                }
+            }
+        }
+    }
+
+    static func attemptPersistence(
+        core: TelemetryRecorderCore,
+        scheduler: any TelemetryRecorderScheduler,
+        iterator: inout AsyncStream<Void>.Iterator,
+        operation: @escaping @Sendable () async throws -> Void
+    ) async -> PersistenceAttemptResult {
+        var retryCount = 0
+        while true {
+            if core.persistenceShouldAbort() {
+                return .aborted
+            }
+            do {
+                try await operation()
+                return .success
+            } catch {
+                core.writerAttemptFailed()
+                guard case .retryableBeforeCommit = error as? TelemetryPersistenceOperationError,
+                      retryCount < core.retryPolicy.maximumPrecommitRetries,
+                      !core.persistenceShouldAbort()
+                else {
+                    return .failure(error)
+                }
+
+                retryCount += 1
+                core.retryScheduled()
+                cancelTimer(core: core, scheduler: scheduler)
+                let token = armTimer(
+                    core: core,
+                    scheduler: scheduler,
+                    purpose: .retry,
+                    delay: core.retryPolicy.delay
+                )
+                while !core.takeRetryTimerIfReady(token: token) {
+                    if core.persistenceShouldAbort() {
+                        cancelTimer(core: core, scheduler: scheduler)
+                        return .aborted
+                    }
+                    guard await iterator.next() != nil else {
+                        return .aborted
+                    }
+                }
+            }
+        }
+    }
+
+    @discardableResult
+    static func armTimer(
+        core: TelemetryRecorderCore,
+        scheduler: any TelemetryRecorderScheduler,
+        purpose: TelemetryRecorderTimerPurpose,
+        delay: Duration
+    ) -> TelemetryRecorderTimerToken {
+        let token = core.armTimer(purpose: purpose)
+        scheduler.schedule(after: max(delay, .zero)) { [weak core] in
+            core?.timerFired(token)
+        }
+        return token
+    }
+
+    static func cancelTimer(
+        core: TelemetryRecorderCore,
+        scheduler: any TelemetryRecorderScheduler
+    ) {
+        if core.cancelTimer() {
+            scheduler.cancelScheduledOperation()
+        }
+    }
+
+    static func terminateRequestedRecorder(
+        core: TelemetryRecorderCore,
+        persistence: any TelemetryRecorderPersistence
+    ) async {
+        let (finalization, intendedCompleteness) = core.prepareRequestedTermination()
+        var resultingCompleteness = intendedCompleteness
+        do {
+            try await persistence.finalizeSession(finalization)
+        } catch {
+            core.writerAttemptFailed()
+            core.persistenceBecameTerminal(error: error, uncertainRecords: [])
+            resultingCompleteness = .failed
+        }
+        core.completeTerminal(resultingCompleteness)
+    }
+
+    static func bestEffortIncompleteFinalization(
+        core: TelemetryRecorderCore,
+        persistence: any TelemetryRecorderPersistence
+    ) async {
+        do {
+            try await persistence.finalizeSession(core.failureFinalization())
+        } catch {
+            core.writerAttemptFailed()
+        }
+    }
+
+    static func nonnegativeDuration(from start: Duration, to end: Duration) -> Duration {
+        max(end - start, .zero)
+    }
+}
+
+enum TelemetryRecorderTimerPurpose: Sendable {
+    case flush
+    case retry
+}
+
+struct TelemetryRecorderTimerToken: Equatable, Sendable {
+    let generation: UInt64
+    let purpose: TelemetryRecorderTimerPurpose
+}
+
+enum TelemetryRecorderConsumerAction: Sendable {
+    case persist([SequencedTelemetryRecord])
+    case scheduleFlush(Duration)
+    case terminateRequested
+    case finalize(TelemetrySessionFinalization, TelemetryRecorderCompleteness)
+    case wait
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorder.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorder.swift
@@ -124,6 +124,15 @@ public final class TelemetryRecorder: @unchecked Sendable {
         }
     }
 
+    @discardableResult
+    public func requestFailure(reason: String) -> Bool {
+        let accepted = core.requestFailure(reason: reason, completion: nil) == nil
+        if accepted {
+            core.wake()
+        }
+        return accepted
+    }
+
     public func cancel() async -> TelemetryFinishResult {
         await withCheckedContinuation { continuation in
             if let immediate = core.requestCancellation(
@@ -134,6 +143,15 @@ public final class TelemetryRecorder: @unchecked Sendable {
                 core.wake()
             }
         }
+    }
+
+    @discardableResult
+    public func requestCancellation() -> Bool {
+        let accepted = core.requestCancellation(completion: nil) == nil
+        if accepted {
+            core.wake()
+        }
+        return accepted
     }
 
     public static func recoverUnfinishedSessions(
@@ -177,6 +195,7 @@ private extension TelemetryRecorder {
     ) async {
         var iterator = stream.makeAsyncIterator()
 
+        let beginIntentGeneration = core.terminalIntentGenerationSnapshot()
         let beginResult = await attemptPersistence(
             core: core,
             scheduler: scheduler,
@@ -196,15 +215,22 @@ private extension TelemetryRecorder {
             continuation.finish()
             return
         case let .failure(error):
-            core.persistenceBecameTerminal(error: error, uncertainRecords: [])
-            core.completeTerminal(.failed)
+            core.persistenceBecameTerminalIfIntentUnchanged(
+                error: error,
+                uncertainRecords: [],
+                expectedGeneration: beginIntentGeneration
+            )
+            await terminateRequestedRecorder(
+                core: core,
+                persistence: persistence
+            )
             continuation.finish()
             return
         }
 
         while true {
             switch core.nextConsumerAction(now: scheduler.now()) {
-            case let .persist(batch):
+            case let .persist(batch, intentGeneration):
                 cancelTimer(core: core, scheduler: scheduler)
                 let startedAt = scheduler.now()
                 let result = await attemptPersistence(
@@ -224,12 +250,15 @@ private extension TelemetryRecorder {
                 case .aborted:
                     core.restoreUncertainBatchForAccounting(batch)
                 case let .failure(error):
-                    core.persistenceBecameTerminal(error: error, uncertainRecords: batch)
-                    await bestEffortIncompleteFinalization(
+                    core.persistenceBecameTerminalIfIntentUnchanged(
+                        error: error,
+                        uncertainRecords: batch,
+                        expectedGeneration: intentGeneration
+                    )
+                    await terminateRequestedRecorder(
                         core: core,
                         persistence: persistence
                     )
-                    core.completeTerminal(.failed)
                     continuation.finish()
                     return
                 }
@@ -251,7 +280,11 @@ private extension TelemetryRecorder {
                 continuation.finish()
                 return
 
-            case let .finalize(finalization, intendedCompleteness):
+            case let .finalize(
+                finalization,
+                intendedCompleteness,
+                intentGeneration
+            ):
                 cancelTimer(core: core, scheduler: scheduler)
                 let result = await attemptPersistence(
                     core: core,
@@ -262,19 +295,27 @@ private extension TelemetryRecorder {
                 }
                 switch result {
                 case .success:
-                    core.completeTerminal(intendedCompleteness)
+                    if !core.completeFinalizationIfUnchanged(intendedCompleteness) {
+                        await terminateRequestedRecorder(
+                            core: core,
+                            persistence: persistence
+                        )
+                    }
                 case .aborted:
                     await terminateRequestedRecorder(
                         core: core,
                         persistence: persistence
                     )
                 case let .failure(error):
-                    core.persistenceBecameTerminal(error: error, uncertainRecords: [])
-                    await bestEffortIncompleteFinalization(
+                    core.persistenceBecameTerminalIfIntentUnchanged(
+                        error: error,
+                        uncertainRecords: [],
+                        expectedGeneration: intentGeneration
+                    )
+                    await terminateRequestedRecorder(
                         core: core,
                         persistence: persistence
                     )
-                    core.completeTerminal(.failed)
                 }
                 continuation.finish()
                 return
@@ -360,26 +401,35 @@ private extension TelemetryRecorder {
         core: TelemetryRecorderCore,
         persistence: any TelemetryRecorderPersistence
     ) async {
-        let (finalization, intendedCompleteness) = core.prepareRequestedTermination()
-        var resultingCompleteness = intendedCompleteness
-        do {
-            try await persistence.finalizeSession(finalization)
-        } catch {
-            core.writerAttemptFailed()
-            core.persistenceBecameTerminal(error: error, uncertainRecords: [])
-            resultingCompleteness = .failed
-        }
-        core.completeTerminal(resultingCompleteness)
-    }
-
-    static func bestEffortIncompleteFinalization(
-        core: TelemetryRecorderCore,
-        persistence: any TelemetryRecorderPersistence
-    ) async {
-        do {
-            try await persistence.finalizeSession(core.failureFinalization())
-        } catch {
-            core.writerAttemptFailed()
+        while true {
+            let (finalization, intendedCompleteness, generation) = core
+                .prepareRequestedTermination()
+            do {
+                try await persistence.finalizeSession(finalization)
+            } catch {
+                core.writerAttemptFailed()
+                guard let failureGeneration = core
+                    .persistenceBecameTerminalIfIntentUnchanged(
+                        error: error,
+                        uncertainRecords: [],
+                        expectedGeneration: generation
+                    ) else {
+                    continue
+                }
+                if core.completeRequestedTerminationIfUnchanged(
+                    .failed,
+                    generation: failureGeneration
+                ) {
+                    return
+                }
+                continue
+            }
+            if core.completeRequestedTerminationIfUnchanged(
+                intendedCompleteness,
+                generation: generation
+            ) {
+                return
+            }
         }
     }
 
@@ -399,9 +449,13 @@ struct TelemetryRecorderTimerToken: Equatable, Sendable {
 }
 
 enum TelemetryRecorderConsumerAction: Sendable {
-    case persist([SequencedTelemetryRecord])
+    case persist([SequencedTelemetryRecord], intentGeneration: UInt64)
     case scheduleFlush(Duration)
     case terminateRequested
-    case finalize(TelemetrySessionFinalization, TelemetryRecorderCompleteness)
+    case finalize(
+        TelemetrySessionFinalization,
+        TelemetryRecorderCompleteness,
+        intentGeneration: UInt64
+    )
     case wait
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorder.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorder.swift
@@ -270,6 +270,10 @@ private extension TelemetryRecorder {
                     )
                 case let .failure(error):
                     core.persistenceBecameTerminal(error: error, uncertainRecords: [])
+                    await bestEffortIncompleteFinalization(
+                        core: core,
+                        persistence: persistence
+                    )
                     core.completeTerminal(.failed)
                 }
                 continuation.finish()

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorderCore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorderCore.swift
@@ -1,0 +1,765 @@
+import Foundation
+import TelemetryDomain
+
+final class TelemetryRecorderCore: @unchecked Sendable {
+    typealias FlushCompletion = @Sendable (TelemetryFlushResult) -> Void
+    typealias FinishCompletion = @Sendable (TelemetryFinishResult) -> Void
+
+    private enum Phase {
+        case beginning
+        case active
+        case finishing(endedAt: Date, endedElapsed: ElapsedDuration)
+        case finalizing(TelemetryRecorderCompleteness)
+        case failing(reason: String)
+        case cancelling
+        case terminal(TelemetryRecorderCompleteness)
+    }
+
+    private struct FlushWaiter {
+        let targetSequence: UInt64?
+        let completion: FlushCompletion
+    }
+
+    let sessionHeader: WorkoutSessionRecord
+    let retryPolicy: TelemetryRetryPolicy
+
+    private let lock = NSLock()
+    private let batchPolicy: TelemetryBatchPolicy
+    private let continuation: AsyncStream<Void>.Continuation
+    private var buffer: BoundedTelemetryBuffer
+    private var phase: Phase = .beginning
+    private var headerIsPersisted = false
+    private var nextSequence: UInt64? = 1
+    private var lastAcceptedSequence: UInt64?
+    private var forcedFlushThrough: UInt64?
+    private var flushWaiters: [FlushWaiter] = []
+    private var finishCompletions: [FinishCompletion] = []
+    private var timerGeneration: UInt64 = 0
+    private var armedTimer: TelemetryRecorderTimerToken?
+    private var readyRetryTimer: TelemetryRecorderTimerToken?
+    private var knownLoss = false
+
+    private var peakQueueDepth = 0
+    private var coalescedFrameCount: UInt64 = 0
+    private var droppedFrameCount: UInt64 = 0
+    private var lostNativeCount: UInt64 = 0
+    private var lostCriticalCount: UInt64 = 0
+    private var writerFailureCount: UInt64 = 0
+    private var retryCount: UInt64 = 0
+    private var successfulFlushCount: UInt64 = 0
+    private var lastCommittedSequence: UInt64?
+    private var lastPersistedElapsed: ElapsedDuration?
+    private var mostRecentFlushDuration: Duration?
+
+    init(
+        sessionHeader: WorkoutSessionRecord,
+        bufferPolicy: TelemetryBufferPolicy,
+        batchPolicy: TelemetryBatchPolicy,
+        retryPolicy: TelemetryRetryPolicy,
+        continuation: AsyncStream<Void>.Continuation
+    ) {
+        self.sessionHeader = sessionHeader
+        self.batchPolicy = batchPolicy
+        self.retryPolicy = retryPolicy
+        self.continuation = continuation
+        buffer = BoundedTelemetryBuffer(policy: bufferPolicy)
+    }
+
+    func wake() {
+        continuation.yield()
+    }
+
+    func yield(
+        _ record: TelemetryPersistenceRecord,
+        at enqueueTime: Duration
+    ) -> TelemetryYieldReceipt {
+        var shouldWake = false
+        let receipt = lock.withLock { () -> TelemetryYieldReceipt in
+            switch phase {
+            case .beginning, .active:
+                break
+            case .finishing:
+                guard let sequence = allocateSequence() else {
+                    accountLoss(for: record.recordClass)
+                    return TelemetryYieldReceipt(
+                        recorderSequence: nil,
+                        disposition: .sequenceExhausted
+                    )
+                }
+                accountLoss(for: record.recordClass)
+                shouldWake = true
+                return TelemetryYieldReceipt(
+                    recorderSequence: sequence,
+                    disposition: .rejectedAfterFinish
+                )
+            case .finalizing:
+                return TelemetryYieldReceipt(
+                    recorderSequence: nil,
+                    disposition: .rejectedTerminal
+                )
+            case .failing, .cancelling:
+                guard let sequence = allocateSequence() else {
+                    accountLoss(for: record.recordClass)
+                    return TelemetryYieldReceipt(
+                        recorderSequence: nil,
+                        disposition: .sequenceExhausted
+                    )
+                }
+                accountLoss(for: record.recordClass)
+                shouldWake = true
+                return TelemetryYieldReceipt(
+                    recorderSequence: sequence,
+                    disposition: .rejectedTerminal
+                )
+            case let .terminal(completeness):
+                guard completeness != .complete else {
+                    return TelemetryYieldReceipt(
+                        recorderSequence: nil,
+                        disposition: .rejectedTerminal
+                    )
+                }
+                guard let sequence = allocateSequence() else {
+                    accountLoss(for: record.recordClass)
+                    return TelemetryYieldReceipt(
+                        recorderSequence: nil,
+                        disposition: .sequenceExhausted
+                    )
+                }
+                accountLoss(for: record.recordClass)
+                return TelemetryYieldReceipt(
+                    recorderSequence: sequence,
+                    disposition: .rejectedTerminal
+                )
+            }
+
+            guard let sequence = allocateSequence() else {
+                accountLoss(for: record.recordClass)
+                shouldWake = true
+                return TelemetryYieldReceipt(
+                    recorderSequence: nil,
+                    disposition: .sequenceExhausted
+                )
+            }
+
+            let wasEmpty = buffer.isEmpty
+            let result = buffer.enqueue(
+                SequencedTelemetryRecord(recorderSequence: sequence, record: record),
+                at: enqueueTime
+            )
+            if result.evictedBulkFrame {
+                increment(&droppedFrameCount)
+                knownLoss = true
+            }
+            switch result.disposition {
+            case .enqueued:
+                lastAcceptedSequence = sequence
+            case .coalescedFrame:
+                increment(&coalescedFrameCount)
+                lastAcceptedSequence = sequence
+            case .droppedFrame:
+                increment(&droppedFrameCount)
+                knownLoss = true
+            case .lostNative:
+                increment(&lostNativeCount)
+                knownLoss = true
+            case .lostCritical:
+                increment(&lostCriticalCount)
+                knownLoss = true
+            case .rejectedAfterFinish, .rejectedTerminal, .sequenceExhausted:
+                preconditionFailure("The active buffer cannot return a lifecycle disposition.")
+            }
+            peakQueueDepth = max(peakQueueDepth, buffer.count)
+            shouldWake = wasEmpty || buffer.count == batchPolicy.maximumRecordCount
+            return TelemetryYieldReceipt(
+                recorderSequence: sequence,
+                disposition: result.disposition
+            )
+        }
+        if shouldWake {
+            wake()
+        }
+        return receipt
+    }
+
+    func requestFlush(reason _: TelemetryFlushReason) {
+        lock.withLock {
+            forcedFlushThrough = laterSequence(forcedFlushThrough, lastAcceptedSequence)
+        }
+    }
+
+    func requestFlush(
+        reason _: TelemetryFlushReason,
+        completion: @escaping FlushCompletion
+    ) -> TelemetryFlushResult? {
+        lock.withLock {
+            if case let .terminal(completeness) = phase {
+                return TelemetryFlushResult(
+                    lastCommittedRecorderSequence: lastCommittedSequence,
+                    completeness: completeness
+                )
+            }
+            let target = lastAcceptedSequence
+            if headerIsPersisted,
+               (target == nil || sequence(lastCommittedSequence, satisfies: target))
+            {
+                return TelemetryFlushResult(
+                    lastCommittedRecorderSequence: lastCommittedSequence,
+                    completeness: currentCompleteness
+                )
+            }
+            forcedFlushThrough = laterSequence(forcedFlushThrough, target)
+            flushWaiters.append(FlushWaiter(targetSequence: target, completion: completion))
+            return nil
+        }
+    }
+
+    func requestFinish(
+        endedAt: Date,
+        endedElapsed: ElapsedDuration,
+        completion: @escaping FinishCompletion
+    ) -> TelemetryFinishResult? {
+        lock.withLock {
+            if case let .terminal(completeness) = phase {
+                return TelemetryFinishResult(
+                    completeness: completeness,
+                    lastCommittedRecorderSequence: lastCommittedSequence
+                )
+            }
+            finishCompletions.append(completion)
+            switch phase {
+            case .beginning, .active:
+                phase = .finishing(endedAt: endedAt, endedElapsed: endedElapsed)
+                forcedFlushThrough = laterSequence(forcedFlushThrough, lastAcceptedSequence)
+            case .finishing, .finalizing, .failing, .cancelling, .terminal:
+                break
+            }
+            return nil
+        }
+    }
+
+    func requestFailure(
+        reason: String,
+        completion: @escaping FinishCompletion
+    ) -> TelemetryFinishResult? {
+        lock.withLock {
+            if case let .terminal(completeness) = phase {
+                return TelemetryFinishResult(
+                    completeness: completeness,
+                    lastCommittedRecorderSequence: lastCommittedSequence
+                )
+            }
+            finishCompletions.append(completion)
+            switch phase {
+            case .finalizing:
+                break
+            case .failing, .cancelling:
+                phase = .failing(reason: reason)
+            case .beginning, .active, .finishing:
+                phase = .failing(reason: reason)
+            case .terminal:
+                break
+            }
+            return nil
+        }
+    }
+
+    @discardableResult
+    func requestCancellation(
+        completion: FinishCompletion?
+    ) -> TelemetryFinishResult? {
+        lock.withLock {
+            if case let .terminal(completeness) = phase {
+                return TelemetryFinishResult(
+                    completeness: completeness,
+                    lastCommittedRecorderSequence: lastCommittedSequence
+                )
+            }
+            if let completion {
+                finishCompletions.append(completion)
+            }
+            switch phase {
+            case .finalizing:
+                break
+            case .beginning, .active, .finishing, .failing, .cancelling:
+                phase = .cancelling
+            case .terminal:
+                break
+            }
+            return nil
+        }
+    }
+
+    func headerPersisted() {
+        lock.withLock {
+            headerIsPersisted = true
+            if case .beginning = phase {
+                phase = .active
+            }
+        }
+    }
+
+    func nextConsumerAction(now: Duration) -> TelemetryRecorderConsumerAction {
+        lock.withLock {
+            switch phase {
+            case .failing, .cancelling:
+                return .terminateRequested
+            case let .finishing(endedAt, endedElapsed):
+                if !buffer.isEmpty {
+                    return .persist(buffer.drain(maximumCount: batchPolicy.maximumRecordCount))
+                }
+                let completeness: TelemetryRecorderCompleteness = knownLoss
+                    ? .incomplete
+                    : .complete
+                phase = .finalizing(completeness)
+                return .finalize(
+                    finalization(
+                        completeness: completeness,
+                        endedAt: endedAt,
+                        endedElapsed: endedElapsed,
+                        reason: knownLoss ? "recorder-loss" : nil
+                    ),
+                    completeness
+                )
+            case .beginning:
+                return .wait
+            case .finalizing:
+                return .wait
+            case .active:
+                break
+            case .terminal:
+                return .wait
+            }
+
+            let forced = forcedFlushThrough.map {
+                !sequence(lastCommittedSequence, satisfies: $0)
+            } ?? false
+            if buffer.count >= batchPolicy.maximumRecordCount || forced {
+                guard !buffer.isEmpty else {
+                    forcedFlushThrough = nil
+                    return .wait
+                }
+                return .persist(buffer.drain(maximumCount: batchPolicy.maximumRecordCount))
+            }
+
+            guard let oldest = buffer.oldestEnqueueTime else {
+                return .wait
+            }
+            guard armedTimer == nil else {
+                return .wait
+            }
+            let age = max(now - oldest, .zero)
+            return .scheduleFlush(max(batchPolicy.maximumInterval - age, .zero))
+        }
+    }
+
+    func batchCommitted(_ batch: [SequencedTelemetryRecord], duration: Duration) {
+        lock.withLock {
+            guard let finalSequence = batch.last?.recorderSequence else {
+                return
+            }
+            lastCommittedSequence = finalSequence
+            for record in batch {
+                guard let elapsed = record.record.persistedElapsed else {
+                    continue
+                }
+                if let existing = lastPersistedElapsed {
+                    lastPersistedElapsed = max(existing, elapsed)
+                } else {
+                    lastPersistedElapsed = elapsed
+                }
+            }
+            increment(&successfulFlushCount)
+            mostRecentFlushDuration = duration
+            if let target = forcedFlushThrough,
+               sequence(lastCommittedSequence, satisfies: target)
+            {
+                forcedFlushThrough = nil
+            }
+        }
+    }
+
+    func writerAttemptFailed() {
+        lock.withLock {
+            increment(&writerFailureCount)
+        }
+    }
+
+    func retryScheduled() {
+        lock.withLock {
+            increment(&retryCount)
+        }
+    }
+
+    func persistenceShouldAbort() -> Bool {
+        lock.withLock {
+            switch phase {
+            case .failing, .cancelling, .terminal:
+                true
+            case .beginning, .active, .finishing, .finalizing:
+                false
+            }
+        }
+    }
+
+    func persistenceBecameTerminal(
+        error: Error,
+        uncertainRecords: [SequencedTelemetryRecord]
+    ) {
+        lock.withLock {
+            accountUncertain(uncertainRecords)
+            accountDiscarded(buffer.discardAll())
+            phase = .failing(reason: persistenceFailureReason(error))
+            knownLoss = true
+        }
+    }
+
+    func restoreUncertainBatchForAccounting(_ batch: [SequencedTelemetryRecord]) {
+        lock.withLock {
+            accountUncertain(batch)
+            knownLoss = true
+        }
+    }
+
+    func prepareRequestedTermination() -> (
+        TelemetrySessionFinalization,
+        TelemetryRecorderCompleteness
+    ) {
+        lock.withLock {
+            accountDiscarded(buffer.discardAll())
+            switch phase {
+            case let .failing(reason):
+                return (
+                    finalization(
+                        completeness: .failed,
+                        endedAt: nil,
+                        endedElapsed: nil,
+                        reason: reason
+                    ),
+                    .failed
+                )
+            case .cancelling:
+                return (
+                    finalization(
+                        completeness: .cancelled,
+                        endedAt: nil,
+                        endedElapsed: nil,
+                        reason: "recorder-cancelled"
+                    ),
+                    .cancelled
+                )
+            case .beginning, .active, .finishing, .finalizing, .terminal:
+                return (
+                    finalization(
+                        completeness: .failed,
+                        endedAt: nil,
+                        endedElapsed: nil,
+                        reason: "recorder-terminated"
+                    ),
+                    .failed
+                )
+            }
+        }
+    }
+
+    func failureFinalization() -> TelemetrySessionFinalization {
+        lock.withLock {
+            finalization(
+                completeness: .failed,
+                endedAt: nil,
+                endedElapsed: nil,
+                reason: "recorder-persistence-failure"
+            )
+        }
+    }
+
+    func completeTerminal(_ completeness: TelemetryRecorderCompleteness) {
+        let flushes: [FlushWaiter]
+        let finishes: [FinishCompletion]
+        let flushResult: TelemetryFlushResult
+        let finishResult: TelemetryFinishResult
+        (flushes, finishes, flushResult, finishResult) = lock.withLock {
+            if case .terminal = phase {
+                return (
+                    [],
+                    [],
+                    TelemetryFlushResult(
+                        lastCommittedRecorderSequence: lastCommittedSequence,
+                        completeness: currentCompleteness
+                    ),
+                    TelemetryFinishResult(
+                        completeness: currentCompleteness,
+                        lastCommittedRecorderSequence: lastCommittedSequence
+                    )
+                )
+            }
+            phase = .terminal(completeness)
+            let flushes = flushWaiters
+            let finishes = finishCompletions
+            flushWaiters.removeAll(keepingCapacity: false)
+            finishCompletions.removeAll(keepingCapacity: false)
+            return (
+                flushes,
+                finishes,
+                TelemetryFlushResult(
+                    lastCommittedRecorderSequence: lastCommittedSequence,
+                    completeness: completeness
+                ),
+                TelemetryFinishResult(
+                    completeness: completeness,
+                    lastCommittedRecorderSequence: lastCommittedSequence
+                )
+            )
+        }
+        for waiter in flushes {
+            waiter.completion(flushResult)
+        }
+        for completion in finishes {
+            completion(finishResult)
+        }
+    }
+
+    func resumeSatisfiedFlushes() {
+        let (waiters, result): ([FlushWaiter], TelemetryFlushResult) = lock.withLock {
+            var satisfied: [FlushWaiter] = []
+            var remaining: [FlushWaiter] = []
+            for waiter in flushWaiters {
+                if headerIsPersisted,
+                   (waiter.targetSequence == nil
+                       || sequence(lastCommittedSequence, satisfies: waiter.targetSequence))
+                {
+                    satisfied.append(waiter)
+                } else {
+                    remaining.append(waiter)
+                }
+            }
+            flushWaiters = remaining
+            return (
+                satisfied,
+                TelemetryFlushResult(
+                    lastCommittedRecorderSequence: lastCommittedSequence,
+                    completeness: currentCompleteness
+                )
+            )
+        }
+        for waiter in waiters {
+            waiter.completion(result)
+        }
+    }
+
+    func operationalState() -> TelemetryRecorderOperationalState {
+        lock.withLock {
+            TelemetryRecorderOperationalState(
+                queueDepth: buffer.count,
+                peakQueueDepth: peakQueueDepth,
+                coalescedFrameCount: coalescedFrameCount,
+                droppedFrameCount: droppedFrameCount,
+                lostNativeCount: lostNativeCount,
+                lostCriticalCount: lostCriticalCount,
+                writerFailureCount: writerFailureCount,
+                retryCount: retryCount,
+                successfulFlushCount: successfulFlushCount,
+                lastCommittedRecorderSequence: lastCommittedSequence,
+                mostRecentFlushDuration: mostRecentFlushDuration,
+                lifecycleState: lifecycleState,
+                completeness: currentCompleteness
+            )
+        }
+    }
+
+    func armTimer(purpose: TelemetryRecorderTimerPurpose) -> TelemetryRecorderTimerToken {
+        lock.withLock {
+            timerGeneration &+= 1
+            let token = TelemetryRecorderTimerToken(
+                generation: timerGeneration,
+                purpose: purpose
+            )
+            armedTimer = token
+            readyRetryTimer = nil
+            return token
+        }
+    }
+
+    func cancelTimer() -> Bool {
+        lock.withLock {
+            let hadTimer = armedTimer != nil
+            if hadTimer {
+                timerGeneration &+= 1
+            }
+            armedTimer = nil
+            readyRetryTimer = nil
+            return hadTimer
+        }
+    }
+
+    func timerFired(_ token: TelemetryRecorderTimerToken) {
+        let shouldWake = lock.withLock { () -> Bool in
+            guard armedTimer == token else {
+                return false
+            }
+            armedTimer = nil
+            switch token.purpose {
+            case .flush:
+                forcedFlushThrough = laterSequence(
+                    forcedFlushThrough,
+                    lastAcceptedSequence
+                )
+            case .retry:
+                readyRetryTimer = token
+            }
+            return true
+        }
+        if shouldWake {
+            wake()
+        }
+    }
+
+    func takeRetryTimerIfReady(token: TelemetryRecorderTimerToken) -> Bool {
+        lock.withLock {
+            guard readyRetryTimer == token else {
+                return false
+            }
+            readyRetryTimer = nil
+            return true
+        }
+    }
+}
+
+private extension TelemetryRecorderCore {
+    var currentCompleteness: TelemetryRecorderCompleteness {
+        switch phase {
+        case let .terminal(completeness):
+            completeness
+        case .failing:
+            .failed
+        case .cancelling:
+            .cancelled
+        case .beginning, .active, .finishing, .finalizing:
+            .incomplete
+        }
+    }
+
+    var lifecycleState: TelemetryRecorderLifecycleState {
+        switch phase {
+        case .beginning: .beginning
+        case .active: .active
+        case .finishing, .finalizing: .finishing
+        case .failing: .failing
+        case .cancelling: .cancelling
+        case let .terminal(completeness):
+            switch completeness {
+            case .complete: .complete
+            case .incomplete: .incomplete
+            case .failed: .failed
+            case .cancelled: .cancelled
+            }
+        }
+    }
+
+    func allocateSequence() -> UInt64? {
+        guard let current = nextSequence else {
+            return nil
+        }
+        if current == UInt64.max {
+            nextSequence = nil
+        } else {
+            nextSequence = current + 1
+        }
+        return current
+    }
+
+    func accountLoss(for recordClass: TelemetryRecordClass) {
+        knownLoss = true
+        switch recordClass {
+        case .critical:
+            increment(&lostCriticalCount)
+        case .native:
+            increment(&lostNativeCount)
+        case .bulkFrame:
+            increment(&droppedFrameCount)
+        }
+    }
+
+    func accountUncertain(_ records: [SequencedTelemetryRecord]) {
+        for record in records {
+            accountLoss(for: record.record.recordClass)
+        }
+    }
+
+    func accountDiscarded(_ discarded: TelemetryDiscardCounts) {
+        if discarded.total > 0 {
+            knownLoss = true
+        }
+        add(discarded.critical, to: &lostCriticalCount)
+        add(discarded.native, to: &lostNativeCount)
+        add(discarded.bulkFrame, to: &droppedFrameCount)
+    }
+
+    func finalization(
+        completeness: TelemetryRecorderCompleteness,
+        endedAt: Date?,
+        endedElapsed: ElapsedDuration?,
+        reason: String?
+    ) -> TelemetrySessionFinalization {
+        let lifecycle: SessionLifecycleState = completeness == .complete
+            ? .completed
+            : .incomplete
+        return TelemetrySessionFinalization(
+            sessionID: sessionHeader.sessionID,
+            lifecycleState: lifecycle,
+            endedAt: endedAt,
+            endedElapsed: endedElapsed,
+            incompleteReason: reason,
+            recorderHealth: RecorderHealthSummary(
+                isComplete: completeness == .complete,
+                lostCriticalRecordCount: lostCriticalCount,
+                lostNativeRecordCount: lostNativeCount,
+                lastPersistedElapsed: lastPersistedElapsed
+            )
+        )
+    }
+
+    func persistenceFailureReason(_ error: Error) -> String {
+        switch error as? TelemetryPersistenceOperationError {
+        case let .retryableBeforeCommit(code),
+             let .terminal(code),
+             let .commitOutcomeUnknown(code):
+            "persistence-\(code)"
+        case nil:
+            "persistence-unknown-failure"
+        }
+    }
+
+    func sequence(_ committed: UInt64?, satisfies target: UInt64?) -> Bool {
+        guard let target else {
+            return true
+        }
+        guard let committed else {
+            return false
+        }
+        return committed >= target
+    }
+
+    func laterSequence(_ lhs: UInt64?, _ rhs: UInt64?) -> UInt64? {
+        switch (lhs, rhs) {
+        case let (lhs?, rhs?): max(lhs, rhs)
+        case let (lhs?, nil): lhs
+        case let (nil, rhs?): rhs
+        case (nil, nil): nil
+        }
+    }
+
+    func increment(_ value: inout UInt64) {
+        if value < UInt64.max {
+            value += 1
+        }
+    }
+
+    func add(_ amount: Int, to value: inout UInt64) {
+        guard amount > 0 else {
+            return
+        }
+        let converted = UInt64(amount)
+        let (sum, overflow) = value.addingReportingOverflow(converted)
+        value = overflow ? UInt64.max : sum
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorderCore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorderCore.swift
@@ -15,6 +15,11 @@ final class TelemetryRecorderCore: @unchecked Sendable {
         case terminal(TelemetryRecorderCompleteness)
     }
 
+    private enum TerminalTransitionExpectation {
+        case finalizing(TelemetryRecorderCompleteness)
+        case requested(TelemetryRecorderCompleteness, generation: UInt64)
+    }
+
     private struct FlushWaiter {
         let targetSequence: UInt64?
         let completion: FlushCompletion
@@ -38,6 +43,7 @@ final class TelemetryRecorderCore: @unchecked Sendable {
     private var armedTimer: TelemetryRecorderTimerToken?
     private var readyRetryTimer: TelemetryRecorderTimerToken?
     private var knownLoss = false
+    private var terminalIntentGeneration: UInt64 = 0
 
     private var peakQueueDepth = 0
     private var coalescedFrameCount: UInt64 = 0
@@ -239,7 +245,7 @@ final class TelemetryRecorderCore: @unchecked Sendable {
 
     func requestFailure(
         reason: String,
-        completion: @escaping FinishCompletion
+        completion: FinishCompletion?
     ) -> TelemetryFinishResult? {
         lock.withLock {
             if case let .terminal(completeness) = phase {
@@ -248,10 +254,12 @@ final class TelemetryRecorderCore: @unchecked Sendable {
                     lastCommittedRecorderSequence: lastCommittedSequence
                 )
             }
-            finishCompletions.append(completion)
+            if let completion {
+                finishCompletions.append(completion)
+            }
             switch phase {
             case .finalizing:
-                break
+                phase = .failing(reason: reason)
             case .failing, .cancelling:
                 phase = .failing(reason: reason)
             case .beginning, .active, .finishing:
@@ -259,6 +267,7 @@ final class TelemetryRecorderCore: @unchecked Sendable {
             case .terminal:
                 break
             }
+            terminalIntentGeneration &+= 1
             return nil
         }
     }
@@ -279,12 +288,13 @@ final class TelemetryRecorderCore: @unchecked Sendable {
             }
             switch phase {
             case .finalizing:
-                break
+                phase = .cancelling
             case .beginning, .active, .finishing, .failing, .cancelling:
                 phase = .cancelling
             case .terminal:
                 break
             }
+            terminalIntentGeneration &+= 1
             return nil
         }
     }
@@ -305,7 +315,10 @@ final class TelemetryRecorderCore: @unchecked Sendable {
                 return .terminateRequested
             case let .finishing(endedAt, endedElapsed):
                 if !buffer.isEmpty {
-                    return .persist(buffer.drain(maximumCount: batchPolicy.maximumRecordCount))
+                    return .persist(
+                        buffer.drain(maximumCount: batchPolicy.maximumRecordCount),
+                        intentGeneration: terminalIntentGeneration
+                    )
                 }
                 let completeness: TelemetryRecorderCompleteness = knownLoss
                     ? .incomplete
@@ -318,7 +331,8 @@ final class TelemetryRecorderCore: @unchecked Sendable {
                         endedElapsed: endedElapsed,
                         reason: knownLoss ? "recorder-loss" : nil
                     ),
-                    completeness
+                    completeness,
+                    intentGeneration: terminalIntentGeneration
                 )
             case .beginning:
                 return .wait
@@ -338,7 +352,10 @@ final class TelemetryRecorderCore: @unchecked Sendable {
                     forcedFlushThrough = nil
                     return .wait
                 }
-                return .persist(buffer.drain(maximumCount: batchPolicy.maximumRecordCount))
+                return .persist(
+                    buffer.drain(maximumCount: batchPolicy.maximumRecordCount),
+                    intentGeneration: terminalIntentGeneration
+                )
             }
 
             guard let oldest = buffer.oldestEnqueueTime else {
@@ -401,15 +418,26 @@ final class TelemetryRecorderCore: @unchecked Sendable {
         }
     }
 
-    func persistenceBecameTerminal(
+    func terminalIntentGenerationSnapshot() -> UInt64 {
+        lock.withLock { terminalIntentGeneration }
+    }
+
+    @discardableResult
+    func persistenceBecameTerminalIfIntentUnchanged(
         error: Error,
-        uncertainRecords: [SequencedTelemetryRecord]
-    ) {
+        uncertainRecords: [SequencedTelemetryRecord],
+        expectedGeneration: UInt64
+    ) -> UInt64? {
         lock.withLock {
             accountUncertain(uncertainRecords)
             accountDiscarded(buffer.discardAll())
-            phase = .failing(reason: persistenceFailureReason(error))
             knownLoss = true
+            guard terminalIntentGeneration == expectedGeneration else {
+                return nil
+            }
+            phase = .failing(reason: persistenceFailureReason(error))
+            terminalIntentGeneration &+= 1
+            return terminalIntentGeneration
         }
     }
 
@@ -422,7 +450,8 @@ final class TelemetryRecorderCore: @unchecked Sendable {
 
     func prepareRequestedTermination() -> (
         TelemetrySessionFinalization,
-        TelemetryRecorderCompleteness
+        TelemetryRecorderCompleteness,
+        UInt64
     ) {
         lock.withLock {
             accountDiscarded(buffer.discardAll())
@@ -435,7 +464,8 @@ final class TelemetryRecorderCore: @unchecked Sendable {
                         endedElapsed: nil,
                         reason: reason
                     ),
-                    .failed
+                    .failed,
+                    terminalIntentGeneration
                 )
             case .cancelling:
                 return (
@@ -445,7 +475,8 @@ final class TelemetryRecorderCore: @unchecked Sendable {
                         endedElapsed: nil,
                         reason: "recorder-cancelled"
                     ),
-                    .cancelled
+                    .cancelled,
+                    terminalIntentGeneration
                 )
             case .beginning, .active, .finishing, .finalizing, .terminal:
                 return (
@@ -455,42 +486,65 @@ final class TelemetryRecorderCore: @unchecked Sendable {
                         endedElapsed: nil,
                         reason: "recorder-terminated"
                     ),
-                    .failed
+                    .failed,
+                    terminalIntentGeneration
                 )
             }
         }
     }
 
-    func failureFinalization() -> TelemetrySessionFinalization {
-        lock.withLock {
-            finalization(
-                completeness: .failed,
-                endedAt: nil,
-                endedElapsed: nil,
-                reason: "recorder-persistence-failure"
-            )
-        }
+    func completeFinalizationIfUnchanged(
+        _ intendedCompleteness: TelemetryRecorderCompleteness
+    ) -> Bool {
+        transitionToTerminal(
+            intendedCompleteness,
+            expectation: .finalizing(intendedCompleteness)
+        )
     }
 
-    func completeTerminal(_ completeness: TelemetryRecorderCompleteness) {
+    func completeRequestedTerminationIfUnchanged(
+        _ intendedCompleteness: TelemetryRecorderCompleteness,
+        generation: UInt64
+    ) -> Bool {
+        transitionToTerminal(
+            intendedCompleteness,
+            expectation: .requested(intendedCompleteness, generation: generation)
+        )
+    }
+    private func transitionToTerminal(
+        _ completeness: TelemetryRecorderCompleteness,
+        expectation: TerminalTransitionExpectation
+    ) -> Bool {
         let flushes: [FlushWaiter]
         let finishes: [FinishCompletion]
         let flushResult: TelemetryFlushResult
         let finishResult: TelemetryFinishResult
-        (flushes, finishes, flushResult, finishResult) = lock.withLock {
+        let transition = lock.withLock { () -> (
+            [FlushWaiter],
+            [FinishCompletion],
+            TelemetryFlushResult,
+            TelemetryFinishResult
+        )? in
+            switch expectation {
+            case let .finalizing(expectedCompleteness):
+                guard case let .finalizing(currentCompleteness) = phase,
+                      currentCompleteness == expectedCompleteness
+                else {
+                    return nil
+                }
+            case let .requested(expectedCompleteness, expectedGeneration):
+                guard terminalIntentGeneration == expectedGeneration else {
+                    return nil
+                }
+                switch (expectedCompleteness, phase) {
+                case (.failed, .failing), (.cancelled, .cancelling):
+                    break
+                case (.complete, _), (.incomplete, _), (.failed, _), (.cancelled, _):
+                    return nil
+                }
+            }
             if case .terminal = phase {
-                return (
-                    [],
-                    [],
-                    TelemetryFlushResult(
-                        lastCommittedRecorderSequence: lastCommittedSequence,
-                        completeness: currentCompleteness
-                    ),
-                    TelemetryFinishResult(
-                        completeness: currentCompleteness,
-                        lastCommittedRecorderSequence: lastCommittedSequence
-                    )
-                )
+                return nil
             }
             phase = .terminal(completeness)
             let flushes = flushWaiters
@@ -510,12 +564,17 @@ final class TelemetryRecorderCore: @unchecked Sendable {
                 )
             )
         }
+        guard let transition else {
+            return false
+        }
+        (flushes, finishes, flushResult, finishResult) = transition
         for waiter in flushes {
             waiter.completion(flushResult)
         }
         for completion in finishes {
             completion(finishResult)
         }
+        return true
     }
 
     func resumeSatisfiedFlushes() {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorderCore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorderCore.swift
@@ -700,9 +700,14 @@ private extension TelemetryRecorderCore {
         endedElapsed: ElapsedDuration?,
         reason: String?
     ) -> TelemetrySessionFinalization {
-        let lifecycle: SessionLifecycleState = completeness == .complete
-            ? .completed
-            : .incomplete
+        let lifecycle: SessionLifecycleState = switch completeness {
+        case .complete:
+            .completed
+        case .cancelled:
+            .cancelled
+        case .incomplete, .failed:
+            .incomplete
+        }
         return TelemetrySessionFinalization(
             sessionID: sessionHeader.sessionID,
             lifecycleState: lifecycle,

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorderScheduler.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorderScheduler.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+public final class ContinuousTelemetryRecorderScheduler: TelemetryRecorderScheduler,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private let clock = ContinuousClock()
+    private let origin: ContinuousClock.Instant
+    private var generation: UInt64 = 0
+    private var scheduledTask: Task<Void, Never>?
+
+    public init() {
+        origin = clock.now
+    }
+
+    deinit {
+        cancelScheduledOperation()
+    }
+
+    public func now() -> Duration {
+        origin.duration(to: clock.now)
+    }
+
+    public func schedule(
+        after delay: Duration,
+        operation: @escaping @Sendable () -> Void
+    ) {
+        let boundedDelay = max(delay, .zero)
+        let previous: Task<Void, Never>?
+        let currentGeneration: UInt64
+        lock.lock()
+        generation &+= 1
+        currentGeneration = generation
+        previous = scheduledTask
+        scheduledTask = Task { [weak self] in
+            guard let self else {
+                return
+            }
+            do {
+                try await clock.sleep(until: clock.now.advanced(by: boundedDelay))
+            } catch {
+                return
+            }
+            guard takeScheduledOperation(generation: currentGeneration) else {
+                return
+            }
+            operation()
+        }
+        lock.unlock()
+        previous?.cancel()
+    }
+
+    public func cancelScheduledOperation() {
+        let previous: Task<Void, Never>? = lock.withLock {
+            generation &+= 1
+            defer { scheduledTask = nil }
+            return scheduledTask
+        }
+        previous?.cancel()
+    }
+
+    private func takeScheduledOperation(generation expected: UInt64) -> Bool {
+        lock.withLock {
+            guard generation == expected else {
+                return false
+            }
+            scheduledTask = nil
+            return true
+        }
+    }
+}
+
+extension NSLock {
+    @inlinable
+    func withLock<Result>(_ body: () throws -> Result) rethrows -> Result {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryRecorderPersistenceAdapterTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryRecorderPersistenceAdapterTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import TelemetryDomain
+import TelemetryPersistence
+import TelemetryRecorder
+import XCTest
+
+final class TelemetryRecorderPersistenceAdapterTests: XCTestCase {
+    func testRecorderBatchUsesOneOrderedStoreBoundary() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = runningSession(seed: 1)
+        let source = TelemetryPersistenceFixtures.source(seed: 2)
+        let heartRate = TelemetryPersistenceFixtures.heartRate(
+            seed: 3,
+            session: session,
+            source: source,
+            arrivalOrder: 1,
+            bpm: 121
+        )
+        let event = TelemetryPersistenceFixtures.event(
+            seed: 4,
+            session: session,
+            kind: .manualStop,
+            elapsed: 2_000_000
+        )
+        try await store.beginSession(session)
+
+        try await store.persistBatch([
+            SequencedTelemetryRecord(
+                recorderSequence: 1,
+                record: .source(
+                    TelemetrySourceRecord(
+                        identity: source,
+                        firstSeen: TelemetryPersistenceFixtures.baseDate,
+                        lastSeen: TelemetryPersistenceFixtures.baseDate
+                    )
+                )
+            ),
+            SequencedTelemetryRecord(recorderSequence: 2, record: .heartRate(heartRate)),
+            SequencedTelemetryRecord(recorderSequence: 3, record: .event(event)),
+        ])
+
+        let storedSources = try await store.fetchSources().map(\.identity)
+        let storedHeartRate = try await store.fetchHeartRate(sessionID: session.sessionID)
+        let storedEvents = try await store.fetchEvents(sessionID: session.sessionID)
+        XCTAssertEqual(storedSources, [source])
+        XCTAssertEqual(storedHeartRate, [heartRate])
+        XCTAssertEqual(storedEvents, [event])
+    }
+
+    func testRecorderBatchRejectsNonMonotonicSequenceBeforeWriting() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = runningSession(seed: 5)
+        let source = TelemetryPersistenceFixtures.source(seed: 6)
+        try await store.beginSession(session)
+
+        do {
+            try await store.persistBatch([
+                SequencedTelemetryRecord(
+                    recorderSequence: 2,
+                    record: .source(
+                        TelemetrySourceRecord(
+                            identity: source,
+                            firstSeen: TelemetryPersistenceFixtures.baseDate,
+                            lastSeen: TelemetryPersistenceFixtures.baseDate
+                        )
+                    )
+                ),
+                SequencedTelemetryRecord(
+                    recorderSequence: 1,
+                    record: .event(
+                        TelemetryPersistenceFixtures.event(
+                            seed: 7,
+                            session: session,
+                            kind: .manualStop,
+                            elapsed: 1
+                        )
+                    )
+                ),
+            ])
+            XCTFail("Expected a non-monotonic recorder batch to fail.")
+        } catch let error as TelemetryPersistenceOperationError {
+            XCTAssertEqual(
+                error,
+                .commitOutcomeUnknown(code: "swiftdata-batch")
+            )
+        }
+        let storedSources = try await store.fetchSources()
+        let storedEvents = try await store.fetchEvents(sessionID: session.sessionID)
+        XCTAssertTrue(storedSources.isEmpty)
+        XCTAssertTrue(storedEvents.isEmpty)
+    }
+
+    func testUnfinishedDiscoveryAndFinalizationPersistIncompleteState() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = runningSession(seed: 8)
+        try await store.beginSession(session)
+
+        let unfinished = try await store.unfinishedSessions().map(\.sessionID)
+        XCTAssertEqual(unfinished, [session.sessionID])
+        let finalization = TelemetrySessionFinalization(
+            sessionID: session.sessionID,
+            lifecycleState: .incomplete,
+            endedAt: nil,
+            endedElapsed: nil,
+            incompleteReason: "test-recovery",
+            recorderHealth: RecorderHealthSummary(
+                isComplete: false,
+                lostCriticalRecordCount: 1,
+                lostNativeRecordCount: 2,
+                lastPersistedElapsed: ElapsedDuration(microseconds: 3)
+            )
+        )
+        try await store.finalizeSession(finalization)
+
+        let storedSessions = try await store.fetchSessions()
+        let reopened = try XCTUnwrap(storedSessions.first { $0.sessionID == session.sessionID })
+        XCTAssertEqual(reopened.lifecycleState, .incomplete)
+        XCTAssertNil(reopened.endedAt)
+        XCTAssertNil(reopened.endedElapsed)
+        XCTAssertEqual(reopened.incompleteReason, "test-recovery")
+        XCTAssertEqual(reopened.recorderHealth, finalization.recorderHealth)
+    }
+
+    private func runningSession(seed: UInt8) -> WorkoutSessionRecord {
+        let base = TelemetryPersistenceFixtures.session(seed: seed)
+        return WorkoutSessionRecord(
+            recordID: base.recordID,
+            sessionID: base.sessionID,
+            profileLocalIdentifier: base.profileLocalIdentifier,
+            lifecycleState: .running,
+            workoutMode: base.workoutMode,
+            startedAt: base.startedAt,
+            endedAt: nil,
+            endedElapsed: nil,
+            incompleteReason: nil,
+            appContext: base.appContext,
+            versions: base.versions,
+            configuration: base.configuration,
+            healthKitWorkoutIdentifier: base.healthKitWorkoutIdentifier,
+            treadmill: base.treadmill,
+            recorderHealth: RecorderHealthSummary(
+                isComplete: false,
+                lostCriticalRecordCount: 0,
+                lostNativeRecordCount: 0,
+                lastPersistedElapsed: nil
+            )
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryRecorderPersistenceAdapterTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryRecorderPersistenceAdapterTests.swift
@@ -121,6 +121,34 @@ final class TelemetryRecorderPersistenceAdapterTests: XCTestCase {
         XCTAssertEqual(reopened.recorderHealth, finalization.recorderHealth)
     }
 
+    func testCancelledSessionIsTerminalAndExcludedFromRecoveryDiscovery() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = runningSession(seed: 9)
+        try await store.beginSession(session)
+
+        try await store.finalizeSession(
+            TelemetrySessionFinalization(
+                sessionID: session.sessionID,
+                lifecycleState: .cancelled,
+                endedAt: nil,
+                endedElapsed: nil,
+                incompleteReason: "recorder-cancelled",
+                recorderHealth: RecorderHealthSummary(
+                    isComplete: false,
+                    lostCriticalRecordCount: 1,
+                    lostNativeRecordCount: 0,
+                    lastPersistedElapsed: nil
+                )
+            )
+        )
+
+        let storedSessions = try await store.fetchSessions()
+        let reopened = try XCTUnwrap(storedSessions.first { $0.sessionID == session.sessionID })
+        let unfinished = try await store.unfinishedSessions()
+        XCTAssertEqual(reopened.lifecycleState, .cancelled)
+        XCTAssertFalse(unfinished.contains { $0.sessionID == session.sessionID })
+    }
+
     private func runningSession(seed: UInt8) -> WorkoutSessionRecord {
         let base = TelemetryPersistenceFixtures.session(seed: seed)
         return WorkoutSessionRecord(

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryRecorderPersistenceAdapterTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryRecorderPersistenceAdapterTests.swift
@@ -119,6 +119,8 @@ final class TelemetryRecorderPersistenceAdapterTests: XCTestCase {
         XCTAssertNil(reopened.endedElapsed)
         XCTAssertEqual(reopened.incompleteReason, "test-recovery")
         XCTAssertEqual(reopened.recorderHealth, finalization.recorderHealth)
+        let unfinishedAfterFinalization = try await store.unfinishedSessions()
+        XCTAssertTrue(unfinishedAfterFinalization.isEmpty)
     }
 
     func testCancelledSessionIsTerminalAndExcludedFromRecoveryDiscovery() async throws {
@@ -149,25 +151,99 @@ final class TelemetryRecorderPersistenceAdapterTests: XCTestCase {
         XCTAssertFalse(unfinished.contains { $0.sessionID == session.sessionID })
     }
 
+    func testRecoveryTargetsOnlyNonterminalSessionsAndIsSemanticallyIdempotent() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let created = session(seed: 10, lifecycleState: .created)
+        let running = session(seed: 11, lifecycleState: .running)
+        let paused = session(seed: 12, lifecycleState: .paused)
+        let completed = session(seed: 13, lifecycleState: .completed)
+        let cancelled = session(
+            seed: 14,
+            lifecycleState: .cancelled,
+            incompleteReason: "original-cancelled"
+        )
+        let originalIncompleteHealth = RecorderHealthSummary(
+            isComplete: false,
+            lostCriticalRecordCount: 7,
+            lostNativeRecordCount: 9,
+            lastPersistedElapsed: ElapsedDuration(microseconds: 11_000)
+        )
+        let incomplete = session(
+            seed: 15,
+            lifecycleState: .incomplete,
+            incompleteReason: "original-incomplete-reason",
+            recorderHealth: originalIncompleteHealth
+        )
+        let allSessions = [created, running, paused, completed, cancelled, incomplete]
+        for record in allSessions {
+            try await store.beginSession(record)
+        }
+
+        let discoveredBeforeRecovery = try await store.unfinishedSessions()
+        XCTAssertEqual(
+            Set(discoveredBeforeRecovery.map(\.sessionID)),
+            Set([created.sessionID, running.sessionID, paused.sessionID])
+        )
+
+        let firstRecovery = try await TelemetryRecorder.recoverUnfinishedSessions(using: store)
+        let secondRecovery = try await TelemetryRecorder.recoverUnfinishedSessions(using: store)
+        XCTAssertEqual(
+            Set(firstRecovery.map(\.sessionID)),
+            Set([created.sessionID, running.sessionID, paused.sessionID])
+        )
+        XCTAssertTrue(secondRecovery.isEmpty)
+
+        let stored = Dictionary(
+            uniqueKeysWithValues: try await store.fetchSessions().map { ($0.sessionID, $0) }
+        )
+        for recoveredID in [created.sessionID, running.sessionID, paused.sessionID] {
+            XCTAssertEqual(stored[recoveredID]?.lifecycleState, .incomplete)
+            XCTAssertEqual(
+                stored[recoveredID]?.incompleteReason,
+                "recorder-recovered-unfinished-session"
+            )
+        }
+        XCTAssertEqual(stored[completed.sessionID]?.lifecycleState, .completed)
+        XCTAssertEqual(stored[cancelled.sessionID]?.lifecycleState, .cancelled)
+        XCTAssertEqual(stored[incomplete.sessionID]?.lifecycleState, .incomplete)
+        XCTAssertEqual(
+            stored[incomplete.sessionID]?.incompleteReason,
+            "original-incomplete-reason"
+        )
+        XCTAssertEqual(stored[incomplete.sessionID]?.recorderHealth, originalIncompleteHealth)
+    }
+
     private func runningSession(seed: UInt8) -> WorkoutSessionRecord {
+        session(seed: seed, lifecycleState: .running)
+    }
+
+    private func session(
+        seed: UInt8,
+        lifecycleState: SessionLifecycleState,
+        incompleteReason: String? = nil,
+        recorderHealth: RecorderHealthSummary? = nil
+    ) -> WorkoutSessionRecord {
         let base = TelemetryPersistenceFixtures.session(seed: seed)
+        let isCompleted = lifecycleState == .completed
         return WorkoutSessionRecord(
             recordID: base.recordID,
             sessionID: base.sessionID,
             profileLocalIdentifier: base.profileLocalIdentifier,
-            lifecycleState: .running,
+            lifecycleState: lifecycleState,
             workoutMode: base.workoutMode,
             startedAt: base.startedAt,
-            endedAt: nil,
-            endedElapsed: nil,
-            incompleteReason: nil,
+            endedAt: isCompleted
+                ? TelemetryPersistenceFixtures.baseDate.addingTimeInterval(1)
+                : nil,
+            endedElapsed: isCompleted ? ElapsedDuration(microseconds: 1_000_000) : nil,
+            incompleteReason: incompleteReason,
             appContext: base.appContext,
             versions: base.versions,
             configuration: base.configuration,
             healthKitWorkoutIdentifier: base.healthKitWorkoutIdentifier,
             treadmill: base.treadmill,
-            recorderHealth: RecorderHealthSummary(
-                isComplete: false,
+            recorderHealth: recorderHealth ?? RecorderHealthSummary(
+                isComplete: isCompleted,
                 lostCriticalRecordCount: 0,
                 lostNativeRecordCount: 0,
                 lastPersistedElapsed: nil

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/BoundedTelemetryBufferTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/BoundedTelemetryBufferTests.swift
@@ -1,0 +1,183 @@
+import TelemetryDomain
+@testable import TelemetryRecorder
+import XCTest
+
+final class BoundedTelemetryBufferTests: XCTestCase {
+    func testExactFrameCoalescingMovesLatestCandidateToGlobalSequenceTail() throws {
+        let session = TelemetryRecorderFixtures.session()
+        var buffer = BoundedTelemetryBuffer(
+            policy: try XCTUnwrap(
+                TelemetryBufferPolicy(
+                    capacity: 6,
+                    reservedCriticalCapacity: 2,
+                    reservedNativeCapacity: 2
+                )
+            )
+        )
+
+        XCTAssertEqual(
+            buffer.enqueue(sequenced(1, TelemetryRecorderFixtures.frame(sessionID: session.sessionID, second: 1)), at: .zero)
+                .disposition,
+            .enqueued
+        )
+        XCTAssertEqual(
+            buffer.enqueue(sequenced(2, TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 2)), at: .zero)
+                .disposition,
+            .enqueued
+        )
+        XCTAssertEqual(
+            buffer.enqueue(sequenced(3, TelemetryRecorderFixtures.frame(sessionID: session.sessionID, second: 1)), at: .zero)
+                .disposition,
+            .coalescedFrame
+        )
+
+        XCTAssertEqual(buffer.drain(maximumCount: 10).map(\.recorderSequence), [2, 3])
+    }
+
+    func testCriticalAdmissionEvictsBulkWithoutReorderingSurvivors() throws {
+        let session = TelemetryRecorderFixtures.session()
+        let source = TelemetryRecorderFixtures.source()
+        var buffer = BoundedTelemetryBuffer(
+            policy: try XCTUnwrap(
+                TelemetryBufferPolicy(
+                    capacity: 6,
+                    reservedCriticalCapacity: 2,
+                    reservedNativeCapacity: 2
+                )
+            )
+        )
+        _ = buffer.enqueue(sequenced(1, TelemetryRecorderFixtures.frame(sessionID: session.sessionID, second: 1)), at: .zero)
+        _ = buffer.enqueue(sequenced(2, TelemetryRecorderFixtures.frame(sessionID: session.sessionID, second: 2)), at: .zero)
+        _ = buffer.enqueue(sequenced(3, TelemetryRecorderFixtures.heartRate(sessionID: session.sessionID, source: source, order: 3)), at: .zero)
+        _ = buffer.enqueue(sequenced(4, TelemetryRecorderFixtures.heartRate(sessionID: session.sessionID, source: source, order: 4)), at: .zero)
+        _ = buffer.enqueue(sequenced(5, TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 5)), at: .zero)
+        _ = buffer.enqueue(sequenced(6, TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 6)), at: .zero)
+
+        let result = buffer.enqueue(
+            sequenced(7, TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 7)),
+            at: .zero
+        )
+
+        XCTAssertTrue(result.evictedBulkFrame)
+        XCTAssertEqual(
+            buffer.drain(maximumCount: 10).map(\.recorderSequence),
+            [2, 3, 4, 5, 6, 7]
+        )
+    }
+
+    func testNativeReservePreventsFramesFromConsumingNonCriticalCapacity() throws {
+        let session = TelemetryRecorderFixtures.session()
+        let source = TelemetryRecorderFixtures.source()
+        var buffer = BoundedTelemetryBuffer(
+            policy: try XCTUnwrap(
+                TelemetryBufferPolicy(
+                    capacity: 8,
+                    reservedCriticalCapacity: 2,
+                    reservedNativeCapacity: 3
+                )
+            )
+        )
+
+        for second in 0..<3 {
+            XCTAssertEqual(
+                buffer.enqueue(
+                    sequenced(
+                        UInt64(second + 1),
+                        TelemetryRecorderFixtures.frame(sessionID: session.sessionID, second: Int64(second))
+                    ),
+                    at: .zero
+                ).disposition,
+                .enqueued
+            )
+        }
+        XCTAssertEqual(
+            buffer.enqueue(
+                sequenced(
+                    4,
+                    TelemetryRecorderFixtures.frame(sessionID: session.sessionID, second: 4)
+                ),
+                at: .zero
+            )
+                .disposition,
+            .droppedFrame
+        )
+        for order in 5...7 {
+            XCTAssertEqual(
+                buffer.enqueue(
+                    sequenced(
+                        UInt64(order),
+                        TelemetryRecorderFixtures.heartRate(
+                            sessionID: session.sessionID,
+                            source: source,
+                            order: UInt64(order),
+                            bpm: 120
+                        )
+                    ),
+                    at: .zero
+                ).disposition,
+                .enqueued
+            )
+        }
+
+        XCTAssertEqual(buffer.bulkFrameCount, 3)
+        XCTAssertEqual(buffer.nativeCount, 3)
+        XCTAssertEqual(buffer.count, 6)
+    }
+
+    func testNativeRecordsAreNeverFuzzilyCoalesced() throws {
+        let session = TelemetryRecorderFixtures.session()
+        let source = TelemetryRecorderFixtures.source()
+        var buffer = BoundedTelemetryBuffer(
+            policy: try XCTUnwrap(
+                TelemetryBufferPolicy(
+                    capacity: 4,
+                    reservedCriticalCapacity: 1,
+                    reservedNativeCapacity: 1
+                )
+            )
+        )
+
+        _ = buffer.enqueue(
+            sequenced(1, TelemetryRecorderFixtures.heartRate(sessionID: session.sessionID, source: source, order: 1, bpm: 120)),
+            at: .zero
+        )
+        _ = buffer.enqueue(
+            sequenced(2, TelemetryRecorderFixtures.heartRate(sessionID: session.sessionID, source: source, order: 1, bpm: 120)),
+            at: .zero
+        )
+
+        XCTAssertEqual(buffer.nativeCount, 2)
+        XCTAssertEqual(buffer.drain(maximumCount: 4).map(\.recorderSequence), [1, 2])
+    }
+
+    func testCatastrophicFullBufferWithoutBulkAccountsIncomingCriticalLoss() throws {
+        let session = TelemetryRecorderFixtures.session()
+        let source = TelemetryRecorderFixtures.source()
+        var buffer = BoundedTelemetryBuffer(
+            policy: try XCTUnwrap(
+                TelemetryBufferPolicy(
+                    capacity: 3,
+                    reservedCriticalCapacity: 1,
+                    reservedNativeCapacity: 1
+                )
+            )
+        )
+        _ = buffer.enqueue(sequenced(1, TelemetryRecorderFixtures.heartRate(sessionID: session.sessionID, source: source, order: 1)), at: .zero)
+        _ = buffer.enqueue(sequenced(2, TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 2)), at: .zero)
+        _ = buffer.enqueue(sequenced(3, TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 3)), at: .zero)
+
+        XCTAssertEqual(
+            buffer.enqueue(sequenced(4, TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 4)), at: .zero)
+                .disposition,
+            .lostCritical
+        )
+        XCTAssertEqual(buffer.count, 3)
+    }
+
+    private func sequenced(
+        _ sequence: UInt64,
+        _ record: TelemetryPersistenceRecord
+    ) -> SequencedTelemetryRecord {
+        SequencedTelemetryRecord(recorderSequence: sequence, record: record)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/TelemetryRecorderBehaviorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/TelemetryRecorderBehaviorTests.swift
@@ -1,0 +1,467 @@
+import Dispatch
+import Foundation
+import TelemetryDomain
+@testable import TelemetryRecorder
+import XCTest
+
+final class TelemetryRecorderBehaviorTests: XCTestCase {
+    func testSessionHeaderPersistsAsynchronouslyWithoutCallerAwait() async {
+        let persistence = InMemoryTelemetryRecorderPersistence()
+        let scheduler = ManualTelemetryRecorderScheduler()
+        let session = TelemetryRecorderFixtures.session()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            scheduler: scheduler
+        )
+
+        await persistence.waitForHeaders(1)
+        let snapshot = await persistence.snapshot()
+        XCTAssertEqual(snapshot.headers, [session])
+        XCTAssertEqual(snapshot.batches.count, 0)
+        _ = await recorder.cancel()
+    }
+
+    func testTerminalHeaderFailurePreventsBodyPersistenceAndMarksLoss() async {
+        let persistence = InMemoryTelemetryRecorderPersistence(beginBehaviors: [.terminal])
+        let scheduler = ManualTelemetryRecorderScheduler()
+        let session = TelemetryRecorderFixtures.session()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            scheduler: scheduler
+        )
+
+        _ = recorder.ingress.yield(
+            TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 1)
+        )
+        let result = await recorder.finish(
+            endedAt: TelemetryRecorderFixtures.baseDate,
+            endedElapsed: .zero
+        )
+
+        let snapshot = await persistence.snapshot()
+        XCTAssertEqual(snapshot.beginCalls, 1)
+        XCTAssertEqual(snapshot.batchCalls, 0)
+        XCTAssertTrue(snapshot.batches.isEmpty)
+        XCTAssertEqual(result.completeness, .failed)
+        XCTAssertEqual(recorder.operationalState.lostCriticalCount, 1)
+    }
+
+    func testConcurrentProducersReceiveUniqueMonotonicSequencesAndPersistInOrder() async throws {
+        let persistence = InMemoryTelemetryRecorderPersistence()
+        let scheduler = ManualTelemetryRecorderScheduler()
+        let session = TelemetryRecorderFixtures.session()
+        let source = TelemetryRecorderFixtures.source()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            bufferPolicy: try XCTUnwrap(
+                TelemetryBufferPolicy(
+                    capacity: 2_000,
+                    reservedCriticalCapacity: 100,
+                    reservedNativeCapacity: 900
+                )
+            ),
+            batchPolicy: try XCTUnwrap(
+                TelemetryBatchPolicy(maximumRecordCount: 2_000, maximumInterval: .seconds(5))
+            ),
+            scheduler: scheduler
+        )
+        let receiptsLock = NSLock()
+        var receipts: [TelemetryYieldReceipt] = []
+
+        DispatchQueue.concurrentPerform(iterations: 1_000) { index in
+            let receipt = recorder.ingress.yield(
+                TelemetryRecorderFixtures.heartRate(
+                    sessionID: session.sessionID,
+                    source: source,
+                    order: UInt64(index),
+                    bpm: UInt16(100 + index % 40)
+                )
+            )
+            receiptsLock.withLock {
+                receipts.append(receipt)
+            }
+        }
+        let result = await recorder.finish(
+            endedAt: TelemetryRecorderFixtures.baseDate.addingTimeInterval(10),
+            endedElapsed: ElapsedDuration(microseconds: 10_000_000)
+        )
+
+        let assigned = receipts.compactMap(\.recorderSequence).sorted()
+        XCTAssertEqual(assigned, Array(1...1_000).map(UInt64.init))
+        XCTAssertEqual(Set(assigned).count, 1_000)
+        let persisted = await persistence.snapshot().batches.flatMap { $0 }
+        XCTAssertEqual(persisted.map(\.recorderSequence), assigned)
+        XCTAssertEqual(result.completeness, .complete)
+    }
+
+    func testCountTriggeredFlushPreservesProviderFields() async throws {
+        let persistence = InMemoryTelemetryRecorderPersistence()
+        let scheduler = ManualTelemetryRecorderScheduler()
+        let session = TelemetryRecorderFixtures.session()
+        let source = TelemetryRecorderFixtures.source()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            batchPolicy: try XCTUnwrap(
+                TelemetryBatchPolicy(maximumRecordCount: 2, maximumInterval: .seconds(5))
+            ),
+            scheduler: scheduler
+        )
+        let first = TelemetryRecorderFixtures.heartRate(
+            sessionID: session.sessionID,
+            source: source,
+            order: 9,
+            bpm: 123
+        )
+        let second = TelemetryRecorderFixtures.treadmill(
+            sessionID: session.sessionID,
+            source: source,
+            order: 4
+        )
+
+        _ = recorder.ingress.yield(first)
+        _ = recorder.ingress.yield(second)
+        await persistence.waitForBatches(1)
+
+        let persistedSnapshot = await persistence.snapshot()
+        let batch = try XCTUnwrap(persistedSnapshot.batches.first)
+        XCTAssertEqual(batch.map(\.record), [first, second])
+        XCTAssertEqual(batch.map(\.recorderSequence), [1, 2])
+        _ = await recorder.cancel()
+    }
+
+    func testTimeTriggeredFlushUsesManualClockWithoutWallSleep() async throws {
+        let persistence = InMemoryTelemetryRecorderPersistence()
+        let scheduler = ManualTelemetryRecorderScheduler()
+        let session = TelemetryRecorderFixtures.session()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            batchPolicy: try XCTUnwrap(
+                TelemetryBatchPolicy(maximumRecordCount: 10, maximumInterval: .seconds(5))
+            ),
+            scheduler: scheduler
+        )
+
+        _ = recorder.ingress.yield(TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 1))
+        await scheduler.waitUntilScheduled()
+        scheduler.advance(by: .seconds(4))
+        let beforeDeadline = await persistence.snapshot()
+        XCTAssertTrue(beforeDeadline.batches.isEmpty)
+        scheduler.advance(by: .seconds(1))
+        await persistence.waitForBatches(1)
+
+        let afterDeadline = await persistence.snapshot()
+        XCTAssertEqual(afterDeadline.batches.first?.count, 1)
+        _ = await recorder.cancel()
+    }
+
+    func testLifecycleFlushAndFinishDrainQueuedEvidence() async throws {
+        let persistence = InMemoryTelemetryRecorderPersistence()
+        let scheduler = ManualTelemetryRecorderScheduler()
+        let session = TelemetryRecorderFixtures.session()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            batchPolicy: try XCTUnwrap(
+                TelemetryBatchPolicy(maximumRecordCount: 10, maximumInterval: .seconds(5))
+            ),
+            scheduler: scheduler
+        )
+
+        _ = recorder.ingress.yield(TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 1))
+        let flush = await recorder.flush(reason: .applicationBackground)
+        XCTAssertEqual(flush.lastCommittedRecorderSequence, 1)
+        _ = recorder.ingress.yield(TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 2))
+        let finish = await recorder.finish(
+            endedAt: TelemetryRecorderFixtures.baseDate.addingTimeInterval(2),
+            endedElapsed: ElapsedDuration(microseconds: 2_000_000)
+        )
+
+        let snapshot = await persistence.snapshot()
+        XCTAssertEqual(snapshot.batches.flatMap { $0 }.map(\.recorderSequence), [1, 2])
+        XCTAssertEqual(snapshot.finalizations.last?.lifecycleState, .completed)
+        XCTAssertEqual(finish.completeness, .complete)
+        XCTAssertEqual(recorder.operationalState.successfulFlushCount, 2)
+    }
+
+    func testRetryablePrecommitFailureRetriesOnceAfterInjectedDelay() async throws {
+        let persistence = InMemoryTelemetryRecorderPersistence(
+            batchBehaviors: [.retryableBeforeCommit, .success]
+        )
+        let scheduler = ManualTelemetryRecorderScheduler()
+        let session = TelemetryRecorderFixtures.session()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            batchPolicy: try XCTUnwrap(
+                TelemetryBatchPolicy(maximumRecordCount: 1, maximumInterval: .seconds(5))
+            ),
+            retryPolicy: try XCTUnwrap(
+                TelemetryRetryPolicy(maximumPrecommitRetries: 1, delay: .milliseconds(250))
+            ),
+            scheduler: scheduler
+        )
+
+        _ = recorder.ingress.yield(TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 1))
+        await persistence.waitForBatchCalls(1)
+        await scheduler.waitUntilScheduled()
+        scheduler.advance(by: .milliseconds(250))
+        await persistence.waitForBatches(1)
+        let finish = await recorder.finish(
+            endedAt: TelemetryRecorderFixtures.baseDate,
+            endedElapsed: .zero
+        )
+
+        let snapshot = await persistence.snapshot()
+        XCTAssertEqual(snapshot.batchCalls, 2)
+        XCTAssertEqual(recorder.operationalState.retryCount, 1)
+        XCTAssertEqual(recorder.operationalState.writerFailureCount, 1)
+        XCTAssertEqual(finish.completeness, .complete)
+    }
+
+    func testRetryExhaustionBecomesFailedAndIncomplete() async throws {
+        let persistence = InMemoryTelemetryRecorderPersistence(
+            batchBehaviors: [.retryableBeforeCommit, .retryableBeforeCommit]
+        )
+        let scheduler = ManualTelemetryRecorderScheduler()
+        let session = TelemetryRecorderFixtures.session()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            batchPolicy: try XCTUnwrap(
+                TelemetryBatchPolicy(maximumRecordCount: 1, maximumInterval: .seconds(5))
+            ),
+            retryPolicy: try XCTUnwrap(
+                TelemetryRetryPolicy(maximumPrecommitRetries: 1, delay: .milliseconds(1))
+            ),
+            scheduler: scheduler
+        )
+
+        _ = recorder.ingress.yield(TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 1))
+        await persistence.waitForBatchCalls(1)
+        await scheduler.waitUntilScheduled()
+        scheduler.advance(by: .milliseconds(1))
+        await persistence.waitForFinalizations(1)
+        let result = await recorder.finish(
+            endedAt: TelemetryRecorderFixtures.baseDate,
+            endedElapsed: .zero
+        )
+
+        let snapshot = await persistence.snapshot()
+        XCTAssertEqual(snapshot.batchCalls, 2)
+        XCTAssertEqual(snapshot.finalizations.last?.lifecycleState, .incomplete)
+        XCTAssertEqual(result.completeness, .failed)
+        XCTAssertEqual(recorder.operationalState.lostCriticalCount, 1)
+    }
+
+    func testExplicitFailureAccountsQueuedTailWithoutPersistingIt() async {
+        let persistence = InMemoryTelemetryRecorderPersistence()
+        let scheduler = ManualTelemetryRecorderScheduler()
+        let session = TelemetryRecorderFixtures.session()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            scheduler: scheduler
+        )
+        await persistence.waitForHeaders(1)
+
+        _ = recorder.ingress.yield(
+            TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 1)
+        )
+        let result = await recorder.fail(reason: "test-explicit-failure")
+
+        let snapshot = await persistence.snapshot()
+        XCTAssertTrue(snapshot.batches.isEmpty)
+        XCTAssertEqual(snapshot.finalizations.last?.lifecycleState, .incomplete)
+        XCTAssertEqual(snapshot.finalizations.last?.incompleteReason, "test-explicit-failure")
+        XCTAssertEqual(result.completeness, .failed)
+        XCTAssertEqual(recorder.operationalState.lostCriticalCount, 1)
+    }
+
+    func testAmbiguousCommitOutcomeIsNeverRetried() async throws {
+        let persistence = InMemoryTelemetryRecorderPersistence(
+            batchBehaviors: [.ambiguousAfterCommit, .success]
+        )
+        let scheduler = ManualTelemetryRecorderScheduler()
+        let session = TelemetryRecorderFixtures.session()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            batchPolicy: try XCTUnwrap(
+                TelemetryBatchPolicy(maximumRecordCount: 1, maximumInterval: .seconds(5))
+            ),
+            retryPolicy: try XCTUnwrap(
+                TelemetryRetryPolicy(maximumPrecommitRetries: 3, delay: .milliseconds(1))
+            ),
+            scheduler: scheduler
+        )
+
+        _ = recorder.ingress.yield(TelemetryRecorderFixtures.event(sessionID: session.sessionID, order: 1))
+        await persistence.waitForBatches(1)
+        await persistence.waitForFinalizations(1)
+
+        let snapshot = await persistence.snapshot()
+        XCTAssertEqual(snapshot.batchCalls, 1)
+        XCTAssertEqual(recorder.operationalState.retryCount, 0)
+        XCTAssertEqual(recorder.operationalState.lifecycleState, .failed)
+    }
+
+    func testCancellationAccountsTailAndASecondRecorderCanRestartDeterministically() async throws {
+        let persistence = InMemoryTelemetryRecorderPersistence()
+        let scheduler = ManualTelemetryRecorderScheduler()
+        let firstSession = TelemetryRecorderFixtures.session()
+        let first = TelemetryRecorder(
+            sessionHeader: firstSession,
+            persistence: persistence,
+            batchPolicy: try XCTUnwrap(
+                TelemetryBatchPolicy(maximumRecordCount: 10, maximumInterval: .seconds(5))
+            ),
+            scheduler: scheduler
+        )
+        await persistence.waitForHeaders(1)
+        _ = first.ingress.yield(TelemetryRecorderFixtures.event(sessionID: firstSession.sessionID, order: 1))
+        let cancelled = await first.cancel()
+
+        XCTAssertEqual(cancelled.completeness, .cancelled)
+        XCTAssertEqual(first.operationalState.lostCriticalCount, 1)
+        XCTAssertEqual(
+            first.ingress.yield(TelemetryRecorderFixtures.event(sessionID: firstSession.sessionID, order: 2))
+                .disposition,
+            .rejectedTerminal
+        )
+
+        let secondSession = TelemetryRecorderFixtures.session()
+        let second = TelemetryRecorder(
+            sessionHeader: secondSession,
+            persistence: persistence,
+            batchPolicy: try XCTUnwrap(
+                TelemetryBatchPolicy(maximumRecordCount: 1, maximumInterval: .seconds(5))
+            ),
+            scheduler: ManualTelemetryRecorderScheduler()
+        )
+        _ = second.ingress.yield(TelemetryRecorderFixtures.event(sessionID: secondSession.sessionID, order: 1))
+        let finished = await second.finish(
+            endedAt: TelemetryRecorderFixtures.baseDate,
+            endedElapsed: .zero
+        )
+        XCTAssertEqual(finished.completeness, .complete)
+        XCTAssertEqual(finished.lastCommittedRecorderSequence, 1)
+    }
+
+    func testUnfinishedSessionRecoveryMarksIncompleteWithoutFabricatedCompletion() async throws {
+        let unfinished = TelemetryRecorderFixtures.session()
+        let persistence = InMemoryTelemetryRecorderPersistence(unfinished: [unfinished])
+
+        let discovered = try await TelemetryRecorder.recoverUnfinishedSessions(
+            using: persistence
+        )
+
+        let recoverySnapshot = await persistence.snapshot()
+        let finalization = try XCTUnwrap(recoverySnapshot.finalizations.last)
+        XCTAssertEqual(discovered, [unfinished])
+        XCTAssertEqual(finalization.lifecycleState, .incomplete)
+        XCTAssertNil(finalization.endedAt)
+        XCTAssertNil(finalization.endedElapsed)
+        XCTAssertFalse(finalization.recorderHealth.isComplete)
+    }
+
+    func testHighVolumeConcurrentStreamStaysBoundedAndUsesOneTimer() async throws {
+        let persistence = InMemoryTelemetryRecorderPersistence()
+        let scheduler = ManualTelemetryRecorderScheduler()
+        let session = TelemetryRecorderFixtures.session()
+        let source = TelemetryRecorderFixtures.source()
+        let capacity = 256
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            bufferPolicy: try XCTUnwrap(
+                TelemetryBufferPolicy(
+                    capacity: capacity,
+                    reservedCriticalCapacity: 32,
+                    reservedNativeCapacity: 64
+                )
+            ),
+            batchPolicy: try XCTUnwrap(
+                TelemetryBatchPolicy(maximumRecordCount: 64, maximumInterval: .seconds(5))
+            ),
+            scheduler: scheduler
+        )
+
+        DispatchQueue.concurrentPerform(iterations: 10_000) { index in
+            if index.isMultiple(of: 10) {
+                _ = recorder.ingress.yield(
+                    TelemetryRecorderFixtures.event(
+                        sessionID: session.sessionID,
+                        order: UInt64(index)
+                    )
+                )
+            } else if index.isMultiple(of: 3) {
+                _ = recorder.ingress.yield(
+                    TelemetryRecorderFixtures.frame(
+                        sessionID: session.sessionID,
+                        second: Int64(index % 500)
+                    )
+                )
+            } else {
+                _ = recorder.ingress.yield(
+                    TelemetryRecorderFixtures.heartRate(
+                        sessionID: session.sessionID,
+                        source: source,
+                        order: UInt64(index),
+                        bpm: UInt16(90 + index % 80)
+                    )
+                )
+            }
+        }
+        let finish = await recorder.finish(
+            endedAt: TelemetryRecorderFixtures.baseDate.addingTimeInterval(100),
+            endedElapsed: ElapsedDuration(microseconds: 100_000_000)
+        )
+
+        let state = recorder.operationalState
+        let persisted = await persistence.snapshot().batches.flatMap { $0 }
+        XCTAssertLessThanOrEqual(state.peakQueueDepth, capacity)
+        XCTAssertEqual(persisted.map(\.recorderSequence), persisted.map(\.recorderSequence).sorted())
+        XCTAssertEqual(Set(persisted.map(\.recorderSequence)).count, persisted.count)
+        XCTAssertLessThanOrEqual(scheduler.maximumOutstandingOperationCount, 1)
+        XCTAssertGreaterThan(state.successfulFlushCount, 0)
+        XCTAssertTrue(finish.completeness == .complete || finish.completeness == .incomplete)
+    }
+
+    func testOperationalCountersExposeOnlyPrivacySafeStateFields() {
+        let state = TelemetryRecorderOperationalState(
+            queueDepth: 1,
+            peakQueueDepth: 2,
+            coalescedFrameCount: 3,
+            droppedFrameCount: 4,
+            lostNativeCount: 5,
+            lostCriticalCount: 6,
+            writerFailureCount: 7,
+            retryCount: 8,
+            successfulFlushCount: 9,
+            lastCommittedRecorderSequence: 10,
+            mostRecentFlushDuration: .milliseconds(11),
+            lifecycleState: .active,
+            completeness: .incomplete
+        )
+
+        let labels = Set(Mirror(reflecting: state).children.compactMap(\.label))
+        XCTAssertEqual(
+            labels,
+            [
+                "queueDepth", "peakQueueDepth", "coalescedFrameCount",
+                "droppedFrameCount", "lostNativeCount", "lostCriticalCount",
+                "writerFailureCount", "retryCount", "successfulFlushCount",
+                "lastCommittedRecorderSequence", "mostRecentFlushDuration",
+                "lifecycleState", "completeness",
+            ]
+        )
+        XCTAssertFalse(labels.contains("beatsPerMinute"))
+        XCTAssertFalse(labels.contains("sourceID"))
+        XCTAssertFalse(labels.contains("rawPayload"))
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/TelemetryRecorderBehaviorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/TelemetryRecorderBehaviorTests.swift
@@ -327,6 +327,8 @@ final class TelemetryRecorderBehaviorTests: XCTestCase {
         let cancelled = await first.cancel()
 
         XCTAssertEqual(cancelled.completeness, .cancelled)
+        let cancelledSnapshot = await persistence.snapshot()
+        XCTAssertEqual(cancelledSnapshot.finalizations.last?.lifecycleState, .cancelled)
         XCTAssertEqual(first.operationalState.lostCriticalCount, 1)
         XCTAssertEqual(
             first.ingress.yield(TelemetryRecorderFixtures.event(sessionID: firstSession.sessionID, order: 2))
@@ -350,6 +352,35 @@ final class TelemetryRecorderBehaviorTests: XCTestCase {
         )
         XCTAssertEqual(finished.completeness, .complete)
         XCTAssertEqual(finished.lastCommittedRecorderSequence, 1)
+    }
+
+    func testAmbiguousCompletionFinalizationDowngradesStoredStateToIncomplete() async {
+        let persistence = InMemoryTelemetryRecorderPersistence(
+            finalizeBehaviors: [.ambiguousAfterCommit, .success]
+        )
+        let scheduler = ManualTelemetryRecorderScheduler()
+        let session = TelemetryRecorderFixtures.session()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            scheduler: scheduler
+        )
+        await persistence.waitForHeaders(1)
+
+        let result = await recorder.finish(
+            endedAt: TelemetryRecorderFixtures.baseDate,
+            endedElapsed: .zero
+        )
+
+        let snapshot = await persistence.snapshot()
+        XCTAssertEqual(snapshot.finalizeCalls, 2)
+        XCTAssertEqual(snapshot.finalizations.map(\.lifecycleState), [.completed, .incomplete])
+        XCTAssertEqual(
+            snapshot.finalizations.last?.incompleteReason,
+            "recorder-persistence-failure"
+        )
+        XCTAssertEqual(result.completeness, .failed)
+        XCTAssertEqual(recorder.operationalState.writerFailureCount, 1)
     }
 
     func testUnfinishedSessionRecoveryMarksIncompleteWithoutFabricatedCompletion() async throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/TelemetryRecorderBehaviorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/TelemetryRecorderBehaviorTests.swift
@@ -377,9 +377,158 @@ final class TelemetryRecorderBehaviorTests: XCTestCase {
         XCTAssertEqual(snapshot.finalizations.map(\.lifecycleState), [.completed, .incomplete])
         XCTAssertEqual(
             snapshot.finalizations.last?.incompleteReason,
-            "recorder-persistence-failure"
+            "persistence-fake-finalize"
         )
         XCTAssertEqual(result.completeness, .failed)
+        XCTAssertEqual(recorder.operationalState.writerFailureCount, 1)
+    }
+
+    func testFailureRequestDuringSuspendedCompletionFinalizationWins() async {
+        let persistence = InMemoryTelemetryRecorderPersistence(
+            suspendNextFinalization: true
+        )
+        let session = TelemetryRecorderFixtures.session()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            scheduler: ManualTelemetryRecorderScheduler()
+        )
+        await persistence.waitForHeaders(1)
+
+        let finishTask = Task {
+            await recorder.finish(
+                endedAt: TelemetryRecorderFixtures.baseDate,
+                endedElapsed: .zero
+            )
+        }
+        await persistence.waitForFinalizeCalls(1)
+
+        XCTAssertTrue(recorder.requestFailure(reason: "test-finalization-race"))
+        XCTAssertEqual(recorder.operationalState.lifecycleState, .failing)
+        await persistence.resumeSuspendedFinalization()
+        let result = await finishTask.value
+
+        let snapshot = await persistence.snapshot()
+        XCTAssertEqual(snapshot.finalizeCalls, 2)
+        XCTAssertEqual(snapshot.finalizations.map(\.lifecycleState), [.completed, .incomplete])
+        XCTAssertEqual(snapshot.finalizations.last?.incompleteReason, "test-finalization-race")
+        XCTAssertEqual(result.completeness, .failed)
+        XCTAssertEqual(recorder.operationalState.lifecycleState, .failed)
+    }
+
+    func testCancellationRequestDuringSuspendedCompletionFinalizationWins() async {
+        let persistence = InMemoryTelemetryRecorderPersistence(
+            suspendNextFinalization: true
+        )
+        let session = TelemetryRecorderFixtures.session()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            scheduler: ManualTelemetryRecorderScheduler()
+        )
+        await persistence.waitForHeaders(1)
+
+        let finishTask = Task {
+            await recorder.finish(
+                endedAt: TelemetryRecorderFixtures.baseDate,
+                endedElapsed: .zero
+            )
+        }
+        await persistence.waitForFinalizeCalls(1)
+
+        XCTAssertTrue(recorder.requestCancellation())
+        XCTAssertEqual(recorder.operationalState.lifecycleState, .cancelling)
+        await persistence.resumeSuspendedFinalization()
+        let result = await finishTask.value
+
+        let snapshot = await persistence.snapshot()
+        XCTAssertEqual(snapshot.finalizeCalls, 2)
+        XCTAssertEqual(snapshot.finalizations.map(\.lifecycleState), [.completed, .cancelled])
+        XCTAssertEqual(snapshot.finalizations.last?.incompleteReason, "recorder-cancelled")
+        XCTAssertEqual(result.completeness, .cancelled)
+        XCTAssertEqual(recorder.operationalState.lifecycleState, .cancelled)
+    }
+
+    func testLatestIntentWinsAcrossSuspendedFailClosedFollowUp() async {
+        let persistence = InMemoryTelemetryRecorderPersistence(
+            suspendNextFinalization: true
+        )
+        let session = TelemetryRecorderFixtures.session()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            scheduler: ManualTelemetryRecorderScheduler()
+        )
+        await persistence.waitForHeaders(1)
+
+        let finishTask = Task {
+            await recorder.finish(
+                endedAt: TelemetryRecorderFixtures.baseDate,
+                endedElapsed: .zero
+            )
+        }
+        await persistence.waitForFinalizeCalls(1)
+        XCTAssertTrue(recorder.requestFailure(reason: "superseded-failure"))
+
+        await persistence.suspendNextFinalization()
+        await persistence.resumeSuspendedFinalization()
+        await persistence.waitForFinalizeCalls(2)
+        XCTAssertTrue(recorder.requestCancellation())
+        XCTAssertEqual(recorder.operationalState.lifecycleState, .cancelling)
+
+        await persistence.resumeSuspendedFinalization()
+        let result = await finishTask.value
+
+        let snapshot = await persistence.snapshot()
+        XCTAssertEqual(snapshot.finalizeCalls, 3)
+        XCTAssertEqual(
+            snapshot.finalizations.map(\.lifecycleState),
+            [.completed, .incomplete, .cancelled]
+        )
+        XCTAssertEqual(snapshot.finalizations.last?.incompleteReason, "recorder-cancelled")
+        XCTAssertEqual(result.completeness, .cancelled)
+        XCTAssertEqual(recorder.operationalState.lifecycleState, .cancelled)
+    }
+
+    func testLatestIntentSurvivesErrorFromSuspendedFailClosedFollowUp() async {
+        let persistence = InMemoryTelemetryRecorderPersistence(
+            finalizeBehaviors: [.success, .ambiguousAfterCommit, .success],
+            suspendNextFinalization: true
+        )
+        let session = TelemetryRecorderFixtures.session()
+        let recorder = TelemetryRecorder(
+            sessionHeader: session,
+            persistence: persistence,
+            scheduler: ManualTelemetryRecorderScheduler()
+        )
+        await persistence.waitForHeaders(1)
+
+        let finishTask = Task {
+            await recorder.finish(
+                endedAt: TelemetryRecorderFixtures.baseDate,
+                endedElapsed: .zero
+            )
+        }
+        await persistence.waitForFinalizeCalls(1)
+        XCTAssertTrue(recorder.requestFailure(reason: "superseded-failure"))
+
+        await persistence.suspendNextFinalization()
+        await persistence.resumeSuspendedFinalization()
+        await persistence.waitForFinalizeCalls(2)
+        XCTAssertTrue(recorder.requestCancellation())
+
+        await persistence.resumeSuspendedFinalization()
+        let result = await finishTask.value
+
+        let snapshot = await persistence.snapshot()
+        XCTAssertEqual(snapshot.finalizeCalls, 3)
+        XCTAssertEqual(
+            snapshot.finalizations.map(\.lifecycleState),
+            [.completed, .incomplete, .cancelled]
+        )
+        XCTAssertEqual(snapshot.finalizations.last?.incompleteReason, "recorder-cancelled")
+        XCTAssertEqual(result.completeness, .cancelled)
+        XCTAssertEqual(recorder.operationalState.lifecycleState, .cancelled)
         XCTAssertEqual(recorder.operationalState.writerFailureCount, 1)
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/TelemetryRecorderBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/TelemetryRecorderBoundaryTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import XCTest
+
+final class TelemetryRecorderBoundaryTests: XCTestCase {
+    func testRecorderTargetHasNoSwiftDataOrPersistenceHotPathDependency() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let recorderDirectory = root.appendingPathComponent("Sources/TelemetryRecorder")
+        let sources = try swiftSources(in: recorderDirectory)
+
+        XCTAssertFalse(sources.contains("import SwiftData"))
+        XCTAssertFalse(sources.contains("ModelContext"))
+        XCTAssertFalse(sources.contains("JSONEncoder"))
+        XCTAssertFalse(sources.contains("JSONDecoder"))
+        XCTAssertFalse(sources.contains("UserDefaults"))
+        XCTAssertFalse(sources.contains("FileManager"))
+    }
+
+    func testProducerFacingYieldContainsNoTaskAwaitOrSlowWork() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let recorder = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/TelemetryRecorder/TelemetryRecorder.swift"
+            ),
+            encoding: .utf8
+        )
+        let ingressStart = try XCTUnwrap(recorder.range(of: "public final class TelemetryIngress"))
+        let recorderStart = try XCTUnwrap(recorder.range(of: "public final class TelemetryRecorder"))
+        let ingress = recorder[ingressStart.lowerBound..<recorderStart.lowerBound]
+
+        for forbidden in [
+            "Task", "await", "SwiftData", "ModelContext", "JSON", "FileManager",
+            "UserDefaults", "URLSession", "removeFirst", ".sorted(",
+        ] {
+            XCTAssertFalse(ingress.contains(forbidden), "Ingress contains forbidden \(forbidden)")
+        }
+        XCTAssertEqual(recorder.components(separatedBy: "Task.detached").count - 1, 1)
+    }
+
+    func testProductionApplicationSourcesDoNotWireRecorder() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let runtimeSources = try swiftSources(in: root.appendingPathComponent("WalkingPadRemote"))
+
+        XCTAssertFalse(runtimeSources.contains("import TelemetryRecorder"))
+        XCTAssertFalse(runtimeSources.contains("TelemetryIngress"))
+        XCTAssertFalse(runtimeSources.contains("TelemetryRecorder("))
+        XCTAssertFalse(runtimeSources.contains("TelemetryStoreFactory.make"))
+    }
+
+    func testPackageDependencyDirectionKeepsRecorderAboveDomainAndBelowPersistence() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let manifest = try String(
+            contentsOf: root.appendingPathComponent("Package.swift"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(
+            manifest.contains(
+                ".target(\n            name: \"TelemetryRecorder\",\n            dependencies: [\"TelemetryDomain\"]"
+            )
+        )
+        XCTAssertTrue(
+            manifest.contains(
+                "name: \"TelemetryPersistence\",\n            dependencies: [\"TelemetryDomain\", \"TelemetryRecorder\"]"
+            )
+        )
+        XCTAssertFalse(manifest.contains("name: \"TelemetryRecorder\",\n            dependencies: [\"TelemetryPersistence\"]"))
+    }
+
+    func testPersistenceAdapterIsNotMainActorBound() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let store = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/TelemetryPersistence/TelemetryStore.swift"
+            ),
+            encoding: .utf8
+        )
+        XCTAssertTrue(store.contains("@ModelActor\npublic actor TelemetryStore"))
+        XCTAssertTrue(store.contains("extension TelemetryStore: TelemetryRecorderPersistence"))
+        XCTAssertFalse(store.contains("@MainActor\nextension TelemetryStore: TelemetryRecorderPersistence"))
+    }
+
+    private func swiftSources(in directory: URL) throws -> String {
+        let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey]
+        )
+        var result = ""
+        while let url = enumerator?.nextObject() as? URL {
+            guard url.pathExtension == "swift" else {
+                continue
+            }
+            result += try String(contentsOf: url, encoding: .utf8)
+        }
+        return result
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/TelemetryRecorderTestSupport.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/TelemetryRecorderTestSupport.swift
@@ -92,21 +92,26 @@ actor InMemoryTelemetryRecorderPersistence: TelemetryRecorderPersistence {
     private var beginBehaviors: [Behavior]
     private var finalizeBehaviors: [Behavior]
     private var unfinished: [WorkoutSessionRecord]
+    private var suspendsNextFinalization: Bool
+    private var suspendedFinalization: CheckedContinuation<Void, Never>?
     private var headerWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
     private var batchWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
     private var finalizationWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
     private var batchCallWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var finalizeCallWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
 
     init(
         batchBehaviors: [Behavior] = [],
         beginBehaviors: [Behavior] = [],
         finalizeBehaviors: [Behavior] = [],
-        unfinished: [WorkoutSessionRecord] = []
+        unfinished: [WorkoutSessionRecord] = [],
+        suspendNextFinalization: Bool = false
     ) {
         self.batchBehaviors = batchBehaviors
         self.beginBehaviors = beginBehaviors
         self.finalizeBehaviors = finalizeBehaviors
         self.unfinished = unfinished
+        suspendsNextFinalization = suspendNextFinalization
     }
 
     func beginSession(_ header: WorkoutSessionRecord) async throws {
@@ -148,7 +153,14 @@ actor InMemoryTelemetryRecorderPersistence: TelemetryRecorderPersistence {
 
     func finalizeSession(_ finalization: TelemetrySessionFinalization) async throws {
         finalizeCallCount += 1
+        resumeFinalizeCallWaiters()
         let behavior = nextBehavior(&finalizeBehaviors)
+        if suspendsNextFinalization {
+            suspendsNextFinalization = false
+            await withCheckedContinuation { continuation in
+                suspendedFinalization = continuation
+            }
+        }
         switch behavior {
         case .success:
             finalizations.append(finalization)
@@ -204,6 +216,28 @@ actor InMemoryTelemetryRecorderPersistence: TelemetryRecorderPersistence {
         }
     }
 
+    func waitForFinalizeCalls(_ count: Int) async {
+        guard finalizeCallCount < count else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            finalizeCallWaiters.append((count, continuation))
+        }
+    }
+
+    func resumeSuspendedFinalization() {
+        guard let continuation = suspendedFinalization else {
+            preconditionFailure("A finalization must be suspended before it can resume.")
+        }
+        suspendedFinalization = nil
+        continuation.resume()
+    }
+
+    func suspendNextFinalization() {
+        precondition(!suspendsNextFinalization)
+        suspendsNextFinalization = true
+    }
+
     func snapshot() -> (
         headers: [WorkoutSessionRecord],
         batches: [[SequencedTelemetryRecord]],
@@ -233,6 +267,10 @@ actor InMemoryTelemetryRecorderPersistence: TelemetryRecorderPersistence {
 
     private func resumeFinalizationWaiters() {
         resume(waiters: &finalizationWaiters, currentCount: finalizations.count)
+    }
+
+    private func resumeFinalizeCallWaiters() {
+        resume(waiters: &finalizeCallWaiters, currentCount: finalizeCallCount)
     }
 
     private func resume(

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/TelemetryRecorderTestSupport.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/TelemetryRecorderTestSupport.swift
@@ -1,0 +1,429 @@
+import Foundation
+import TelemetryDomain
+@testable import TelemetryRecorder
+
+final class ManualTelemetryRecorderScheduler: TelemetryRecorderScheduler,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var current: Duration = .zero
+    private var deadline: Duration?
+    private var operation: (@Sendable () -> Void)?
+    private var scheduleWaiters: [CheckedContinuation<Void, Never>] = []
+    private(set) var maximumOutstandingOperationCount = 0
+
+    func now() -> Duration {
+        lock.withLock { current }
+    }
+
+    func schedule(after delay: Duration, operation: @escaping @Sendable () -> Void) {
+        let waiters: [CheckedContinuation<Void, Never>] = lock.withLock {
+            deadline = current + max(delay, .zero)
+            self.operation = operation
+            maximumOutstandingOperationCount = max(maximumOutstandingOperationCount, 1)
+            defer { scheduleWaiters.removeAll(keepingCapacity: false) }
+            return scheduleWaiters
+        }
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    func cancelScheduledOperation() {
+        lock.withLock {
+            deadline = nil
+            operation = nil
+        }
+    }
+
+    func advance(by duration: Duration) {
+        let ready: (@Sendable () -> Void)? = lock.withLock {
+            current += max(duration, .zero)
+            guard let deadline, deadline <= current else {
+                return nil
+            }
+            defer {
+                self.deadline = nil
+                operation = nil
+            }
+            return operation
+        }
+        ready?()
+    }
+
+    var hasScheduledOperation: Bool {
+        lock.withLock { operation != nil }
+    }
+
+    func waitUntilScheduled() async {
+        if hasScheduledOperation {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            let resumeImmediately = lock.withLock { () -> Bool in
+                if operation != nil {
+                    return true
+                }
+                scheduleWaiters.append(continuation)
+                return false
+            }
+            if resumeImmediately {
+                continuation.resume()
+            }
+        }
+    }
+}
+
+actor InMemoryTelemetryRecorderPersistence: TelemetryRecorderPersistence {
+    enum Behavior: Sendable {
+        case success
+        case retryableBeforeCommit
+        case terminal
+        case ambiguousAfterCommit
+    }
+
+    private(set) var headers: [WorkoutSessionRecord] = []
+    private(set) var batches: [[SequencedTelemetryRecord]] = []
+    private(set) var finalizations: [TelemetrySessionFinalization] = []
+    private(set) var batchCallCount = 0
+    private(set) var beginCallCount = 0
+    private(set) var finalizeCallCount = 0
+    private var batchBehaviors: [Behavior]
+    private var beginBehaviors: [Behavior]
+    private var finalizeBehaviors: [Behavior]
+    private var unfinished: [WorkoutSessionRecord]
+    private var headerWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var batchWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var finalizationWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var batchCallWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    init(
+        batchBehaviors: [Behavior] = [],
+        beginBehaviors: [Behavior] = [],
+        finalizeBehaviors: [Behavior] = [],
+        unfinished: [WorkoutSessionRecord] = []
+    ) {
+        self.batchBehaviors = batchBehaviors
+        self.beginBehaviors = beginBehaviors
+        self.finalizeBehaviors = finalizeBehaviors
+        self.unfinished = unfinished
+    }
+
+    func beginSession(_ header: WorkoutSessionRecord) async throws {
+        beginCallCount += 1
+        let behavior = nextBehavior(&beginBehaviors)
+        switch behavior {
+        case .success:
+            headers.append(header)
+            resumeHeaderWaiters()
+        case .retryableBeforeCommit:
+            throw TelemetryPersistenceOperationError.retryableBeforeCommit(code: "fake-begin")
+        case .terminal:
+            throw TelemetryPersistenceOperationError.terminal(code: "fake-begin")
+        case .ambiguousAfterCommit:
+            headers.append(header)
+            resumeHeaderWaiters()
+            throw TelemetryPersistenceOperationError.commitOutcomeUnknown(code: "fake-begin")
+        }
+    }
+
+    func persistBatch(_ records: [SequencedTelemetryRecord]) async throws {
+        batchCallCount += 1
+        resumeBatchCallWaiters()
+        let behavior = nextBehavior(&batchBehaviors)
+        switch behavior {
+        case .success:
+            batches.append(records)
+            resumeBatchWaiters()
+        case .retryableBeforeCommit:
+            throw TelemetryPersistenceOperationError.retryableBeforeCommit(code: "fake-batch")
+        case .terminal:
+            throw TelemetryPersistenceOperationError.terminal(code: "fake-batch")
+        case .ambiguousAfterCommit:
+            batches.append(records)
+            resumeBatchWaiters()
+            throw TelemetryPersistenceOperationError.commitOutcomeUnknown(code: "fake-batch")
+        }
+    }
+
+    func finalizeSession(_ finalization: TelemetrySessionFinalization) async throws {
+        finalizeCallCount += 1
+        let behavior = nextBehavior(&finalizeBehaviors)
+        switch behavior {
+        case .success:
+            finalizations.append(finalization)
+            resumeFinalizationWaiters()
+        case .retryableBeforeCommit:
+            throw TelemetryPersistenceOperationError.retryableBeforeCommit(code: "fake-finalize")
+        case .terminal:
+            throw TelemetryPersistenceOperationError.terminal(code: "fake-finalize")
+        case .ambiguousAfterCommit:
+            finalizations.append(finalization)
+            resumeFinalizationWaiters()
+            throw TelemetryPersistenceOperationError.commitOutcomeUnknown(code: "fake-finalize")
+        }
+    }
+
+    func unfinishedSessions() async throws -> [WorkoutSessionRecord] {
+        unfinished
+    }
+
+    func waitForHeaders(_ count: Int) async {
+        guard headers.count < count else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            headerWaiters.append((count, continuation))
+        }
+    }
+
+    func waitForBatches(_ count: Int) async {
+        guard batches.count < count else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            batchWaiters.append((count, continuation))
+        }
+    }
+
+    func waitForBatchCalls(_ count: Int) async {
+        guard batchCallCount < count else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            batchCallWaiters.append((count, continuation))
+        }
+    }
+
+    func waitForFinalizations(_ count: Int) async {
+        guard finalizations.count < count else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            finalizationWaiters.append((count, continuation))
+        }
+    }
+
+    func snapshot() -> (
+        headers: [WorkoutSessionRecord],
+        batches: [[SequencedTelemetryRecord]],
+        finalizations: [TelemetrySessionFinalization],
+        batchCalls: Int,
+        beginCalls: Int,
+        finalizeCalls: Int
+    ) {
+        (headers, batches, finalizations, batchCallCount, beginCallCount, finalizeCallCount)
+    }
+
+    private func nextBehavior(_ behaviors: inout [Behavior]) -> Behavior {
+        behaviors.isEmpty ? .success : behaviors.removeFirst()
+    }
+
+    private func resumeHeaderWaiters() {
+        resume(waiters: &headerWaiters, currentCount: headers.count)
+    }
+
+    private func resumeBatchWaiters() {
+        resume(waiters: &batchWaiters, currentCount: batches.count)
+    }
+
+    private func resumeBatchCallWaiters() {
+        resume(waiters: &batchCallWaiters, currentCount: batchCallCount)
+    }
+
+    private func resumeFinalizationWaiters() {
+        resume(waiters: &finalizationWaiters, currentCount: finalizations.count)
+    }
+
+    private func resume(
+        waiters: inout [(Int, CheckedContinuation<Void, Never>)],
+        currentCount: Int
+    ) {
+        var remaining: [(Int, CheckedContinuation<Void, Never>)] = []
+        for waiter in waiters {
+            if currentCount >= waiter.0 {
+                waiter.1.resume()
+            } else {
+                remaining.append(waiter)
+            }
+        }
+        waiters = remaining
+    }
+}
+
+enum TelemetryRecorderFixtures {
+    static let baseDate = Date(timeIntervalSince1970: 1_820_000_000)
+
+    static func session() -> WorkoutSessionRecord {
+        WorkoutSessionRecord(
+            recordID: RecordID(),
+            sessionID: SessionID(),
+            profileLocalIdentifier: "recorder-test-profile",
+            lifecycleState: .running,
+            workoutMode: .heartRateControlled,
+            startedAt: baseDate,
+            endedAt: nil,
+            endedElapsed: nil,
+            incompleteReason: nil,
+            appContext: AppRuntimeContext(
+                appVersion: "1.0",
+                buildNumber: "1",
+                operatingSystemVersion: "test"
+            ),
+            versions: RuntimeVersionContext(
+                telemetrySchema: TelemetrySchemaVersion(rawValue: "1.0.0"),
+                algorithm: AlgorithmVersion(rawValue: "test-algorithm"),
+                safetyPolicy: SafetyPolicyVersion(rawValue: "test-safety"),
+                workoutProtocol: WorkoutProtocolVersion(rawValue: "test-workout")
+            ),
+            configuration: ImmutableConfigurationSnapshot(
+                id: ConfigurationSnapshotID(),
+                formatVersion: 1,
+                format: .canonicalJSON,
+                canonicalPayload: Data("{}".utf8),
+                contentHash: ContentHash(
+                    algorithm: .sha256,
+                    lowercaseHexDigest: String(repeating: "0", count: 64)
+                )
+            ),
+            healthKitWorkoutIdentifier: nil,
+            treadmill: nil,
+            recorderHealth: RecorderHealthSummary(
+                isComplete: false,
+                lostCriticalRecordCount: 0,
+                lostNativeRecordCount: 0,
+                lastPersistedElapsed: nil
+            )
+        )
+    }
+
+    static func source() -> SignalSourceIdentity {
+        SignalSourceIdentity(
+            id: SourceID(),
+            providerKind: .healthKitSelected,
+            stableLocalKey: UUID().uuidString
+        )
+    }
+
+    static func sourceRecord(_ source: SignalSourceIdentity? = nil) -> TelemetryPersistenceRecord {
+        .source(
+            TelemetrySourceRecord(
+                identity: source ?? self.source(),
+                firstSeen: baseDate,
+                lastSeen: baseDate
+            )
+        )
+    }
+
+    static func heartRate(
+        sessionID: SessionID,
+        source: SignalSourceIdentity,
+        order: UInt64,
+        bpm: UInt16 = 120
+    ) -> TelemetryPersistenceRecord {
+        let elapsed = ElapsedDuration(microseconds: Int64(order) * 1_000)
+        return .heartRate(
+            HeartRateObservation(
+                recordID: RecordID(),
+                observationID: ObservationID(),
+                sessionID: sessionID,
+                source: source,
+                beatsPerMinute: bpm,
+                arrivalOrder: order,
+                providerSequence: Int64(order),
+                providerSampleIdentity: nil,
+                timestamp: ObservationTimestamp(
+                    measuredAt: baseDate,
+                    receivedAt: baseDate,
+                    recordedAt: baseDate,
+                    measuredElapsed: elapsed,
+                    receivedElapsed: elapsed,
+                    recordedElapsed: elapsed
+                ),
+                provenance: .measuredByProvider,
+                freshness: EvidenceFreshness(
+                    state: .fresh,
+                    evaluatedAt: RecordTimestamp(recordedAt: baseDate, elapsed: elapsed),
+                    age: .zero,
+                    policyVersion: SafetyPolicyVersion(rawValue: "test-safety")
+                ),
+                quality: [],
+                controlUse: .acceptedNotUsed
+            )
+        )
+    }
+
+    static func treadmill(
+        sessionID: SessionID,
+        source: SignalSourceIdentity,
+        order: UInt64
+    ) -> TelemetryPersistenceRecord {
+        let elapsed = ElapsedDuration(microseconds: Int64(order) * 1_000)
+        return .treadmill(
+            TreadmillObservation(
+                recordID: RecordID(),
+                observationID: ObservationID(),
+                sessionID: sessionID,
+                source: source,
+                nativeSpeed: NativeTreadmillSpeed(value: 5, unit: .kilometresPerHour),
+                deviceState: .moving,
+                arrivalOrder: order,
+                timestamp: ObservationTimestamp(
+                    measuredAt: baseDate,
+                    receivedAt: baseDate,
+                    recordedAt: baseDate,
+                    measuredElapsed: elapsed,
+                    receivedElapsed: elapsed,
+                    recordedElapsed: elapsed
+                ),
+                provenance: .decodedDeviceReport,
+                freshness: EvidenceFreshness(
+                    state: .fresh,
+                    evaluatedAt: RecordTimestamp(recordedAt: baseDate, elapsed: elapsed),
+                    age: .zero,
+                    policyVersion: SafetyPolicyVersion(rawValue: "test-safety")
+                ),
+                quality: []
+            )
+        )
+    }
+
+    static func event(sessionID: SessionID, order: UInt64) -> TelemetryPersistenceRecord {
+        let elapsed = ElapsedDuration(microseconds: Int64(order) * 1_000)
+        return .event(
+            WorkoutEvent(
+                recordID: RecordID(),
+                sessionID: sessionID,
+                timestamp: EventTimestamp(
+                    occurredAt: baseDate,
+                    recordedAt: baseDate,
+                    occurredElapsed: elapsed,
+                    recordedElapsed: elapsed
+                ),
+                payload: EventPayloadEnvelope(
+                    schemaVersion: 1,
+                    payload: .recorderHealth(
+                        RecorderHealthEvent(kind: .drain, count: order)
+                    )
+                )
+            )
+        )
+    }
+
+    static func frame(sessionID: SessionID, second: Int64) -> TelemetryPersistenceRecord {
+        .frame(
+            CanonicalFrame(
+                frameID: FrameID(),
+                recordID: RecordID(),
+                sessionID: sessionID,
+                canonicalElapsedSecond: second,
+                materializedAt: RecordTimestamp(
+                    recordedAt: baseDate,
+                    elapsed: ElapsedDuration(microseconds: second * 1_000_000)
+                ),
+                heartRateEvidence: nil,
+                treadmillEvidence: nil
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add an unwired TelemetryRecorder target with synchronous non-throwing ingress, recorder-local ordering, fixed-capacity priority-aware buffering, one asynchronous consumer, and count/time batching.
- Adapt the existing SwiftData TelemetryStore to the recorder persistence protocol with one explicit transaction per ordered body batch.
- Add deterministic recorder, pressure, failure, cancellation, recovery, boundary, and 10,000-record concurrent workload coverage.
- Document the concrete Issue #27 semantics and the explicit no-production-wiring boundary.

## Verification

- [x] `PYTHONPYCACHEPREFIX=/private/tmp/walkingpad-issue27-pycache python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py`
- [x] `cd ios/WalkingPadRemote/WalkingPadRemote && swift test --disable-sandbox -q` — 216 tests, 0 failures; the previously accepted 1,000-hour full profile remains intentionally skipped.
- [x] Focused TelemetryRecorder tests — 25 tests, 0 failures.
- [x] TelemetryPersistence adapter tests — 4 tests, 0 failures.
- [x] `swift package --disable-sandbox dump-package`
- [x] `xcodebuild -list -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj`
- [x] unsigned generic iOS/watchOS build with `CODE_SIGNING_ALLOWED=NO`
- [x] `git diff --check 232dca9371a58e3a2b982d35540f9b2244d11d97...988aa9df9e352ac4cacfe662e0442cb91918186a`
- [x] Fresh independent final review: GO; no P0/P1/P2 findings.

## Risks / Notes

- Initial internal defaults are injected: 2,048 slots, 256 critical reserve, 512 native reserve, 128 records or 5 seconds, and one pre-commit retry after 250 ms. Issue #31 owns integrated soak tuning.
- Exact canonical-frame identity may coalesce; bulk pressure drops or evicts frames before native/critical evidence. Any known loss prevents complete telemetry.
- A non-blocking P3 review note recommends a dedicated stale-timer-token regression when scheduler behavior next changes; generation invalidation is already implemented.
- No runtime producer, UIApplication lifecycle callback, BLE/control path, UI, or legacy persistence path is wired or changed.
- No migration, configuration, deployment, installation, launch, or physical device action is required or performed. Rollback is branch/PR removal because production runtime behavior is unchanged.

Closes #27