### PR TITLE
Refactor Codex governance and context ownership

### DIFF
--- a/.agents/skills/walkingpad-pr-lifecycle/SKILL.md
+++ b/.agents/skills/walkingpad-pr-lifecycle/SKILL.md
@@ -5,35 +5,97 @@ description: Implement one WalkingPad GitHub issue from an exact main SHA throug
 
 # WalkingPad PR lifecycle
 
-1. Read the complete issue and PM addenda. Record explicit scope, non-goals, exact base, done criteria, risks, safe checks, and stop conditions.
-2. Fetch GitHub `main`, resolve its exact SHA, and compare it with the approved base before editing. Stop for PM if the base is ambiguous or has drifted.
-3. Create one `codex/...` branch in one isolated worktree. Never edit, stash, reset, or clean the user's dirty worktree.
-4. Keep the parent/Goal agent as sole writer. Use read-only subagents only for non-overlapping bounded work that materially reduces risk; do not fill capacity.
-5. For substantial autonomous work, select `gpt-5.6-sol` with `high` reasoning for the parent when the client supports parent model and effort choice. Use cheaper effort only for genuinely simple scoped work. If selection is unavailable or unexposed, do not claim it; disclose the effective parent model, effort, and fallback.
-6. Route mapping or narrow primary-source research to Luna/medium and safety challenge or final review to Terra/high by default. Disclose effective model, effort, outcome, and fallback.
-7. Make the smallest in-scope implementation. Run focused checks and every applicable safe repository check without install, launch, BLE, or hardware activity.
-8. Inspect the complete base-to-head diff for correctness, scope, safety, secrets, generated artifacts, and missing tests.
-9. For substantial work, assign the completed diff to one fresh read-only reviewer. Fix in-scope material findings and use a fresh reviewer again; allow at most two correction cycles, then stop for PM if material findings remain.
-10. Push only the feature branch and open one Draft PR into `main`. Implementation delivery never marks Ready or merges. Do not force-push, deploy, install, or perform unrelated GitHub administration.
-11. Fetch `main` again. Confirm it still matches the approved base and required pull-request CI tests the exact current head against that base. Missing, queued, cancelled, stale, or failed required CI blocks handoff readiness.
-12. Report exact base/head, branch, changed files, preserved history, checks, CI, independent review, agent usage, and unresolved risks. End with `READY FOR PM REVIEW` only when every gate is satisfied.
+This skill is the canonical owner of the repository's implementation delivery
+workflow. Root `AGENTS.md` owns global authority and safety boundaries; the
+current Issue and active PM decisions own task-specific behavior.
 
-## Token and context efficiency
+## Context and contract
 
-- Unless the task overrides them, use soft planning ranges of about `200k-300k` tokens for small scoped maintenance or correction, `300k-500k` for a substantial feature, and `400k-600k` for large safety-critical work. Checkpoint substantial tasks near `500k`; about `700k` is a soft ceiling, never a hard cutoff.
-- A task-specific budget or checkpoint supersedes generic targets without weakening safety, review, build, or exact-head CI gates.
-- At a checkpoint or soft ceiling, report exposed usage, explain any concrete reason to continue, stop optional exploration, add no low-value agents, and choose a bounded completion path or PM escalation. Do not ship unsafe or knowingly incomplete work to save tokens.
-- Use agents only when they materially reduce risk or review cost. Do not repeat accepted repository archaeology without a new reason. Start corrections from the finding and relevant diff; summarize long successful logs.
-- Run focused tests during implementation, then one full applicable suite after the change is coherent. Repeat a successful full suite or build only after a relevant change or failure.
-- Give reviewers the contract, exact base-to-head diff, and concise evidence. Use exact historical references selectively instead of sending the full transcript or re-reading broad history.
-- Report final token/time usage when exposed, and explicitly mark unverifiable model, effort, token, or timing details.
+1. Read the complete current Issue and every active PM decision. Record scope,
+   non-goals, done criteria, risks, safe checks, and hard stops before editing.
+2. Use current code/tests and directly relevant canonical docs as the default
+   context. Read predecessor Issues, PRs, commits, or historical notes only when
+   a concrete ambiguity remains.
+3. When a later PM decision supersedes body wording, follow the decision and
+   preserve its link in the Issue's `Current binding decisions` index. Do not
+   erase historical comments.
+4. Before relying on non-trivial or unstable external behavior, consult the
+   applicable primary official documentation and retain only the finding that
+   affected the implementation.
+
+## Implementation and verification
+
+1. Fetch GitHub `main`, resolve its exact live SHA, and compare it with the
+   approved contract before editing. Stop for PM on ambiguous or invalidating
+   base drift.
+2. Use exactly one `codex/...` branch in one isolated worktree created from that
+   SHA. Never reset, stash, clean, or reuse the user's dirty worktree.
+3. Keep the parent/Goal agent as sole writer. Mapper or research agents are
+   conditional and read-only. Use a safety challenger and a fresh independent
+   final reviewer whenever the Issue, risk class, or repository contract
+   requires them.
+   For substantial work, select `gpt-5.6-sol` with `high` reasoning for the
+   parent when the client exposes that choice. Route repository mapping or
+   narrow primary-source research to Luna/medium and safety challenge or final
+   review to Terra/high by default. Report the effective model, effort, role,
+   outcome, and any fallback; never claim an unexposed selection.
+4. Make the smallest in-scope change. Run focused checks while iterating and the
+   full applicable safe suite once the coherent change is ready. Repeat a
+   successful full suite only after a relevant change or failure.
+5. Inspect the complete base-to-head diff for correctness, scope, safety,
+   secrets, private data, generated artifacts, and missing tests. Summarize long
+   successful logs instead of carrying their full output forward.
+6. Give the final reviewer the authoritative contract, exact base and head,
+   complete base-to-head diff, and concise check evidence. Review the diff, not
+   the implementation transcript.
+7. Correct material in-scope findings from the finding and changed delta. Use a
+   fresh reviewer after a correction. After two correction cycles with material
+   findings still open, stop for PM direction.
+
+## Draft PR and exact-head gate
+
+1. Commit intentionally, push only the feature branch, and open exactly one
+   Draft PR into `main` with the required closing reference.
+2. Do not mark Ready, merge, force-push, deploy, install, launch on a device,
+   perform hardware/BLE activity, or start another Issue during delivery.
+   Custom GitHub labels are never a delivery dependency.
+3. Fetch `main` again. Confirm that it still equals the approved base, the live
+   PR head equals the reviewed local head, mergeability is acceptable, and every
+   required CI result is successful for that exact head and base.
+4. Missing, queued, cancelled, stale, failed, or wrong-head required CI blocks
+   `READY FOR PM REVIEW`.
+5. Report exact base/head, branch, changed files, preserved history, checks, CI,
+   independent review, agent roles and effective model/effort when exposed,
+   assumptions, and remaining risks.
+
+## Token observability
+
+Token usage is post-hoc observability. It is never by itself a reason to stop,
+request continuation, skip required verification, or reduce safety assurance.
+Report token and elapsed-time usage when the client exposes them; otherwise mark
+those fields unverifiable.
 
 ## PM review and standing merge authorization
 
