### PR TITLE
Add treadmill truth and command lifecycle telemetry

### DIFF
--- a/docs/telemetry-v2/treadmill-truth-and-command-lifecycle.md
+++ b/docs/telemetry-v2/treadmill-truth-and-command-lifecycle.md
@@ -1,0 +1,174 @@
+# Treadmill truth and command lifecycle
+
+Issue #29 adds typed, synchronous observation seams around the existing runtime.
+The seams are representation-only: they do not authorize or influence BLE,
+control, queueing, retry, units, HR, cooldown, Start, or stop behavior.
+
+## Ownership and risk map
+
+| Runtime owner | Authoritative truth | Observation point | Risk boundary |
+| --- | --- | --- | --- |
+| `BLETransportCodec` | Protocol-native decode | After the existing state update | Preserve native value and quality; never substitute an app target or estimate |
+| `ControllerUnitsTruthTracker` | WalkingPad unit truth and connection epoch | After `record` or `recordMalformed` | Unknown, stale, invalid, malformed, or old-epoch truth leaves normalized factual speed absent |
+| `CommandQueueService` and `BluetoothManager` | Command bytes, equality, admission, order, coalescing, interval, and write | Side metadata after the authoritative queue operation | IDs never enter `Command`; missing or mismatched metadata loses correlation instead of changing control |
+| Legacy global ACK/timeout slot | Existing ACK and timeout behavior | After the existing flag mutation | Association is `unresolvedByLegacyRuntime` with nil command and attempt IDs |
+| `StopObservationService` | The only stopped predicate | After its evaluation and finalization | Target zero, modeled zero, write success, ACK, or timeout cannot confirm stop |
+| Existing HR decision branch | The HR deliveries actually used by control | At the existing #28 control-use seam | HR decisions reuse exactly those causal references; other decisions have none |
+| Existing SwiftUI and runtime gates | Start affordance and post-tap motion authorization | Regression coverage only | Telemetry cannot become a UI or runtime gate |
+
+## Protocol observations
+
+### WalkingPad
+
+- FE01 reports speed as native controller-unit tenths.
+- The raw tenths value is retained before the legacy `raw / 10` presentation and
+  control conversion.
+- Physical km/h is produced only when the current connection epoch has fresh,
+  checksum-valid controller-unit truth.
+- Metric tenths normalize directly. Imperial tenths convert with 1 mile =
+  1.609344 km.
+- Unknown, not-read, stale, malformed, invalid-checksum, or old-epoch unit truth
+  retains the native evidence but produces no factual physical km/h.
+- The callback exposes receive time, not device measurement time, so
+  `measuredAt` is nil.
+
+### FTMS
+
+- Treadmill Data instantaneous speed is protocol-native hundredths of km/h.
+- The raw hundredths value and the existing moving state are retained.
+- No device measurement timestamp is exposed by the current parser.
+- Control Point notifications preserve their existing legacy ACK treatment; they
+  are not inferred to acknowledge a particular attempt.
+
+### FitShow
+
+- Current decoded speed is native tenths of km/h.
+- Checksum quality is retained. A bad checksum still follows the existing legacy
+  state-update path but cannot create valid factual speed evidence.
+- Status state is retained as a raw value; this change does not invent a new
+  state interpretation.
+- No device measurement timestamp is exposed.
+
+### Unknown protocol
+
+Unknown remains unknown. No factual speed, state, ACK association, or stop result
+is fabricated.
+
+## Typed speed semantics
+
+The domain keeps separate types for:
+
+- protocol-native controller/device speed;
+- normalized factual physical km/h;
+- a controller-reported target, if a protocol genuinely reports one;
+- desired app speed;
+- commanded speed;
+- expected or modeled app estimates.
+
+`speedKmh` is the existing modeled ramp. `expectedSpeedKmh` is parsed from an app
+command label. `desiredSpeedKmh` is an app intent and `deviceTargetSpeedKmh` is a
+commanded target. None can populate factual observation evidence.
+
+## Connection epoch
+
+`controllerUnitsConnectionEpoch` remains the single authoritative epoch concept.
+Treadmill observations, decisions, command lifecycle evidence, ACK/timeout
+observations, and stop evidence wrap that UUID; they do not create a competing
+runtime epoch.
+
+Queued metadata from an older epoch is cancelled observationally and cannot be
+attached to a later write. If the legacy runtime still performs a write for
+which metadata is missing or stale, the evidence is explicitly unassociated.
+Telemetry never cancels or delays the legacy write.
+
+## Decision, command, and attempt identity
+
+- `DecisionID` identifies a manual, Start, HR, cooldown, stop, or maintenance
+  decision when the existing path exposes one.
+- `CommandID` identifies a semantic command request.
+- `CommandAttemptID` identifies each actual BLE write attempt.
+- Commanded speed retains the exact protocol-native wire scale: WalkingPad
+  controller tenths, FTMS hundredths of km/h, or FitShow tenths of km/h.
+  WalkingPad command evidence never borrows controller-unit truth or claims km/h.
+- Scheduled legacy stop retries reuse one `CommandID` and receive distinct
+  attempt IDs and monotonically increasing attempt numbers.
+- A sidecar mirrors only labels and typed metadata. The legacy
+  `CommandQueueService.Command` remains exactly `Data + label`, so random IDs do
+  not affect equality, coalescing, order, or admission.
+- Queue delay is observed from authoritative enqueue and write timestamps.
+
+If sidecar order or epoch cannot be proven, correlation becomes nil. The control
+path never reads the sidecar or sink disposition.
+
+## ACK, timeout, write result, and response semantics
+
+The legacy runtime has one global pending-ACK flag rather than per-attempt ACK
+identity. Per the binding PM decision on Issue #29:
+
+- a matching notification is retained as a factual ACK observation;
+- its association is `unresolvedByLegacyRuntime`;
+- `commandID` and `attemptID` are nil;
+- it never completes a telemetry attempt;
+- replay cannot infer an association from latest/oldest/nearest command, timing,
+  queue order, target, expected/modelled speed, packet similarity, or the global
+  pending slot;
+- reconnect epoch prevents later cross-attachment.
+
+The same honesty applies to the global timeout and characteristic write-result
+callbacks. `didWriteValueFor` is a write result, not an ACK.
+
+A later treadmill report is always a new factual observation. It remains
+unassociated unless a protocol-independent deterministic proof exists; sending a
+target or waiting is not proof of response.
+
+## Stop truth
+
+`StopObservationService` remains the sole stop predicate. For WalkingPad it
+requires the existing post-write, same-context, fresh, checksum-valid FE01 report
+with raw speed zero and an accepted non-running state. Telemetry observes that
+evaluation and its finalization.
+
+FTMS and FitShow do not currently participate in that lifecycle. Their stop
+outcome therefore remains explicitly unconfirmed/confirmation-unavailable.
+
+The following are never stop confirmation:
+
+- desired, target, commanded, expected, or modeled speed zero;
+- a write call or successful write callback;
+- an ACK signal;
+- timeout;
+- a stale, missing, wrong-epoch, or checksum-invalid report.
+
+The existing retry schedule, WalkingPad toggle fallback, raw/app/modelled speed
+fallback, unavailable-stop handling, freshness window, and disconnect behavior
+are unchanged.
+
+## HR and Start invariants
+
+An HR speed decision reuses the exact `HeartRateControlUseEvidence.inputs` built
+at the accepted #28 decision branch. Manual, cooldown, Start, stop, and maintenance
+decisions do not borrow the latest HR observation.
+
+The Start HR Control affordance remains:
+
+`treadmill connected && current/fresh HR visible`
+
+It does not read factual speed, units quality, command IDs, ACK correlation, sink
+health, recorder, or persistence. After a tap, the existing Watch and controller
+units gates still fail closed before `startWithSpeed` and are not weakened.
+
+## Failure isolation and #30 boundary
+
+The optional sink is synchronous and nonthrowing. Its disposition is discarded.
+Absent, accepted, degraded, and rejected sinks must produce the same packets,
+queue order, deterministic send timing, ACK/timeout/retry behavior, targets, and
+stop outcome.
+
+No treadmill observation path performs SwiftData, `ModelContext`, filesystem or
+JSON persistence, network work, `Task`, or `await`. No raw BLE `Data` or hex is in
+the typed treadmill evidence or sidecar.
+
+Issue #30 remains responsible for production recorder/session ownership,
+persistence binding, canonical frame production, and lifecycle orchestration.
+Issue #29 does not instantiate `TelemetryRecorder`, `TelemetryPersistence`, or a
+Telemetry V2 session.