-This skill's implementation run always stops at a Draft PR. If the user later hands the completed PR to PM with a completion report and asks for GitHub review, that request is standing authorization in the same PM review turn to merge only after PM gives an explicit final `GO` or `APPROVED` verdict.
+Implementation delivery always stops at a Draft PR. If the user later hands the
+completed Draft PR to PM with a completion report and asks for GitHub review,
+that request authorizes merge in the same PM review turn only after an explicit
+final `GO` or `APPROVED` verdict.
 
-PM may then refresh the PR and live `main`; verify exact base/head, no base drift, exact-head required CI, any contract-required real app build, and no unresolved P0/P1/material P2; perform metadata-only PR cleanup; mark Ready; squash-merge using the exact expected head SHA; verify the new `main`; and verify or, when needed, close the completed linked issue.
+PM may then refresh the PR and live `main`; verify exact base/head, no base
+drift, exact-head required CI, any contract-required real app build, and no open
+P0/P1/material P2; perform metadata-only PR cleanup; mark Ready; squash-merge
+using the exact expected head SHA; verify new `main`; and verify or, when needed,
+close the linked completed Issue.
 
-Do not use standing authorization if the verdict is not explicit `GO`/`APPROVED`; the head moved; the base drifted; CI is missing, queued, stale, cancelled, failed, or for the wrong head; a required build is absent or failed; any P0/P1/material P2, reviewer, or scope finding remains; scope or safety was violated; safety uncertainty needs an explicit decision; the merge is conflicted or non-clean; or a more specific policy requires separate `GO`.
+The authorization is cancelled by any non-`GO`/non-`APPROVED` verdict, moved
+head, base drift, conflict, non-clean merge, missing/queued/stale/cancelled/
+failed/wrong-head required CI, missing required build, unresolved material
+finding, scope or safety violation, unresolved safety uncertainty requiring an
+explicit decision, or a more specific gate requiring separate approval.
 
-Standing authorization never covers hardware/BLE/treadmill experiments or physical commands, install/device launch outside explicit task scope, deploy/release, firmware/OTA/service-menu actions, controller preference or unit writes outside their own contract, force-push, branch/tag deletion or destructive cleanup, or work on the next issue. Those remain separate gates.
+It never covers hardware/BLE/treadmill experiments or physical commands;
+install/device launch outside explicit scope; deploy/release; firmware, OTA, or
+service-menu actions; controller preference or unit writes outside their own
+contract; force-push; branch/tag deletion; destructive cleanup; or work on the
+next Issue.

--- a/.github/ISSUE_TEMPLATE/codex-implementation.md
+++ b/.github/ISSUE_TEMPLATE/codex-implementation.md
@@ -1,0 +1,55 @@
+---
+name: Codex implementation
+about: One scoped implementation Issue using repository-owned contracts
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Parent and dependency
+
+- Parent:
+- Depends on:
+- Safety/data classification:
+
+## Goal
+
+Describe the task-specific outcome.
+
+## Accepted behavior contract
+
+State the current owner, behavior to preserve, allowed mutations, failure
+behavior, and positive/negative regression requirements.
+
+## Required changes
+
+-
+
+## Tests and acceptance evidence
+
+-
+
+## Non-goals
+
+-
+
+## Definition of done
+
+-
+
+## Applicable contracts
+
+- [Repository constitution](../../AGENTS.md)
+- [Codex/GitHub workflow ownership](../../docs/engineering/codex-github-workflow.md)
+- [WalkingPad PR lifecycle](../../.agents/skills/walkingpad-pr-lifecycle/SKILL.md)
+- Add only directly relevant subsystem and domain contracts.
+
+## Current binding decisions
+
+- None at creation. Add links to later active PM decisions and integrate their
+  settled task-specific requirements into this body without deleting comments.
+
+## Task-specific hard stops
+
+- Stop for PM when satisfying this Issue requires scope or behavior not
+  explicitly authorized above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,80 +1,87 @@
-# Repository contract
+# Repository constitution
 
 ## Scope and authority
 
-- GitHub `main` is the canonical development base. Resolve and record its exact current SHA before implementation.
-- Use one issue, one `codex/...` branch, one isolated worktree, and one Draft PR. Never edit, reset, stash, clean, or otherwise reuse the user's dirty worktree.
-- Change only files authorized by the issue. Preserve unrelated work and stop when a required change would exceed the approved scope.
-- Read-only tasks may inspect repository files, logs, captures, and public documentation. They do not authorize code changes, GitHub mutations, device connections, or external writes.
-- For implementation, the parent/Goal agent is the sole writer unless the issue explicitly authorizes another writer. Subagents are read-only and used only for bounded independent work that materially reduces risk.
+- GitHub `main` is the canonical development base. Resolve its exact live SHA
+  before implementation; planning-time SHAs are context, not authority.
+- Change only files and external metadata authorized by the current Issue and
+  active PM decisions. Preserve unrelated work and stop when a required change
+  would exceed that scope.
+- Read-only work does not authorize code changes, GitHub mutations, deployment,
+  device access, BLE/controller commands, or other external writes.
+- The parent/Goal agent is the sole writer unless the Issue explicitly says
+  otherwise. Subagents are read-only and conditional on a concrete reduction in
+  mapping, research, safety-review, or final-review risk.
 
-## Delivery lifecycle
+## Context ownership and precedence
 
-1. Read the complete issue and PM addenda; record scope, non-goals, exact base, done criteria, risks, and focused checks.
-2. Fetch GitHub `main`, confirm the approved exact SHA, and create the isolated branch/worktree from it.
-3. Implement the smallest in-scope change and run focused checks plus every applicable safe repository check.
-4. Inspect the complete base-to-head diff for correctness, scope, safety, secrets, artifacts, and missing tests.
-5. For substantial work, run one fresh independent read-only final reviewer. Fix in-scope material findings and repeat with a fresh reviewer, with at most two correction cycles before stopping for PM direction.
-6. Push only the feature branch, open one Draft PR into `main`, re-check the live base and exact-head CI, and stop for PM review.
+- Default working context is the current Issue, its active PM decisions, directly
+  relevant canonical docs, and current code/tests.
+- Read predecessor Issues, PRs, commits, or historical notes only to resolve a
+  concrete ambiguity that current authoritative sources leave open.
+- Root `AGENTS.md` owns repository-wide authority, safety, and boundary rules.
+  Nested `AGENTS.md` files add only subtree-specific constraints.
+- [`walkingpad-pr-lifecycle`](.agents/skills/walkingpad-pr-lifecycle/SKILL.md)
+  exclusively owns the detailed implementation, review, Draft PR, exact-head CI,
+  correction, token-observability, and conditional PM merge workflow.
+- Canonical domain docs own cross-Issue semantics. Issue bodies own task-specific
+  goals, accepted behavior, tests, non-goals, and hard stops. Later active PM
+  decisions override stale wording without erasing the historical comments.
 
-Implementation delivery stops at a Draft PR and must not mark it Ready or merge it. A later PM GitHub review may use the standing merge authorization below, but a Draft PR, reviewer result, or green local check alone is not authorization. Do not force-push, deploy, install, launch on a device, run hardware/BLE experiments, or make custom GitHub labels a delivery dependency.
+## Implementation entry point
 
-Use [`walkingpad-pr-lifecycle`](.agents/skills/walkingpad-pr-lifecycle/SKILL.md) for normal implementation delivery. Report agent role, bounded task, effective model, reasoning effort, outcome, and any fallback. Default routing is Luna/medium for repository mapping or narrow documentation research and Terra/high for scope challenge or independent review; spawn only roles the task needs.
-
-For substantial autonomous work, select `gpt-5.6-sol` with `high` reasoning for the parent/Goal agent when the client exposes parent model and effort choice. Use cheaper effort only for genuinely simple scoped work. If the client does not expose the selection or the preferred model is unavailable, do not claim it was selected; report the effective parent model, effort, and fallback in the handoff.
-
-## Token and context efficiency
-
-- Use these soft planning ranges unless a task supplies its own budget: about `200k-300k` tokens for small scoped maintenance or correction, `300k-500k` for a substantial feature, and `400k-600k` for large safety-critical work. For substantial tasks, checkpoint near `500k`; treat about `700k` as a soft ceiling, not a hard cutoff.
-- A task-specific token budget or checkpoint supersedes these generic targets, but never weakens safety, review, build, or exact-head CI gates.
-- At a checkpoint or soft ceiling, report usage when the client exposes it, state the concrete reason for any continuation, stop optional exploration, avoid new low-value agents, and choose a bounded completion path or escalate to PM. Never ship unsafe or knowingly incomplete work merely to save tokens.
-- Use a subagent only when it materially reduces risk or review cost. Do not repeat accepted repository archaeology without a new reason; start correction work from the finding and relevant diff. Summarize long successful logs instead of reproducing them.
-- Prefer focused tests while implementing and one full applicable suite after the change is coherent. Do not repeat a successful full suite or build unless a relevant change or failure justifies it.
-- Give reviewers the contract, exact base-to-head diff, and concise evidence rather than a full transcript. Consult historical commits or files selectively and cite exact references.
-- In the handoff, report final token and elapsed-time usage when available. Mark model, effort, token, or timing details as unverifiable when the client does not expose them.
-
-## PM review and standing merge authorization
-
-When a user hands a completed Codex Draft PR back to PM with a completion report and asks PM to review it on GitHub, that request is standing authorization for the same PM review turn to complete the merge only if PM's final verdict is explicitly `GO` or `APPROVED`. It does not let the implementation agent merge during delivery.
-
-Under that authorization, PM may refresh the PR and live `main`, verify the exact base and head with no base drift, confirm required exact-head CI and any contract-required real app build, confirm there are no unresolved P0/P1 or material P2 findings, perform metadata-only PR cleanup, mark Draft as Ready, squash-merge with the exact expected head SHA, verify the new `main`, and verify linked issue closure (closing a completed linked issue if needed).
-
-The standing authorization is cancelled when any of these conditions applies:
-
-- the final PM verdict is not explicit `GO` or `APPROVED`;
-- the PR head moved, the base drifted, or the merge is conflicted or non-clean;
-- required CI is missing, queued, stale, cancelled, failed, or tests the wrong head;
-- a required build is missing or failed;
-- a P0, P1, material P2, reviewer finding, or scope finding remains unresolved;
-- scope or safety was violated, or safety uncertainty requires an explicit decision;
-- a more specific repository or task policy requires a separate `GO`.
-
-Standing merge authorization never covers hardware/BLE/treadmill experiments or physical commands; installation or device launch unless explicitly in task scope; deployment or release; firmware, OTA, or service-menu actions; controller preference or unit writes outside their own approved contract; branch/tag deletion or destructive cleanup; force-push; or automatic work on the next issue. Each remains a separate gate.
+Use [`walkingpad-pr-lifecycle`](.agents/skills/walkingpad-pr-lifecycle/SKILL.md)
+for normal Issue implementation. Delivery stops at one Draft PR for PM review;
+it does not mark Ready or merge. Do not force-push, deploy, release, install,
+launch on a physical device, or start the next Issue unless a separate explicit
+authorization covers that action.
 
 ## Treadmill safety invariants
 