--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -44,6 +44,7 @@ let package = Package(
         ),
         .target(
             name: "WalkingPadCoreLogic",
+            dependencies: ["TelemetryDomain"],
             path: "WalkingPadRemote",
             exclude: [
                 "Assets.xcassets",
@@ -80,7 +81,8 @@ let package = Package(
                 "TreadmillTestRunService.swift",
                 "TrainingTelemetryWriter.swift",
                 "CommandQueueService.swift",
-                "TreadmillSpeedBoundsService.swift"
+                "TreadmillSpeedBoundsService.swift",
+                "TreadmillCommandTelemetrySidecar.swift"
             ]
         ),
         .testTarget(

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/TreadmillTruth.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/TreadmillTruth.swift
@@ -1,0 +1,1040 @@
+import Foundation
+
+public struct TreadmillConnectionEpoch: RawRepresentable, Codable, Hashable, Sendable,
+    CustomStringConvertible
+{
+    public let rawValue: UUID
+
+    public nonisolated init(rawValue: UUID) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String {
+        rawValue.uuidString.lowercased()
+    }
+}
+
+public enum TreadmillProtocolKind: String, Codable, Hashable, Sendable {
+    case walkingPad
+    case ftms
+    case fitShow
+    case unknown
+}
+
+public enum TreadmillNativeSpeedResolution: String, Codable, Hashable, Sendable {
+    case tenths
+    case hundredths
+
+    public var multiplier: Double {
+        switch self {
+        case .tenths:
+            0.1
+        case .hundredths:
+            0.01
+        }
+    }
+}
+
+public enum TreadmillReportedSpeedUnit: String, Codable, Hashable, Sendable {
+    case controllerUnit
+    case kilometresPerHour
+    case milesPerHour
+}
+
+public struct ReportedTreadmillNativeSpeed: Codable, Hashable, Sendable {
+    public let rawValue: Int
+    public let resolution: TreadmillNativeSpeedResolution
+    public let unit: TreadmillReportedSpeedUnit
+
+    public init(
+        rawValue: Int,
+        resolution: TreadmillNativeSpeedResolution,
+        unit: TreadmillReportedSpeedUnit
+    ) {
+        self.rawValue = rawValue
+        self.resolution = resolution
+        self.unit = unit
+    }
+
+    public var scaledValue: Double {
+        Double(rawValue) * resolution.multiplier
+    }
+}
+
+public enum TreadmillPhysicalSpeedUnit: String, Codable, Hashable, Sendable {
+    case kilometresPerHour
+    case milesPerHour
+}
+
+public enum TreadmillUnitsTruth: Codable, Hashable, Sendable {
+    case valid(
+        unit: TreadmillPhysicalSpeedUnit,
+        connectionEpoch: TreadmillConnectionEpoch,
+        observedAt: Date
+    )
+    case notRead(connectionEpoch: TreadmillConnectionEpoch)
+    case unknown(connectionEpoch: TreadmillConnectionEpoch)
+    case invalidChecksum(connectionEpoch: TreadmillConnectionEpoch)
+    case malformed(connectionEpoch: TreadmillConnectionEpoch)
+
+    public var connectionEpoch: TreadmillConnectionEpoch {
+        switch self {
+        case let .valid(_, connectionEpoch, _),
+             let .notRead(connectionEpoch),
+             let .unknown(connectionEpoch),
+             let .invalidChecksum(connectionEpoch),
+             let .malformed(connectionEpoch):
+            connectionEpoch
+        }
+    }
+}
+
+public enum TreadmillObservationQualityFlag: String, Codable, Hashable, Sendable,
+    CaseIterable
+{
+    case missingMeasurementTime
+    case missingSpeed
+    case invalidChecksum
+    case invalidNativeValue
+    case unitsNotRead
+    case unitsUnknown
+    case unitsStale
+    case unitsMalformed
+    case unitsInvalidChecksum
+    case unitsEpochMismatch
+    case unsupportedProtocol
+}
+
+public struct TreadmillObservationQualityFlags: Codable, Hashable, Sendable,
+    ExpressibleByArrayLiteral
+{
+    public private(set) var values: Set<TreadmillObservationQualityFlag>
+
+    public init(_ values: Set<TreadmillObservationQualityFlag> = []) {
+        self.values = values
+    }
+
+    public init(arrayLiteral elements: TreadmillObservationQualityFlag...) {
+        self.init(Set(elements))
+    }
+
+    public func contains(_ flag: TreadmillObservationQualityFlag) -> Bool {
+        values.contains(flag)
+    }
+
+    public mutating func insert(_ flag: TreadmillObservationQualityFlag) {
+        values.insert(flag)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(Set(try container.decode([TreadmillObservationQualityFlag].self)))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(values.sorted { $0.rawValue < $1.rawValue })
+    }
+}
+
+public enum TreadmillObservationFreshness: String, Codable, Hashable, Sendable {
+    case freshAtReceipt
+    case unknown
+}
+
+public enum TreadmillObservedResponseAssociation: Codable, Hashable, Sendable {
+    case unassociated
+    case deterministicallyCorrelated(commandID: CommandID, attemptID: CommandAttemptID)
+
+    public var commandID: CommandID? {
+        switch self {
+        case .unassociated:
+            nil
+        case let .deterministicallyCorrelated(commandID, _):
+            commandID
+        }
+    }
+
+    public var attemptID: CommandAttemptID? {
+        switch self {
+        case .unassociated:
+            nil
+        case let .deterministicallyCorrelated(_, attemptID):
+            attemptID
+        }
+    }
+}
+
+public struct TreadmillProviderObservation: Codable, Hashable, Sendable {
+    public let protocolKind: TreadmillProtocolKind
+    public let connectionEpoch: TreadmillConnectionEpoch
+    public let nativeSpeed: ReportedTreadmillNativeSpeed?
+    public let rawDeviceState: Int?
+    public let deviceState: TreadmillDeviceState
+    public let checksumValid: Bool?
+    public let measuredAt: Date?
+    public let receivedAt: Date
+
+    public init(
+        protocolKind: TreadmillProtocolKind,
+        connectionEpoch: TreadmillConnectionEpoch,
+        nativeSpeed: ReportedTreadmillNativeSpeed?,
+        rawDeviceState: Int?,
+        deviceState: TreadmillDeviceState,
+        checksumValid: Bool?,
+        measuredAt: Date?,
+        receivedAt: Date
+    ) {
+        self.protocolKind = protocolKind
+        self.connectionEpoch = connectionEpoch
+        self.nativeSpeed = nativeSpeed
+        self.rawDeviceState = rawDeviceState
+        self.deviceState = deviceState
+        self.checksumValid = checksumValid
+        self.measuredAt = measuredAt
+        self.receivedAt = receivedAt
+    }
+
+    public static func walkingPad(
+        speedRawTenths: Int?,
+        rawState: Int?,
+        deviceState: TreadmillDeviceState,
+        checksumValid: Bool,
+        connectionEpoch: TreadmillConnectionEpoch,
+        receivedAt: Date
+    ) -> Self {
+        Self(
+            protocolKind: .walkingPad,
+            connectionEpoch: connectionEpoch,
+            nativeSpeed: speedRawTenths.map {
+                ReportedTreadmillNativeSpeed(
+                    rawValue: $0,
+                    resolution: .tenths,
+                    unit: .controllerUnit
+                )
+            },
+            rawDeviceState: rawState,
+            deviceState: deviceState,
+            checksumValid: checksumValid,
+            measuredAt: nil,
+            receivedAt: receivedAt
+        )
+    }
+
+    public static func ftms(
+        speedRawHundredthsKmh: Int?,
+        rawState: Int?,
+        deviceState: TreadmillDeviceState,
+        connectionEpoch: TreadmillConnectionEpoch,
+        receivedAt: Date
+    ) -> Self {
+        Self(
+            protocolKind: .ftms,
+            connectionEpoch: connectionEpoch,
+            nativeSpeed: speedRawHundredthsKmh.map {
+                ReportedTreadmillNativeSpeed(
+                    rawValue: $0,
+                    resolution: .hundredths,
+                    unit: .kilometresPerHour
+                )
+            },
+            rawDeviceState: rawState,
+            deviceState: deviceState,
+            checksumValid: nil,
+            measuredAt: nil,
+            receivedAt: receivedAt
+        )
+    }
+
+    public static func fitShow(
+        speedRawTenthsKmh: Int?,
+        rawState: Int?,
+        deviceState: TreadmillDeviceState,
+        checksumValid: Bool,
+        connectionEpoch: TreadmillConnectionEpoch,
+        receivedAt: Date
+    ) -> Self {
+        Self(
+            protocolKind: .fitShow,
+            connectionEpoch: connectionEpoch,
+            nativeSpeed: speedRawTenthsKmh.map {
+                ReportedTreadmillNativeSpeed(
+                    rawValue: $0,
+                    resolution: .tenths,
+                    unit: .kilometresPerHour
+                )
+            },
+            rawDeviceState: rawState,
+            deviceState: deviceState,
+            checksumValid: checksumValid,
+            measuredAt: nil,
+            receivedAt: receivedAt
+        )
+    }
+
+    public static func unknown(
+        connectionEpoch: TreadmillConnectionEpoch,
+        receivedAt: Date
+    ) -> Self {
+        Self(
+            protocolKind: .unknown,
+            connectionEpoch: connectionEpoch,
+            nativeSpeed: nil,
+            rawDeviceState: nil,
+            deviceState: .unknown,
+            checksumValid: nil,
+            measuredAt: nil,
+            receivedAt: receivedAt
+        )
+    }
+}
+
+public struct TreadmillObservationEvidence: Codable, Hashable, Sendable {
+    public let observationID: ObservationID
+    public let protocolKind: TreadmillProtocolKind
+    public let connectionEpoch: TreadmillConnectionEpoch
+    public let nativeSpeed: ReportedTreadmillNativeSpeed?
+    public let factualSpeed: FactualSpeedKilometresPerHour?
+    public let rawDeviceState: Int?
+    public let deviceState: TreadmillDeviceState
+    public let measuredAt: Date?
+    public let receivedAt: Date
+    public let recordedAt: Date
+    public let arrivalOrder: UInt64
+    public let freshness: TreadmillObservationFreshness
+    public let quality: TreadmillObservationQualityFlags
+    public let provenance: EvidenceProvenance
+    public let responseAssociation: TreadmillObservedResponseAssociation
+
+    public var commandID: CommandID? {
+        responseAssociation.commandID
+    }
+
+    public var attemptID: CommandAttemptID? {
+        responseAssociation.attemptID
+    }
+}
+
+public struct TreadmillObservationNormalizer: Sendable {
+    public static let defaultControllerUnitsFreshnessInterval: TimeInterval = 30
+
+    private var nextArrivalOrder: UInt64 = 1
+    private let controllerUnitsFreshnessInterval: TimeInterval
+
+    public init(
+        controllerUnitsFreshnessInterval: TimeInterval = Self.defaultControllerUnitsFreshnessInterval
+    ) {
+        self.controllerUnitsFreshnessInterval = controllerUnitsFreshnessInterval
+    }
+
+    public mutating func normalize(
+        _ observation: TreadmillProviderObservation,
+        unitsTruth: TreadmillUnitsTruth?,
+        observationID: ObservationID,
+        recordedAt: Date
+    ) -> TreadmillObservationEvidence {
+        var quality: TreadmillObservationQualityFlags = []
+        if observation.measuredAt == nil {
+            quality.insert(.missingMeasurementTime)
+        }
+        if observation.nativeSpeed == nil {
+            quality.insert(.missingSpeed)
+        }
+        if observation.checksumValid == false {
+            quality.insert(.invalidChecksum)
+        }
+        if observation.protocolKind == .unknown {
+            quality.insert(.unsupportedProtocol)
+        }
+
+        let factualSpeed = normalizedFactualSpeed(
+            for: observation,
+            unitsTruth: unitsTruth,
+            quality: &quality
+        )
+        let arrivalOrder = nextArrivalOrder
+        if nextArrivalOrder < UInt64.max {
+            nextArrivalOrder += 1
+        }
+
+        return TreadmillObservationEvidence(
+            observationID: observationID,
+            protocolKind: observation.protocolKind,
+            connectionEpoch: observation.connectionEpoch,
+            nativeSpeed: observation.nativeSpeed,
+            factualSpeed: factualSpeed,
+            rawDeviceState: observation.rawDeviceState,
+            deviceState: observation.deviceState,
+            measuredAt: observation.measuredAt,
+            receivedAt: observation.receivedAt,
+            recordedAt: recordedAt,
+            arrivalOrder: arrivalOrder,
+            freshness: observation.protocolKind == .unknown ? .unknown : .freshAtReceipt,
+            quality: quality,
+            provenance: .decodedDeviceReport,
+            responseAssociation: .unassociated
+        )
+    }
+
+    private func normalizedFactualSpeed(
+        for observation: TreadmillProviderObservation,
+        unitsTruth: TreadmillUnitsTruth?,
+        quality: inout TreadmillObservationQualityFlags
+    ) -> FactualSpeedKilometresPerHour? {
+        guard observation.checksumValid != false,
+              let nativeSpeed = observation.nativeSpeed,
+              nativeSpeed.rawValue >= 0 else {
+            if observation.nativeSpeed?.rawValue ?? 0 < 0 {
+                quality.insert(.invalidNativeValue)
+            }
+            return nil
+        }
+
+        switch observation.protocolKind {
+        case .ftms, .fitShow:
+            return FactualSpeedKilometresPerHour.normalized(
+                from: NativeTreadmillSpeed(
+                    value: nativeSpeed.scaledValue,
+                    unit: nativeSpeed.unit == .milesPerHour
+                        ? .milesPerHour
+                        : .kilometresPerHour
+                ),
+                provenance: .decodedDeviceReport
+            )
+
+        case .walkingPad:
+            guard let unitsTruth else {
+                quality.insert(.unitsUnknown)
+                return nil
+            }
+            guard unitsTruth.connectionEpoch == observation.connectionEpoch else {
+                quality.insert(.unitsEpochMismatch)
+                return nil
+            }
+            switch unitsTruth {
+            case let .valid(unit, _, observedAt):
+                let age = observation.receivedAt.timeIntervalSince(observedAt)
+                guard age >= 0, age <= controllerUnitsFreshnessInterval else {
+                    quality.insert(.unitsStale)
+                    return nil
+                }
+                let nativeUnit: TreadmillNativeSpeedUnit = unit == .milesPerHour
+                    ? .milesPerHour
+                    : .kilometresPerHour
+                return FactualSpeedKilometresPerHour.normalized(
+                    from: NativeTreadmillSpeed(
+                        value: nativeSpeed.scaledValue,
+                        unit: nativeUnit
+                    ),
+                    provenance: .decodedDeviceReport
+                )
+            case .notRead:
+                quality.insert(.unitsNotRead)
+                return nil
+            case .unknown:
+                quality.insert(.unitsUnknown)
+                return nil
+            case .invalidChecksum:
+                quality.insert(.unitsInvalidChecksum)
+                return nil
+            case .malformed:
+                quality.insert(.unitsMalformed)
+                return nil
+            }
+
+        case .unknown:
+            return nil
+        }
+    }
+}
+
+public struct ControllerReportedTargetSpeed: Codable, Hashable, Sendable {
+    public let nativeValue: Double
+    public let nativeUnit: TreadmillNativeSpeedUnit
+
+    public init(nativeValue: Double, nativeUnit: TreadmillNativeSpeedUnit) {
+        self.nativeValue = nativeValue
+        self.nativeUnit = nativeUnit
+    }
+}
+
+public struct TreadmillSpeedSemanticsSnapshot: Codable, Hashable, Sendable {
+    public let desired: DesiredSpeedKilometresPerHour?
+    public let commanded: CommandedSpeed?
+    public let controllerReportedTarget: ControllerReportedTargetSpeed?
+    public let expectedEstimate: EstimatedSpeedKilometresPerHour?
+    public let modeledEstimate: EstimatedSpeedKilometresPerHour?
+
+    public init(
+        desired: DesiredSpeedKilometresPerHour?,
+        commanded: CommandedSpeed?,
+        controllerReportedTarget: ControllerReportedTargetSpeed?,
+        expectedEstimate: EstimatedSpeedKilometresPerHour?,
+        modeledEstimate: EstimatedSpeedKilometresPerHour?
+    ) {
+        self.desired = desired
+        self.commanded = commanded
+        self.controllerReportedTarget = controllerReportedTarget
+        self.expectedEstimate = expectedEstimate
+        self.modeledEstimate = modeledEstimate
+    }
+}
+
+public enum TreadmillCommandedSpeedRepresentation {
+    public static func walkingPad(rawControllerTenths: Int) -> CommandedSpeed {
+        CommandedSpeed(
+            nativeValue: Double(rawControllerTenths),
+            nativeUnit: .controllerNative(code: "walkingpad_controller_tenths")
+        )
+    }
+
+    public static func ftms(rawHundredthsKmh: UInt16) -> CommandedSpeed {
+        CommandedSpeed(
+            nativeValue: Double(rawHundredthsKmh),
+            nativeUnit: .controllerNative(code: "ftms_hundredths_kmh")
+        )
+    }
+
+    public static func fitShow(rawTenthsKmh: UInt8) -> CommandedSpeed {
+        CommandedSpeed(
+            nativeValue: Double(rawTenthsKmh),
+            nativeUnit: .controllerNative(code: "fitshow_tenths_kmh")
+        )
+    }
+
+}
+
+public enum TreadmillControlDecisionSource: String, Codable, Hashable, Sendable {
+    case manual
+    case heartRateControl
+    case cooldown
+    case start
+    case stop
+    case protocolMaintenance
+    case unknown
+}
+
+public enum TreadmillControlDecisionIntent: Codable, Hashable, Sendable {
+    case startAtDesiredSpeed(DesiredSpeedKilometresPerHour)
+    case setDesiredSpeed(DesiredSpeedKilometresPerHour)
+    case stop
+    case hold
+    case requestControl
+    case queryControllerUnits
+    case other(String)
+}
+
+public struct TreadmillControlDecisionEvidence: Codable, Hashable, Sendable {
+    public let decisionID: DecisionID
+    public let source: TreadmillControlDecisionSource
+    public let intent: TreadmillControlDecisionIntent
+    public let heartRateInputs: [HeartRateCausalReference]
+    public let occurredAt: Date
+    public let connectionEpoch: TreadmillConnectionEpoch
+
+    public init(
+        decisionID: DecisionID,
+        source: TreadmillControlDecisionSource,
+        intent: TreadmillControlDecisionIntent,
+        heartRateInputs: [HeartRateCausalReference],
+        occurredAt: Date,
+        connectionEpoch: TreadmillConnectionEpoch
+    ) {
+        self.decisionID = decisionID
+        self.source = source
+        self.intent = intent
+        self.heartRateInputs = source == .heartRateControl ? heartRateInputs : []
+        self.occurredAt = occurredAt
+        self.connectionEpoch = connectionEpoch
+    }
+}
+
+public enum TreadmillCommandWriteType: String, Codable, Hashable, Sendable {
+    case withResponse
+    case withoutResponse
+}
+
+public struct TreadmillCommandEnqueuedEvidence: Codable, Hashable, Sendable {
+    public let commandID: CommandID
+    public let decisionID: DecisionID?
+    public let kind: CommandKind
+    public let protocolKind: TreadmillProtocolKind
+    public let connectionEpoch: TreadmillConnectionEpoch
+    public let enqueuedAt: Date
+
+    public init(
+        commandID: CommandID,
+        decisionID: DecisionID?,
+        kind: CommandKind,
+        protocolKind: TreadmillProtocolKind,
+        connectionEpoch: TreadmillConnectionEpoch,
+        enqueuedAt: Date
+    ) {
+        self.commandID = commandID
+        self.decisionID = decisionID
+        self.kind = kind
+        self.protocolKind = protocolKind
+        self.connectionEpoch = connectionEpoch
+        self.enqueuedAt = enqueuedAt
+    }
+}
+
+public struct TreadmillCommandSendAttemptEvidence: Codable, Hashable, Sendable {
+    public let commandID: CommandID
+    public let decisionID: DecisionID?
+    public let attemptID: CommandAttemptID
+    public let attemptNumber: UInt16
+    public let protocolKind: TreadmillProtocolKind
+    public let connectionEpoch: TreadmillConnectionEpoch
+    public let sentAt: Date
+    public let writeType: TreadmillCommandWriteType
+
+    public init(
+        commandID: CommandID,
+        decisionID: DecisionID?,
+        attemptID: CommandAttemptID,
+        attemptNumber: UInt16,
+        protocolKind: TreadmillProtocolKind,
+        connectionEpoch: TreadmillConnectionEpoch,
+        sentAt: Date,
+        writeType: TreadmillCommandWriteType
+    ) {
+        self.commandID = commandID
+        self.decisionID = decisionID
+        self.attemptID = attemptID
+        self.attemptNumber = attemptNumber
+        self.protocolKind = protocolKind
+        self.connectionEpoch = connectionEpoch
+        self.sentAt = sentAt
+        self.writeType = writeType
+    }
+}
+
+public struct UnassociatedLegacyWriteObservation: Codable, Hashable, Sendable {
+    public let protocolKind: TreadmillProtocolKind
+    public let connectionEpoch: TreadmillConnectionEpoch
+    public let sentAt: Date
+    public let writeType: TreadmillCommandWriteType
+
+    public init(
+        protocolKind: TreadmillProtocolKind,
+        connectionEpoch: TreadmillConnectionEpoch,
+        sentAt: Date,
+        writeType: TreadmillCommandWriteType
+    ) {
+        self.protocolKind = protocolKind
+        self.connectionEpoch = connectionEpoch
+        self.sentAt = sentAt
+        self.writeType = writeType
+    }
+}
+
+public struct TreadmillCommandQueueDelayEvidence: Codable, Hashable, Sendable {
+    public let commandID: CommandID
+    public let decisionID: DecisionID?
+    public let connectionEpoch: TreadmillConnectionEpoch
+    public let enqueuedAt: Date
+    public let sentAt: Date
+
+    public init(
+        commandID: CommandID,
+        decisionID: DecisionID?,
+        connectionEpoch: TreadmillConnectionEpoch,
+        enqueuedAt: Date,
+        sentAt: Date
+    ) {
+        self.commandID = commandID
+        self.decisionID = decisionID
+        self.connectionEpoch = connectionEpoch
+        self.enqueuedAt = enqueuedAt
+        self.sentAt = sentAt
+    }
+
+    public var delay: TimeInterval {
+        max(0, sentAt.timeIntervalSince(enqueuedAt))
+    }
+}
+
+public enum LegacyAcknowledgementAssociation: Codable, Hashable, Sendable {
+    case unresolvedByLegacyRuntime
+    case deterministicallyCorrelated(commandID: CommandID, attemptID: CommandAttemptID)
+}
+
+/// An opaque capability supplied only by a decoder that has independently
+/// proven an ACK-to-attempt edge. Current production protocols create none.
+public struct TreadmillDeterministicAcknowledgementProof: Hashable, Sendable {
+    private let evidenceKey: UUID
+
+    init(evidenceKey: UUID) {
+        self.evidenceKey = evidenceKey
+    }
+}
+
+public struct LegacyAcknowledgementObservation: Codable, Hashable, Sendable {
+    public let protocolKind: TreadmillProtocolKind
+    public let connectionEpoch: TreadmillConnectionEpoch
+    public let receivedAt: Date
+    public let recordedAt: Date
+    public let association: LegacyAcknowledgementAssociation
+
+    public var commandID: CommandID? {
+        switch association {
+        case .unresolvedByLegacyRuntime:
+            nil
+        case let .deterministicallyCorrelated(commandID, _):
+            commandID
+        }
+    }
+
+    public var attemptID: CommandAttemptID? {
+        switch association {
+        case .unresolvedByLegacyRuntime:
+            nil
+        case let .deterministicallyCorrelated(_, attemptID):
+            attemptID
+        }
+    }
+
+    public static func unresolved(
+        protocolKind: TreadmillProtocolKind,
+        connectionEpoch: TreadmillConnectionEpoch,
+        receivedAt: Date,
+        recordedAt: Date
+    ) -> Self {
+        Self(
+            protocolKind: protocolKind,
+            connectionEpoch: connectionEpoch,
+            receivedAt: receivedAt,
+            recordedAt: recordedAt,
+            association: .unresolvedByLegacyRuntime
+        )
+    }
+
+    public static func deterministicallyAssociated(
+        protocolKind: TreadmillProtocolKind,
+        connectionEpoch: TreadmillConnectionEpoch,
+        receivedAt: Date,
+        recordedAt: Date,
+        sendAttempt: TreadmillCommandSendAttemptEvidence,
+        proof: TreadmillDeterministicAcknowledgementProof
+    ) -> Self? {
+        _ = proof
+        guard sendAttempt.connectionEpoch == connectionEpoch else {
+            return nil
+        }
+        return Self(
+            protocolKind: protocolKind,
+            connectionEpoch: connectionEpoch,
+            receivedAt: receivedAt,
+            recordedAt: recordedAt,
+            association: .deterministicallyCorrelated(
+                commandID: sendAttempt.commandID,
+                attemptID: sendAttempt.attemptID
+            )
+        )
+    }
+}
+
+public struct LegacyCommandTimeoutObservation: Codable, Hashable, Sendable {
+    public let protocolKind: TreadmillProtocolKind
+    public let connectionEpoch: TreadmillConnectionEpoch
+    public let occurredAt: Date
+    public let association: LegacyAcknowledgementAssociation
+
+    public init(
+        protocolKind: TreadmillProtocolKind,
+        connectionEpoch: TreadmillConnectionEpoch,
+        occurredAt: Date
+    ) {
+        self.protocolKind = protocolKind
+        self.connectionEpoch = connectionEpoch
+        self.occurredAt = occurredAt
+        self.association = .unresolvedByLegacyRuntime
+    }
+
+    public var commandID: CommandID? { nil }
+
+    public var attemptID: CommandAttemptID? { nil }
+
+    private enum CodingKeys: String, CodingKey {
+        case protocolKind
+        case connectionEpoch
+        case occurredAt
+        case association
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let association = try container.decode(
+            LegacyAcknowledgementAssociation.self,
+            forKey: .association
+        )
+        guard association == .unresolvedByLegacyRuntime else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .association,
+                in: container,
+                debugDescription: "Legacy timeout association must remain unresolved"
+            )
+        }
+        self.protocolKind = try container.decode(
+            TreadmillProtocolKind.self,
+            forKey: .protocolKind
+        )
+        self.connectionEpoch = try container.decode(
+            TreadmillConnectionEpoch.self,
+            forKey: .connectionEpoch
+        )
+        self.occurredAt = try container.decode(Date.self, forKey: .occurredAt)
+        self.association = association
+    }
+}
+
+public enum TreadmillWriteResultStatus: String, Codable, Hashable, Sendable {
+    case succeeded
+    case failed
+}
+
+public struct LegacyWriteResultObservation: Codable, Hashable, Sendable {
+    public let protocolKind: TreadmillProtocolKind
+    public let connectionEpoch: TreadmillConnectionEpoch
+    public let occurredAt: Date
+    public let status: TreadmillWriteResultStatus
+    public let association: LegacyAcknowledgementAssociation
+
+    public init(
+        protocolKind: TreadmillProtocolKind,
+        connectionEpoch: TreadmillConnectionEpoch,
+        occurredAt: Date,
+        status: TreadmillWriteResultStatus
+    ) {
+        self.protocolKind = protocolKind
+        self.connectionEpoch = connectionEpoch
+        self.occurredAt = occurredAt
+        self.status = status
+        self.association = .unresolvedByLegacyRuntime
+    }
+
+    public var commandID: CommandID? { nil }
+
+    public var attemptID: CommandAttemptID? { nil }
+
+    private enum CodingKeys: String, CodingKey {
+        case protocolKind
+        case connectionEpoch
+        case occurredAt
+        case status
+        case association
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let association = try container.decode(
+            LegacyAcknowledgementAssociation.self,
+            forKey: .association
+        )
+        guard association == .unresolvedByLegacyRuntime else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .association,
+                in: container,
+                debugDescription: "Legacy write-result association must remain unresolved"
+            )
+        }
+        self.protocolKind = try container.decode(
+            TreadmillProtocolKind.self,
+            forKey: .protocolKind
+        )
+        self.connectionEpoch = try container.decode(
+            TreadmillConnectionEpoch.self,
+            forKey: .connectionEpoch
+        )
+        self.occurredAt = try container.decode(Date.self, forKey: .occurredAt)
+        self.status = try container.decode(
+            TreadmillWriteResultStatus.self,
+            forKey: .status
+        )
+        self.association = association
+    }
+}
+
+public struct TreadmillCommandFailureObservation: Codable, Hashable, Sendable {
+    public let commandID: CommandID?
+    public let decisionID: DecisionID?
+    public let attemptID: CommandAttemptID?
+    public let connectionEpoch: TreadmillConnectionEpoch?
+    public let occurredAt: Date
+    public let reason: CommandFailureReason
+
+    public init(
+        commandID: CommandID?,
+        decisionID: DecisionID?,
+        attemptID: CommandAttemptID?,
+        connectionEpoch: TreadmillConnectionEpoch?,
+        occurredAt: Date,
+        reason: CommandFailureReason
+    ) {
+        self.commandID = commandID
+        self.decisionID = decisionID
+        self.attemptID = attemptID
+        self.connectionEpoch = connectionEpoch
+        self.occurredAt = occurredAt
+        self.reason = reason
+    }
+}
+
+public struct TreadmillCommandCancellationObservation: Codable, Hashable, Sendable {
+    public let commandID: CommandID
+    public let decisionID: DecisionID?
+    public let connectionEpoch: TreadmillConnectionEpoch
+    public let occurredAt: Date
+    public let reason: CommandCancellationReason
+
+    public init(
+        commandID: CommandID,
+        decisionID: DecisionID?,
+        connectionEpoch: TreadmillConnectionEpoch,
+        occurredAt: Date,
+        reason: CommandCancellationReason
+    ) {
+        self.commandID = commandID
+        self.decisionID = decisionID
+        self.connectionEpoch = connectionEpoch
+        self.occurredAt = occurredAt
+        self.reason = reason
+    }
+}
+
+public struct TreadmillUnitsTruthEvidence: Codable, Hashable, Sendable {
+    public let truth: TreadmillUnitsTruth
+    public let observedAt: Date
+
+    public init(truth: TreadmillUnitsTruth, observedAt: Date) {
+        self.truth = truth
+        self.observedAt = observedAt
+    }
+}
+
+public struct TreadmillStopTruthEvidence: Codable, Hashable, Sendable {
+    public let stopAttemptID: UUID
+    public let decisionID: DecisionID?
+    public let commandID: CommandID?
+    public let observationID: ObservationID?
+    public let connectionEpoch: TreadmillConnectionEpoch
+    public let protocolKind: TreadmillProtocolKind
+    public let conclusion: StopEvidenceConclusion
+    public let rawSpeedTenths: Int?
+    public let rawDeviceState: Int?
+    public let checksumValid: Bool?
+    public let observationReceivedAt: Date?
+    public let evaluatedAt: Date
+
+    public init(
+        stopAttemptID: UUID,
+        decisionID: DecisionID?,
+        commandID: CommandID?,
+        observationID: ObservationID?,
+        connectionEpoch: TreadmillConnectionEpoch,
+        protocolKind: TreadmillProtocolKind,
+        conclusion: StopEvidenceConclusion,
+        rawSpeedTenths: Int?,
+        rawDeviceState: Int?,
+        checksumValid: Bool?,
+        observationReceivedAt: Date?,
+        evaluatedAt: Date
+    ) {
+        self.stopAttemptID = stopAttemptID
+        self.decisionID = decisionID
+        self.commandID = commandID
+        self.observationID = observationID
+        self.connectionEpoch = connectionEpoch
+        self.protocolKind = protocolKind
+        self.conclusion = conclusion
+        self.rawSpeedTenths = rawSpeedTenths
+        self.rawDeviceState = rawDeviceState
+        self.checksumValid = checksumValid
+        self.observationReceivedAt = observationReceivedAt
+        self.evaluatedAt = evaluatedAt
+    }
+}
+
+public enum TreadmillAttemptEvidenceState: String, Codable, Hashable, Sendable {
+    case sent
+    case acknowledged
+    case timedOut
+    case failed
+    case cancelled
+}
+
+public struct TreadmillCommandEvidenceLedger: Sendable {
+    private struct Entry: Sendable {
+        let sendAttempt: TreadmillCommandSendAttemptEvidence
+        var state: TreadmillAttemptEvidenceState
+    }
+
+    private var entries: [CommandAttemptID: Entry] = [:]
+
+    public init() {}
+
+    public var attemptCount: Int {
+        entries.count
+    }
+
+    public mutating func recordSendAttempt(_ sendAttempt: TreadmillCommandSendAttemptEvidence) {
+        entries[sendAttempt.attemptID] = Entry(sendAttempt: sendAttempt, state: .sent)
+    }
+
+    public mutating func observeAcknowledgement(_ acknowledgement: LegacyAcknowledgementObservation) {
+        guard case let .deterministicallyCorrelated(commandID, attemptID) = acknowledgement.association,
+              var entry = entries[attemptID],
+              entry.sendAttempt.commandID == commandID,
+              entry.sendAttempt.connectionEpoch == acknowledgement.connectionEpoch else {
+            return
+        }
+        entry.state = .acknowledged
+        entries[attemptID] = entry
+    }
+
+    public func state(for attemptID: CommandAttemptID) -> TreadmillAttemptEvidenceState? {
+        entries[attemptID]?.state
+    }
+}
+
+public enum TreadmillTelemetrySinkDisposition: String, Codable, Hashable, Sendable,
+    CaseIterable
+{
+    case accepted
+    case degraded
+    case rejected
+    case unavailable
+}
+
+public enum TreadmillTelemetryEvidence: Codable, Hashable, Sendable {
+    case observation(TreadmillObservationEvidence)
+    case unitsTruth(TreadmillUnitsTruthEvidence)
+    case decision(TreadmillControlDecisionEvidence)
+    case commandEnqueued(TreadmillCommandEnqueuedEvidence)
+    case commandQueueDelay(TreadmillCommandQueueDelayEvidence)
+    case sendAttempt(TreadmillCommandSendAttemptEvidence)
+    case unassociatedWrite(UnassociatedLegacyWriteObservation)
+    case acknowledgement(LegacyAcknowledgementObservation)
+    case writeResult(LegacyWriteResultObservation)
+    case commandTimeout(LegacyCommandTimeoutObservation)
+    case commandFailed(TreadmillCommandFailureObservation)
+    case commandCancelled(TreadmillCommandCancellationObservation)
+    case stopEvidence(TreadmillStopTruthEvidence)
+}
+
+public protocol TreadmillTelemetrySink: AnyObject {
+    func observeTreadmillEvidence(
+        _ evidence: TreadmillTelemetryEvidence
+    ) -> TreadmillTelemetrySinkDisposition
+}
+
+public enum TreadmillObservationalTee {
+    public static func afterLegacyAction(
+        _ legacyAction: () -> Void,
+        observe: (() -> TreadmillTelemetrySinkDisposition)?
+    ) {
+        legacyAction()
+        _ = observe?()
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/TreadmillTruthTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/TreadmillTruthTests.swift
@@ -1,0 +1,697 @@
+import Foundation
+import XCTest
+@testable import TelemetryDomain
+
+final class TreadmillTruthTests: XCTestCase {
+    private let receivedAt = Date(timeIntervalSince1970: 1_700_000_100)
+    private let recordedAt = Date(timeIntervalSince1970: 1_700_000_101)
+
+    func testWalkingPadMetricTruthNormalizesRawTenthsInCurrentEpoch() throws {
+        let epoch = connectionEpoch(1)
+        var normalizer = TreadmillObservationNormalizer()
+
+        let evidence = normalizer.normalize(
+            .walkingPad(
+                speedRawTenths: 37,
+                rawState: 1,
+                deviceState: .moving,
+                checksumValid: true,
+                connectionEpoch: epoch,
+                receivedAt: receivedAt
+            ),
+            unitsTruth: .valid(
+                unit: .kilometresPerHour,
+                connectionEpoch: epoch,
+                observedAt: receivedAt.addingTimeInterval(-1)
+            ),
+            observationID: observationID(1),
+            recordedAt: recordedAt
+        )
+
+        XCTAssertEqual(evidence.nativeSpeed?.rawValue, 37)
+        XCTAssertEqual(evidence.nativeSpeed?.resolution, .tenths)
+        XCTAssertEqual(evidence.nativeSpeed?.unit, .controllerUnit)
+        XCTAssertEqual(try XCTUnwrap(evidence.factualSpeed).value, 3.7, accuracy: 0.000_001)
+        XCTAssertEqual(evidence.measuredAt, nil)
+        XCTAssertEqual(evidence.connectionEpoch, epoch)
+    }
+
+    func testWalkingPadImperialTruthNormalizesThroughExplicitPhysicalUnit() throws {
+        let epoch = connectionEpoch(2)
+        var normalizer = TreadmillObservationNormalizer()
+        let evidence = normalizer.normalize(
+            .walkingPad(
+                speedRawTenths: 25,
+                rawState: 1,
+                deviceState: .moving,
+                checksumValid: true,
+                connectionEpoch: epoch,
+                receivedAt: receivedAt
+            ),
+            unitsTruth: .valid(
+                unit: .milesPerHour,
+                connectionEpoch: epoch,
+                observedAt: receivedAt
+            ),
+            observationID: observationID(2),
+            recordedAt: recordedAt
+        )
+
+        XCTAssertEqual(
+            try XCTUnwrap(evidence.factualSpeed).value,
+            2.5 * 1.609_344,
+            accuracy: 0.000_001
+        )
+        XCTAssertEqual(evidence.quality.values, [.missingMeasurementTime])
+    }
+
+    func testWalkingPadUnknownStaleMalformedAndOldEpochTruthNeverNormalizes() {
+        let currentEpoch = connectionEpoch(3)
+        let oldEpoch = connectionEpoch(4)
+        let input = TreadmillProviderObservation.walkingPad(
+            speedRawTenths: 42,
+            rawState: 1,
+            deviceState: .moving,
+            checksumValid: true,
+            connectionEpoch: currentEpoch,
+            receivedAt: receivedAt
+        )
+        let cases: [(TreadmillUnitsTruth, TreadmillObservationQualityFlag)] = [
+            (.unknown(connectionEpoch: currentEpoch), .unitsUnknown),
+            (
+                .valid(
+                    unit: .kilometresPerHour,
+                    connectionEpoch: currentEpoch,
+                    observedAt: receivedAt.addingTimeInterval(-31)
+                ),
+                .unitsStale
+            ),
+            (.malformed(connectionEpoch: currentEpoch), .unitsMalformed),
+            (.invalidChecksum(connectionEpoch: currentEpoch), .unitsInvalidChecksum),
+            (
+                .valid(
+                    unit: .kilometresPerHour,
+                    connectionEpoch: oldEpoch,
+                    observedAt: receivedAt
+                ),
+                .unitsEpochMismatch
+            ),
+        ]
+
+        for (index, testCase) in cases.enumerated() {
+            var normalizer = TreadmillObservationNormalizer()
+            let evidence = normalizer.normalize(
+                input,
+                unitsTruth: testCase.0,
+                observationID: observationID(10 + index),
+                recordedAt: recordedAt
+            )
+            XCTAssertNil(evidence.factualSpeed)
+            XCTAssertTrue(evidence.quality.contains(testCase.1))
+            XCTAssertEqual(evidence.nativeSpeed?.rawValue, 42)
+        }
+    }
+
+    func testChecksumFailureAndMissingSpeedPreserveEvidenceWithoutFactualSpeed() {
+        let epoch = connectionEpoch(5)
+        let units = TreadmillUnitsTruth.valid(
+            unit: .kilometresPerHour,
+            connectionEpoch: epoch,
+            observedAt: receivedAt
+        )
+        var normalizer = TreadmillObservationNormalizer()
+
+        let invalidChecksum = normalizer.normalize(
+            .walkingPad(
+                speedRawTenths: 10,
+                rawState: 1,
+                deviceState: .moving,
+                checksumValid: false,
+                connectionEpoch: epoch,
+                receivedAt: receivedAt
+            ),
+            unitsTruth: units,
+            observationID: observationID(20),
+            recordedAt: recordedAt
+        )
+        let missingSpeed = normalizer.normalize(
+            .walkingPad(
+                speedRawTenths: nil,
+                rawState: 0,
+                deviceState: .stopped,
+                checksumValid: true,
+                connectionEpoch: epoch,
+                receivedAt: receivedAt
+            ),
+            unitsTruth: units,
+            observationID: observationID(21),
+            recordedAt: recordedAt
+        )
+
+        XCTAssertEqual(invalidChecksum.nativeSpeed?.rawValue, 10)
+        XCTAssertNil(invalidChecksum.factualSpeed)
+        XCTAssertTrue(invalidChecksum.quality.contains(.invalidChecksum))
+        XCTAssertNil(missingSpeed.nativeSpeed)
+        XCTAssertNil(missingSpeed.factualSpeed)
+        XCTAssertTrue(missingSpeed.quality.contains(.missingSpeed))
+    }
+
+    func testFtmsAndFitShowPreserveProtocolNativeSemantics() throws {
+        let epoch = connectionEpoch(6)
+        var normalizer = TreadmillObservationNormalizer()
+
+        let ftms = normalizer.normalize(
+            .ftms(
+                speedRawHundredthsKmh: 425,
+                rawState: nil,
+                deviceState: .moving,
+                connectionEpoch: epoch,
+                receivedAt: receivedAt
+            ),
+            unitsTruth: nil,
+            observationID: observationID(30),
+            recordedAt: recordedAt
+        )
+        let invalidFitShow = normalizer.normalize(
+            .fitShow(
+                speedRawTenthsKmh: 32,
+                rawState: 1,
+                deviceState: .moving,
+                checksumValid: false,
+                connectionEpoch: epoch,
+                receivedAt: receivedAt
+            ),
+            unitsTruth: nil,
+            observationID: observationID(31),
+            recordedAt: recordedAt
+        )
+
+        XCTAssertEqual(ftms.nativeSpeed?.resolution, .hundredths)
+        XCTAssertEqual(ftms.nativeSpeed?.unit, .kilometresPerHour)
+        XCTAssertEqual(try XCTUnwrap(ftms.factualSpeed).value, 4.25, accuracy: 0.000_001)
+        XCTAssertEqual(invalidFitShow.nativeSpeed?.rawValue, 32)
+        XCTAssertNil(invalidFitShow.factualSpeed)
+        XCTAssertTrue(invalidFitShow.quality.contains(.invalidChecksum))
+    }
+
+    func testUnknownProtocolRemainsUnknownAndDoesNotFabricateSpeed() {
+        let epoch = connectionEpoch(7)
+        var normalizer = TreadmillObservationNormalizer()
+        let evidence = normalizer.normalize(
+            .unknown(connectionEpoch: epoch, receivedAt: receivedAt),
+            unitsTruth: nil,
+            observationID: observationID(40),
+            recordedAt: recordedAt
+        )
+
+        XCTAssertEqual(evidence.protocolKind, .unknown)
+        XCTAssertNil(evidence.nativeSpeed)
+        XCTAssertNil(evidence.factualSpeed)
+        XCTAssertTrue(evidence.quality.contains(.unsupportedProtocol))
+    }
+
+    func testDesiredCommandedAndEstimatedValuesCannotPopulateFactualObservation() {
+        let snapshot = TreadmillSpeedSemanticsSnapshot(
+            desired: DesiredSpeedKilometresPerHour(value: 4.0),
+            commanded: CommandedSpeed(nativeValue: 40, nativeUnit: .controllerNative(code: "tenths")),
+            controllerReportedTarget: nil,
+            expectedEstimate: EstimatedSpeedKilometresPerHour(
+                value: 4.0,
+                method: "legacy-label-expected-speed",
+                version: "v1"
+            ),
+            modeledEstimate: EstimatedSpeedKilometresPerHour(
+                value: 3.4,
+                method: "legacy-one-second-ramp",
+                version: "v1"
+            )
+        )
+
+        XCTAssertEqual(snapshot.desired?.value, 4.0)
+        XCTAssertEqual(snapshot.commanded?.nativeValue, 40)
+        XCTAssertEqual(snapshot.expectedEstimate?.value, 4.0)
+        XCTAssertEqual(snapshot.modeledEstimate?.value, 3.4)
+        // There is intentionally no factual-speed field on this non-observation type.
+    }
+
+    func testProtocolNativeCommandedSpeedsPreserveWireScaleWithoutUnitInference() {
+        let walkingPad = TreadmillCommandedSpeedRepresentation.walkingPad(
+            rawControllerTenths: 40
+        )
+        let ftms = TreadmillCommandedSpeedRepresentation.ftms(rawHundredthsKmh: 400)
+        let fitShow = TreadmillCommandedSpeedRepresentation.fitShow(rawTenthsKmh: 40)
+
+        XCTAssertEqual(walkingPad.nativeValue, 40)
+        XCTAssertEqual(
+            walkingPad.nativeUnit,
+            .controllerNative(code: "walkingpad_controller_tenths")
+        )
+        XCTAssertEqual(ftms.nativeValue, 400)
+        XCTAssertEqual(ftms.nativeUnit, .controllerNative(code: "ftms_hundredths_kmh"))
+        XCTAssertEqual(fitShow.nativeValue, 40)
+        XCTAssertEqual(fitShow.nativeUnit, .controllerNative(code: "fitshow_tenths_kmh"))
+    }
+
+    func testWalkingPadCommandRepresentationNeverBorrowsUnitsTruth() {
+        let metric = TreadmillCommandedSpeedRepresentation.walkingPad(
+            rawControllerTenths: 55
+        )
+        let imperialOrUnknown = TreadmillCommandedSpeedRepresentation.walkingPad(
+            rawControllerTenths: 55
+        )
+
+        XCTAssertEqual(metric, imperialOrUnknown)
+        XCTAssertEqual(
+            metric.nativeUnit,
+            .controllerNative(code: "walkingpad_controller_tenths")
+        )
+        XCTAssertNil(
+            FactualSpeedKilometresPerHour.normalized(
+                from: NativeTreadmillSpeed(
+                    value: metric.nativeValue,
+                    unit: metric.nativeUnit
+                ),
+                provenance: .decodedDeviceReport
+            )
+        )
+    }
+
+    func testArrivalOrderIsMonotonicWithinNormalizerAndRestartsOnlyWithNewInstance() {
+        let epoch = connectionEpoch(8)
+        var normalizer = TreadmillObservationNormalizer()
+        let first = normalizer.normalize(
+            .ftms(
+                speedRawHundredthsKmh: 100,
+                rawState: nil,
+                deviceState: .moving,
+                connectionEpoch: epoch,
+                receivedAt: receivedAt
+            ),
+            unitsTruth: nil,
+            observationID: observationID(50),
+            recordedAt: recordedAt
+        )
+        let second = normalizer.normalize(
+            .ftms(
+                speedRawHundredthsKmh: 110,
+                rawState: nil,
+                deviceState: .moving,
+                connectionEpoch: epoch,
+                receivedAt: receivedAt
+            ),
+            unitsTruth: nil,
+            observationID: observationID(51),
+            recordedAt: recordedAt
+        )
+
+        XCTAssertEqual(first.arrivalOrder, 1)
+        XCTAssertEqual(second.arrivalOrder, 2)
+    }
+
+    private func connectionEpoch(_ value: UInt8) -> TreadmillConnectionEpoch {
+        TreadmillConnectionEpoch(rawValue: uuid(value))
+    }
+
+    private func observationID(_ value: Int) -> ObservationID {
+        ObservationID(rawValue: uuid(UInt8(truncatingIfNeeded: value)))
+    }
+
+    private func uuid(_ value: UInt8) -> UUID {
+        UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, value))
+    }
+}
+
+final class TreadmillCommandDecisionTests: XCTestCase {
+    private let epochA = TreadmillConnectionEpoch(
+        rawValue: UUID(uuidString: "00000000-0000-0000-0000-0000000000a1")!
+    )
+    private let epochB = TreadmillConnectionEpoch(
+        rawValue: UUID(uuidString: "00000000-0000-0000-0000-0000000000b2")!
+    )
+    private let receivedAt = Date(timeIntervalSince1970: 1_700_001_000)
+
+    // PM decision test 1: legacy scheduling may send two commands before an ACK.
+    func testTwoSendAttemptsRemainIndependentBeforeOneAcknowledgementSignal() {
+        var ledger = TreadmillCommandEvidenceLedger()
+        let first = attempt(command: 1, attempt: 11, epoch: epochA, number: 1)
+        let second = attempt(command: 2, attempt: 22, epoch: epochA, number: 1)
+        ledger.recordSendAttempt(first)
+        ledger.recordSendAttempt(second)
+
+        XCTAssertEqual(ledger.state(for: first.attemptID), .sent)
+        XCTAssertEqual(ledger.state(for: second.attemptID), .sent)
+        XCTAssertEqual(ledger.attemptCount, 2)
+    }
+
+    // PM decision test 2: ambiguous ACK is factual but has no causal IDs.
+    func testAmbiguousAcknowledgementHasNilCausalIDsAndExplicitUnknownAssociation() {
+        let ack = LegacyAcknowledgementObservation.unresolved(
+            protocolKind: .walkingPad,
+            connectionEpoch: epochA,
+            receivedAt: receivedAt,
+            recordedAt: receivedAt
+        )
+
+        XCTAssertEqual(ack.association, .unresolvedByLegacyRuntime)
+        XCTAssertNil(ack.commandID)
+        XCTAssertNil(ack.attemptID)
+    }
+
+    // PM decision test 3: neither latest nor oldest command is selected heuristically.
+    func testUnresolvedAcknowledgementDoesNotChooseLatestOrOldestCommand() {
+        var ledger = TreadmillCommandEvidenceLedger()
+        let first = attempt(command: 3, attempt: 31, epoch: epochA, number: 1)
+        let second = attempt(command: 4, attempt: 41, epoch: epochA, number: 1)
+        ledger.recordSendAttempt(first)
+        ledger.recordSendAttempt(second)
+        let ack = LegacyAcknowledgementObservation.unresolved(
+            protocolKind: .ftms,
+            connectionEpoch: epochA,
+            receivedAt: receivedAt,
+            recordedAt: receivedAt
+        )
+
+        ledger.observeAcknowledgement(ack)
+
+        XCTAssertEqual(ledger.state(for: first.attemptID), .sent)
+        XCTAssertEqual(ledger.state(for: second.attemptID), .sent)
+    }
+
+    // PM decision test 4: unknown ACK never completes an attempt.
+    func testUnassociatedAcknowledgementDoesNotMutateAttemptEvidenceState() {
+        var ledger = TreadmillCommandEvidenceLedger()
+        let send = attempt(command: 5, attempt: 51, epoch: epochA, number: 1)
+        ledger.recordSendAttempt(send)
+        ledger.observeAcknowledgement(
+            .unresolved(
+                protocolKind: .fitShow,
+                connectionEpoch: epochA,
+                receivedAt: receivedAt,
+                recordedAt: receivedAt
+            )
+        )
+
+        XCTAssertEqual(ledger.state(for: send.attemptID), .sent)
+    }
+
+    // PM decision test 5: every sink disposition leaves the legacy trace identical.
+    func testTelemetryDispositionCannotChangeLegacyBytesOrderTimingTimeoutOrRetryTrace() {
+        let dispositions: [TreadmillTelemetrySinkDisposition?] = [
+            .accepted,
+            .degraded,
+            .rejected,
+            nil,
+        ]
+
+        let traces = dispositions.map { disposition -> LegacyTrace in
+            var trace = LegacyTrace()
+            TreadmillObservationalTee.afterLegacyAction(
+                {
+                    trace.bytes = [[0x02], [0x02, 0x90, 0x01]]
+                    trace.sendOffsets = [0.0, 0.25]
+                    trace.timeoutOffsets = [3.0]
+                    trace.retryOffsets = [3.25]
+                    trace.target = 4.0
+                    trace.stopConfirmed = false
+                },
+                observe: disposition.map { value in { value } }
+            )
+            return trace
+        }
+
+        XCTAssertTrue(traces.dropFirst().allSatisfy { $0 == traces[0] })
+    }
+
+    // PM decision test 6: an ACK cannot attach across a reconnect epoch.
+    func testConnectionEpochChangePreventsDeterministicAssociation() {
+        let send = attempt(command: 6, attempt: 61, epoch: epochA, number: 1)
+
+        XCTAssertNil(
+            LegacyAcknowledgementObservation.deterministicallyAssociated(
+                protocolKind: .walkingPad,
+                connectionEpoch: epochB,
+                receivedAt: receivedAt,
+                recordedAt: receivedAt,
+                sendAttempt: send,
+                proof: TreadmillDeterministicAcknowledgementProof(evidenceKey: uuid(60))
+            )
+        )
+    }
+
+    // PM decision test 7: a proven same-epoch edge remains typed and precise.
+    func testIndependentSameEpochProofCanCreateKnownAssociation() throws {
+        let send = attempt(command: 7, attempt: 71, epoch: epochA, number: 1)
+        let ack = try XCTUnwrap(
+            LegacyAcknowledgementObservation.deterministicallyAssociated(
+                protocolKind: .ftms,
+                connectionEpoch: epochA,
+                receivedAt: receivedAt,
+                recordedAt: receivedAt,
+                sendAttempt: send,
+                proof: TreadmillDeterministicAcknowledgementProof(evidenceKey: uuid(70))
+            )
+        )
+
+        XCTAssertEqual(ack.commandID, send.commandID)
+        XCTAssertEqual(ack.attemptID, send.attemptID)
+        XCTAssertEqual(
+            ack.association,
+            .deterministicallyCorrelated(commandID: send.commandID, attemptID: send.attemptID)
+        )
+    }
+
+    // PM decision test 8: replay cannot backfill an unknown edge during Codable round-trip.
+    func testUnknownAssociationRoundTripStaysUnknownWithoutCausalIDs() throws {
+        let ack = LegacyAcknowledgementObservation.unresolved(
+            protocolKind: .walkingPad,
+            connectionEpoch: epochA,
+            receivedAt: receivedAt,
+            recordedAt: receivedAt
+        )
+        let decoded = try JSONDecoder().decode(
+            LegacyAcknowledgementObservation.self,
+            from: JSONEncoder().encode(ack)
+        )
+
+        XCTAssertEqual(decoded, ack)
+        XCTAssertEqual(decoded.association, .unresolvedByLegacyRuntime)
+        XCTAssertNil(decoded.commandID)
+        XCTAssertNil(decoded.attemptID)
+    }
+
+    func testLegacyRetryUsesOneCommandWithDistinctAttempts() {
+        let first = attempt(command: 8, attempt: 81, epoch: epochA, number: 1)
+        let retry = attempt(command: 8, attempt: 82, epoch: epochA, number: 2)
+
+        XCTAssertEqual(first.commandID, retry.commandID)
+        XCTAssertNotEqual(first.attemptID, retry.attemptID)
+        XCTAssertEqual(first.attemptNumber, 1)
+        XCTAssertEqual(retry.attemptNumber, 2)
+    }
+
+    func testLegacyTimeoutRemainsUnresolvedWithoutAttemptMutation() {
+        let timeout = LegacyCommandTimeoutObservation(
+            protocolKind: .walkingPad,
+            connectionEpoch: epochA,
+            occurredAt: receivedAt
+        )
+
+        XCTAssertEqual(timeout.association, .unresolvedByLegacyRuntime)
+        XCTAssertNil(timeout.commandID)
+        XCTAssertNil(timeout.attemptID)
+    }
+
+    func testLegacyWriteResultRemainsUnresolvedWithoutCausalIDs() {
+        for status in [TreadmillWriteResultStatus.succeeded, .failed] {
+            let result = LegacyWriteResultObservation(
+                protocolKind: .fitShow,
+                connectionEpoch: epochA,
+                occurredAt: receivedAt,
+                status: status
+            )
+
+            XCTAssertEqual(result.association, .unresolvedByLegacyRuntime)
+            XCTAssertNil(result.commandID)
+            XCTAssertNil(result.attemptID)
+        }
+    }
+
+    func testLegacyTimeoutAndWriteResultRejectBackfilledAssociationDuringReplay() throws {
+        let association = LegacyAcknowledgementAssociation.deterministicallyCorrelated(
+            commandID: commandID(91),
+            attemptID: attemptID(92)
+        )
+        let timeout = FabricatedLegacyTimeout(
+            protocolKind: .walkingPad,
+            connectionEpoch: epochA,
+            occurredAt: receivedAt,
+            association: association
+        )
+        let writeResult = FabricatedLegacyWriteResult(
+            protocolKind: .walkingPad,
+            connectionEpoch: epochA,
+            occurredAt: receivedAt,
+            status: .succeeded,
+            association: association
+        )
+
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(
+                LegacyCommandTimeoutObservation.self,
+                from: JSONEncoder().encode(timeout)
+            )
+        )
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(
+                LegacyWriteResultObservation.self,
+                from: JSONEncoder().encode(writeResult)
+            )
+        )
+    }
+
+    func testObservedResponseIsFactualAndUnassociatedUntilIndependentProofExists() {
+        var normalizer = TreadmillObservationNormalizer()
+        let observation = normalizer.normalize(
+            .ftms(
+                speedRawHundredthsKmh: 350,
+                rawState: 1,
+                deviceState: .moving,
+                connectionEpoch: epochA,
+                receivedAt: receivedAt
+            ),
+            unitsTruth: nil,
+            observationID: ObservationID(),
+            recordedAt: receivedAt
+        )
+
+        XCTAssertEqual(observation.nativeSpeed?.rawValue, 350)
+        XCTAssertEqual(observation.responseAssociation, .unassociated)
+        XCTAssertNil(observation.commandID)
+        XCTAssertNil(observation.attemptID)
+    }
+
+    func testStopEvidenceRetainsDecisionCommandAndFactualObservationChain() {
+        let decision = decisionID(12)
+        let command = commandID(13)
+        let observation = ObservationID(rawValue: uuid(14))
+        let evidence = TreadmillStopTruthEvidence(
+            stopAttemptID: uuid(15),
+            decisionID: decision,
+            commandID: command,
+            observationID: observation,
+            connectionEpoch: epochA,
+            protocolKind: .walkingPad,
+            conclusion: .confirmedByFreshFactualObservation(observation),
+            rawSpeedTenths: 0,
+            rawDeviceState: 0,
+            checksumValid: true,
+            observationReceivedAt: receivedAt,
+            evaluatedAt: receivedAt
+        )
+
+        XCTAssertEqual(evidence.decisionID, decision)
+        XCTAssertEqual(evidence.commandID, command)
+        XCTAssertEqual(evidence.observationID, observation)
+        XCTAssertEqual(evidence.rawSpeedTenths, 0)
+    }
+
+    func testHeartRateDecisionKeepsExactAcceptedControlUseReferences() {
+        let reference = HeartRateCausalReference(
+            deliveryID: HeartRateDeliveryID(
+                rawValue: UUID(uuidString: "00000000-0000-0000-0000-000000000101")!
+            ),
+            canonicalObservationID: HeartRateCanonicalObservationID(
+                rawValue: UUID(uuidString: "00000000-0000-0000-0000-000000000102")!
+            )
+        )
+        let decision = TreadmillControlDecisionEvidence(
+            decisionID: decisionID(8),
+            source: .heartRateControl,
+            intent: .setDesiredSpeed(DesiredSpeedKilometresPerHour(value: 4.2)),
+            heartRateInputs: [reference],
+            occurredAt: receivedAt,
+            connectionEpoch: epochA
+        )
+
+        XCTAssertEqual(decision.heartRateInputs, [reference])
+        XCTAssertEqual(decision.source, .heartRateControl)
+    }
+
+    func testManualCooldownAndStopDecisionsDoNotBorrowHeartRateInputs() {
+        for source in [
+            TreadmillControlDecisionSource.manual,
+            .cooldown,
+            .stop,
+        ] {
+            let decision = TreadmillControlDecisionEvidence(
+                decisionID: decisionID(UInt8(source == .manual ? 9 : source == .cooldown ? 10 : 11)),
+                source: source,
+                intent: source == .stop
+                    ? .stop
+                    : .setDesiredSpeed(DesiredSpeedKilometresPerHour(value: 3.5)),
+                heartRateInputs: [],
+                occurredAt: receivedAt,
+                connectionEpoch: epochA
+            )
+            XCTAssertTrue(decision.heartRateInputs.isEmpty)
+        }
+    }
+
+    private func attempt(
+        command: UInt8,
+        attempt: UInt8,
+        epoch: TreadmillConnectionEpoch,
+        number: UInt16
+    ) -> TreadmillCommandSendAttemptEvidence {
+        TreadmillCommandSendAttemptEvidence(
+            commandID: commandID(command),
+            decisionID: nil,
+            attemptID: attemptID(attempt),
+            attemptNumber: number,
+            protocolKind: .walkingPad,
+            connectionEpoch: epoch,
+            sentAt: receivedAt,
+            writeType: .withResponse
+        )
+    }
+
+    private func commandID(_ value: UInt8) -> CommandID {
+        CommandID(rawValue: uuid(value))
+    }
+
+    private func attemptID(_ value: UInt8) -> CommandAttemptID {
+        CommandAttemptID(rawValue: uuid(value))
+    }
+
+    private func decisionID(_ value: UInt8) -> DecisionID {
+        DecisionID(rawValue: uuid(value))
+    }
+
+    private func uuid(_ value: UInt8) -> UUID {
+        UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, value))
+    }
+}
+
+private struct LegacyTrace: Equatable {
+    var bytes: [[UInt8]] = []
+    var sendOffsets: [TimeInterval] = []
+    var timeoutOffsets: [TimeInterval] = []
+    var retryOffsets: [TimeInterval] = []
+    var target: Double = 0
+    var stopConfirmed = false
+}
+
+private struct FabricatedLegacyTimeout: Encodable {
+    let protocolKind: TreadmillProtocolKind
+    let connectionEpoch: TreadmillConnectionEpoch
+    let occurredAt: Date
+    let association: LegacyAcknowledgementAssociation
+}
+
+private struct FabricatedLegacyWriteResult: Encodable {
+    let protocolKind: TreadmillProtocolKind
+    let connectionEpoch: TreadmillConnectionEpoch
+    let occurredAt: Date
+    let status: TreadmillWriteResultStatus
+    let association: LegacyAcknowledgementAssociation
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj/project.pbxproj
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj/project.pbxproj
@@ -8,6 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		A28000012F80000000000001 /* HeartRateNormalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28000022F80000000000002 /* HeartRateNormalization.swift */; };
+		A29000012F90000000000001 /* TreadmillTruth.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29000022F90000000000002 /* TreadmillTruth.swift */; };
+		A29100012F90000000000001 /* Identifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100022F90000000000002 /* Identifiers.swift */; };
+		A29200012F90000000000001 /* Observations.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29200022F90000000000002 /* Observations.swift */; };
+		A29300012F90000000000001 /* Provenance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29300022F90000000000002 /* Provenance.swift */; };
+		A29400012F90000000000001 /* Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29400022F90000000000002 /* Time.swift */; };
+		A29500012F90000000000001 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29500022F90000000000002 /* Configuration.swift */; };
+		A29600012F90000000000001 /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29600022F90000000000002 /* Events.swift */; };
 		E31F57CB2F293B5600C6C470 /* WorkoutSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31F57CA2F293B5500C6C470 /* WorkoutSessionController.swift */; };
 		E31F57CD2F293B7100C6C470 /* TreadmillStatsPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31F57CC2F293B7100C6C470 /* TreadmillStatsPublisher.swift */; };
 		E37051C22F233FC100D2FA22 /* WalkingPadRemoteWatch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = E37051B82F233FBE00D2FA22 /* WalkingPadRemoteWatch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -39,6 +46,13 @@
 
 /* Begin PBXFileReference section */
 		A28000022F80000000000002 /* HeartRateNormalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/HeartRateNormalization.swift; sourceTree = "<group>"; };
+		A29000022F90000000000002 /* TreadmillTruth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/TreadmillTruth.swift; sourceTree = "<group>"; };
+		A29100022F90000000000002 /* Identifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/Identifiers.swift; sourceTree = "<group>"; };
+		A29200022F90000000000002 /* Observations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/Observations.swift; sourceTree = "<group>"; };
+		A29300022F90000000000002 /* Provenance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/Provenance.swift; sourceTree = "<group>"; };
+		A29400022F90000000000002 /* Time.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/Time.swift; sourceTree = "<group>"; };
+		A29500022F90000000000002 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/Configuration.swift; sourceTree = "<group>"; };
+		A29600022F90000000000002 /* Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/Events.swift; sourceTree = "<group>"; };
 		E31F57CA2F293B5500C6C470 /* WorkoutSessionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSessionController.swift; sourceTree = "<group>"; };
 		E31F57CC2F293B7100C6C470 /* TreadmillStatsPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreadmillStatsPublisher.swift; sourceTree = "<group>"; };
 		E37051762F22AB0C00D2FA22 /* WalkingPadRemote.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WalkingPadRemote.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -82,6 +96,13 @@
 				E37051782F22AB0C00D2FA22 /* WalkingPadRemote */,
 				E37051B92F233FBE00D2FA22 /* WalkingPadRemoteWatch Watch App */,
 				A28000022F80000000000002 /* HeartRateNormalization.swift */,