-- Ordinary implementation and design work must not connect to a treadmill or send BLE/controller commands.
-- Stop/start/speed behavior, command retries and confirmation, controller units/preferences, HR safety gates, persistent BLE writes, telemetry semantics, and persistence behavior are safety-critical. Change them only through [`walkingpad-safety-change`](.agents/skills/walkingpad-safety-change/SKILL.md) with an explicit PM-approved behavior contract.
-- Real controller experiments require [`walkingpad-hardware-experiment`](.agents/skills/walkingpad-hardware-experiment/SKILL.md) and a separate PM-approved experiment contract. Never infer authorization from implementation scope.
-- Do not use or promote arbitrary `raw`/`seq` commands, unknown packet replay, service-menu writes, unapproved or silent controller unit changes, firmware/OTA actions, or unlock attempts.
-- A PM-approved controller unit/preference change is allowed only through `walkingpad-safety-change`. Any physical validation additionally requires its own PM-approved `walkingpad-hardware-experiment` contract with an exact fixed packet whitelist and read-back verification.
-- Debug and simulator paths must not bypass production safety gates. Missing, stale, or ambiguous telemetry is not proof of a safe stopped state or valid unit semantics.
-- Use [`walkingpad-evidence-analysis`](.agents/skills/walkingpad-evidence-analysis/SKILL.md) for read-only JSONL/CSV, capture, protocol, and stop-forensics analysis.
+- Ordinary implementation and design work must not connect to a treadmill or
+  send BLE/controller commands.
+- Stop/start/speed behavior, command retries and confirmation, controller
+  units/preferences, HR safety gates, persistent BLE writes, telemetry semantics,
+  and persistence behavior are safety-critical. Change them only through
+  [`walkingpad-safety-change`](.agents/skills/walkingpad-safety-change/SKILL.md)
+  with an explicit PM-approved behavior contract.
+- Real controller experiments require
+  [`walkingpad-hardware-experiment`](.agents/skills/walkingpad-hardware-experiment/SKILL.md)
+  and a separate PM-approved experiment contract. Never infer hardware authority
+  from implementation scope.
+- A PM-approved controller unit/preference change is allowed only through the
+  safety-change workflow. Any physical validation additionally requires a fixed
+  packet whitelist and read-back verification in its own approved hardware-
+  experiment contract.
+- Do not use or promote arbitrary `raw`/`seq` commands, unknown packet replay,
+  service-menu writes, silent controller-unit changes, firmware/OTA actions, or
+  unlock attempts.
+- Debug and simulator paths must not bypass production safety gates. Missing,
+  stale, or ambiguous telemetry is not proof of a safe stopped state or valid
+  unit semantics.
+- Use [`walkingpad-evidence-analysis`](.agents/skills/walkingpad-evidence-analysis/SKILL.md)
+  for read-only JSONL/CSV, capture, protocol, and stop-forensics analysis.
 
 ## Repository boundaries and verification
 
-- Never commit secrets, pairing material, device identifiers, private health/workout exports, local captures, or generated diagnostic logs.
-- Keep runtime changes out of governance/docs-only tasks. In particular, do not touch Swift runtime sources, Xcode project settings, BLE Python tools, or command shell helpers unless the issue explicitly names them.
-- Run the narrowest applicable checks and report only commands actually run. Standard safe checks are:
+- Never commit secrets, pairing material, device identifiers, private
+  health/workout exports, local captures, or generated diagnostic logs.
+- Governance/docs-only work must not touch Swift runtime sources, Xcode project
+  settings, BLE Python tools, command helpers, or runtime persistence code unless
+  the Issue explicitly authorizes them.
+- Run the narrowest applicable checks and report only commands actually run.
+  Standard safe checks are:
   - `python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py`
   - `cd ios/WalkingPadRemote/WalkingPadRemote && swift test`
-  - unsigned generic builds only when app/project changes require them; a build never authorizes install, launch, BLE, or hardware activity.
-- Before handoff, run `git diff --check`, inspect `git diff --name-status <base>...HEAD`, verify the exact live base and exact PR head, and confirm required CI is successful. Failed, missing, cancelled, queued, or stale required CI blocks `READY FOR PM REVIEW`.
+  - unsigned generic builds only when app/project changes require them.
+- A build never authorizes install, launch, BLE, or hardware activity.
 
 ## Documentation map
 
+- Codex/GitHub contract ownership: [`docs/engineering/codex-github-workflow.md`](docs/engineering/codex-github-workflow.md)
+- Telemetry V2 reading routes and precedence: [`docs/telemetry-v2/index.md`](docs/telemetry-v2/index.md)
 - Swift/iOS extensions: [`ios/WalkingPadRemote/WalkingPadRemote/AGENTS.md`](ios/WalkingPadRemote/WalkingPadRemote/AGENTS.md)
 - Contributor setup and checks: [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`ios/README.md`](ios/README.md)
 - Security reporting: [`SECURITY.md`](SECURITY.md)
-- Historical implementation notes moved from the active instruction chain: [`docs/archive/README.md`](docs/archive/README.md)
+- Historical implementation notes: [`docs/archive/README.md`](docs/archive/README.md)
 - Redesign state and decisions: [`docs/design/`](docs/design/)

--- a/docs/engineering/codex-github-workflow.md
+++ b/docs/engineering/codex-github-workflow.md
@@ -1,0 +1,85 @@
+# Codex and GitHub contract ownership
+
+Status: canonical governance map for repository work.
+
+This document explains where project knowledge belongs. It intentionally does
+not duplicate the implementation sequence owned by
+[`walkingpad-pr-lifecycle`](../../.agents/skills/walkingpad-pr-lifecycle/SKILL.md).
+
+## Canonical owners
+
+| Concern | Canonical owner | Keep out of |
+| --- | --- | --- |
+| Repository authority, safety boundaries, documentation map | root [`AGENTS.md`](../../AGENTS.md) | child Issues and launch prompts |
+| Detailed branch/worktree/review/Draft PR/CI/correction workflow | [`walkingpad-pr-lifecycle`](../../.agents/skills/walkingpad-pr-lifecycle/SKILL.md) | root instructions and Issue bodies |
+| Subtree-specific engineering rules | nearest nested `AGENTS.md` | unrelated subtrees and root history |
+| Cross-Issue Telemetry V2 semantics | [`docs/telemetry-v2/`](../telemetry-v2/index.md) | repeated Issue boilerplate |
+| Task goal, accepted behavior, tests, non-goals, hard stops | current Issue body | global docs unless the decision is durable across Issues |
+| Later task-specific PM decisions | linked owner comments and integrated current body | rewritten or deleted comment history |
+| Historical implementation context | Git/Issue/PR history and archived docs | default launch context |
+
+When two sources differ, apply the precedence rules in the root constitution and
+the relevant domain index. Escalate instead of guessing when the difference
+changes safety, scope, or accepted behavior.
+
+## Progressive disclosure
+
+Start with the current Issue, its `Current binding decisions`, the applicable
+contract links, and current code/tests. Read a predecessor Issue, PR, commit, or
+archived document only when a named ambiguity cannot be resolved from those
+sources. Record the ambiguity that justified the historical lookup.
+
+Successful logs are evidence to summarize, not context to reproduce. A review
+packet should contain the contract, exact base/head, complete diff, changed-file
+scope, and concise check results. A correction should start from the exact
+finding and inspect the resulting delta; accepted repository archaeology is not
+repeated without a new reason.
+
+## Issue body shape
+
+Implementation Issues should contain only task-specific material plus:
+
+- `Applicable contracts`: links to root/subsystem instructions, the lifecycle
+  skill, and relevant canonical domain docs;
+- `Current binding decisions`: links to active comments whose decisions remain
+  relevant, with settled requirements integrated into the body;
+- explicit predecessor/dependency state, behavior contract, tests, non-goals,
+  done criteria, and hard stops where the task needs them.
+
+Do not paste repository-global Telemetry invariants or the standard lifecycle
+into each Issue. Comments remain audit history; integrating a decision into the
+body does not delete or rewrite the original comment.
+
+The template at
+[`codex-implementation.md`](../../.github/ISSUE_TEMPLATE/codex-implementation.md)
+implements this shape.
+
+## Thin launch prompt
+
+A launch prompt identifies the repository, Issue number, execution role, and
+required terminal verdict. It directs Codex to the current Issue, active
+decisions, root/nested instructions, and applicable skill. It may restate a
+task-specific hard boundary when omission would be risky, but does not copy the
+Issue body, global invariants, or detailed lifecycle.
+
+## Review and correction evidence
+
+Review findings use priority and exact file/line or GitHub metadata references.
+The reviewer receives the base-to-head diff rather than a full transcript.
+Corrections describe the finding, the bounded delta, and checks rerun because of
+that delta. Required full checks and exact-head CI remain mandatory regardless
+of context size or token use.
+
+## GitHub metadata updates
+
+For an authorized Issue-body change:
+
+1. read the complete current body and comments;
+2. record the pre-update body identity;
+3. update only the authorized Issue;
+4. read it back and verify the expected sections, links, and task semantics;
+5. never delete PM comments to make the body appear cleaner.
+
+GitHub does not provide one transaction spanning multiple Issues. A multi-Issue
+governance edit is auditable when every Issue is verified individually and the
+handoff enumerates the changed Issue numbers.