+				A29000022F90000000000002 /* TreadmillTruth.swift */,
+				A29100022F90000000000002 /* Identifiers.swift */,
+				A29200022F90000000000002 /* Observations.swift */,
+				A29300022F90000000000002 /* Provenance.swift */,
+				A29400022F90000000000002 /* Time.swift */,
+				A29500022F90000000000002 /* Configuration.swift */,
+				A29600022F90000000000002 /* Events.swift */,
 				E37051772F22AB0C00D2FA22 /* Products */,
 				E31F57CA2F293B5500C6C470 /* WorkoutSessionController.swift */,
 				E31F57CC2F293B7100C6C470 /* TreadmillStatsPublisher.swift */,
@@ -207,6 +228,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				A28000012F80000000000001 /* HeartRateNormalization.swift in Sources */,
+				A29000012F90000000000001 /* TreadmillTruth.swift in Sources */,
+				A29100012F90000000000001 /* Identifiers.swift in Sources */,
+				A29200012F90000000000001 /* Observations.swift in Sources */,
+				A29300012F90000000000001 /* Provenance.swift in Sources */,
+				A29400012F90000000000001 /* Time.swift in Sources */,
+				A29500012F90000000000001 /* Configuration.swift in Sources */,
+				A29600012F90000000000001 /* Events.swift in Sources */,
 				E31F57CB2F293B5600C6C470 /* WorkoutSessionController.swift in Sources */,
 				E31F57CD2F293B7100C6C470 /* TreadmillStatsPublisher.swift in Sources */,
 			);

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BLETransportCodec.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BLETransportCodec.swift
@@ -12,6 +12,7 @@ enum BLETransportCodec {
     }
 
     struct FtmsTreadmillData {
+        let instantaneousSpeedRawHundredthsKmh: UInt16
         let instantaneousSpeedKmh: Double
         let isMoving: Bool
     }