--- a/docs/engineering/codex-issue-efficiency-audit.md
+++ b/docs/engineering/codex-issue-efficiency-audit.md
@@ -1,0 +1,79 @@
+# Codex Issue efficiency audit
+
+Status: Issue #45 governance audit against base
+`de56b53de811af74a5b829212c64397aae0dd17f`.
+
+## Finding
+
+The base repeated the implementation lifecycle and numerical token-control
+guidance in root instructions, the lifecycle skill, and child Issue bodies.
+Telemetry V2 Issues #30-#36 also repeated the global invariant block, while
+active task decisions lived only in later comments. The Epic checklist still
+showed accepted Issues #26-#29 as open work.
+
+That structure increased default context, made later decisions harder to find,
+and risked treating token checkpoints as execution gates.
+
+## Resolution
+
+- Root `AGENTS.md` is the repository constitution and map.
+- `walkingpad-pr-lifecycle` is the sole detailed implementation lifecycle.
+- Token usage is observable after execution and does not control completion.
+- Telemetry V2 cross-Issue rules live in canonical docs routed by
+  [`docs/telemetry-v2/index.md`](../telemetry-v2/index.md).
+- Child implementation Issues contain task-specific semantics, compact
+  `Applicable contracts`, and linked `Current binding decisions`.
+- Historical PM comments remain intact.
+- Repository history is retrieved only for a concrete ambiguity.
+
+## Durable acceptance checks
+
+Run from the repository root:
+
+```sh
+python3 scripts/check_codex_governance.py
+git diff --check
+git diff --name-status <exact-base>...HEAD
+```
+
+For live Issues #30-#37, verify that each body contains `Applicable contracts`
+and `Current binding decisions`, and that none contains the copied headings
+`Global Telemetry V2 invariants` or `Binding execution contract`. Verify #22's
+checklist and queue against current GitHub state.
+
+The delivery audit must also confirm:
+
+- no runtime Swift, Xcode project, BLE/control helper, or persistence-runtime
+  file changed;
+- local Markdown links in governance and Telemetry routing docs resolve;
+- #30 says at most one observed frame per elapsed second, permits gaps, and
+  prohibits backfill;
+- #36 requires #37 `GO FOR LEGACY RETIREMENT` or a named PM waiver;
+- #37 remains a read-only real-evidence gate;
+- exact-head required CI is successful.
+
+Live GitHub body identities and post-update verification belong in the PR
+handoff because they can change independently of the repository.
+
+## Issue #45 metadata update evidence
+
+Each authorized body was updated only after its live pre-update SHA-256 matched,
+then read back byte-for-byte and checked with the original PM comment count
+unchanged. Hashes below use the UTF-8 body returned by GitHub without its trailing
+newline.
+
+| Issue | Pre-update SHA-256 | Post-update SHA-256 | Comments preserved |
+| --- | --- | --- | ---: |
+| #22 | `4f1d9eb00b02ba5c0540b79874103fd67ef959d337a53bb2a24a889c947c609a` | `364a0e9b46bb6360463d22613f581849388a001e338a284d8d324ec8f90c3416` | 5 |
+| #30 | `c7aed6fe7634e61425683520c604c58d0105724be2ae7a727a88127fb80b2b85` | `ac9ff74f2e4e73b808686887710f4f16e42323c05aa03d155892aeb13016c517` | 6 |
+| #31 | `ed1a836cc27b8cc1eba4bbdeed28a18ad1d1b64708591aaf6ac1992a007c4607` | `1da82e902bf997e1f9aa689a85834d1aef9dd445ea7fda0f178f69d692df4dff` | 1 |
+| #32 | `c3639a339fef8ccdf116909ed6b7e054ff23f83ee3fbc0740954b580834d6d36` | `0e5f653420d01d15ec32623d7a0f86474504b887580d15c1029f995ed8f08eb8` | 1 |
+| #33 | `7d42764ef6e284738e811a27f17dfb6aa6557b8b1fa1ca791d7593648c4abf52` | `2298018382042990ca9c31801000676a4f489be77c14cdeade33fe8294b84654` | 3 |
+| #34 | `f976f287e5315dbe630a0a4097a63c7ed74e93bd02800b760838a331d64a838d` | `1d24ab8ffc8a67a144ec369bc50cc66cebb3e61d8c069faee6730059c8fd4d3d` | 3 |
+| #35 | `38897b2a4947895d19e11eb9c232d440822efaea42c763a8800930408cd767c0` | `5e0b39a4e6a951c3e0008e25d46afa786c770239b6ea580cd17db4b7e6489f81` | 3 |
+| #36 | `9a3fd30981094ac1333aa42d233f16dd3598cbe2e59d244a12a01e071c60a306` | `572d3b6b2fddd0ed4a6e3eae2b491403ddedb9833beac55de7d11da4463bfbde` | 3 |
+| #37 | `5d4244aa8785407190e405e1e0d78f1af0d17589f105167fb45129584ab042c8` | `f5ff2efd6465b76b64026c4431c9f711c0cea50419a6e683fdcb8f78f606f8a3` | 2 |
+
+Every linked `Current binding decisions` comment was resolved through the live
+GitHub API after the update. The live queue was also checked: #23, #39, and
+#26-#29 are closed; #45 and #30-#37 are open.

--- a/docs/telemetry-v2/data-contract.md
+++ b/docs/telemetry-v2/data-contract.md
@@ -115,13 +115,11 @@ observation(s) used -> decision -> command enqueue/send
 - ACK, timeout, write result, cancellation, retry, and transport failure MUST be
   separate factual events. They reference a command attempt only when the
   runtime or protocol proves that exact edge deterministically.
-- The accepted legacy global ACK/timeout/write-result callbacks do not prove an
-  attempt. Their association is `unresolvedByLegacyRuntime`, with `commandID`
-  and `attemptID` absent. Such an event MUST NOT complete or mutate a specific
-  attempt in evidence state.
-- A consumer MUST NOT infer association from latest/oldest/nearest command,
-  timing proximity, queue position, target or expected/modelled speed, packet
-  similarity, a canonical frame, or the global pending-ACK slot.
+- When association cannot be proved, it MUST remain explicitly unknown with no
+  causal IDs and MUST NOT complete or mutate a specific attempt in evidence
+  state. A consumer MUST NOT manufacture association heuristically. Exact legacy
+  runtime rules are owned by
+  [`treadmill-truth-and-command-lifecycle.md`](treadmill-truth-and-command-lifecycle.md).
 - A retry-scheduled event's queryable primary attempt ID is the next scheduled
   attempt; its typed payload MUST also retain the previous attempt ID so the
   retry edge is not lost.

--- a/docs/telemetry-v2/data-contract.md
+++ b/docs/telemetry-v2/data-contract.md
@@ -112,14 +112,23 @@ observation(s) used -> decision -> command enqueue/send
   immutable configuration/safety-policy version under which it ran.
 - A command lifecycle event MUST reference its decision and command IDs when
   applicable.
-- ACK, timeout, cancellation, retry, and transport failure MUST be separate
-  events referencing the command attempt they describe.
+- ACK, timeout, write result, cancellation, retry, and transport failure MUST be
+  separate factual events. They reference a command attempt only when the
+  runtime or protocol proves that exact edge deterministically.
+- The accepted legacy global ACK/timeout/write-result callbacks do not prove an
+  attempt. Their association is `unresolvedByLegacyRuntime`, with `commandID`
+  and `attemptID` absent. Such an event MUST NOT complete or mutate a specific
+  attempt in evidence state.
+- A consumer MUST NOT infer association from latest/oldest/nearest command,
+  timing proximity, queue position, target or expected/modelled speed, packet
+  similarity, a canonical frame, or the global pending-ACK slot.
 - A retry-scheduled event's queryable primary attempt ID is the next scheduled
   attempt; its typed payload MUST also retain the previous attempt ID so the
   retry edge is not lost.
-- A later treadmill observation MAY reference the command as a candidate causal
-  response only when the implementation has real correlation evidence. Mere
-  temporal proximity MUST NOT be recorded as proven causation.
+- A later treadmill observation MAY reference the command as a causal response
+  only when independent deterministic evidence proves the edge. Otherwise its
+  command and attempt association remains nil/unknown; mere temporal proximity
+  MUST NOT be recorded as causation.
 - Absence of ACK or observed response remains absence, not success.
 
 ## Units

--- a/docs/telemetry-v2/index.md
+++ b/docs/telemetry-v2/index.md
@@ -12,7 +12,8 @@ is not a second architecture summary.
 2. [`safety-boundary.md`](safety-boundary.md) owns cross-Issue safety and
    one-way-authority invariants.
 3. [`data-contract.md`](data-contract.md) owns evidence, provenance, time,
-   identity, causal-association, frame, and analysis semantics.
+   identity, general causal-proof, frame, and analysis semantics. Protocol- and
+   runtime-specific association rules belong to their topic document.
 4. Topic documents below refine those canonical contracts for their named seam.
 5. Current code and executable regressions provide exact implemented names and
    evidence. They do not override a PM-approved behavior contract.

--- a/docs/telemetry-v2/index.md
+++ b/docs/telemetry-v2/index.md
@@ -1,0 +1,54 @@
+# Telemetry V2 documentation index
+
+Status: canonical reading routes and precedence map.
+
+Use this index to load only the documents relevant to the current question. It
+is not a second architecture summary.
+
+## Precedence
+
+1. The current Issue and linked active PM decisions own task-specific scope and
+   accepted behavior. A later active decision supersedes stale Issue wording.
+2. [`safety-boundary.md`](safety-boundary.md) owns cross-Issue safety and
+   one-way-authority invariants.
+3. [`data-contract.md`](data-contract.md) owns evidence, provenance, time,
+   identity, causal-association, frame, and analysis semantics.
+4. Topic documents below refine those canonical contracts for their named seam.
+5. Current code and executable regressions provide exact implemented names and
+   evidence. They do not override a PM-approved behavior contract.
+
+If these sources leave a safety- or scope-relevant ambiguity, stop for PM rather
+than infer a rule from history. Read predecessor Issues/PRs/commits only to
+resolve a concrete remaining ambiguity.
+
+## Read when
+
+| Question | Read |
+| --- | --- |
+| System components, dependency direction, or queue ownership | [`architecture.md`](architecture.md) |
+| Motion/control isolation, Start HR Control availability, stop truth, or device-evidence limits | [`safety-boundary.md`](safety-boundary.md) |
+| Evidence vocabulary, timestamps, provenance, causal identity, frames, or analyzer semantics | [`data-contract.md`](data-contract.md) |
+| HR provider normalization, delivery identity, or control-use evidence | [`heart-rate-normalization.md`](heart-rate-normalization.md) |
+| Treadmill factual truth, command/attempt IDs, legacy ACK/timeout/write-result uncertainty, or response association | [`treadmill-truth-and-command-lifecycle.md`](treadmill-truth-and-command-lifecycle.md) |
+| Producer ingress, pressure classes, buffering, loss, drain, or recovery | [`recorder-ingress.md`](recorder-ingress.md) |
+| SwiftData ownership, transactions, retention, protection, backup, or store failure | [`persistence-and-retention.md`](persistence-and-retention.md) |
+| Hosted SwiftData scale/crash evidence and device-only carry-over | [`swiftdata-gate.md`](swiftdata-gate.md) |
+| Performance targets, soak measurements, privacy-safe instrumentation, or tuning evidence | [`performance-budget.md`](performance-budget.md) |
+| Dual-write, parity, migration, cutover, physical gate, rollback, or retirement | [`rollout-and-migration.md`](rollout-and-migration.md) |
+
+## Durable cross-Issue decisions
+
+- Start HR Control UI availability remains based on the existing connected
+  treadmill plus current/fresh visible HR rule. Telemetry health, readiness,
+  persistence, analysis, migration, and evidence completeness never add an
+  affordance gate. Existing non-telemetry runtime checks after a tap remain
+  fail-closed. Canonical owner: [`safety-boundary.md`](safety-boundary.md).
+- Canonical frames are observed materialized views, with at most one frame per
+  elapsed second. Missing seconds remain gaps and are never backfilled.
+  Canonical owner: [`data-contract.md`](data-contract.md).
+- The accepted legacy runtime does not deterministically associate ACK, timeout,
+  write-result, or a later factual response with a command attempt unless an
+  independent proof exists. Unknown association remains explicit with nil IDs;
+  proximity, queue order, targets, estimates, and frame state are not proof.
+  Canonical owner:
+  [`treadmill-truth-and-command-lifecycle.md`](treadmill-truth-and-command-lifecycle.md).

--- a/docs/telemetry-v2/safety-boundary.md
+++ b/docs/telemetry-v2/safety-boundary.md
@@ -27,6 +27,12 @@ Throughout this Epic:
    production gates or reach production transport.
 8. Telemetry, persistence, export, and analyzer failure MUST be fail-independent:
    they may degrade evidence health, never motion safety.