@@ -191,7 +192,11 @@ enum BLETransportCodec {
         guard data.count >= 4 else { return nil }
         guard let rawSpeed = readUInt16LE(data, at: 2) else { return nil }
         let kmh = Double(rawSpeed) / 100.0
-        return FtmsTreadmillData(instantaneousSpeedKmh: kmh, isMoving: kmh > 0.2)
+        return FtmsTreadmillData(
+            instantaneousSpeedRawHundredthsKmh: rawSpeed,
+            instantaneousSpeedKmh: kmh,
+            isMoving: kmh > 0.2
+        )
     }
 
     static func parseFtmsSupportedSpeedRange(_ data: Data) -> FtmsSupportedSpeedRange? {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -5903,27 +5903,24 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             characteristic: characteristic,
             data: data
         )
-        let legacyAcknowledgementEvidence = treadmillTelemetryConnectionEpoch.flatMap {
-            isLegacyAcknowledgementSignal
-                ? LegacyAcknowledgementObservation.unresolved(
-                    protocolKind: treadmillTelemetryProtocolKind,
-                    connectionEpoch: $0,
-                    receivedAt: now,
-                    recordedAt: Date()
-                )
-                : nil
-        }
+        let legacyAcknowledgementDecision = LegacyAcknowledgementObservationSeam.evaluate(
+            isAwaitingAcknowledgement: lastCommandAwaitingAck,
+            sentAt: lastCommandSentAt,
+            receivedAt: now,
+            timeout: commandAckTimeoutSeconds,
+            isQualifyingSignal: isLegacyAcknowledgementSignal,
+            protocolKind: treadmillTelemetryProtocolKind,
+            connectionEpoch: treadmillTelemetryConnectionEpoch,
+            recordedAt: Date()
+        )
         defer {
-            if let legacyAcknowledgementEvidence {
+            if let observation = legacyAcknowledgementDecision.observation {
                 observeTreadmillTelemetry(
-                    .acknowledgement(legacyAcknowledgementEvidence)
+                    .acknowledgement(observation)
                 )
             }
         }
-        if lastCommandAwaitingAck,
-           let sentAt = lastCommandSentAt,
-           now.timeIntervalSince(sentAt) <= commandAckTimeoutSeconds,
-           isLegacyAcknowledgementSignal {
+        if legacyAcknowledgementDecision.isAcceptedByLegacyRuntime {
             lastCommandAwaitingAck = false
             lastCommandAckedAt = now
         }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -192,6 +192,23 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var heartRateObservationNormalizer = HeartRateObservationNormalizer()
     private var heartRateTelemetrySink: (any HeartRateTelemetrySink)?
     private var latestHeartRateDelivery: HeartRateDeliveryEvidence?
+    private var treadmillObservationNormalizer = TreadmillObservationNormalizer(
+        controllerUnitsFreshnessInterval: ControllerUnitsSafetyPolicy.freshnessInterval
+    )
+    private var treadmillTelemetrySink: (any TreadmillTelemetrySink)?
+    private var latestTreadmillObservationEvidence: TreadmillObservationEvidence?
+    private var treadmillCommandTelemetrySidecar = TreadmillCommandTelemetrySidecar()
+    private var treadmillCommandAttemptNumbers: [CommandID: UInt16] = [:]
+    private struct TreadmillCommandTelemetryRequest {
+        let commandID: CommandID
+        let decisionID: DecisionID?
+        let kind: CommandKind
+    }
+    private struct TreadmillStopTelemetryChain {
+        let decisionID: DecisionID
+        let commandID: CommandID?
+    }
+    private var activeTreadmillStopTelemetryChain: TreadmillStopTelemetryChain?
     private var expectedSpeedKmh: Double? = nil
     private var expectedSpeedSetAt: Date? = nil
     private var expectedSpeedSource: String? = nil
@@ -1131,7 +1148,18 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             deviceTargetSpeedKmh = speedEffect.targetKmh
             recordSpeedChange(from: old, to: speedEffect.targetKmh, reason: "cooldown_set")
             lastCommandLine = String(format: "CMD cooldown adjust -> %.1f", speedEffect.targetKmh)
-            sendTreadmillSetSpeed(speedEffect.targetKmh, label: String(format: "SPEED %.1f km/h (cooldown)", speedEffect.targetKmh))
+            let telemetryDecision = makeTreadmillDecision(
+                source: .cooldown,
+                intent: .setDesiredSpeed(
+                    DesiredSpeedKilometresPerHour(value: speedEffect.targetKmh)
+                )
+            )
+            defer { observeTreadmillDecision(telemetryDecision) }
+            sendTreadmillSetSpeed(
+                speedEffect.targetKmh,
+                label: String(format: "SPEED %.1f km/h (cooldown)", speedEffect.targetKmh),
+                decision: telemetryDecision
+            )
             appendLog(
                 "HR cooldown speed: \(String(format: "%.1f", speedEffect.targetKmh)) " +
                 "HR=\(speedEffect.hrBpm) step=\(String(format: "%.1f", speedEffect.stepKmh)) " +
@@ -2749,6 +2777,11 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         // Cancel any pending delayed writes (e.g. stop retries) before starting a new run.
         resetCommandQueue(reason: "startWithSpeed")
         let v = clampRunningSpeedKmh(kmh)
+        let telemetryDecision = makeTreadmillDecision(
+            source: .start,
+            intent: .startAtDesiredSpeed(DesiredSpeedKilometresPerHour(value: v))
+        )
+        defer { observeTreadmillDecision(telemetryDecision) }
         let old = deviceTargetSpeedKmh
         desiredSpeedKmh = v
         deviceTargetSpeedKmh = v
@@ -2761,31 +2794,109 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             let modePacket = buildCmdPacket(cmd: 0x02, value: 0x01)
             let startPacket = buildCmdPacket(cmd: 0x04, value: 0x01)
             if !manualModeSet {
-                writeCommand(modePacket, label: "MODE MANUAL")
+                writeCommand(
+                    modePacket,
+                    label: "MODE MANUAL",
+                    telemetryRequest: treadmillCommandRequest(
+                        kind: .other("mode_manual"),
+                        decision: telemetryDecision
+                    )
+                )
                 manualModeSet = true
             }
             if shouldSendStart {
-                scheduleWrite(startPacket, label: "START", after: 0.2)
-                scheduleWrite(buildWalkingPadSetSpeedPacket(kmh: v), label: String(format: "SPEED %.1f km/h", v), after: 0.45)
+                scheduleWrite(
+                    startPacket,
+                    label: "START",
+                    after: 0.2,
+                    telemetryRequest: treadmillCommandRequest(
+                        kind: .other("start"),
+                        decision: telemetryDecision
+                    )
+                )
+                scheduleWrite(
+                    buildWalkingPadSetSpeedPacket(kmh: v),
+                    label: String(format: "SPEED %.1f km/h", v),
+                    after: 0.45,
+                    telemetryRequest: treadmillCommandRequest(
+                        kind: treadmillSetSpeedCommandKind(v),
+                        decision: telemetryDecision
+                    )
+                )
             } else {
-                scheduleWrite(buildWalkingPadSetSpeedPacket(kmh: v), label: String(format: "SPEED %.1f km/h", v), after: 0.2)
+                scheduleWrite(
+                    buildWalkingPadSetSpeedPacket(kmh: v),
+                    label: String(format: "SPEED %.1f km/h", v),
+                    after: 0.2,
+                    telemetryRequest: treadmillCommandRequest(
+                        kind: treadmillSetSpeedCommandKind(v),
+                        decision: telemetryDecision
+                    )
+                )
             }
 
         case .ftms:
-            enqueueFtmsRequestControlIfNeeded()
+            enqueueFtmsRequestControlIfNeeded(decision: telemetryDecision)
             if shouldSendStart {
-                scheduleWrite(buildFtmsStartOrResumePacket(), label: "FTMS START/RESUME", after: 0.2)
-                scheduleWrite(buildFtmsSetSpeedPacket(kmh: v), label: String(format: "SPEED %.1f km/h (FTMS)", v), after: 0.45)
+                scheduleWrite(
+                    buildFtmsStartOrResumePacket(),
+                    label: "FTMS START/RESUME",
+                    after: 0.2,
+                    telemetryRequest: treadmillCommandRequest(
+                        kind: .other("start"),
+                        decision: telemetryDecision
+                    )
+                )
+                scheduleWrite(
+                    buildFtmsSetSpeedPacket(kmh: v),
+                    label: String(format: "SPEED %.1f km/h (FTMS)", v),
+                    after: 0.45,
+                    telemetryRequest: treadmillCommandRequest(
+                        kind: treadmillSetSpeedCommandKind(v),
+                        decision: telemetryDecision
+                    )
+                )
             } else {
-                scheduleWrite(buildFtmsSetSpeedPacket(kmh: v), label: String(format: "SPEED %.1f km/h (FTMS)", v), after: 0.2)
+                scheduleWrite(
+                    buildFtmsSetSpeedPacket(kmh: v),
+                    label: String(format: "SPEED %.1f km/h (FTMS)", v),
+                    after: 0.2,
+                    telemetryRequest: treadmillCommandRequest(
+                        kind: treadmillSetSpeedCommandKind(v),
+                        decision: telemetryDecision
+                    )
+                )
             }
 
         case .fitShow:
             if shouldSendStart {
-                writeCommand(buildFitShowStartOrResumePacket(), label: "FitShow START/RESUME")
-                scheduleWrite(buildFitShowSetSpeedPacket(kmh: v, incline: 0), label: String(format: "SPEED %.1f km/h (FitShow)", v), after: 0.35)
+                writeCommand(
+                    buildFitShowStartOrResumePacket(),
+                    label: "FitShow START/RESUME",
+                    telemetryRequest: treadmillCommandRequest(
+                        kind: .other("start"),
+                        decision: telemetryDecision
+                    )
+                )
+                scheduleWrite(
+                    buildFitShowSetSpeedPacket(kmh: v, incline: 0),
+                    label: String(format: "SPEED %.1f km/h (FitShow)", v),
+                    after: 0.35,
+                    telemetryRequest: treadmillCommandRequest(
+                        kind: treadmillSetSpeedCommandKind(v),
+                        decision: telemetryDecision
+                    )
+                )
             } else {
-                scheduleWrite(buildFitShowSetSpeedPacket(kmh: v, incline: 0), label: String(format: "SPEED %.1f km/h (FitShow)", v), after: 0.2)
+                scheduleWrite(
+                    buildFitShowSetSpeedPacket(kmh: v, incline: 0),
+                    label: String(format: "SPEED %.1f km/h (FitShow)", v),
+                    after: 0.2,
+                    telemetryRequest: treadmillCommandRequest(
+                        kind: treadmillSetSpeedCommandKind(v),
+                        decision: telemetryDecision
+                    )
+                )
             }
 
         case .unknown:
@@ -2795,6 +2906,15 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
     func stopBelt() {
         guard isConnected else { return }
+        let telemetryDecision = makeTreadmillDecision(
+            source: .stop,
+            intent: .stop
+        )
+        defer { observeTreadmillDecision(telemetryDecision) }
+        let telemetryRequest = treadmillCommandRequest(
+            kind: .stop,
+            decision: telemetryDecision
+        )
         let old = deviceTargetSpeedKmh
         desiredSpeedKmh = 0
         deviceTargetSpeedKmh = 0
@@ -2802,20 +2922,44 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         lastCommandLine = "CMD stop"
         resetSessionStats()
         if treadmillProtocol == .ftms {
-            enqueueFtmsRequestControlIfNeeded()
+            enqueueFtmsRequestControlIfNeeded(decision: telemetryDecision)
         }
         guard let packet = buildTreadmillStopPacket() else {
             appendLog("STOP skipped: unknown treadmill protocol")
             return
         }
-        writeCommand(packet, label: "STOP", highPriority: true)
-        scheduleWrite(packet, label: "STOP retry", after: 2.0)
-        scheduleWrite(packet, label: "STOP retry", after: 4.0)
-        beginStopObservation(source: "direct")
+        let telemetryChain = telemetryDecision.map {
+            TreadmillStopTelemetryChain(
+                decisionID: $0.decisionID,
+                commandID: telemetryRequest.commandID
+            )
+        }
+        writeCommand(
+            packet,
+            label: "STOP",
+            highPriority: true,
+            telemetryRequest: telemetryRequest
+        )
+        scheduleWrite(
+            packet,
+            label: "STOP retry",
+            after: 2.0,
+            telemetryRequest: telemetryRequest
+        )
+        scheduleWrite(
+            packet,
+            label: "STOP retry",
+            after: 4.0,
+            telemetryRequest: telemetryRequest
+        )
+        beginStopObservation(source: "direct", telemetryChain: telemetryChain)
     }
 
-    private func stopBeltOnce() {
-        guard isConnected else { return }
+    private func stopBeltOnce(
+        telemetryDecision: TreadmillControlDecisionEvidence?,
+        telemetryRequest: TreadmillCommandTelemetryRequest
+    ) -> Bool {
+        guard isConnected else { return false }
         let old = deviceTargetSpeedKmh
         desiredSpeedKmh = 0
         deviceTargetSpeedKmh = 0
@@ -2823,34 +2967,70 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         lastCommandLine = "CMD stop"
         resetSessionStats()
         if treadmillProtocol == .ftms {
-            enqueueFtmsRequestControlIfNeeded()
+            enqueueFtmsRequestControlIfNeeded(decision: telemetryDecision)
         }
         guard let packet = buildTreadmillStopPacket() else {
             appendLog("STOP skipped: unknown treadmill protocol")
-            return
+            return false
         }
-        writeCommand(packet, label: "STOP", highPriority: true)
+        writeCommand(
+            packet,
+            label: "STOP",
+            highPriority: true,
+            telemetryRequest: telemetryRequest
+        )
+        return true
     }
 
     private func stopBeltWithToggle(reason: String) {
         let wasRunning = (deviceTargetSpeedKmh > 0.3) || (speedKmh > 0.3)
+        let telemetryDecision = makeTreadmillDecision(
+            source: .stop,
+            intent: .stop
+        )
+        defer { observeTreadmillDecision(telemetryDecision) }
+        let telemetryRequest = treadmillCommandRequest(
+            kind: .stop,
+            decision: telemetryDecision
+        )
         appendLog("STOP sequence (\(reason))")
-        stopBeltOnce()
+        let stopCommandWasEnqueued = stopBeltOnce(
+            telemetryDecision: telemetryDecision,
+            telemetryRequest: telemetryRequest
+        )
+        let telemetryChain = telemetryDecision.map {
+            TreadmillStopTelemetryChain(
+                decisionID: $0.decisionID,
+                commandID: stopCommandWasEnqueued ? telemetryRequest.commandID : nil
+            )
+        }
         guard wasRunning else {
-            beginStopObservation(source: reason)
+            beginStopObservation(source: reason, telemetryChain: telemetryChain)
             return
         }
         switch treadmillProtocol {
         case .walkingPad:
             let toggle = buildCmdPacket(cmd: 0x04, value: 0x01)
-            scheduleWrite(toggle, label: "START/STOP TOGGLE", after: 2.0)
+            scheduleWrite(
+                toggle,
+                label: "START/STOP TOGGLE",
+                after: 2.0,
+                telemetryRequest: treadmillCommandRequest(
+                    kind: .other("legacy_stop_toggle"),
+                    decision: telemetryDecision
+                )
+            )
             DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) { [weak self] in
                 guard let self else { return }
                 let reported = self.deviceReportedSpeedKmh
                 let observed = max(self.speedKmh, reported)
                 if observed > 0.2 {
                     if let stopPacket = self.buildTreadmillStopPacket() {
-                        self.writeCommand(stopPacket, label: "STOP retry")
+                        self.writeCommand(
+                            stopPacket,
+                            label: "STOP retry",
+                            telemetryRequest: telemetryRequest
+                        )
                     }
                 }
             }
@@ -2858,13 +3038,23 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         case .ftms, .fitShow, .unknown:
             if let stopPacket = buildTreadmillStopPacket() {
                 if treadmillProtocol == .ftms {
-                    enqueueFtmsRequestControlIfNeeded()
+                    enqueueFtmsRequestControlIfNeeded(decision: telemetryDecision)
                 }
-                scheduleWrite(stopPacket, label: "STOP retry", after: 2.0)
-                scheduleWrite(stopPacket, label: "STOP retry", after: 4.0)
+                scheduleWrite(
+                    stopPacket,
+                    label: "STOP retry",
+                    after: 2.0,
+                    telemetryRequest: telemetryRequest
+                )
+                scheduleWrite(
+                    stopPacket,
+                    label: "STOP retry",
+                    after: 4.0,
+                    telemetryRequest: telemetryRequest
+                )
             }
         }
-        beginStopObservation(source: reason)
+        beginStopObservation(source: reason, telemetryChain: telemetryChain)
     }
 
     private func currentStopObservationContext() -> StopObservationContext? {
@@ -2881,13 +3071,18 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         )
     }
 
-    private func beginStopObservation(source: String, now: Date = Date()) {
+    private func beginStopObservation(
+        source: String,
+        telemetryChain: TreadmillStopTelemetryChain? = nil,
+        now: Date = Date()
+    ) {
         stopObservationFreshnessWorkItem?.cancel()
         stopObservationFreshnessWorkItem = nil
         finishActiveStopObservationUnconfirmed(reason: "superseded_by_new_attempt", now: now)
         if let pendingAttemptID = unavailableStopAttempt?.id {
             finalizeUnavailableStopAttempt(attemptID: pendingAttemptID)
         }
+        activeTreadmillStopTelemetryChain = telemetryChain
         guard let context = currentStopObservationContext() else {
             recordUnavailableStopAttempt(source: source, attemptedAt: now)
             return
@@ -2944,6 +3139,26 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             ? "confirmation_context_unavailable"
             : "stop_command_not_sent_transport_unavailable"
         logTrainingEvent("stop_attempt_started", fields: fields)
+        let telemetryEvidence = treadmillTelemetryConnectionEpoch.map {
+            TreadmillStopTruthEvidence(
+                stopAttemptID: attemptID,
+                decisionID: activeTreadmillStopTelemetryChain?.decisionID,
+                commandID: activeTreadmillStopTelemetryChain?.commandID,
+                observationID: nil,
+                connectionEpoch: $0,
+                protocolKind: treadmillTelemetryProtocolKind,
+                conclusion: .unconfirmed(
+                    reason: transportCanSend
+                        ? "legacy_stop_confirmation_unavailable_for_protocol"
+                        : "stop_command_not_sent_transport_unavailable"
+                ),
+                rawSpeedTenths: nil,
+                rawDeviceState: nil,
+                checksumValid: nil,
+                observationReceivedAt: nil,
+                evaluatedAt: attemptedAt
+            )
+        }
 
         if transportCanSend {
             stopTruthStatusText = "stop requested • confirmation unavailable"
@@ -2955,6 +3170,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
             self?.finalizeUnavailableStopAttempt(attemptID: attemptID)
+        }
+        if let telemetryEvidence {
+            observeTreadmillTelemetry(.stopEvidence(telemetryEvidence))
         }
     }
 
@@ -3240,6 +3458,11 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             stopTrainingStructuredLog(reason: lifecycle.finalResult?.rawValue ?? "stop_observation_finished")
             stopObservationOwnsTrainingLog = false
         }
+        observeCurrentStopTruth(
+            lifecycle: lifecycle,
+            evaluation: evaluation,
+            evaluatedAt: now
+        )
     }
 
     private func finishActiveStopObservationUnconfirmed(reason: String, now: Date = Date()) {
@@ -3264,6 +3487,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
         stopObservationLifecycle = nil
         stopTruthStatusText = ""
+        activeTreadmillStopTelemetryChain = nil
     }
     func setTargetSpeedFromSlider(_ kmh: Double) {
         let v = clampRunningSpeedKmh(kmh)
@@ -3276,7 +3500,16 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         deviceTargetSpeedKmh = v
         recordSpeedChange(from: old, to: v, reason: "manual_slider")
         lastCommandLine = "CMD set speed=\(String(format: "%.1f", v))"
-        sendTreadmillSetSpeed(v, label: String(format: "SPEED %.1f km/h", v))
+        let telemetryDecision = makeTreadmillDecision(
+            source: .manual,
+            intent: .setDesiredSpeed(DesiredSpeedKilometresPerHour(value: v))
+        )
+        defer { observeTreadmillDecision(telemetryDecision) }
+        sendTreadmillSetSpeed(
+            v,
+            label: String(format: "SPEED %.1f km/h", v),
+            decision: telemetryDecision
+        )
     }
     func adjustSpeed(delta: Double) {
         guard isConnected else { return }
@@ -3288,7 +3521,16 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         deviceTargetSpeedKmh = v
         recordSpeedChange(from: old, to: v, reason: "manual_adjust")
         lastCommandLine = "CMD adjust delta=\(String(format: "%.1f", delta)) -> \(String(format: "%.1f", v))"
-        sendTreadmillSetSpeed(v, label: String(format: "SPEED %.1f km/h", v))
+        let telemetryDecision = makeTreadmillDecision(
+            source: .manual,
+            intent: .setDesiredSpeed(DesiredSpeedKilometresPerHour(value: v))
+        )
+        defer { observeTreadmillDecision(telemetryDecision) }
+        sendTreadmillSetSpeed(
+            v,
+            label: String(format: "SPEED %.1f km/h", v),
+            decision: telemetryDecision
+        )
     }
 
     // HR control actions
@@ -3795,7 +4037,19 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                         deviceTargetSpeedKmh = nextSpeed
                         recordSpeedChange(from: old, to: nextSpeed, reason: "hr_decision_set")
                         lastCommandLine = "CMD HR adjust -> \(String(format: "%.1f", nextSpeed))"
-                        sendTreadmillSetSpeed(nextSpeed, label: String(format: "SPEED %.1f km/h (HR)", nextSpeed))
+                        let telemetryDecision = makeTreadmillDecision(
+                            source: .heartRateControl,
+                            intent: .setDesiredSpeed(
+                                DesiredSpeedKilometresPerHour(value: nextSpeed)
+                            ),
+                            heartRateInputs: controlUseEvidence?.inputs ?? []
+                        )
+                        defer { observeTreadmillDecision(telemetryDecision) }
+                        sendTreadmillSetSpeed(
+                            nextSpeed,
+                            label: String(format: "SPEED %.1f km/h (HR)", nextSpeed),
+                            decision: telemetryDecision
+                        )
                         hrStatusLine = diff > 0 ? "HR‑контроль: уменьшаем скорость" : "HR‑контроль: увеличиваем скорость"
                         hrDecisionDetails = "\(decisionPrefix) · шаг \(stepDebugLabel) \(String(format: "%.1f", step)) км/ч · скорость \(String(format: "%.1f", currentTarget)) → \(String(format: "%+.1f", nextSpeed - currentTarget)) км/ч"
                         appendLog("HR decision: set \(String(format: "%.1f", nextSpeed)) from \(String(format: "%.1f", currentTarget)) HR=\(heartRateBPM) diff=\(diff) stepTag=\(stepDebugLabel) step=\(String(format: "%.1f", step))")
@@ -3894,11 +4148,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             treadmillStatusText = "stopped • \(awakeText) • \(proto)"
         }
 
+        var observedLegacyCommandTimeout = false
         if lastCommandAwaitingAck, let sentAt = lastCommandSentAt {
             if now.timeIntervalSince(sentAt) > commandAckTimeoutSeconds {
                 lastCommandAwaitingAck = false
                 lastCommandTimeouts += 1
                 lastCommandTimeoutsCount = lastCommandTimeouts
+                observedLegacyCommandTimeout = true
                 appendLog("CMD ack timeout: \(lastCommandLine)")
                 logTrainingEvent("command_ack_timeout", fields: [
                     "last_command": lastCommandLine,
@@ -3917,24 +4173,50 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         } else {
             lastCommandAckStatusText = ""
         }
+        if observedLegacyCommandTimeout,
+           let connectionEpoch = treadmillTelemetryConnectionEpoch {
+            observeTreadmillTelemetry(
+                .commandTimeout(
+                    LegacyCommandTimeoutObservation(
+                        protocolKind: treadmillTelemetryProtocolKind,
+                        connectionEpoch: connectionEpoch,
+                        occurredAt: now
+                    )
+                )
+            )
+        }
     }
 
     // MARK: - BLE write helpers
-    private func writeCommand(_ data: Data, label: String, highPriority: Bool = false) {
+    private func writeCommand(
+        _ data: Data,
+        label: String,
+        highPriority: Bool = false,
+        telemetryRequest: TreadmillCommandTelemetryRequest? = nil
+    ) {
 #if STOP_TRUTH_EXPERIMENT_CAPABILITY
         guard stopTruthExperimentController?.isActive != true else {
             appendLog("Production command blocked while fixed Stop-truth experiment is active: \(label)")
             return
         }
 #endif
-        enqueueCommand(data, label: label, highPriority: highPriority)
+        enqueueCommand(
+            data,
+            label: label,
+            highPriority: highPriority,
+            telemetryRequest: telemetryRequest
+        )
     }
 
     private func isSpeedCommandLabel(_ label: String) -> Bool {
         label.lowercased().hasPrefix("speed")
     }
 
-    private func resetCommandQueue(reason: String) {
+    @discardableResult
+    private func resetCommandQueue(
+        reason: String,
+        observeTelemetryImmediately: Bool = true
+    ) -> [TreadmillCommandEnqueuedEvidence] {
         let dropped = CommandQueueService.clear(queue: &commandQueue)
         commandQueueEpoch += 1
         isCommandQueueProcessing = false
@@ -3944,14 +4226,56 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             "reason": reason,
             "dropped_count": dropped
         ])
+        let cancelledTelemetry = treadmillCommandTelemetrySidecar.clear()
+        if observeTelemetryImmediately {
+            observeCancelledTreadmillCommands(
+                cancelledTelemetry,
+                reason: .other("legacy_queue_reset")
+            )
+        }
+        return cancelledTelemetry
     }
 
-    private func enqueueCommand(_ data: Data, label: String, highPriority: Bool) {
+    private func enqueueCommand(
+        _ data: Data,
+        label: String,
+        highPriority: Bool,
+        telemetryRequest: TreadmillCommandTelemetryRequest?
+    ) {
         let command = CommandQueueService.Command(data: data, label: label)
+        let request = telemetryRequest ?? treadmillCommandRequest(kind: .other(label))
+        let telemetryEvidence = treadmillTelemetryConnectionEpoch.map {
+            TreadmillCommandEnqueuedEvidence(
+                commandID: request.commandID,
+                decisionID: request.decisionID,
+                kind: request.kind,
+                protocolKind: treadmillTelemetryProtocolKind,
+                connectionEpoch: $0,
+                enqueuedAt: Date()
+            )
+        }
         if highPriority {
-            resetCommandQueue(reason: "high priority → \(label)")
+            let cancelled = resetCommandQueue(
+                reason: "high priority → \(label)",
+                observeTelemetryImmediately: false
+            )
             CommandQueueService.replaceWithHighPriority(queue: &commandQueue, command: command)
+            var superseded: [TreadmillCommandEnqueuedEvidence] = []
+            if let telemetryEvidence {
+                superseded = treadmillCommandTelemetrySidecar.replaceWithHighPriority(
+                    label: label,
+                    evidence: telemetryEvidence
+                )
+            }
             processCommandQueue()
+            observeCancelledTreadmillCommands(
+                cancelled,
+                reason: .other("legacy_queue_reset")
+            )
+            observeSupersededTreadmillCommands(superseded)
+            if let telemetryEvidence {
+                observeTreadmillTelemetry(.commandEnqueued(telemetryEvidence))
+            }
             return
         }
 
@@ -3960,6 +4284,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             command: command,
             isSpeedLabel: isSpeedCommandLabel
         )
+        var superseded: [TreadmillCommandEnqueuedEvidence] = []
+        if let telemetryEvidence {
+            superseded = treadmillCommandTelemetrySidecar.enqueueRegular(
+                label: label,
+                evidence: telemetryEvidence,
+                isSpeedLabel: isSpeedCommandLabel
+            )
+        }
         if result.coalescedSpeedCount > 0 {
             logTrainingEvent("command_speed_coalesced", fields: [
                 "new_label": label,
@@ -3968,6 +4300,47 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             ])
         }
         processCommandQueue()
+        observeSupersededTreadmillCommands(superseded)
+        if let telemetryEvidence {
+            observeTreadmillTelemetry(.commandEnqueued(telemetryEvidence))
+        }
+    }
+
+    private func observeCancelledTreadmillCommands(
+        _ commands: [TreadmillCommandEnqueuedEvidence],
+        reason: CommandCancellationReason
+    ) {
+        for command in commands {
+            observeTreadmillTelemetry(
+                .commandCancelled(
+                    TreadmillCommandCancellationObservation(
+                        commandID: command.commandID,
+                        decisionID: command.decisionID,
+                        connectionEpoch: command.connectionEpoch,
+                        occurredAt: Date(),
+                        reason: reason
+                    )
+                )
+            )
+        }
+    }
+
+    private func observeSupersededTreadmillCommands(
+        _ commands: [TreadmillCommandEnqueuedEvidence]
+    ) {
+        for command in commands {
+            observeTreadmillTelemetry(
+                .commandCancelled(
+                    TreadmillCommandCancellationObservation(
+                        commandID: command.commandID,
+                        decisionID: command.decisionID,
+                        connectionEpoch: command.connectionEpoch,
+                        occurredAt: Date(),
+                        reason: .superseded
+                    )
+                )
+            )
+        }
     }
 
     private func processCommandQueue() {
@@ -3996,29 +4369,103 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 return
             }
             let next = self.commandQueue.removeFirst()
-            self.performWrite(next.data, label: next.label)
+            let telemetryEvidence: TreadmillCommandEnqueuedEvidence?
+            var postWriteTelemetry: [TreadmillTelemetryEvidence] = []
+            switch self.treadmillCommandTelemetrySidecar.dequeue(
+                expectedLabel: next.label,
+                currentEpoch: self.treadmillTelemetryConnectionEpoch
+            ) {
+            case .matched(let evidence):
+                telemetryEvidence = evidence
+            case .staleEpoch(let evidence):
+                telemetryEvidence = nil
+                postWriteTelemetry.append(
+                    .commandCancelled(
+                        TreadmillCommandCancellationObservation(
+                            commandID: evidence.commandID,
+                            decisionID: evidence.decisionID,
+                            connectionEpoch: evidence.connectionEpoch,
+                            occurredAt: Date(),
+                            reason: .other("connection_epoch_changed_before_write")
+                        )
+                    )
+                )
+            case .correlationLost(let evidence):
+                telemetryEvidence = nil
+                postWriteTelemetry.append(
+                    contentsOf: evidence.map {
+                        .commandCancelled(
+                            TreadmillCommandCancellationObservation(
+                                commandID: $0.commandID,
+                                decisionID: $0.decisionID,
+                                connectionEpoch: $0.connectionEpoch,
+                                occurredAt: Date(),
+                                reason: .other("telemetry_sidecar_order_mismatch")
+                            )
+                        )
+                    }
+                )
+            case .missing:
+                telemetryEvidence = nil
+            }
+            postWriteTelemetry.append(
+                contentsOf: self.performWrite(
+                    next.data,
+                    label: next.label,
+                    telemetryEvidence: telemetryEvidence
+                )
+            )
             self.nextCommandAllowedAt = Date().addingTimeInterval(self.commandMinIntervalSecondsForCurrentProtocol())
             self.isCommandQueueProcessing = false
             if !self.commandQueue.isEmpty {
                 self.processCommandQueue()
             }
+            for evidence in postWriteTelemetry {
+                self.observeTreadmillTelemetry(evidence)
+            }
         }
     }
 
-    private func performWrite(_ data: Data, label: String) {
+    private func performWrite(
+        _ data: Data,
+        label: String,
+        telemetryEvidence: TreadmillCommandEnqueuedEvidence?
+    ) -> [TreadmillTelemetryEvidence] {
         guard isConnected else {
             appendLog("WRITE SKIPPED (not connected): \(label)")
             if label == "STOP" {
                 markInitialStopCommandNotSent(reason: "not_connected")
             }
-            return
+            return [
+                .commandFailed(
+                    TreadmillCommandFailureObservation(
+                        commandID: telemetryEvidence?.commandID,
+                        decisionID: telemetryEvidence?.decisionID,
+                        attemptID: nil,
+                        connectionEpoch: telemetryEvidence?.connectionEpoch,
+                        occurredAt: Date(),
+                        reason: .transportUnavailable
+                    )
+                )
+            ]
         }
         guard let p = connectedPeripheral, let ch = commandCharacteristic else {
             appendLog("WRITE SKIPPED (no characteristic): \(label)")
             if label == "STOP" {
                 markInitialStopCommandNotSent(reason: "characteristic_unavailable")
             }
-            return
+            return [
+                .commandFailed(
+                    TreadmillCommandFailureObservation(
+                        commandID: telemetryEvidence?.commandID,
+                        decisionID: telemetryEvidence?.decisionID,
+                        attemptID: nil,
+                        connectionEpoch: telemetryEvidence?.connectionEpoch,
+                        occurredAt: Date(),
+                        reason: .transportUnavailable
+                    )
+                )
+            ]
         }
         let type: CBCharacteristicWriteType = ch.properties.contains(.writeWithoutResponse) ? .withoutResponse : .withResponse
         lastCommandSentAt = Date()
@@ -4038,6 +4485,54 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         ])
         trackExpectedSpeedIfNeeded(label: label)
         p.writeValue(data, for: ch, type: type)
+        let sentAt = lastCommandSentAt ?? Date()
+        let telemetryWriteType: TreadmillCommandWriteType = type == .withoutResponse
+            ? .withoutResponse
+            : .withResponse
+        if let telemetryEvidence {
+            let previousAttemptNumber = treadmillCommandAttemptNumbers[
+                telemetryEvidence.commandID
+            ] ?? 0
+            let attemptNumber = previousAttemptNumber == UInt16.max
+                ? UInt16.max
+                : previousAttemptNumber + 1
+            treadmillCommandAttemptNumbers[telemetryEvidence.commandID] = attemptNumber
+            return [
+                .commandQueueDelay(
+                    TreadmillCommandQueueDelayEvidence(
+                        commandID: telemetryEvidence.commandID,
+                        decisionID: telemetryEvidence.decisionID,
+                        connectionEpoch: telemetryEvidence.connectionEpoch,
+                        enqueuedAt: telemetryEvidence.enqueuedAt,
+                        sentAt: sentAt
+                    )
+                ),
+                .sendAttempt(
+                    TreadmillCommandSendAttemptEvidence(
+                        commandID: telemetryEvidence.commandID,
+                        decisionID: telemetryEvidence.decisionID,
+                        attemptID: CommandAttemptID(),
+                        attemptNumber: attemptNumber,
+                        protocolKind: telemetryEvidence.protocolKind,
+                        connectionEpoch: telemetryEvidence.connectionEpoch,
+                        sentAt: sentAt,
+                        writeType: telemetryWriteType
+                    )
+                ),
+            ]
+        } else if let connectionEpoch = treadmillTelemetryConnectionEpoch {
+            return [
+                .unassociatedWrite(
+                    UnassociatedLegacyWriteObservation(
+                        protocolKind: treadmillTelemetryProtocolKind,
+                        connectionEpoch: connectionEpoch,
+                        sentAt: sentAt,
+                        writeType: telemetryWriteType
+                    )
+                )
+            ]
+        }
+        return []
     }
 
     private func markInitialStopCommandSent(at sentAt: Date) {
@@ -4137,6 +4632,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     private func resetProtocolState() {
+        let cancelledTelemetry = treadmillCommandTelemetrySidecar.clear()
+        treadmillCommandAttemptNumbers.removeAll()
+        latestTreadmillObservationEvidence = nil
+        activeTreadmillStopTelemetryChain = nil
         treadmillProtocol = .unknown
         ftmsHasControl = false
         ftmsControlRequestInFlight = false
@@ -4163,6 +4662,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         controllerUnitsTruth = controllerUnitsTruthTracker.state
         lastControllerUnitsQueryAt = nil
         lastControllerUnitsQueryTrigger = nil
+        observeCancelledTreadmillCommands(
+            cancelledTelemetry,
+            reason: .other("connection_epoch_reset")
+        )
     }
 
     private var controllerUnitsTruthRequired: Bool {
@@ -4359,7 +4862,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
     }
 
-    private func enqueueFtmsRequestControlIfNeeded() {
+    private func enqueueFtmsRequestControlIfNeeded(
+        decision: TreadmillControlDecisionEvidence? = nil
+    ) {
         guard treadmillProtocol == .ftms else { return }
         guard !ftmsHasControl else { return }
         guard !ftmsControlRequestInFlight else { return }
@@ -4368,7 +4873,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             return
         }
         ftmsControlRequestInFlight = true
-        writeCommand(buildFtmsRequestControlPacket(), label: "FTMS REQUEST CONTROL")
+        writeCommand(
+            buildFtmsRequestControlPacket(),
+            label: "FTMS REQUEST CONTROL",
+            telemetryRequest: treadmillCommandRequest(
+                kind: .other("request_control"),
+                decision: decision
+            )
+        )
     }
 
     private func commandMinIntervalSecondsForCurrentProtocol() -> TimeInterval {
@@ -4392,24 +4904,63 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         return observed < 0.2
     }
 
-    private func sendTreadmillSetSpeed(_ kmh: Double, label: String) {
+    private func sendTreadmillSetSpeed(
+        _ kmh: Double,
+        label: String,
+        decision: TreadmillControlDecisionEvidence? = nil
+    ) {
         if kmh > 0.1 {
             endStopObservationForNewMotion()
         }
         switch treadmillProtocol {
         case .walkingPad:
-            writeCommand(buildWalkingPadSetSpeedPacket(kmh: kmh), label: label)
+            writeCommand(
+                buildWalkingPadSetSpeedPacket(kmh: kmh),
+                label: label,
+                telemetryRequest: treadmillCommandRequest(
+                    kind: treadmillSetSpeedCommandKind(kmh),
+                    decision: decision
+                )
+            )
         case .ftms:
-            enqueueFtmsRequestControlIfNeeded()
+            enqueueFtmsRequestControlIfNeeded(decision: decision)
             if shouldAutoStartForSpeedChange(kmh: kmh) {
-                writeCommand(buildFtmsStartOrResumePacket(), label: "FTMS START/RESUME (auto)")
+                writeCommand(
+                    buildFtmsStartOrResumePacket(),
+                    label: "FTMS START/RESUME (auto)",
+                    telemetryRequest: treadmillCommandRequest(
+                        kind: .other("auto_start"),
+                        decision: decision
+                    )
+                )
             }
-            writeCommand(buildFtmsSetSpeedPacket(kmh: kmh), label: label)
+            writeCommand(
+                buildFtmsSetSpeedPacket(kmh: kmh),
+                label: label,
+                telemetryRequest: treadmillCommandRequest(
+                    kind: treadmillSetSpeedCommandKind(kmh),
+                    decision: decision
+                )
+            )
         case .fitShow:
             if shouldAutoStartForSpeedChange(kmh: kmh) {
-                writeCommand(buildFitShowStartOrResumePacket(), label: "FitShow START/RESUME (auto)")
+                writeCommand(
+                    buildFitShowStartOrResumePacket(),
+                    label: "FitShow START/RESUME (auto)",
+                    telemetryRequest: treadmillCommandRequest(
+                        kind: .other("auto_start"),
+                        decision: decision
+                    )
+                )
             }
-            writeCommand(buildFitShowSetSpeedPacket(kmh: kmh, incline: 0), label: label)
+            writeCommand(
+                buildFitShowSetSpeedPacket(kmh: kmh, incline: 0),
+                label: label,
+                telemetryRequest: treadmillCommandRequest(
+                    kind: treadmillSetSpeedCommandKind(kmh),
+                    decision: decision
+                )
+            )
         case .unknown:
             appendLog("Set speed skipped: unknown treadmill protocol (speed=\(String(format: "%.1f", kmh)))")
         }
@@ -4488,7 +5039,12 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         BLETransportCodec.parseFitShowFrame(data)
     }
 
-    private func applyFitShowFrame(_ frame: FitShowFrame) {
+    private func applyFitShowFrame(
+        _ frame: FitShowFrame,
+        peripheral: CBPeripheral,
+        characteristic: CBCharacteristic,
+        receivedAt: Date
+    ) {
         let cmdHex = String(format: "0x%02X", frame.cmd)
         let subHex = frame.subcmd.map { String(format: "0x%02X", $0) } ?? "-"
 
@@ -4508,6 +5064,20 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     self.deviceReportedSpeedKmh = speedKmh
                     self.deviceReportedAppSpeedKmh = speedKmh
                     self.deviceReportedManualMode = incline
+                    if peripheral.identifier == self.connectedPeripheralId,
+                       characteristic.uuid == self.fitShowCharRx,
+                       let connectionEpoch = self.treadmillTelemetryConnectionEpoch {
+                        _ = self.observeTreadmillProviderObservation(
+                            .fitShow(
+                                speedRawTenthsKmh: speedTenths,
+                                rawState: nil,
+                                deviceState: .unknown,
+                                checksumValid: frame.checksumOk,
+                                connectionEpoch: connectionEpoch,
+                                receivedAt: receivedAt
+                            )
+                        )
+                    }
                 }
                 appendLog("Notify FitShow speed: speed=\(String(format: "%.1f", speedKmh)) km/h incline=\(incline) checksum=\(frame.checksumOk ? "ok" : "bad")")
                 logActualSpeedChangeIfNeeded(speedKmh, source: "fitshow_notify")
@@ -4524,12 +5094,31 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             // Status response.
             guard !frame.payload.isEmpty else {
                 appendLog("Notify FitShow status: empty payload checksum=\(frame.checksumOk ? "ok" : "bad")")
+                DispatchQueue.main.async {
+                    guard peripheral.identifier == self.connectedPeripheralId,
+                          characteristic.uuid == self.fitShowCharRx,
+                          let connectionEpoch = self.treadmillTelemetryConnectionEpoch else {
+                        return
+                    }
+                    _ = self.observeTreadmillProviderObservation(
+                        .fitShow(
+                            speedRawTenthsKmh: nil,
+                            rawState: nil,
+                            deviceState: .unknown,
+                            checksumValid: frame.checksumOk,
+                            connectionEpoch: connectionEpoch,
+                            receivedAt: receivedAt
+                        )
+                    )
+                }
                 return
             }
             let state = Int(frame.payload[0])
             var speedKmh: Double? = nil
+            var speedRawTenths: Int? = nil
             if frame.payload.count >= 3 {
                 let speedTenths = Int(frame.payload[1])
+                speedRawTenths = speedTenths
                 speedKmh = Double(speedTenths) / 10.0
             }
             DispatchQueue.main.async {
@@ -4537,6 +5126,20 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 if let speedKmh {
                     self.deviceReportedSpeedKmh = speedKmh
                     self.deviceReportedAppSpeedKmh = speedKmh
+                }
+                if peripheral.identifier == self.connectedPeripheralId,
+                   characteristic.uuid == self.fitShowCharRx,
+                   let connectionEpoch = self.treadmillTelemetryConnectionEpoch {
+                    _ = self.observeTreadmillProviderObservation(
+                        .fitShow(
+                            speedRawTenthsKmh: speedRawTenths,
+                            rawState: state,
+                            deviceState: .unknown,
+                            checksumValid: frame.checksumOk,
+                            connectionEpoch: connectionEpoch,
+                            receivedAt: receivedAt
+                        )
+                    )
                 }
             }
             appendLog("Notify FitShow status: state=\(state) speed=\(speedKmh.map { String(format: "%.1f", $0) } ?? "-") km/h checksum=\(frame.checksumOk ? "ok" : "bad")")
@@ -4671,6 +5274,189 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     func setHeartRateTelemetrySink(_ sink: (any HeartRateTelemetrySink)?) {
         heartRateTelemetrySink = sink
+    }
+
+    func setTreadmillTelemetrySink(_ sink: (any TreadmillTelemetrySink)?) {
+        treadmillTelemetrySink = sink
+    }
+
+    private var treadmillTelemetryConnectionEpoch: TreadmillConnectionEpoch? {
+        controllerUnitsConnectionEpoch.map(TreadmillConnectionEpoch.init(rawValue:))
+    }
+
+    private var treadmillTelemetryProtocolKind: TreadmillProtocolKind {
+        switch treadmillProtocol {
+        case .walkingPad: return .walkingPad
+        case .ftms: return .ftms
+        case .fitShow: return .fitShow
+        case .unknown: return .unknown
+        }
+    }
+
+    private func observeTreadmillTelemetry(_ evidence: TreadmillTelemetryEvidence) {
+        _ = treadmillTelemetrySink?.observeTreadmillEvidence(evidence)
+    }
+
+    private func makeTreadmillDecision(
+        source: TreadmillControlDecisionSource,
+        intent: TreadmillControlDecisionIntent,
+        heartRateInputs: [HeartRateCausalReference] = [],
+        occurredAt: Date = Date()
+    ) -> TreadmillControlDecisionEvidence? {
+        guard let connectionEpoch = treadmillTelemetryConnectionEpoch else { return nil }
+        return TreadmillControlDecisionEvidence(
+            decisionID: DecisionID(),
+            source: source,
+            intent: intent,
+            heartRateInputs: heartRateInputs,
+            occurredAt: occurredAt,
+            connectionEpoch: connectionEpoch
+        )
+    }
+
+    private func observeTreadmillDecision(
+        _ decision: TreadmillControlDecisionEvidence?
+    ) {
+        guard let decision else { return }
+        observeTreadmillTelemetry(.decision(decision))
+    }
+
+    private func treadmillCommandRequest(
+        kind: CommandKind,
+        decision: TreadmillControlDecisionEvidence? = nil,
+        commandID: CommandID = CommandID()
+    ) -> TreadmillCommandTelemetryRequest {
+        TreadmillCommandTelemetryRequest(
+            commandID: commandID,
+            decisionID: decision?.decisionID,
+            kind: kind
+        )
+    }
+
+    private func treadmillSetSpeedCommandKind(_ kmh: Double) -> CommandKind {
+        let commandedSpeed: CommandedSpeed
+        switch treadmillProtocol {
+        case .walkingPad:
+            commandedSpeed = TreadmillCommandedSpeedRepresentation.walkingPad(
+                rawControllerTenths: clampSpeedTenths(kmh)
+            )
+        case .ftms:
+            let raw = UInt16(max(0, min(65_535, (kmh * 100.0).rounded())))
+            commandedSpeed = TreadmillCommandedSpeedRepresentation.ftms(
+                rawHundredthsKmh: raw
+            )
+        case .fitShow:
+            let raw = UInt8(max(0, min(250, Int((kmh * 10.0).rounded()))))
+            commandedSpeed = TreadmillCommandedSpeedRepresentation.fitShow(
+                rawTenthsKmh: raw
+            )
+        case .unknown:
+            commandedSpeed = .init(nativeValue: kmh, nativeUnit: .unknown)
+        }
+        return .setSpeed(commandedSpeed)
+    }
+
+    private func treadmillUnitsTruthEvidence() -> TreadmillUnitsTruth? {
+        guard let currentEpoch = treadmillTelemetryConnectionEpoch else { return nil }
+        guard controllerUnitsTruth.connectionEpoch == currentEpoch.rawValue else {
+            return .notRead(connectionEpoch: currentEpoch)
+        }
+        switch controllerUnitsTruth.status {
+        case .notRead:
+            return .notRead(connectionEpoch: currentEpoch)
+        case .invalidChecksum:
+            return .invalidChecksum(connectionEpoch: currentEpoch)
+        case .malformed:
+            return .malformed(connectionEpoch: currentEpoch)
+        case .valid:
+            guard let observedAt = controllerUnitsTruth.observedAt else {
+                return .malformed(connectionEpoch: currentEpoch)
+            }
+            switch controllerUnitsTruth.units {
+            case .metric:
+                return .valid(
+                    unit: .kilometresPerHour,
+                    connectionEpoch: currentEpoch,
+                    observedAt: observedAt
+                )
+            case .imperial:
+                return .valid(
+                    unit: .milesPerHour,
+                    connectionEpoch: currentEpoch,
+                    observedAt: observedAt
+                )
+            case .unknown:
+                return .unknown(connectionEpoch: currentEpoch)
+            }
+        }
+    }
+
+    private func observeTreadmillProviderObservation(
+        _ observation: TreadmillProviderObservation,
+        unitsTruth: TreadmillUnitsTruth? = nil,
+        recordedAt: Date = Date()
+    ) -> TreadmillObservationEvidence {
+        let evidence = treadmillObservationNormalizer.normalize(
+            observation,
+            unitsTruth: unitsTruth,
+            observationID: ObservationID(),
+            recordedAt: recordedAt
+        )
+        latestTreadmillObservationEvidence = evidence
+        observeTreadmillTelemetry(.observation(evidence))
+        return evidence
+    }
+
+    private func walkingPadTelemetryDeviceState(
+        status: BLETransportCodec.WalkingPadStatus
+    ) -> TreadmillDeviceState {
+        if status.speedRawTenths > 0 { return .moving }
+        if StopObservationPolicy.acceptedNonRunningStates.contains(status.beltState) {
+            return .stopped
+        }
+        return .unknown
+    }
+
+    private func observeCurrentStopTruth(
+        lifecycle: StopObservationLifecycle,
+        evaluation: StopObservationEvaluation,
+        evaluatedAt: Date
+    ) {
+        guard let connectionEpoch = treadmillTelemetryConnectionEpoch,
+              lifecycle.context.connectionEpoch == connectionEpoch.rawValue else {
+            return
+        }
+        let latest = lifecycle.observations.last
+        let factualObservation = latestTreadmillObservationEvidence.flatMap { observation in
+            observation.protocolKind == .walkingPad
+                && observation.connectionEpoch == connectionEpoch
+                && observation.receivedAt == latest?.observedAt
+                ? observation
+                : nil
+        }
+        let conclusion: StopEvidenceConclusion = evaluation.isConfirmed
+            ? factualObservation.map {
+                .confirmedByFreshFactualObservation($0.observationID)
+            } ?? .unconfirmed(reason: "confirmed_predicate_without_correlated_observation_id")
+            : .unconfirmed(reason: lifecycle.finalReason ?? evaluation.reason)
+        observeTreadmillTelemetry(
+            .stopEvidence(
+                TreadmillStopTruthEvidence(
+                    stopAttemptID: lifecycle.attemptID,
+                    decisionID: activeTreadmillStopTelemetryChain?.decisionID,
+                    commandID: activeTreadmillStopTelemetryChain?.commandID,
+                    observationID: factualObservation?.observationID,
+                    connectionEpoch: connectionEpoch,
+                    protocolKind: .walkingPad,
+                    conclusion: conclusion,
+                    rawSpeedTenths: latest?.speedRawTenths,
+                    rawDeviceState: latest?.state,
+                    checksumValid: latest?.checksumValid,
+                    observationReceivedAt: latest?.observedAt,
+                    evaluatedAt: evaluatedAt
+                )
+            )
+        )
     }
 
     private func observeHeartRateDelivery(
@@ -4904,12 +5690,21 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         expectedSpeedSource = nil
     }
 
-    private func scheduleWrite(_ data: Data, label: String, after delay: TimeInterval) {
+    private func scheduleWrite(
+        _ data: Data,
+        label: String,
+        after delay: TimeInterval,
+        telemetryRequest: TreadmillCommandTelemetryRequest? = nil
+    ) {
         let epoch = commandQueueEpoch
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
             guard let self else { return }
             guard self.commandQueueEpoch == epoch else { return }
-            self.writeCommand(data, label: label)
+            self.writeCommand(
+                data,
+                label: label,
+                telemetryRequest: telemetryRequest
+            )
         }
     }
 
@@ -5104,10 +5899,31 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let experimentReceiveUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
 #endif
         lastNotifyAt = now
+        let isLegacyAcknowledgementSignal = shouldTreatAsCommandAck(
+            characteristic: characteristic,
+            data: data
+        )
+        let legacyAcknowledgementEvidence = treadmillTelemetryConnectionEpoch.flatMap {
+            isLegacyAcknowledgementSignal
+                ? LegacyAcknowledgementObservation.unresolved(
+                    protocolKind: treadmillTelemetryProtocolKind,
+                    connectionEpoch: $0,
+                    receivedAt: now,
+                    recordedAt: Date()
+                )
+                : nil
+        }
+        defer {
+            if let legacyAcknowledgementEvidence {
+                observeTreadmillTelemetry(
+                    .acknowledgement(legacyAcknowledgementEvidence)
+                )
+            }
+        }
         if lastCommandAwaitingAck,
            let sentAt = lastCommandSentAt,
            now.timeIntervalSince(sentAt) <= commandAckTimeoutSeconds,
-           shouldTreatAsCommandAck(characteristic: characteristic, data: data) {
+           isLegacyAcknowledgementSignal {
             lastCommandAwaitingAck = false
             lastCommandAckedAt = now
         }
@@ -5179,6 +5995,16 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                             "start_speed_raw_tenths": params?.startSpeedRawTenths ?? -1
                         ]) { current, _ in current }
                     )
+                    if let truth = self.treadmillUnitsTruthEvidence() {
+                        self.observeTreadmillTelemetry(
+                            .unitsTruth(
+                                TreadmillUnitsTruthEvidence(
+                                    truth: truth,
+                                    observedAt: observedAt
+                                )
+                            )
+                        )
+                    }
                 }
             } else if let status = BLETransportCodec.parseWalkingPadStatus(data) {
                 let hexStr = hex(data)
@@ -5213,6 +6039,28 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                         characteristic: characteristic,
                         observedAt: now
                     )
+                    if peripheral.identifier == self.connectedPeripheralId,
+                       characteristic === self.notifyCharacteristic,
+                       let connectionEpoch = self.treadmillTelemetryConnectionEpoch {
+                        _ = self.observeTreadmillProviderObservation(
+                            .walkingPad(
+                                speedRawTenths: Int(status.speedRawTenths),
+                                rawState: status.beltState,
+                                deviceState: self.walkingPadTelemetryDeviceState(status: status),
+                                checksumValid: status.checksumOk,
+                                connectionEpoch: connectionEpoch,
+                                receivedAt: now
+                            ),
+                            unitsTruth: self.treadmillUnitsTruthEvidence()
+                        )
+                        if let lifecycle = self.stopObservationLifecycle {
+                            self.observeCurrentStopTruth(
+                                lifecycle: lifecycle,
+                                evaluation: lifecycle.currentEvaluation(at: Date()),
+                                evaluatedAt: Date()
+                            )
+                        }
+                    }
                 }
                 appendLog("Notify FE01 parsed: state=\(status.beltState) speed=\(String(format: "%.1f", status.speedKmh)) appSpeed=\(String(format: "%.1f", status.appSpeedKmh)) mode=\(status.manualMode) time=\(status.timeSeconds)s dist=\(status.distance10m*10)m steps=\(status.steps) button=\(status.lastButton) checksum=\(status.checksumOk ? "ok" : "bad")")
                 logActualSpeedChangeIfNeeded(status.speedKmh, source: "fe01_notify")