+9. The Start HR Control affordance MUST remain available under the existing
+   connected-treadmill plus current/fresh-visible-HR rule. Telemetry health,
+   readiness, factual-speed availability, persistence, migration, analysis,
+   history, export, or evidence completeness MUST NOT add an affordance gate.
+   Existing non-telemetry runtime authorization checks after a tap remain
+   fail-closed.
 
 These are safety boundaries, not learnable parameters.
 
@@ -130,3 +136,10 @@ A failure involving safety, factual provenance, causal correlation, unexplained
 critical loss, or control divergence blocks legacy retirement. An unverified
 item requires explicit PM disposition; simulation alone is not authority to
 delete the comparison path.
+
+Executable regression references include
+`HeartRateLegacyBehaviorContractTests.testStartAffordanceIsSeparateFromRuntimeAuthorization`
+and
+`TreadmillTelemetryBoundaryTests.testStartAffordanceAndRuntimeAuthorizationDoNotReadTreadmillTelemetry`.
+Treadmill unknown-association and no-heuristic-correlation coverage lives in
+`TreadmillTruthTests`.

--- a/scripts/check_codex_governance.py
+++ b/scripts/check_codex_governance.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Validate the repository's Codex governance ownership and local Markdown links."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from urllib.parse import unquote
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROOT_AGENTS = ROOT / "AGENTS.md"
+LIFECYCLE = ROOT / ".agents/skills/walkingpad-pr-lifecycle/SKILL.md"
+ISSUE_TEMPLATE = ROOT / ".github/ISSUE_TEMPLATE/codex-implementation.md"
+TELEMETRY_INDEX = ROOT / "docs/telemetry-v2/index.md"
+
+LOCAL_LINK = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+NUMERIC_TOKEN_CONTROL = re.compile(
+    r"(?:\b\d+[kK]\b[^\n]{0,80}\btoken|\btoken[^\n]{0,80}\b\d+[kK]\b)",
+    re.IGNORECASE,
+)
+
+
+def tracked_markdown_files() -> list[Path]:
+    result = subprocess.run(
+        [
+            "git",
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+            "*.md",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [ROOT / line for line in sorted(result.stdout.splitlines()) if line]
+
+
+def local_target(raw_target: str) -> str | None:
+    target = raw_target.strip()
+    if target.startswith("<") and ">" in target:
+        target = target[1 : target.index(">")]
+    else:
+        target = target.split(maxsplit=1)[0]
+    if target.startswith(("http://", "https://", "mailto:", "#")):
+        return None
+    return unquote(target.split("#", maxsplit=1)[0]) or None
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    for required in (ROOT_AGENTS, LIFECYCLE, ISSUE_TEMPLATE, TELEMETRY_INDEX):
+        if not required.is_file():
+            errors.append(f"missing required governance file: {required.relative_to(ROOT)}")
+
+    for policy_file in (ROOT_AGENTS, LIFECYCLE):
+        if policy_file.is_file() and NUMERIC_TOKEN_CONTROL.search(
+            policy_file.read_text(encoding="utf-8")
+        ):
+            errors.append(
+                f"numeric token control remains in {policy_file.relative_to(ROOT)}"
+            )
+
+    if ISSUE_TEMPLATE.is_file():
+        template = ISSUE_TEMPLATE.read_text(encoding="utf-8")
+        for duplicated_heading in (
+            "## Global Telemetry V2 invariants",
+            "## Binding execution contract",
+        ):
+            if duplicated_heading in template:
+                errors.append(f"issue template repeats {duplicated_heading!r}")
+        for required_heading in (
+            "## Applicable contracts",
+            "## Current binding decisions",
+        ):
+            if required_heading not in template:
+                errors.append(f"issue template is missing {required_heading!r}")
+
+    for markdown_file in tracked_markdown_files():
+        text = markdown_file.read_text(encoding="utf-8")
+        for match in LOCAL_LINK.finditer(text):
+            target = local_target(match.group(1))
+            if target is None:
+                continue
+            resolved = (markdown_file.parent / target).resolve()
+            if not resolved.exists():
+                errors.append(
+                    f"broken local link in {markdown_file.relative_to(ROOT)}: {target}"
+                )
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+
+    print("Codex governance ownership and local Markdown links: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- make root `AGENTS.md` the repository constitution/map and the lifecycle skill
  the single owner of detailed implementation delivery and token observability;
- add progressive-disclosure governance docs, a compact Codex Issue template,
  a Telemetry V2 reading index, and a lightweight governance/link checker;
- promote the accepted Start HR Control, observed-frame, and legacy causal-
  uncertainty decisions into their canonical documentation owners;
- update Epic #22 and Issues #30-#37 with current task semantics, applicable
  contracts, binding-decision links, and the corrected remaining queue.

## GitHub metadata evidence

- Updated only Issue bodies #22 and #30-#37.
- Every update used a matching pre-update SHA-256 guard and exact post-update
  read-back.
- Original PM comment counts were preserved and all 25 active-decision links
  resolved through the live GitHub API.
- The repository audit records the before/after body hashes.

## Verification

- `python3 scripts/check_codex_governance.py`
- `~/.codex/scripts/check-agents-instruction-chain.sh --path .`
- `python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py scripts/check_codex_governance.py`
- `git diff --check de56b53de811af74a5b829212c64397aae0dd17f...d4dfdd71b6def55782c28d6d14c04b2bfde4714d`
- docs-only runtime/scope, secrets, private-data, and generated-artifact scans
- fresh independent correction-cycle review: GO, P0/P1/P2 = 0

Local Swift/app build suites were intentionally not repeated for this
governance/docs-only diff. Required exact-head hosted CI remains the delivery
gate.

## Safety and scope

No Swift runtime, Xcode project, BLE/protocol/control, HR/start/stale, command
queue/ACK/timeout/retry, units, cooldown, stop, persistence runtime/schema, UI,
device, or hardware behavior changed. No install, launch, deploy, release, BLE,
or treadmill action was performed.

Closes #45