@@ -5273,6 +6121,21 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     self.deviceReportedAppSpeedKmh = parsed.instantaneousSpeedKmh
                     self.deviceReportedState = parsed.isMoving ? 1 : 0
                     self.deviceReportedRawHex = ""
+                    if peripheral.identifier == self.connectedPeripheralId,
+                       characteristic.uuid == self.ftmsCharTreadmillData,
+                       let connectionEpoch = self.treadmillTelemetryConnectionEpoch {
+                        _ = self.observeTreadmillProviderObservation(
+                            .ftms(
+                                speedRawHundredthsKmh: Int(
+                                    parsed.instantaneousSpeedRawHundredthsKmh
+                                ),
+                                rawState: parsed.isMoving ? 1 : 0,
+                                deviceState: parsed.isMoving ? .moving : .stopped,
+                                connectionEpoch: connectionEpoch,
+                                receivedAt: now
+                            )
+                        )
+                    }
                 }
                 appendLog("Notify FTMS treadmill data: speed=\(String(format: "%.2f", parsed.instantaneousSpeedKmh)) km/h moving=\(parsed.isMoving)")
                 logActualSpeedChangeIfNeeded(parsed.instantaneousSpeedKmh, source: "ftms_treadmill_data")
@@ -5306,7 +6169,12 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
         case .fitShow:
             if let frame = parseFitShowFrame(data) {
-                applyFitShowFrame(frame)
+                applyFitShowFrame(
+                    frame,
+                    peripheral: peripheral,
+                    characteristic: characteristic,
+                    receivedAt: now
+                )
             } else {
                 appendLog("Notify \(characteristic.uuid.uuidString): \(hex(data))")
             }
@@ -5330,6 +6198,19 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 "char_uuid": characteristic.uuid.uuidString,
                 "status": "ok"
             ])
+        }
+        if peripheral.identifier == connectedPeripheralId,
+           let connectionEpoch = treadmillTelemetryConnectionEpoch {
+            observeTreadmillTelemetry(
+                .writeResult(
+                    LegacyWriteResultObservation(
+                        protocolKind: treadmillTelemetryProtocolKind,
+                        connectionEpoch: connectionEpoch,
+                        occurredAt: Date(),
+                        status: error == nil ? .succeeded : .failed
+                    )
+                )
+            )
         }
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TreadmillCommandTelemetrySidecar.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TreadmillCommandTelemetrySidecar.swift
@@ -1,0 +1,66 @@
+import Foundation
+#if SWIFT_PACKAGE
+import TelemetryDomain
+#endif
+
+/// Observational metadata that mirrors the legacy queue without participating in
+/// command equality, admission, ordering, coalescing, or transport decisions.
+struct TreadmillCommandTelemetrySidecar {
+    enum DequeueResult: Equatable {
+        case matched(TreadmillCommandEnqueuedEvidence)
+        case staleEpoch(TreadmillCommandEnqueuedEvidence)
+        case correlationLost([TreadmillCommandEnqueuedEvidence])
+        case missing
+    }
+
+    private(set) var queued: [(label: String, evidence: TreadmillCommandEnqueuedEvidence)] = []
+
+    var count: Int { queued.count }
+
+    mutating func enqueueRegular(
+        label: String,
+        evidence: TreadmillCommandEnqueuedEvidence,
+        isSpeedLabel: (String) -> Bool
+    ) -> [TreadmillCommandEnqueuedEvidence] {
+        var superseded: [TreadmillCommandEnqueuedEvidence] = []
+        if isSpeedLabel(label) {
+            superseded = queued.compactMap { entry in
+                isSpeedLabel(entry.label) ? entry.evidence : nil
+            }
+            queued.removeAll { isSpeedLabel($0.label) }
+        }
+        queued.append((label, evidence))
+        return superseded
+    }
+
+    mutating func replaceWithHighPriority(
+        label: String,
+        evidence: TreadmillCommandEnqueuedEvidence
+    ) -> [TreadmillCommandEnqueuedEvidence] {
+        let superseded = queued.map(\.evidence)
+        queued = [(label, evidence)]
+        return superseded
+    }
+
+    mutating func clear() -> [TreadmillCommandEnqueuedEvidence] {
+        let cancelled = queued.map(\.evidence)
+        queued.removeAll()
+        return cancelled
+    }
+
+    mutating func dequeue(
+        expectedLabel: String,
+        currentEpoch: TreadmillConnectionEpoch?
+    ) -> DequeueResult {
+        guard let first = queued.first else { return .missing }
+        guard first.label == expectedLabel else {
+            let lost = clear()
+            return .correlationLost(lost)
+        }
+        queued.removeFirst()
+        guard first.evidence.connectionEpoch == currentEpoch else {
+            return .staleEpoch(first.evidence)
+        }
+        return .matched(first.evidence)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TreadmillCommandTelemetrySidecar.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TreadmillCommandTelemetrySidecar.swift
@@ -64,3 +64,39 @@ struct TreadmillCommandTelemetrySidecar {
         return .matched(first.evidence)
     }
 }
+
+/// Mirrors the existing global legacy ACK acceptance predicate without adding
+/// command/attempt correlation or participating in transport behavior.
+struct LegacyAcknowledgementObservationSeam {
+    let isAcceptedByLegacyRuntime: Bool
+    let observation: LegacyAcknowledgementObservation?
+
+    static func evaluate(
+        isAwaitingAcknowledgement: Bool,
+        sentAt: Date?,
+        receivedAt: Date,
+        timeout: TimeInterval,
+        isQualifyingSignal: Bool,
+        protocolKind: TreadmillProtocolKind,
+        connectionEpoch: TreadmillConnectionEpoch?,
+        recordedAt: Date
+    ) -> Self {
+        let isAcceptedByLegacyRuntime = isAwaitingAcknowledgement
+            && sentAt.map { receivedAt.timeIntervalSince($0) <= timeout } == true
+            && isQualifyingSignal
+        let observation = connectionEpoch.flatMap {
+            isAcceptedByLegacyRuntime
+                ? LegacyAcknowledgementObservation.unresolved(
+                    protocolKind: protocolKind,
+                    connectionEpoch: $0,
+                    receivedAt: receivedAt,
+                    recordedAt: recordedAt
+                )
+                : nil
+        }
+        return Self(
+            isAcceptedByLegacyRuntime: isAcceptedByLegacyRuntime,
+            observation: observation
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/CommandQueueServiceTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/CommandQueueServiceTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TelemetryDomain
 import XCTest
 @testable import WalkingPadCoreLogic
 
@@ -64,5 +65,90 @@ final class CommandQueueServiceTests: XCTestCase {
         let dropped = CommandQueueService.clear(queue: &queue)
         XCTAssertEqual(dropped, 3)
         XCTAssertTrue(queue.isEmpty)
+    }
+
+    func testTelemetrySidecarMirrorsCoalescingWithoutChangingCommandEquality() {
+        let epoch = TreadmillConnectionEpoch(rawValue: UUID())
+        let sharedBytes = Data([0xF7, 0xA2, 0x01, 0x20])
+        let legacyA = CommandQueueService.Command(data: sharedBytes, label: "SPEED 3.2")
+        let legacyB = CommandQueueService.Command(data: sharedBytes, label: "SPEED 3.2")
+        XCTAssertEqual(legacyA, legacyB)
+
+        var legacyQueue: [CommandQueueService.Command] = []
+        var sidecar = TreadmillCommandTelemetrySidecar()
+        let first = evidence(label: "SPEED 3.2", epoch: epoch)
+        let second = evidence(label: "PING", epoch: epoch)
+        let third = evidence(label: "SPEED 4.0", epoch: epoch)
+
+        _ = CommandQueueService.enqueueRegular(
+            queue: &legacyQueue,
+            command: legacyA,
+            isSpeedLabel: isSpeed
+        )
+        XCTAssertTrue(
+            sidecar.enqueueRegular(label: "SPEED 3.2", evidence: first, isSpeedLabel: isSpeed)
+                .isEmpty
+        )
+        _ = CommandQueueService.enqueueRegular(
+            queue: &legacyQueue,
+            command: .init(data: Data([0x01]), label: "PING"),
+            isSpeedLabel: isSpeed
+        )
+        _ = sidecar.enqueueRegular(label: "PING", evidence: second, isSpeedLabel: isSpeed)
+        let result = CommandQueueService.enqueueRegular(
+            queue: &legacyQueue,
+            command: .init(data: Data([0x02]), label: "SPEED 4.0"),
+            isSpeedLabel: isSpeed
+        )
+        let superseded = sidecar.enqueueRegular(
+            label: "SPEED 4.0",
+            evidence: third,
+            isSpeedLabel: isSpeed
+        )
+
+        XCTAssertEqual(result.coalescedSpeedCount, 1)
+        XCTAssertEqual(superseded.map(\.commandID), [first.commandID])
+        XCTAssertEqual(legacyQueue.map(\.label), ["PING", "SPEED 4.0"])
+        XCTAssertEqual(sidecar.count, legacyQueue.count)
+        XCTAssertEqual(sidecar.dequeue(expectedLabel: "PING", currentEpoch: epoch), .matched(second))
+        XCTAssertEqual(
+            sidecar.dequeue(expectedLabel: "SPEED 4.0", currentEpoch: epoch),
+            .matched(third)
+        )
+    }
+
+    func testTelemetrySidecarFailsCorrelationClosedAcrossEpochOrOrderMismatch() {
+        let oldEpoch = TreadmillConnectionEpoch(rawValue: UUID())
+        let newEpoch = TreadmillConnectionEpoch(rawValue: UUID())
+        let first = evidence(label: "PING", epoch: oldEpoch)
+        var sidecar = TreadmillCommandTelemetrySidecar()
+        _ = sidecar.enqueueRegular(label: "PING", evidence: first, isSpeedLabel: isSpeed)
+
+        XCTAssertEqual(
+            sidecar.dequeue(expectedLabel: "PING", currentEpoch: newEpoch),
+            .staleEpoch(first)
+        )
+
+        let second = evidence(label: "STATUS", epoch: newEpoch)
+        _ = sidecar.enqueueRegular(label: "STATUS", evidence: second, isSpeedLabel: isSpeed)
+        XCTAssertEqual(
+            sidecar.dequeue(expectedLabel: "DIFFERENT", currentEpoch: newEpoch),
+            .correlationLost([second])
+        )
+        XCTAssertEqual(sidecar.count, 0)
+    }
+
+    private func evidence(
+        label: String,
+        epoch: TreadmillConnectionEpoch
+    ) -> TreadmillCommandEnqueuedEvidence {
+        TreadmillCommandEnqueuedEvidence(
+            commandID: CommandID(),
+            decisionID: nil,
+            kind: .other(label),
+            protocolKind: .walkingPad,
+            connectionEpoch: epoch,
+            enqueuedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/StopCommandBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/StopCommandBehaviorContractTests.swift
@@ -70,23 +70,33 @@ final class StopCommandBehaviorContractTests: XCTestCase {
 
     func testDirectStopKeepsHighPriorityAndTwoExistingRetries() throws {
         let body = try functionBody("func stopBelt()")
-        let initial = "writeCommand(packet, label: \"STOP\", highPriority: true)"
-        let retry2 = "scheduleWrite(packet, label: \"STOP retry\", after: 2.0)"
-        let retry4 = "scheduleWrite(packet, label: \"STOP retry\", after: 4.0)"
-
-        assertOrdered([initial, retry2, retry4], in: body)
-        XCTAssertEqual(body.components(separatedBy: initial).count - 1, 1)
-        XCTAssertEqual(body.components(separatedBy: retry2).count - 1, 1)
-        XCTAssertEqual(body.components(separatedBy: retry4).count - 1, 1)
+        assertOrdered(
+            [
+                "writeCommand(",
+                "label: \"STOP\"",
+                "highPriority: true",
+                "scheduleWrite(",
+                "label: \"STOP retry\"",
+                "after: 2.0",
+                "scheduleWrite(",
+                "label: \"STOP retry\"",
+                "after: 4.0",
+            ],
+            in: body
+        )
+        XCTAssertEqual(body.components(separatedBy: "label: \"STOP\"").count - 1, 1)
+        XCTAssertEqual(body.components(separatedBy: "label: \"STOP retry\"").count - 1, 2)
+        XCTAssertEqual(body.components(separatedBy: "after: 2.0").count - 1, 1)
+        XCTAssertEqual(body.components(separatedBy: "after: 4.0").count - 1, 1)
     }
 
     func testManualAndHrStopSequenceKeepsStopToggleAndConditionalRetryOrder() throws {
         let body = try functionBody("private func stopBeltWithToggle(reason: String)")
-        let initial = "stopBeltOnce()"
+        let initial = "let stopCommandWasEnqueued = stopBeltOnce("
         let togglePacket = "let toggle = buildCmdPacket(cmd: 0x04, value: 0x01)"
-        let toggleDelay = "scheduleWrite(toggle, label: \"START/STOP TOGGLE\", after: 2.0)"
+        let toggleDelay = "label: \"START/STOP TOGGLE\""
         let retryDelay = "DispatchQueue.main.asyncAfter(deadline: .now() + 4.0)"
-        let conditionalRetry = "self.writeCommand(stopPacket, label: \"STOP retry\")"
+        let conditionalRetry = "self.writeCommand("
 
         assertOrdered([initial, togglePacket, toggleDelay, retryDelay, conditionalRetry], in: body)
         XCTAssertEqual(body.components(separatedBy: togglePacket).count - 1, 1)
@@ -100,21 +110,24 @@ final class StopCommandBehaviorContractTests: XCTestCase {
 
         assertOrdered(
             [
-                "stopBeltOnce()",
-                "scheduleWrite(toggle, label: \"START/STOP TOGGLE\", after: 2.0)",
+                "let stopCommandWasEnqueued = stopBeltOnce(",
+                "label: \"START/STOP TOGGLE\"",
                 "DispatchQueue.main.asyncAfter(deadline: .now() + 4.0)",
-                "beginStopObservation(source: reason)"
+                "beginStopObservation(source: reason, telemetryChain: telemetryChain)"
             ],
             in: body
         )
-        let onceBody = try functionBody("private func stopBeltOnce()")
-        XCTAssertTrue(onceBody.contains("writeCommand(packet, label: \"STOP\", highPriority: true)"))
+        let onceBody = try functionBody("private func stopBeltOnce(")
+        assertOrdered(
+            ["writeCommand(", "label: \"STOP\"", "highPriority: true"],
+            in: onceBody
+        )
 
         let directBody = try functionBody("func stopBelt()")
         assertOrdered(
             [
-                "scheduleWrite(packet, label: \"STOP retry\", after: 4.0)",
-                "beginStopObservation(source: \"direct\")"
+                "after: 4.0",
+                "beginStopObservation(source: \"direct\", telemetryChain: telemetryChain)"
             ],
             in: directBody
         )
@@ -138,7 +151,7 @@ final class StopCommandBehaviorContractTests: XCTestCase {
     }
 
     func testStopTruthAnchorsToActualInitialWriteAndPersistsUnavailableOutcome() throws {
-        let writeBody = try functionBody("private func performWrite(_ data: Data, label: String)")
+        let writeBody = try functionBody("private func performWrite(")
         assertOrdered(
             [
                 "lastCommandSentAt = Date()",
@@ -149,7 +162,7 @@ final class StopCommandBehaviorContractTests: XCTestCase {
             in: writeBody
         )
 
-        let beginBody = try functionBody("private func beginStopObservation(source: String, now: Date = Date())")
+        let beginBody = try functionBody("private func beginStopObservation(")
         assertOrdered(
             [
                 "if let pendingAttemptID = unavailableStopAttempt?.id",
@@ -177,7 +190,7 @@ final class StopCommandBehaviorContractTests: XCTestCase {
     }
 
     func testNewMotionIntentAndCurrentFreshnessInvalidateConfirmedStopStatus() throws {
-        let setSpeedBody = try functionBody("private func sendTreadmillSetSpeed(_ kmh: Double, label: String)")
+        let setSpeedBody = try functionBody("private func sendTreadmillSetSpeed(")
         assertOrdered(
             [
                 "if kmh > 0.1",

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TreadmillTelemetryBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TreadmillTelemetryBoundaryTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+import XCTest
+
+final class TreadmillTelemetryBoundaryTests: XCTestCase {
+    private lazy var managerSource = try! source("BluetoothManager.swift")
+    private lazy var queueSource = try! source("CommandQueueService.swift")
+    private lazy var sidecarSource = try! source("TreadmillCommandTelemetrySidecar.swift")
+    private lazy var truthSource = try! telemetryDomainSource("TreadmillTruth.swift")
+
+    func testCommandIdentityRemainsOutsideLegacyEqualityAndQueueDecisions() throws {
+        let command = try declarationBody("struct Command: Equatable", in: queueSource)
+        XCTAssertTrue(command.contains("let data: Data"))
+        XCTAssertTrue(command.contains("let label: String"))
+        XCTAssertFalse(command.contains("CommandID"))
+        XCTAssertFalse(command.contains("DecisionID"))
+        XCTAssertFalse(command.contains("AttemptID"))
+
+        XCTAssertFalse(sidecarSource.contains("Data"))
+        XCTAssertFalse(sidecarSource.contains("writeValue"))
+        XCTAssertFalse(sidecarSource.contains("CommandQueueService"))
+    }
+
+    func testTelemetryHotPathHasNoPersistenceAsyncOrRawPacketSurface() {
+        let forbidden = [
+            "TelemetryRecorder",
+            "TelemetryPersistence",
+            "TelemetryStore",
+            "SwiftData",
+            "ModelContext",
+            "FileHandle",
+            "URLSession",
+            "Task {",
+            "await ",
+            "Data",
+            "rawHex",
+            "hex(",
+        ]
+        for token in forbidden {
+            XCTAssertFalse(truthSource.contains(token), "Treadmill truth exposes \(token)")
+            XCTAssertFalse(sidecarSource.contains(token), "Treadmill sidecar exposes \(token)")
+        }
+        XCTAssertFalse(managerSource.contains("TreadmillTelemetrySinkDisposition"))
+    }
+
+    func testLegacyAcknowledgementIsAlwaysObservedWithoutCausalIDs() throws {
+        let callback = try functionBody(
+            "func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor",
+            in: managerSource
+        )
+        XCTAssertTrue(callback.contains("isLegacyAcknowledgementSignal"))
+        XCTAssertTrue(callback.contains(".unresolved("))
+        XCTAssertFalse(callback.contains("deterministicallyAssociated"))
+        XCTAssertFalse(callback.contains("observeAcknowledgement"))
+        XCTAssertFalse(callback.contains("lastCommandSentAt.map"))
+    }
+
+    func testStartAffordanceAndRuntimeAuthorizationDoNotReadTreadmillTelemetry() throws {
+        let affordance = try declarationBody(
+            "var isHrControlStartAffordanceAvailable: Bool",
+            in: managerSource
+        )
+        let start = try functionBody("func startHrControl()", in: managerSource)
+        XCTAssertFalse(affordance.lowercased().contains("telemetry"))
+        XCTAssertFalse(affordance.contains("factual"))
+        XCTAssertFalse(affordance.contains("commandID"))
+        XCTAssertFalse(affordance.contains("treadmillTelemetrySink"))
+        XCTAssertTrue(start.contains("heartRateRuntimePrerequisitesAllowStart"))
+        XCTAssertTrue(start.contains("controllerUnitsGateDecision"))
+        XCTAssertFalse(start.contains("treadmillTelemetrySink"))
+    }
+
+    func testFactualAndStopEvidenceOnlyUseDecodedObservationAndExistingPredicate() throws {
+        let normalization = try functionBody(
+            "private func observeTreadmillProviderObservation(",
+            in: managerSource
+        )
+        XCTAssertFalse(normalization.contains("speedKmh"))
+        XCTAssertFalse(normalization.contains("expectedSpeedKmh"))
+        XCTAssertFalse(normalization.contains("desiredSpeedKmh"))
+        XCTAssertFalse(normalization.contains("deviceTargetSpeedKmh"))
+
+        let stop = try functionBody("private func observeCurrentStopTruth(", in: managerSource)
+        XCTAssertTrue(managerSource.contains("evaluation: StopObservationEvaluation"))
+        XCTAssertTrue(stop.contains("evaluation.isConfirmed"))
+        XCTAssertFalse(stop.contains("expectedSpeedKmh"))
+        XCTAssertFalse(stop.contains("desiredSpeedKmh"))
+        XCTAssertFalse(stop.contains("deviceTargetSpeedKmh"))
+    }
+
+    func testCommandedSpeedUsesProtocolNativeWireScaleWithoutUnitsInference() throws {
+        let mapping = try functionBody(
+            "private func treadmillSetSpeedCommandKind(",
+            in: managerSource
+        )
+        XCTAssertTrue(mapping.contains("switch treadmillProtocol"))
+        XCTAssertTrue(mapping.contains("rawControllerTenths: clampSpeedTenths(kmh)"))
+        XCTAssertTrue(mapping.contains("rawHundredthsKmh: raw"))
+        XCTAssertTrue(mapping.contains("rawTenthsKmh: raw"))
+        XCTAssertTrue(mapping.contains("nativeUnit: .unknown"))
+        XCTAssertFalse(mapping.contains("nativeUnit: .kilometresPerHour"))
+    }
+
+    func testLegacyWriteResultCannotClaimCommandOrAttemptIdentity() throws {
+        let callback = try functionBody(
+            "func peripheral(_ peripheral: CBPeripheral, didWriteValueFor",
+            in: managerSource
+        )
+        XCTAssertTrue(callback.contains("LegacyWriteResultObservation("))
+        XCTAssertFalse(callback.contains("commandID:"))
+        XCTAssertFalse(callback.contains("attemptID:"))
+        XCTAssertFalse(callback.contains("deterministicallyAssociated"))
+    }
+
+    func testLegacyStopRetriesReuseTelemetryCommandIdentityWithoutChangingSchedule() throws {
+        let stop = try functionBody("func stopBelt()", in: managerSource)
+        XCTAssertTrue(stop.contains("after: 2.0"))
+        XCTAssertTrue(stop.contains("after: 4.0"))
+        XCTAssertEqual(
+            stop.components(separatedBy: "telemetryRequest: telemetryRequest").count - 1,
+            3
+        )
+    }
+
+    func testSinkCallsOccurAfterAuthoritativeQueueAndWriteEffects() throws {
+        let enqueue = try functionBody("private func enqueueCommand(", in: managerSource)
+        XCTAssertLessThan(
+            try XCTUnwrap(enqueue.range(of: "processCommandQueue()")?.lowerBound),
+            try XCTUnwrap(enqueue.range(of: "observeTreadmillTelemetry")?.lowerBound)
+        )
+
+        let write = try functionBody("private func performWrite(", in: managerSource)
+        XCTAssertTrue(write.contains("p.writeValue(data, for: ch, type: type)"))
+        XCTAssertFalse(write.contains("observeTreadmillTelemetry"))
+
+        let process = try functionBody("private func processCommandQueue()", in: managerSource)
+        let writeIndex = try XCTUnwrap(process.range(of: "self.performWrite(")?.lowerBound)
+        let nextAllowedIndex = try XCTUnwrap(
+            process.range(of: "self.nextCommandAllowedAt =")?.lowerBound
+        )
+        let sinkIndex = try XCTUnwrap(
+            process.range(of: "self.observeTreadmillTelemetry(evidence)")?.lowerBound
+        )
+        XCTAssertLessThan(writeIndex, nextAllowedIndex)
+        XCTAssertLessThan(nextAllowedIndex, sinkIndex)
+    }
+
+    private func source(_ filename: String) throws -> String {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("WalkingPadRemote")
+            .appendingPathComponent(filename)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private func telemetryDomainSource(_ filename: String) throws -> String {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/TelemetryDomain")
+            .appendingPathComponent(filename)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private func functionBody(_ signature: String, in source: String) throws -> String {
+        try declarationBody(signature, in: source)
+    }
+
+    private func declarationBody(_ signature: String, in source: String) throws -> String {
+        guard let signatureRange = source.range(of: signature),
+              let openingBrace = source[signatureRange.lowerBound...].firstIndex(of: "{") else {
+            throw NSError(domain: "TreadmillTelemetryBoundaryTests", code: 1)
+        }
+        var depth = 0
+        var index = openingBrace
+        while index < source.endIndex {
+            switch source[index] {
+            case "{": depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 {
+                    return String(source[openingBrace...index])
+                }
+            default: break
+            }
+            index = source.index(after: index)
+        }
+        throw NSError(domain: "TreadmillTelemetryBoundaryTests", code: 2)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TreadmillTelemetryBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TreadmillTelemetryBoundaryTests.swift
@@ -1,5 +1,7 @@
 import Foundation
+import TelemetryDomain
 import XCTest
+@testable import WalkingPadCoreLogic
 
 final class TreadmillTelemetryBoundaryTests: XCTestCase {
     private lazy var managerSource = try! source("BluetoothManager.swift")
@@ -42,16 +44,101 @@ final class TreadmillTelemetryBoundaryTests: XCTestCase {
         XCTAssertFalse(managerSource.contains("TreadmillTelemetrySinkDisposition"))
     }
 
-    func testLegacyAcknowledgementIsAlwaysObservedWithoutCausalIDs() throws {
+    func testLegacyAcknowledgementObservationMirrorsAcceptedRuntimeMutation() throws {
         let callback = try functionBody(
             "func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor",
             in: managerSource
         )
         XCTAssertTrue(callback.contains("isLegacyAcknowledgementSignal"))
-        XCTAssertTrue(callback.contains(".unresolved("))
+        XCTAssertTrue(callback.contains("LegacyAcknowledgementObservationSeam.evaluate("))
+        XCTAssertTrue(
+            callback.contains("isAwaitingAcknowledgement: lastCommandAwaitingAck")
+        )
+        XCTAssertTrue(callback.contains("sentAt: lastCommandSentAt"))
+        XCTAssertTrue(callback.contains("timeout: commandAckTimeoutSeconds"))
+        XCTAssertTrue(
+            callback.contains("isQualifyingSignal: isLegacyAcknowledgementSignal")
+        )
+        XCTAssertTrue(callback.contains("legacyAcknowledgementDecision.observation"))
+        XCTAssertTrue(
+            callback.contains("if legacyAcknowledgementDecision.isAcceptedByLegacyRuntime")
+        )
         XCTAssertFalse(callback.contains("deterministicallyAssociated"))
         XCTAssertFalse(callback.contains("observeAcknowledgement"))
         XCTAssertFalse(callback.contains("lastCommandSentAt.map"))
+        XCTAssertFalse(callback.contains("if lastCommandAwaitingAck,"))
+    }
+
+    func testRoutineWalkingPadStatusWithoutPendingAckProducesNoObservation() {
+        let statusPacket: [UInt8] = [0xF8, 0xA2, 0x00, 0x00]
+        let decision = acknowledgementDecision(
+            isAwaiting: false,
+            sentAt: Date(timeIntervalSince1970: 100),
+            receivedAt: Date(timeIntervalSince1970: 101),
+            isQualifyingSignal: statusPacket.first == 0xF8
+        )
+
+        XCTAssertFalse(decision.isAcceptedByLegacyRuntime)
+        XCTAssertTrue([decision.observation].compactMap { $0 }.isEmpty)
+    }
+
+    func testPendingQualifyingSignalInsideWindowMutatesLegacyStateAndEmitsOnce() throws {
+        let receivedAt = Date(timeIntervalSince1970: 102)
+        let decision = acknowledgementDecision(
+            isAwaiting: true,
+            sentAt: Date(timeIntervalSince1970: 99),
+            receivedAt: receivedAt,
+            isQualifyingSignal: true
+        )
+        var isAwaiting = true
+        var acknowledgedAt: Date?
+        if decision.isAcceptedByLegacyRuntime {
+            isAwaiting = false
+            acknowledgedAt = receivedAt
+        }
+        let observations = [decision.observation].compactMap { $0 }
+        let observation = try XCTUnwrap(observations.first)
+
+        XCTAssertFalse(isAwaiting)
+        XCTAssertEqual(acknowledgedAt, receivedAt)
+        XCTAssertEqual(observations.count, 1)
+        XCTAssertEqual(observation.association, .unresolvedByLegacyRuntime)
+        XCTAssertNil(observation.commandID)
+        XCTAssertNil(observation.attemptID)
+    }
+
+    func testQualifyingSignalOutsideWindowLeavesTimeoutOwnershipAndEmitsNothing() {
+        let sentAt = Date(timeIntervalSince1970: 100)
+        let receivedAt = Date(timeIntervalSince1970: 103.001)
+        let decision = acknowledgementDecision(
+            isAwaiting: true,
+            sentAt: sentAt,
+            receivedAt: receivedAt,
+            isQualifyingSignal: true
+        )
+        var isAwaiting = true
+        if decision.isAcceptedByLegacyRuntime {
+            isAwaiting = false
+        }
+
+        XCTAssertFalse(decision.isAcceptedByLegacyRuntime)
+        XCTAssertNil(decision.observation)
+        XCTAssertTrue(isAwaiting)
+        XCTAssertTrue(receivedAt.timeIntervalSince(sentAt) > 3.0)
+    }
+
+    func testLegacyTimeoutOwnerRemainsOutsideNotificationCallback() throws {
+        let callback = try functionBody(
+            "func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor",
+            in: managerSource
+        )
+        let update = try functionBody("private func updateTreadmillStatus()", in: managerSource)
+
+        XCTAssertFalse(callback.contains("lastCommandTimeouts += 1"))
+        XCTAssertTrue(update.contains("now.timeIntervalSince(sentAt) > commandAckTimeoutSeconds"))
+        XCTAssertTrue(update.contains("lastCommandAwaitingAck = false"))
+        XCTAssertTrue(update.contains("lastCommandTimeouts += 1"))
+        XCTAssertTrue(update.contains("observedLegacyCommandTimeout = true"))
     }
 
     func testStartAffordanceAndRuntimeAuthorizationDoNotReadTreadmillTelemetry() throws {
@@ -151,6 +238,26 @@ final class TreadmillTelemetryBoundaryTests: XCTestCase {
             .appendingPathComponent("WalkingPadRemote")
             .appendingPathComponent(filename)
         return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private func acknowledgementDecision(
+        isAwaiting: Bool,
+        sentAt: Date?,
+        receivedAt: Date,
+        isQualifyingSignal: Bool
+    ) -> LegacyAcknowledgementObservationSeam {
+        LegacyAcknowledgementObservationSeam.evaluate(
+            isAwaitingAcknowledgement: isAwaiting,
+            sentAt: sentAt,
+            receivedAt: receivedAt,
+            timeout: 3.0,
+            isQualifyingSignal: isQualifyingSignal,
+            protocolKind: .walkingPad,
+            connectionEpoch: TreadmillConnectionEpoch(
+                rawValue: UUID(uuidString: "00000000-0000-0000-0000-000000000044")!
+            ),
+            recordedAt: receivedAt
+        )
     }
 
     private func telemetryDomainSource(_ filename: String) throws -> String {


### PR DESCRIPTION
## Summary

- add typed treadmill-native, factual, desired, commanded, and estimated speed evidence with authoritative controller-unit and connection-epoch semantics
- add synchronous failure-isolated decision, queue, send-attempt, response, ACK/timeout/write-result, and stop observation seams without changing legacy control behavior
- preserve unresolved legacy ACK association with nil command/attempt IDs, exact #28 HR causal references, the existing Start gates, and `StopObservationService` as the sole stopped predicate
- document the internal ownership/truth/observation/risk map and the Issue #30 persistence boundary

Closes #29

## Verification

- `swift test --disable-sandbox` — 283 tests passed, 1 existing gate test skipped, 0 failures
- `swift test --disable-sandbox --filter TreadmillTelemetryBoundaryTests` — 9 passed
- `swift test --disable-sandbox --filter 'TreadmillTruthTests|TreadmillCommandDecisionTests|TreadmillTelemetryBoundaryTests|CommandQueueServiceTests'` — focused suites passed
- `xcodebuild -quiet -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` — passed
- `python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py` — passed
- `swift package dump-package` — passed
- `git diff --check a75bbcdfa567bfb25c9ab580ca5706446657a5bd...fed8688320c026c1d968b5694cd1e86d7c83dd5c` — passed
- two-cycle independent read-only safety review — initial P1/P2 corrected; fresh reviewer found no P0/P1/material P2

## Risks / Notes

- no packet bytes, write type, queue equality/admission/order/coalescing, minimum intervals, ACK/timeout/retry cadence, stop predicate, HR/cooldown behavior, Start affordance/runtime gates, controller-unit writes, or hardware behavior were changed
- WalkingPad command evidence preserves raw controller tenths without claiming physical km/h; factual WalkingPad km/h remains nil unless valid, fresh, same-epoch controller-unit truth exists
- ambiguous legacy ACK, timeout, and write-result evidence stays `unresolvedByLegacyRuntime` and cannot complete a command attempt or acquire causal IDs during replay
- no recorder, persistence/session ownership, SwiftData wiring, migration, configuration, deployment, install, device launch, BLE connection, or treadmill activity is included; Issue #30 remains out of scope
- rollback is a normal revert of this representation-only commit; no data migration or deployment rollback is required
