### PR TITLE
Integrate passive Telemetry V2 dual-write

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -24,6 +24,10 @@ let package = Package(
         .library(
             name: "TelemetryPersistence",
             targets: ["TelemetryPersistence"]
+        ),
+        .library(
+            name: "TelemetryRuntime",
+            targets: ["TelemetryRuntime"]
         )
     ],
     targets: [
@@ -36,6 +40,10 @@ let package = Package(
         ),
         .target(
             name: "TelemetryPersistence",
+            dependencies: ["TelemetryDomain", "TelemetryRecorder"]
+        ),
+        .target(
+            name: "TelemetryRuntime",
             dependencies: ["TelemetryDomain", "TelemetryRecorder"]
         ),
         .executableTarget(
@@ -97,6 +105,10 @@ let package = Package(
         .testTarget(
             name: "TelemetryRecorderTests",
             dependencies: ["TelemetryDomain", "TelemetryRecorder"]
+        ),
+        .testTarget(
+            name: "TelemetryRuntimeTests",
+            dependencies: ["TelemetryDomain", "TelemetryRecorder", "TelemetryRuntime"]
         ),
         .testTarget(
             name: "TelemetryPersistenceTests",

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Events.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Events.swift
@@ -129,16 +129,25 @@ public struct SessionLifecycleEvent: Codable, Hashable, Sendable {
     public let previous: SessionLifecycleState?
     public let current: SessionLifecycleState
     public let incompleteReason: String?
+    public let reason: String?
 
     public init(
         previous: SessionLifecycleState?,
         current: SessionLifecycleState,
-        incompleteReason: String? = nil
+        incompleteReason: String? = nil,
+        reason: String? = nil
     ) {
         self.previous = previous
         self.current = current
         self.incompleteReason = incompleteReason
+        self.reason = reason
     }
+}
+
+public enum HeartRateRuntimeEvidence: Codable, Hashable, Sendable {
+    case delivery(HeartRateNormalizationResult)
+    case sourceLifecycle(HeartRateSourceLifecycleEvidence)
+    case controlUse(HeartRateControlUseEvidence)
 }
 
 public struct WorkoutPhaseTransition: Codable, Hashable, Sendable {
@@ -297,6 +306,8 @@ public enum WorkoutEventPayload: Codable, Hashable, Sendable {
     case safety(SafetyEvent)
     case stopEvidence(StopEvidenceEvent)
     case recorderHealth(RecorderHealthEvent)
+    case heartRateEvidence(HeartRateRuntimeEvidence)
+    case treadmillEvidence(TreadmillTelemetryEvidence)
 
     public var kind: WorkoutEventKind {
         switch self {
@@ -311,6 +322,8 @@ public enum WorkoutEventPayload: Codable, Hashable, Sendable {
         case .safety: .safety
         case .stopEvidence: .stopEvidence
         case .recorderHealth: .recorderHealth
+        case .heartRateEvidence: .heartRateEvidence
+        case .treadmillEvidence: .treadmillEvidence
         }
     }
 
@@ -328,6 +341,8 @@ public enum WorkoutEventPayload: Codable, Hashable, Sendable {
                 commandID: record.commandID,
                 attemptID: record.lifecycle.primaryAttemptID
             )
+        case let .treadmillEvidence(evidence):
+            evidence.causalIDs
         default:
             WorkoutEventCausalIDs(decisionID: nil, commandID: nil, attemptID: nil)
         }
@@ -379,6 +394,83 @@ public enum WorkoutEventKind: String, Codable, Hashable, Sendable {
     case safety
     case stopEvidence
     case recorderHealth
+    case heartRateEvidence
+    case treadmillEvidence
+}
+
+private extension TreadmillTelemetryEvidence {
+    var causalIDs: WorkoutEventCausalIDs {
+        switch self {
+        case let .observation(evidence):
+            return WorkoutEventCausalIDs(
+                decisionID: nil,
+                commandID: evidence.commandID,
+                attemptID: evidence.attemptID
+            )
+        case .unitsTruth, .unassociatedWrite:
+            return WorkoutEventCausalIDs(decisionID: nil, commandID: nil, attemptID: nil)
+        case let .decision(evidence):
+            return WorkoutEventCausalIDs(
+                decisionID: evidence.decisionID,
+                commandID: nil,
+                attemptID: nil
+            )
+        case let .commandEnqueued(evidence):
+            return WorkoutEventCausalIDs(
+                decisionID: evidence.decisionID,
+                commandID: evidence.commandID,
+                attemptID: nil
+            )
+        case let .commandQueueDelay(evidence):
+            return WorkoutEventCausalIDs(
+                decisionID: evidence.decisionID,
+                commandID: evidence.commandID,
+                attemptID: nil
+            )
+        case let .sendAttempt(evidence):
+            return WorkoutEventCausalIDs(
+                decisionID: evidence.decisionID,
+                commandID: evidence.commandID,
+                attemptID: evidence.attemptID
+            )
+        case let .acknowledgement(evidence):
+            return WorkoutEventCausalIDs(
+                decisionID: nil,
+                commandID: evidence.commandID,
+                attemptID: evidence.attemptID
+            )
+        case let .writeResult(evidence):
+            return WorkoutEventCausalIDs(
+                decisionID: nil,
+                commandID: evidence.commandID,
+                attemptID: evidence.attemptID
+            )
+        case let .commandTimeout(evidence):
+            return WorkoutEventCausalIDs(
+                decisionID: nil,
+                commandID: evidence.commandID,
+                attemptID: evidence.attemptID
+            )
+        case let .commandFailed(evidence):
+            return WorkoutEventCausalIDs(
+                decisionID: evidence.decisionID,
+                commandID: evidence.commandID,
+                attemptID: evidence.attemptID
+            )
+        case let .commandCancelled(evidence):
+            return WorkoutEventCausalIDs(
+                decisionID: evidence.decisionID,
+                commandID: evidence.commandID,
+                attemptID: nil
+            )
+        case let .stopEvidence(evidence):
+            return WorkoutEventCausalIDs(
+                decisionID: evidence.decisionID,
+                commandID: evidence.commandID,
+                attemptID: nil
+            )
+        }
+    }
 }
 
 public struct EventPayloadEnvelope: Codable, Hashable, Sendable {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Events.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Events.swift
@@ -279,17 +279,23 @@ public struct RecorderHealthEvent: Codable, Hashable, Sendable {
     public let kind: RecorderHealthKind
     public let affectedRecordClass: String?
     public let count: UInt64?
+    public let firstAffectedElapsed: ElapsedDuration?
+    public let lastAffectedElapsed: ElapsedDuration?
     public let detailCode: String?
 
     public init(
         kind: RecorderHealthKind,
         affectedRecordClass: String? = nil,
         count: UInt64? = nil,
+        firstAffectedElapsed: ElapsedDuration? = nil,
+        lastAffectedElapsed: ElapsedDuration? = nil,
         detailCode: String? = nil
     ) {
         self.kind = kind
         self.affectedRecordClass = affectedRecordClass
         self.count = count
+        self.firstAffectedElapsed = firstAffectedElapsed
+        self.lastAffectedElapsed = lastAffectedElapsed
         self.detailCode = detailCode
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Observations.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Observations.swift
@@ -289,24 +289,91 @@ public struct TreadmillObservation: Codable, Hashable, Sendable {
         self.quality = quality
     }
 
+    public init?(
+        recordID: RecordID,
+        sessionID: SessionID,
+        source: SignalSourceIdentity,
+        observedEvidence: TreadmillObservationEvidence,
+        nativeUnit: TreadmillNativeSpeedUnit,
+        timestamp: ObservationTimestamp,
+        freshness: EvidenceFreshness,
+        quality: QualityFlags
+    ) {
+        guard let reportedNativeSpeed = observedEvidence.nativeSpeed else { return nil }
+        switch (reportedNativeSpeed.unit, nativeUnit) {
+        case (.kilometresPerHour, .kilometresPerHour),
+             (.milesPerHour, .milesPerHour),
+             (.controllerUnit, .controllerNative),
+             (.controllerUnit, .unknown):
+            break
+        default:
+            return nil
+        }
+        self.init(
+            recordID: recordID,
+            observationID: observedEvidence.observationID,
+            sessionID: sessionID,
+            source: source,
+            nativeSpeed: NativeTreadmillSpeed(
+                value: reportedNativeSpeed.scaledValue,
+                unit: nativeUnit
+            ),
+            factualSpeed: observedEvidence.factualSpeed,
+            deviceState: observedEvidence.deviceState,
+            arrivalOrder: observedEvidence.arrivalOrder,
+            timestamp: timestamp,
+            provenance: observedEvidence.provenance,
+            freshness: freshness,
+            quality: quality
+        )
+    }
+
+    private init(
+        recordID: RecordID,
+        observationID: ObservationID,
+        sessionID: SessionID,
+        source: SignalSourceIdentity,
+        nativeSpeed: NativeTreadmillSpeed,
+        factualSpeed: FactualSpeedKilometresPerHour?,
+        deviceState: TreadmillDeviceState,
+        arrivalOrder: UInt64,
+        timestamp: ObservationTimestamp,
+        provenance: EvidenceProvenance,
+        freshness: EvidenceFreshness,
+        quality: QualityFlags
+    ) {
+        self.recordID = recordID
+        self.observationID = observationID
+        self.sessionID = sessionID
+        self.source = source
+        self.nativeSpeed = nativeSpeed
+        self.factualSpeed = factualSpeed
+        self.deviceState = deviceState
+        self.arrivalOrder = arrivalOrder
+        self.timestamp = timestamp
+        self.provenance = provenance
+        self.freshness = freshness
+        self.quality = quality
+    }
+
     public init(from decoder: Decoder) throws {
         let decoded = try CodingRepresentation(from: decoder)
-        self.init(
-            recordID: decoded.recordID,
-            observationID: decoded.observationID,
-            sessionID: decoded.sessionID,
-            source: decoded.source,
-            nativeSpeed: decoded.nativeSpeed,
-            deviceState: decoded.deviceState,
-            arrivalOrder: decoded.arrivalOrder,
-            timestamp: decoded.timestamp,
+        let deterministicallyNormalized = FactualSpeedKilometresPerHour.normalized(
+            from: decoded.nativeSpeed,
             provenance: decoded.provenance,
-            freshness: decoded.freshness,
-            quality: decoded.quality,
             normalizationRule: decoded.factualSpeed?.normalizationRule
                 ?? .nativeToKilometresPerHourV1
         )
-        guard factualSpeed == decoded.factualSpeed else {
+        let factualSpeedIsConsistent: Bool
+        switch decoded.nativeSpeed.unit {
+        case .controllerNative:
+            factualSpeedIsConsistent = true
+        case .unknown:
+            factualSpeedIsConsistent = decoded.factualSpeed == nil
+        case .kilometresPerHour, .milesPerHour:
+            factualSpeedIsConsistent = deterministicallyNormalized == decoded.factualSpeed
+        }
+        guard factualSpeedIsConsistent else {
             throw DecodingError.dataCorrupted(
                 DecodingError.Context(
                     codingPath: decoder.codingPath,
@@ -314,6 +381,20 @@ public struct TreadmillObservation: Codable, Hashable, Sendable {
                 )
             )
         }
+        self = Self(
+            recordID: decoded.recordID,
+            observationID: decoded.observationID,
+            sessionID: decoded.sessionID,
+            source: decoded.source,
+            nativeSpeed: decoded.nativeSpeed,
+            factualSpeed: decoded.factualSpeed,
+            deviceState: decoded.deviceState,
+            arrivalOrder: decoded.arrivalOrder,
+            timestamp: decoded.timestamp,
+            provenance: decoded.provenance,
+            freshness: decoded.freshness,
+            quality: decoded.quality
+        )
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Observations.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Observations.swift
@@ -124,6 +124,19 @@ public struct FactualSpeedKilometresPerHour: Codable, Hashable, Sendable {
         self.normalizationRule = normalizationRule
     }
 
+    fileprivate init?(
+        restoringValue value: Double,
+        provenance: EvidenceProvenance,
+        normalizationRule: FactualSpeedNormalizationRule
+    ) {
+        guard value.isFinite, value >= 0 else { return nil }
+        self.init(
+            value: value,
+            provenance: provenance,
+            normalizationRule: normalizationRule
+        )
+    }
+
     private enum CodingKeys: String, CodingKey {
         case value
         case provenance
@@ -356,24 +369,63 @@ public struct TreadmillObservation: Codable, Hashable, Sendable {
         self.quality = quality
     }
 
+    package init?(
+        restoringRecordID recordID: RecordID,
+        observationID: ObservationID,
+        sessionID: SessionID,
+        source: SignalSourceIdentity,
+        nativeSpeed: NativeTreadmillSpeed,
+        factualKilometresPerHour: Double?,
+        factualNormalizationRule: FactualSpeedNormalizationRule?,
+        deviceState: TreadmillDeviceState,
+        arrivalOrder: UInt64,
+        timestamp: ObservationTimestamp,
+        provenance: EvidenceProvenance,
+        freshness: EvidenceFreshness,
+        quality: QualityFlags
+    ) {
+        let factualSpeed: FactualSpeedKilometresPerHour?
+        switch (factualKilometresPerHour, factualNormalizationRule) {
+        case (nil, nil):
+            factualSpeed = nil
+        case let (value?, rule?):
+            guard let restored = FactualSpeedKilometresPerHour(
+                restoringValue: value,
+                provenance: provenance,
+                normalizationRule: rule
+            ) else { return nil }
+            factualSpeed = restored
+        default:
+            return nil
+        }
+        guard Self.factualSpeedIsConsistent(
+            factualSpeed,
+            with: nativeSpeed,
+            provenance: provenance
+        ) else { return nil }
+        self.init(
+            recordID: recordID,
+            observationID: observationID,
+            sessionID: sessionID,
+            source: source,
+            nativeSpeed: nativeSpeed,
+            factualSpeed: factualSpeed,
+            deviceState: deviceState,
+            arrivalOrder: arrivalOrder,
+            timestamp: timestamp,
+            provenance: provenance,
+            freshness: freshness,
+            quality: quality
+        )
+    }
+
     public init(from decoder: Decoder) throws {
         let decoded = try CodingRepresentation(from: decoder)
-        let deterministicallyNormalized = FactualSpeedKilometresPerHour.normalized(
-            from: decoded.nativeSpeed,
-            provenance: decoded.provenance,
-            normalizationRule: decoded.factualSpeed?.normalizationRule
-                ?? .nativeToKilometresPerHourV1
-        )
-        let factualSpeedIsConsistent: Bool
-        switch decoded.nativeSpeed.unit {
-        case .controllerNative:
-            factualSpeedIsConsistent = true
-        case .unknown:
-            factualSpeedIsConsistent = decoded.factualSpeed == nil
-        case .kilometresPerHour, .milesPerHour:
-            factualSpeedIsConsistent = deterministicallyNormalized == decoded.factualSpeed
-        }
-        guard factualSpeedIsConsistent else {
+        guard Self.factualSpeedIsConsistent(
+            decoded.factualSpeed,
+            with: decoded.nativeSpeed,
+            provenance: decoded.provenance
+        ) else {
             throw DecodingError.dataCorrupted(
                 DecodingError.Context(
                     codingPath: decoder.codingPath,
@@ -395,6 +447,26 @@ public struct TreadmillObservation: Codable, Hashable, Sendable {
             freshness: decoded.freshness,
             quality: decoded.quality
         )
+    }
+
+    private static func factualSpeedIsConsistent(
+        _ factualSpeed: FactualSpeedKilometresPerHour?,
+        with nativeSpeed: NativeTreadmillSpeed,
+        provenance: EvidenceProvenance
+    ) -> Bool {
+        switch nativeSpeed.unit {
+        case .controllerNative:
+            return true
+        case .unknown:
+            return factualSpeed == nil
+        case .kilometresPerHour, .milesPerHour:
+            return FactualSpeedKilometresPerHour.normalized(
+                from: nativeSpeed,
+                provenance: provenance,
+                normalizationRule: factualSpeed?.normalizationRule
+                    ?? .nativeToKilometresPerHourV1
+            ) == factualSpeed
+        }
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
@@ -609,7 +609,7 @@ public actor TelemetryStore {
             for sequenced in records {
                 switch sequenced.record {
                 case let .source(source):
-                    try insertSource(
+                    try reuseOrInsertRecorderSource(
                         source.identity,
                         firstSeen: source.firstSeen,
                         lastSeen: source.lastSeen
@@ -851,6 +851,46 @@ public actor TelemetryStore {
             throw TelemetryStoreError.missingSource(sourceID)
         }
         return model
+    }
+
+    private func reuseOrInsertRecorderSource(
+        _ source: SignalSourceIdentity,
+        firstSeen: Date,
+        lastSeen: Date
+    ) throws {
+        let sourceKey = source.id.description
+        let stableIdentityKey = try Self.sourceStableIdentityKey(source)
+        let providerKindPayload = try Self.encode(source.providerKind)
+        let savingSourcePayload = try source.savingSource.map(Self.encode)
+        let knownDevicePayload = try source.knownDevice.map(Self.encode)
+        var idDescriptor = FetchDescriptor<TelemetrySignalSourceV1>(
+            predicate: #Predicate { $0.sourceID == sourceKey }
+        )
+        idDescriptor.fetchLimit = 1
+        var stableDescriptor = FetchDescriptor<TelemetrySignalSourceV1>(
+            predicate: #Predicate { $0.stableIdentityKey == stableIdentityKey }
+        )
+        stableDescriptor.fetchLimit = 1
+        let byID = try modelContext.fetch(idDescriptor).first
+        let byStableIdentity = try modelContext.fetch(stableDescriptor).first
+
+        guard byID != nil || byStableIdentity != nil else {
+            try insertSource(source, firstSeen: firstSeen, lastSeen: lastSeen)
+            return
+        }
+        guard let existing = byID,
+              let stableExisting = byStableIdentity,
+              existing.sourceID == stableExisting.sourceID,
+              existing.providerKindKey == Self.providerKindKey(source.providerKind),
+              existing.providerKindPayload == providerKindPayload,
+              existing.stableLocalKey == source.stableLocalKey,
+              existing.savingSourcePayload == savingSourcePayload,
+              existing.knownDevicePayload == knownDevicePayload
+        else {
+            throw TelemetryStoreError.conflictingStableIdentity(stableIdentityKey)
+        }
+        existing.firstSeen = min(existing.firstSeen, firstSeen)
+        existing.lastSeen = max(existing.lastSeen, lastSeen)
     }
 
     private func configurationModel(
@@ -1133,8 +1173,8 @@ private extension TelemetryStore {
         default:
             throw TelemetryStoreError.corruptStoredRecord(model.observationID)
         }
-        let observation = TreadmillObservation(
-            recordID: try uuid(model.recordID, as: RecordIDTag.self),
+        guard let observation = TreadmillObservation(
+            restoringRecordID: try uuid(model.recordID, as: RecordIDTag.self),
             observationID: try uuid(model.observationID, as: ObservationIDTag.self),
             sessionID: try uuid(model.sessionID, as: SessionIDTag.self),
             source: try domainSource(source).identity,
@@ -1142,6 +1182,8 @@ private extension TelemetryStore {
                 value: model.nativeValue,
                 unit: try decode(TreadmillNativeSpeedUnit.self, from: model.nativeUnitPayload)
             ),
+            factualKilometresPerHour: model.factualKilometresPerHour,
+            factualNormalizationRule: normalizationRule,
             deviceState: deviceState,
             arrivalOrder: arrivalOrder,
             timestamp: observationTimestamp(
@@ -1154,12 +1196,8 @@ private extension TelemetryStore {
             ),
             provenance: provenance,
             freshness: try decode(EvidenceFreshness.self, from: model.freshnessPayload),
-            quality: try decode(QualityFlags.self, from: model.qualityPayload),
-            normalizationRule: normalizationRule ?? .nativeToKilometresPerHourV1
-        )
-        guard observation.factualSpeed?.value == model.factualKilometresPerHour,
-              observation.factualSpeed?.normalizationRule == normalizationRule
-        else {
+            quality: try decode(QualityFlags.self, from: model.qualityPayload)
+        ) else {
             throw TelemetryStoreError.corruptStoredRecord(model.observationID)
         }
         return observation

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorder.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorder.swift
@@ -139,14 +139,16 @@ public final class TelemetryRecorder: @unchecked Sendable {
         endedElapsed: ElapsedDuration,
         reason: String,
         lostCriticalRecordCount: UInt64,
-        lostNativeRecordCount: UInt64
+        lostNativeRecordCount: UInt64,
+        droppedFrameCount: UInt64
     ) -> Bool {
         let accepted = core.requestIncomplete(
             endedAt: endedAt,
             endedElapsed: endedElapsed,
             reason: reason,
             lostCriticalRecordCount: lostCriticalRecordCount,
-            lostNativeRecordCount: lostNativeRecordCount
+            lostNativeRecordCount: lostNativeRecordCount,
+            droppedFrameCount: droppedFrameCount
         ) == nil
         if accepted {
             core.wake()

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorder.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorder.swift
@@ -133,6 +133,27 @@ public final class TelemetryRecorder: @unchecked Sendable {
         return accepted
     }
 
+    @discardableResult
+    public func requestIncomplete(
+        endedAt: Date,
+        endedElapsed: ElapsedDuration,
+        reason: String,
+        lostCriticalRecordCount: UInt64,
+        lostNativeRecordCount: UInt64
+    ) -> Bool {
+        let accepted = core.requestIncomplete(
+            endedAt: endedAt,
+            endedElapsed: endedElapsed,
+            reason: reason,
+            lostCriticalRecordCount: lostCriticalRecordCount,
+            lostNativeRecordCount: lostNativeRecordCount
+        ) == nil
+        if accepted {
+            core.wake()
+        }
+        return accepted
+    }
+
     public func cancel() async -> TelemetryFinishResult {
         await withCheckedContinuation { continuation in
             if let immediate = core.requestCancellation(

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorderCore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorderCore.swift
@@ -256,7 +256,8 @@ final class TelemetryRecorderCore: @unchecked Sendable {
         endedElapsed: ElapsedDuration,
         reason: String,
         lostCriticalRecordCount: UInt64,
-        lostNativeRecordCount: UInt64
+        lostNativeRecordCount: UInt64,
+        droppedFrameCount: UInt64
     ) -> TelemetryFinishResult? {
         lock.withLock {
             if case let .terminal(completeness) = phase {
@@ -267,6 +268,7 @@ final class TelemetryRecorderCore: @unchecked Sendable {
             }
             add(lostCriticalRecordCount, to: &lostCriticalCount)
             add(lostNativeRecordCount, to: &lostNativeCount)
+            add(droppedFrameCount, to: &self.droppedFrameCount)
             knownLoss = true
             switch phase {
             case .beginning, .active:

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorderCore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRecorder/TelemetryRecorderCore.swift
@@ -8,7 +8,11 @@ final class TelemetryRecorderCore: @unchecked Sendable {
     private enum Phase {
         case beginning
         case active
-        case finishing(endedAt: Date, endedElapsed: ElapsedDuration)
+        case finishing(
+            endedAt: Date,
+            endedElapsed: ElapsedDuration,
+            incompleteReason: String?
+        )
         case finalizing(TelemetryRecorderCompleteness)
         case failing(reason: String)
         case cancelling
@@ -234,9 +238,51 @@ final class TelemetryRecorderCore: @unchecked Sendable {
             finishCompletions.append(completion)
             switch phase {
             case .beginning, .active:
-                phase = .finishing(endedAt: endedAt, endedElapsed: endedElapsed)
+                phase = .finishing(
+                    endedAt: endedAt,
+                    endedElapsed: endedElapsed,
+                    incompleteReason: nil
+                )
                 forcedFlushThrough = laterSequence(forcedFlushThrough, lastAcceptedSequence)
             case .finishing, .finalizing, .failing, .cancelling, .terminal:
+                break
+            }
+            return nil
+        }
+    }
+
+    func requestIncomplete(
+        endedAt: Date,
+        endedElapsed: ElapsedDuration,
+        reason: String,
+        lostCriticalRecordCount: UInt64,
+        lostNativeRecordCount: UInt64
+    ) -> TelemetryFinishResult? {
+        lock.withLock {
+            if case let .terminal(completeness) = phase {
+                return TelemetryFinishResult(
+                    completeness: completeness,
+                    lastCommittedRecorderSequence: lastCommittedSequence
+                )
+            }
+            add(lostCriticalRecordCount, to: &lostCriticalCount)
+            add(lostNativeRecordCount, to: &lostNativeCount)
+            knownLoss = true
+            switch phase {
+            case .beginning, .active:
+                phase = .finishing(
+                    endedAt: endedAt,
+                    endedElapsed: endedElapsed,
+                    incompleteReason: reason
+                )
+                forcedFlushThrough = laterSequence(forcedFlushThrough, lastAcceptedSequence)
+            case let .finishing(existingEndedAt, existingEndedElapsed, existingReason):
+                phase = .finishing(
+                    endedAt: existingEndedAt,
+                    endedElapsed: existingEndedElapsed,
+                    incompleteReason: existingReason ?? reason
+                )
+            case .finalizing, .failing, .cancelling, .terminal:
                 break
             }
             return nil
@@ -313,7 +359,7 @@ final class TelemetryRecorderCore: @unchecked Sendable {
             switch phase {
             case .failing, .cancelling:
                 return .terminateRequested
-            case let .finishing(endedAt, endedElapsed):
+            case let .finishing(endedAt, endedElapsed, incompleteReason):
                 if !buffer.isEmpty {
                     return .persist(
                         buffer.drain(maximumCount: batchPolicy.maximumRecordCount),
@@ -329,7 +375,7 @@ final class TelemetryRecorderCore: @unchecked Sendable {
                         completeness: completeness,
                         endedAt: endedAt,
                         endedElapsed: endedElapsed,
-                        reason: knownLoss ? "recorder-loss" : nil
+                        reason: knownLoss ? (incompleteReason ?? "recorder-loss") : nil
                     ),
                     completeness,
                     intentGeneration: terminalIntentGeneration
@@ -824,6 +870,11 @@ private extension TelemetryRecorderCore {
         }
         let converted = UInt64(amount)
         let (sum, overflow) = value.addingReportingOverflow(converted)
+        value = overflow ? UInt64.max : sum
+    }
+
+    func add(_ amount: UInt64, to value: inout UInt64) {
+        let (sum, overflow) = value.addingReportingOverflow(amount)
         value = overflow ? UInt64.max : sum
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
@@ -247,25 +247,63 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
                 (1, 0)
             }
         }
+
+        func sourceID(for descriptor: TelemetryV2SessionDescriptor) -> SourceID? {
+            let stableKey: String?
+            switch self {
+            case let .heartRate(result):
+                stableKey = "hr:\(result.delivery.source.stableLocalKey)"
+            case let .sourceLifecycle(evidence):
+                stableKey = "hr:\(evidence.source.stableLocalKey)"
+            case .controlUse:
+                stableKey = "hr:\(descriptor.configuration.heartRateProviderStableLocalKey)"
+            case let .treadmill(evidence):
+                guard let stableDevice = descriptor.configuration.treadmill.stableLocalIdentifier,
+                      !stableDevice.isEmpty else { return nil }
+                stableKey = "treadmill:\(stableDevice):\(evidence.protocolKind.rawValue)"
+            case .event, .workoutPhase:
+                stableKey = nil
+            }
+            return stableKey.map {
+                SourceID(
+                    rawValue: TelemetryV2SessionDescriptor.deterministicUUID(key: $0)
+                )
+            }
+        }
     }
 
     fileprivate struct PendingLossSummary: Sendable {
         var lostCriticalRecordCount: UInt64 = 0
         var lostNativeRecordCount: UInt64 = 0
+        var droppedFrameCount: UInt64 = 0
         var firstCriticalAffectedElapsed: ElapsedDuration?
         var lastCriticalAffectedElapsed: ElapsedDuration?
         var firstNativeAffectedElapsed: ElapsedDuration?
         var lastNativeAffectedElapsed: ElapsedDuration?
+        var firstBulkFrameAffectedElapsed: ElapsedDuration?
+        var lastBulkFrameAffectedElapsed: ElapsedDuration?
 
         var hasLoss: Bool {
-            lostCriticalRecordCount > 0 || lostNativeRecordCount > 0
+            lostCriticalRecordCount > 0
+                || lostNativeRecordCount > 0
+                || droppedFrameCount > 0
         }
 
-        mutating func record(_ evidence: PendingEvidence, at elapsed: ElapsedDuration) {
+        mutating func recordDroppedFrame(at elapsed: ElapsedDuration) {
+            droppedFrameCount = Self.saturatedSum(droppedFrameCount, 1)
+            firstBulkFrameAffectedElapsed = firstBulkFrameAffectedElapsed ?? elapsed
+            lastBulkFrameAffectedElapsed = elapsed
+        }
+
+        mutating func record(
+            _ evidence: PendingEvidence,
+            at elapsed: ElapsedDuration,
+            losesSourceRecord: Bool
+        ) {
             let counts = evidence.lostRecordCounts
             lostCriticalRecordCount = Self.saturatedSum(
                 lostCriticalRecordCount,
-                counts.critical
+                Self.saturatedSum(counts.critical, losesSourceRecord ? 1 : 0)
             )
             lostNativeRecordCount = Self.saturatedSum(
                 lostNativeRecordCount,
@@ -294,6 +332,8 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         var isStarting: Bool
         var evidence: [PendingEvidence]
         var lossSummary: PendingLossSummary
+        var lastObservedFrameSecond: Int64?
+        var seenSourceIDs: Set<SourceID>
     }
 
     private static let pendingEvidenceCapacity = 256
@@ -360,7 +400,9 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
                 startedMonotonic: runtimeClock.now(),
                 isStarting: false,
                 evidence: [],
-                lossSummary: PendingLossSummary()
+                lossSummary: PendingLossSummary(),
+                lastObservedFrameSecond: nil,
+                seenSourceIDs: []
             )
             setStatusLocked(.starting)
             return (previous, true)
@@ -394,7 +436,9 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
 
     @discardableResult
     public func observeCurrentElapsedSecond() -> TelemetryYieldDisposition? {
-        guard let session = currentActiveSession() else { return nil }
+        guard let session = currentActiveSession() else {
+            return recordPendingFrameDrop()
+        }
         let disposition = session.observeCurrentElapsedSecond()
         refreshStatus(from: session)
         return disposition
@@ -599,17 +643,41 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         withLock {
             guard var pending = pendingSession else { return nil }
             guard pending.evidence.count < Self.pendingEvidenceCapacity else {
+                let sourceID = evidence.sourceID(for: pending.descriptor)
+                let losesSourceRecord = sourceID.map {
+                    pending.seenSourceIDs.insert($0).inserted
+                } ?? false
                 pending.lossSummary.record(
                     evidence,
-                    at: Self.elapsedDuration(runtimeClock.now() - pending.startedMonotonic)
+                    at: Self.elapsedDuration(runtimeClock.now() - pending.startedMonotonic),
+                    losesSourceRecord: losesSourceRecord
                 )
                 pendingSession = pending
                 setStatusLocked(.incomplete("pre-recorder-staging-overflow"))
                 return evidence.lostRecordCounts.critical > 0 ? .lostCritical : .lostNative
             }
             pending.evidence.append(evidence)
+            if let sourceID = evidence.sourceID(for: pending.descriptor) {
+                pending.seenSourceIDs.insert(sourceID)
+            }
             pendingSession = pending
             return .enqueued
+        }
+    }
+
+    private func recordPendingFrameDrop() -> TelemetryYieldDisposition? {
+        withLock {
+            guard var pending = pendingSession else { return nil }
+            let elapsed = Self.elapsedDuration(runtimeClock.now() - pending.startedMonotonic)
+            let currentSecond = max(0, elapsed.microseconds / 1_000_000)
+            guard pending.lastObservedFrameSecond != currentSecond else {
+                return .coalescedFrame
+            }
+            pending.lastObservedFrameSecond = currentSecond
+            pending.lossSummary.recordDroppedFrame(at: elapsed)
+            pendingSession = pending
+            setStatusLocked(.incomplete("pre-recorder-staging-overflow"))
+            return .droppedFrame
         }
     }
 
@@ -780,12 +848,29 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
                 sourceID: nil
             )
         }
+        if summary.droppedFrameCount > 0 {
+            _ = yieldEvent(
+                .recorderHealth(
+                    RecorderHealthEvent(
+                        kind: .loss,
+                        affectedRecordClass: "bulkFrame",
+                        count: summary.droppedFrameCount,
+                        firstAffectedElapsed: summary.firstBulkFrameAffectedElapsed,
+                        lastAffectedElapsed: summary.lastBulkFrameAffectedElapsed,
+                        detailCode: "pre-recorder-staging-overflow"
+                    )
+                ),
+                occurredAt: occurredAt,
+                sourceID: nil
+            )
+        }
         _ = recorder.requestIncomplete(
             endedAt: occurredAt,
             endedElapsed: elapsed(),
             reason: "pre-recorder-staging-overflow",
             lostCriticalRecordCount: summary.lostCriticalRecordCount,
-            lostNativeRecordCount: summary.lostNativeRecordCount
+            lostNativeRecordCount: summary.lostNativeRecordCount,
+            droppedFrameCount: summary.droppedFrameCount
         )
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
@@ -230,6 +230,61 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         case treadmill(TreadmillTelemetryEvidence)
         case event(WorkoutEventPayload, Date)
         case workoutPhase(WorkoutPhase, Date)
+
+        var lostRecordCounts: (critical: UInt64, native: UInt64) {
+            switch self {
+            case let .heartRate(result):
+                (1, result.canonicalObservation == nil ? 0 : 1)
+            case let .treadmill(evidence):
+                if case let .observation(observation) = evidence,
+                   observation.nativeSpeed != nil
+                {
+                    (1, 1)
+                } else {
+                    (1, 0)
+                }
+            case .sourceLifecycle, .controlUse, .event, .workoutPhase:
+                (1, 0)
+            }
+        }
+    }
+
+    fileprivate struct PendingLossSummary: Sendable {
+        var lostCriticalRecordCount: UInt64 = 0
+        var lostNativeRecordCount: UInt64 = 0
+        var firstCriticalAffectedElapsed: ElapsedDuration?
+        var lastCriticalAffectedElapsed: ElapsedDuration?
+        var firstNativeAffectedElapsed: ElapsedDuration?
+        var lastNativeAffectedElapsed: ElapsedDuration?
+
+        var hasLoss: Bool {
+            lostCriticalRecordCount > 0 || lostNativeRecordCount > 0
+        }
+
+        mutating func record(_ evidence: PendingEvidence, at elapsed: ElapsedDuration) {
+            let counts = evidence.lostRecordCounts
+            lostCriticalRecordCount = Self.saturatedSum(
+                lostCriticalRecordCount,
+                counts.critical
+            )
+            lostNativeRecordCount = Self.saturatedSum(
+                lostNativeRecordCount,
+                counts.native
+            )
+            if counts.critical > 0 {
+                firstCriticalAffectedElapsed = firstCriticalAffectedElapsed ?? elapsed
+                lastCriticalAffectedElapsed = elapsed
+            }
+            if counts.native > 0 {
+                firstNativeAffectedElapsed = firstNativeAffectedElapsed ?? elapsed
+                lastNativeAffectedElapsed = elapsed
+            }
+        }
+
+        private static func saturatedSum(_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
+            let result = lhs.addingReportingOverflow(rhs)
+            return result.overflow ? UInt64.max : result.partialValue
+        }
     }
 
     private struct PendingSession {
@@ -238,7 +293,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         let startedMonotonic: Duration
         var isStarting: Bool
         var evidence: [PendingEvidence]
-        var droppedEvidenceCount: UInt64
+        var lossSummary: PendingLossSummary
     }
 
     private static let pendingEvidenceCapacity = 256
@@ -305,7 +360,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
                 startedMonotonic: runtimeClock.now(),
                 isStarting: false,
                 evidence: [],
-                droppedEvidenceCount: 0
+                lossSummary: PendingLossSummary()
             )
             setStatusLocked(.starting)
             return (previous, true)
@@ -478,7 +533,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
     private func install(_ session: TelemetryV2ActiveSession, generation: UInt64) {
         session.activate()
         while true {
-            let next: ([PendingEvidence], UInt64)? = withLock {
+            let next: ([PendingEvidence], PendingLossSummary)? = withLock {
                 guard self.generation == generation,
                       var pending = pendingSession,
                       pending.generation == generation else { return nil }
@@ -486,24 +541,24 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
                     pendingSession = nil
                     activeSession = session
                     setStatusLocked(
-                        pending.droppedEvidenceCount == 0
+                        !pending.lossSummary.hasLoss
                             ? .active(.complete)
                             : .incomplete("pre-recorder-staging-overflow")
                     )
-                    return ([], pending.droppedEvidenceCount)
+                    return ([], pending.lossSummary)
                 }
                 let evidence = pending.evidence
                 pending.evidence.removeAll(keepingCapacity: true)
                 pendingSession = pending
-                return (evidence, pending.droppedEvidenceCount)
+                return (evidence, pending.lossSummary)
             }
             guard let next else {
                 session.requestCancellation()
                 return
             }
             if next.0.isEmpty {
-                if next.1 > 0 {
-                    session.emitStagingLoss(count: next.1)
+                if next.1.hasLoss {
+                    session.emitStagingLoss(next.1)
                 }
                 refreshStatus(from: session)
                 return
@@ -544,10 +599,13 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         withLock {
             guard var pending = pendingSession else { return nil }
             guard pending.evidence.count < Self.pendingEvidenceCapacity else {
-                pending.droppedEvidenceCount &+= 1
+                pending.lossSummary.record(
+                    evidence,
+                    at: Self.elapsedDuration(runtimeClock.now() - pending.startedMonotonic)
+                )
                 pendingSession = pending
                 setStatusLocked(.incomplete("pre-recorder-staging-overflow"))
-                return .lostNative
+                return evidence.lostRecordCounts.critical > 0 ? .lostCritical : .lostNative
             }
             pending.evidence.append(evidence)
             pendingSession = pending
@@ -611,6 +669,17 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
     private static func errorCode(_ error: Error) -> String {
         String(describing: type(of: error))
     }
+
+    private static func elapsedDuration(_ duration: Duration) -> ElapsedDuration {
+        let components = duration.components
+        let seconds = components.seconds.multipliedReportingOverflow(by: 1_000_000)
+        guard !seconds.overflow else { return ElapsedDuration(microseconds: Int64.max) }
+        let fractional = components.attoseconds / 1_000_000_000_000
+        let total = seconds.partialValue.addingReportingOverflow(fractional)
+        return ElapsedDuration(
+            microseconds: total.overflow ? Int64.max : max(0, total.partialValue)
+        )
+    }
 }
 
 private final class TelemetryV2ActiveSession: @unchecked Sendable {
@@ -626,7 +695,7 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
     private var firstMissingFrameSecond: Int64?
     private var currentWorkoutPhase: WorkoutPhase?
     private var ending = false
-    private var stagingLostEvidenceCount: UInt64 = 0
+    private var stagingLossSummary = TelemetryV2RuntimeCoordinator.PendingLossSummary()
 
     init(
         descriptor: TelemetryV2SessionDescriptor,
@@ -645,7 +714,7 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
     }
 
     var hasStagingLoss: Bool {
-        withLock { stagingLostEvidenceCount > 0 }
+        withLock { stagingLossSummary.hasLoss }
     }
 
     func activate() {
@@ -676,21 +745,48 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
         }
     }
 
-    func emitStagingLoss(count: UInt64) {
-        withLock { stagingLostEvidenceCount = count }
-        _ = yieldEvent(
-            .recorderHealth(
-                RecorderHealthEvent(
-                    kind: .loss,
-                    affectedRecordClass: "native-evidence",
-                    count: count,
-                    detailCode: "pre-recorder-staging-overflow"
-                )
-            ),
-            occurredAt: runtimeClock.nowDate(),
-            sourceID: nil
+    func emitStagingLoss(_ summary: TelemetryV2RuntimeCoordinator.PendingLossSummary) {
+        withLock { stagingLossSummary = summary }
+        let occurredAt = runtimeClock.nowDate()
+        if summary.lostCriticalRecordCount > 0 {
+            _ = yieldEvent(
+                .recorderHealth(
+                    RecorderHealthEvent(
+                        kind: .loss,
+                        affectedRecordClass: "critical",
+                        count: summary.lostCriticalRecordCount,
+                        firstAffectedElapsed: summary.firstCriticalAffectedElapsed,
+                        lastAffectedElapsed: summary.lastCriticalAffectedElapsed,
+                        detailCode: "pre-recorder-staging-overflow"
+                    )
+                ),
+                occurredAt: occurredAt,
+                sourceID: nil
+            )
+        }
+        if summary.lostNativeRecordCount > 0 {
+            _ = yieldEvent(
+                .recorderHealth(
+                    RecorderHealthEvent(
+                        kind: .loss,
+                        affectedRecordClass: "native",
+                        count: summary.lostNativeRecordCount,
+                        firstAffectedElapsed: summary.firstNativeAffectedElapsed,
+                        lastAffectedElapsed: summary.lastNativeAffectedElapsed,
+                        detailCode: "pre-recorder-staging-overflow"
+                    )
+                ),
+                occurredAt: occurredAt,
+                sourceID: nil
+            )
+        }
+        _ = recorder.requestIncomplete(
+            endedAt: occurredAt,
+            endedElapsed: elapsed(),
+            reason: "pre-recorder-staging-overflow",
+            lostCriticalRecordCount: summary.lostCriticalRecordCount,
+            lostNativeRecordCount: summary.lostNativeRecordCount
         )
-        _ = recorder.requestFailure(reason: "pre-recorder-staging-overflow")
     }
 
     func requestCancellation() {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
@@ -1,0 +1,1189 @@
+import CryptoKit
+import Dispatch
+import Foundation
+#if canImport(TelemetryDomain)
+import TelemetryDomain
+#endif
+#if canImport(TelemetryRecorder)
+import TelemetryRecorder
+#endif
+public enum TelemetryV2RuntimeStatus: Equatable, Sendable {
+    case idle
+    case preparing
+    case starting
+    case active(TelemetryRecorderCompleteness)
+    case finishing
+    case unavailable(String)
+    case incomplete(String)
+}
+
+public protocol TelemetryV2RuntimeClock: AnyObject, Sendable {
+    func nowDate() -> Date
+    func now() -> Duration
+}
+
+public final class ContinuousTelemetryV2RuntimeClock: TelemetryV2RuntimeClock,
+    @unchecked Sendable
+{
+    private let clock = ContinuousClock()
+    private let origin: ContinuousClock.Instant
+
+    public init() {
+        origin = clock.now
+    }
+
+    public func nowDate() -> Date {
+        Date()
+    }
+
+    public func now() -> Duration {
+        origin.duration(to: clock.now)
+    }
+}
+
+public struct TelemetryV2TreadmillContext: Codable, Equatable, Sendable {
+    public let stableLocalIdentifier: String?
+    public let model: String?
+    public let protocolName: String
+    public let protocolVersion: String?
+    public let minimumSpeedKilometresPerHour: Double
+    public let maximumSpeedKilometresPerHour: Double
+    public let speedIncrementKilometresPerHour: Double
+
+    public init(
+        stableLocalIdentifier: String?,
+        model: String?,
+        protocolName: String,
+        protocolVersion: String?,
+        minimumSpeedKilometresPerHour: Double,
+        maximumSpeedKilometresPerHour: Double,
+        speedIncrementKilometresPerHour: Double
+    ) {
+        self.stableLocalIdentifier = stableLocalIdentifier
+        self.model = model
+        self.protocolName = protocolName
+        self.protocolVersion = protocolVersion
+        self.minimumSpeedKilometresPerHour = minimumSpeedKilometresPerHour
+        self.maximumSpeedKilometresPerHour = maximumSpeedKilometresPerHour
+        self.speedIncrementKilometresPerHour = speedIncrementKilometresPerHour
+    }
+}
+
+public struct TelemetryV2ConfigurationInput: Codable, Equatable, Sendable {
+    public let profileLocalIdentifier: String
+    public let workoutMode: WorkoutMode
+    public let targetHeartRate: Int
+    public let durationMinutes: Int
+    public let decisionIntervalSeconds: Int
+    public let adaptiveStepEnabled: Bool
+    public let maximumStepKilometresPerHour: Double
+    public let heartRateZones: [Int]
+    public let cooldownTargetHeartRate: Int
+    public let cooldownMinimumSpeedKilometresPerHour: Double
+    public let cooldownMaximumMinutes: Int
+    public let heartRateProviderKind: String
+    public let heartRateProviderStableLocalKey: String
+    public let treadmill: TelemetryV2TreadmillContext
+
+    public init(
+        profileLocalIdentifier: String,
+        workoutMode: WorkoutMode,
+        targetHeartRate: Int,
+        durationMinutes: Int,
+        decisionIntervalSeconds: Int,
+        adaptiveStepEnabled: Bool,
+        maximumStepKilometresPerHour: Double,
+        heartRateZones: [Int],
+        cooldownTargetHeartRate: Int,
+        cooldownMinimumSpeedKilometresPerHour: Double,
+        cooldownMaximumMinutes: Int,
+        heartRateProviderKind: String,
+        heartRateProviderStableLocalKey: String,
+        treadmill: TelemetryV2TreadmillContext
+    ) {
+        self.profileLocalIdentifier = profileLocalIdentifier
+        self.workoutMode = workoutMode
+        self.targetHeartRate = targetHeartRate
+        self.durationMinutes = durationMinutes
+        self.decisionIntervalSeconds = decisionIntervalSeconds
+        self.adaptiveStepEnabled = adaptiveStepEnabled
+        self.maximumStepKilometresPerHour = maximumStepKilometresPerHour
+        self.heartRateZones = heartRateZones
+        self.cooldownTargetHeartRate = cooldownTargetHeartRate
+        self.cooldownMinimumSpeedKilometresPerHour = cooldownMinimumSpeedKilometresPerHour
+        self.cooldownMaximumMinutes = cooldownMaximumMinutes
+        self.heartRateProviderKind = heartRateProviderKind
+        self.heartRateProviderStableLocalKey = heartRateProviderStableLocalKey
+        self.treadmill = treadmill
+    }
+}
+
+public struct TelemetryV2SessionDescriptor: Sendable {
+    public let sessionID: SessionID
+    public let deterministicLegacySessionID: UUID?
+    public let startedAt: Date
+    public let appContext: AppRuntimeContext
+    public let configuration: TelemetryV2ConfigurationInput
+    public let versions: RuntimeVersionContext
+    public let heartRateFreshnessLimitSeconds: TimeInterval
+    public let treadmillFreshnessLimitSeconds: TimeInterval
+
+    public init(
+        sessionID: SessionID,
+        deterministicLegacySessionID: UUID?,
+        startedAt: Date,
+        appContext: AppRuntimeContext,
+        configuration: TelemetryV2ConfigurationInput,
+        versions: RuntimeVersionContext,
+        heartRateFreshnessLimitSeconds: TimeInterval,
+        treadmillFreshnessLimitSeconds: TimeInterval
+    ) {
+        precondition(
+            deterministicLegacySessionID == nil
+                || deterministicLegacySessionID == sessionID.rawValue,
+            "A legacy session may be linked only by exact identity."
+        )
+        self.sessionID = sessionID
+        self.deterministicLegacySessionID = deterministicLegacySessionID
+        self.startedAt = startedAt
+        self.appContext = appContext
+        self.configuration = configuration
+        self.versions = versions
+        self.heartRateFreshnessLimitSeconds = heartRateFreshnessLimitSeconds
+        self.treadmillFreshnessLimitSeconds = treadmillFreshnessLimitSeconds
+    }
+
+    public static func sessionID(deterministicallyLinkedTo legacySessionID: UUID?) -> SessionID {
+        SessionID(rawValue: legacySessionID ?? UUID())
+    }
+
+    fileprivate func header() throws -> WorkoutSessionRecord {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let payload = try encoder.encode(configuration)
+        let digest = SHA256.hash(data: payload).map { String(format: "%02x", $0) }.joined()
+        let snapshot = ImmutableConfigurationSnapshot(
+            id: ConfigurationSnapshotID(
+                rawValue: Self.deterministicUUID(key: "configuration:\(digest)")
+            ),
+            formatVersion: 1,
+            format: .canonicalJSON,
+            canonicalPayload: payload,
+            contentHash: ContentHash(algorithm: .sha256, lowercaseHexDigest: digest)
+        )
+        return WorkoutSessionRecord(
+            recordID: RecordID(),
+            sessionID: sessionID,
+            profileLocalIdentifier: configuration.profileLocalIdentifier,
+            lifecycleState: .running,
+            workoutMode: configuration.workoutMode,
+            startedAt: startedAt,
+            endedAt: nil,
+            endedElapsed: nil,
+            incompleteReason: nil,
+            appContext: appContext,
+            versions: versions,
+            configuration: snapshot,
+            healthKitWorkoutIdentifier: nil,
+            treadmill: KnownTreadmillMetadata(
+                stableLocalIdentifier: configuration.treadmill.stableLocalIdentifier,
+                model: configuration.treadmill.model,
+                protocolName: configuration.treadmill.protocolName,
+                protocolVersion: configuration.treadmill.protocolVersion
+            ),
+            recorderHealth: RecorderHealthSummary(
+                isComplete: false,
+                lostCriticalRecordCount: 0,
+                lostNativeRecordCount: 0,
+                lastPersistedElapsed: nil
+            )
+        )
+    }
+
+    fileprivate static func deterministicUUID(key: String) -> UUID {
+        var bytes = Array(SHA256.hash(data: Data(key.utf8)).prefix(16))
+        bytes[6] = (bytes[6] & 0x0f) | 0x80
+        bytes[8] = (bytes[8] & 0x3f) | 0x80
+        let hex = bytes.map { String(format: "%02x", $0) }
+        return UUID(
+            uuidString: [
+                hex[0...3].joined(),
+                hex[4...5].joined(),
+                hex[6...7].joined(),
+                hex[8...9].joined(),
+                hex[10...15].joined(),
+            ].joined(separator: "-")
+        )!
+    }
+}
+
+public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
+    TreadmillTelemetrySink, @unchecked Sendable
+{
+    public typealias PersistenceFactory = @Sendable () throws -> any TelemetryRecorderPersistence
+    public typealias StatusHandler = @Sendable (TelemetryV2RuntimeStatus) -> Void
+
+    fileprivate enum PendingEvidence: Sendable {
+        case heartRate(HeartRateNormalizationResult)
+        case sourceLifecycle(HeartRateSourceLifecycleEvidence)
+        case controlUse(HeartRateControlUseEvidence)
+        case treadmill(TreadmillTelemetryEvidence)
+        case event(WorkoutEventPayload, Date)
+        case workoutPhase(WorkoutPhase, Date)
+    }
+
+    private struct PendingSession {
+        let generation: UInt64
+        let descriptor: TelemetryV2SessionDescriptor
+        let startedMonotonic: Duration
+        var isStarting: Bool
+        var evidence: [PendingEvidence]
+        var droppedEvidenceCount: UInt64
+    }
+
+    private static let pendingEvidenceCapacity = 256
+    private let lock = NSLock()
+    private let persistenceFactory: PersistenceFactory
+    private let statusHandler: StatusHandler?
+    private let runtimeClock: any TelemetryV2RuntimeClock
+    private var persistence: (any TelemetryRecorderPersistence)?
+    private var preparationStarted = false
+    private var preparationFailed = false
+    private var generation: UInt64 = 0
+    private var pendingSession: PendingSession?
+    private var activeSession: TelemetryV2ActiveSession?
+    private var storedStatus: TelemetryV2RuntimeStatus = .idle
+
+    public init(
+        persistenceFactory: @escaping PersistenceFactory,
+        runtimeClock: any TelemetryV2RuntimeClock = ContinuousTelemetryV2RuntimeClock(),
+        statusHandler: StatusHandler? = nil
+    ) {
+        self.persistenceFactory = persistenceFactory
+        self.runtimeClock = runtimeClock
+        self.statusHandler = statusHandler
+    }
+
+    public var status: TelemetryV2RuntimeStatus {
+        withLock { storedStatus }
+    }
+
+    public func prepareStoreAndRecover() {
+        let shouldStart: Bool = withLock {
+            guard !preparationStarted else { return false }
+            preparationStarted = true
+            setStatusLocked(.preparing)
+            return true
+        }
+        guard shouldStart else { return }
+
+        let factory = persistenceFactory
+        Task.detached(priority: .utility) { [weak self] in
+            do {
+                let persistence = try factory()
+                _ = try await TelemetryRecorder.recoverUnfinishedSessions(using: persistence)
+                self?.storePrepared(persistence)
+            } catch {
+                self?.storePreparationFailed(error)
+            }
+        }
+    }
+
+    public func beginSession(_ descriptor: TelemetryV2SessionDescriptor) {
+        let state: (TelemetryV2ActiveSession?, Bool) = withLock {
+            generation &+= 1
+            let previous = activeSession
+            activeSession = nil
+            guard !preparationFailed else {
+                pendingSession = nil
+                setStatusLocked(.unavailable("store-unavailable"))
+                return (previous, false)
+            }
+            pendingSession = PendingSession(
+                generation: generation,
+                descriptor: descriptor,
+                startedMonotonic: runtimeClock.now(),
+                isStarting: false,
+                evidence: [],
+                droppedEvidenceCount: 0
+            )
+            setStatusLocked(.starting)
+            return (previous, true)
+        }
+        state.0?.requestCancellation()
+        guard state.1 else { return }
+        prepareStoreAndRecover()
+        launchPendingSessionIfPossible()
+    }
+
+    public func endSession(reason: String) {
+        let ending: (TelemetryV2ActiveSession?, UInt64, Bool) = withLock {
+            guard pendingSession != nil || activeSession != nil else {
+                return (nil, generation, false)
+            }
+            generation &+= 1
+            pendingSession = nil
+            let session = activeSession
+            activeSession = nil
+            setStatusLocked(session == nil ? .incomplete("ended-before-recorder-ready") : .finishing)
+            return (session, generation, true)
+        }
+        guard ending.2 else { return }
+        guard let session = ending.0 else { return }
+        session.emitSessionEnd(reason: reason)
+        Task.detached(priority: .utility) { [weak self] in
+            let result = await session.finish()
+            self?.sessionFinished(result, generation: ending.1)
+        }
+    }
+
+    @discardableResult
+    public func observeCurrentElapsedSecond() -> TelemetryYieldDisposition? {
+        guard let session = currentActiveSession() else { return nil }
+        let disposition = session.observeCurrentElapsedSecond()
+        refreshStatus(from: session)
+        return disposition
+    }
+
+    public func observeHeartRate(
+        _ result: HeartRateNormalizationResult
+    ) -> HeartRateTelemetrySinkDisposition {
+        guard let session = currentActiveSession() else {
+            guard let disposition = bufferDisposition(.heartRate(result)) else {
+                return .unavailable
+            }
+            return Self.heartRateDisposition(disposition)
+        }
+        let disposition = session.observeHeartRate(result)
+        refreshStatus(from: session)
+        return Self.heartRateDisposition(disposition)
+    }
+
+    public func observeSourceLifecycle(
+        _ evidence: HeartRateSourceLifecycleEvidence
+    ) -> HeartRateTelemetrySinkDisposition {
+        guard let session = currentActiveSession() else {
+            guard let disposition = bufferDisposition(.sourceLifecycle(evidence)) else {
+                return .unavailable
+            }
+            return Self.heartRateDisposition(disposition)
+        }
+        let disposition = session.observeHeartRateRuntime(.sourceLifecycle(evidence))
+        refreshStatus(from: session)
+        return Self.heartRateDisposition(disposition)
+    }
+
+    public func observeControlUse(
+        _ evidence: HeartRateControlUseEvidence
+    ) -> HeartRateTelemetrySinkDisposition {
+        guard let session = currentActiveSession() else {
+            guard let disposition = bufferDisposition(.controlUse(evidence)) else {
+                return .unavailable
+            }
+            return Self.heartRateDisposition(disposition)
+        }
+        let disposition = session.observeHeartRateRuntime(.controlUse(evidence))
+        refreshStatus(from: session)
+        return Self.heartRateDisposition(disposition)
+    }
+
+    public func observeTreadmillEvidence(
+        _ evidence: TreadmillTelemetryEvidence
+    ) -> TreadmillTelemetrySinkDisposition {
+        guard let session = currentActiveSession() else {
+            guard let disposition = bufferDisposition(.treadmill(evidence)) else {
+                return .unavailable
+            }
+            return Self.treadmillDisposition(disposition)
+        }
+        let disposition = session.observeTreadmill(evidence)
+        refreshStatus(from: session)
+        return Self.treadmillDisposition(disposition)
+    }
+
+    @discardableResult
+    public func observeEvent(
+        _ payload: WorkoutEventPayload,
+        occurredAt: Date
+    ) -> TelemetryYieldDisposition? {
+        guard let session = currentActiveSession() else {
+            return bufferDisposition(.event(payload, occurredAt))
+        }
+        let disposition = session.observeEvent(payload, occurredAt: occurredAt)
+        refreshStatus(from: session)
+        return disposition
+    }
+
+    @discardableResult
+    public func observeWorkoutPhase(
+        _ phase: WorkoutPhase,
+        occurredAt: Date
+    ) -> TelemetryYieldDisposition? {
+        guard let session = currentActiveSession() else {
+            return bufferDisposition(.workoutPhase(phase, occurredAt))
+        }
+        let disposition = session.observeWorkoutPhase(phase, occurredAt: occurredAt)
+        refreshStatus(from: session)
+        return disposition
+    }
+
+    private func storePrepared(_ persistence: any TelemetryRecorderPersistence) {
+        withLock {
+            self.persistence = persistence
+            if pendingSession == nil, activeSession == nil, storedStatus == .preparing {
+                setStatusLocked(.idle)
+            }
+        }
+        launchPendingSessionIfPossible()
+    }
+
+    private func storePreparationFailed(_ error: Error) {
+        withLock {
+            preparationFailed = true
+            pendingSession = nil
+            setStatusLocked(.unavailable("store-or-recovery-failed:\(Self.errorCode(error))"))
+        }
+    }
+
+    private func launchPendingSessionIfPossible() {
+        let work: (PendingSession, any TelemetryRecorderPersistence)? = withLock {
+            guard var pendingSession,
+                  !pendingSession.isStarting,
+                  let persistence else { return nil }
+            pendingSession.isStarting = true
+            self.pendingSession = pendingSession
+            return (pendingSession, persistence)
+        }
+        guard let work else { return }
+        Task.detached(priority: .utility) { [weak self] in
+            do {
+                let header = try work.0.descriptor.header()
+                let recorder = TelemetryRecorder(
+                    sessionHeader: header,
+                    persistence: work.1
+                )
+                let session = TelemetryV2ActiveSession(
+                    descriptor: work.0.descriptor,
+                    recorder: recorder,
+                    runtimeClock: self?.runtimeClock ?? ContinuousTelemetryV2RuntimeClock(),
+                    startedMonotonic: work.0.startedMonotonic
+                )
+                self?.install(session, generation: work.0.generation)
+            } catch {
+                self?.sessionStartFailed(error, generation: work.0.generation)
+            }
+        }
+    }
+
+    private func install(_ session: TelemetryV2ActiveSession, generation: UInt64) {
+        session.activate()
+        while true {
+            let next: ([PendingEvidence], UInt64)? = withLock {
+                guard self.generation == generation,
+                      var pending = pendingSession,
+                      pending.generation == generation else { return nil }
+                if pending.evidence.isEmpty {
+                    pendingSession = nil
+                    activeSession = session
+                    setStatusLocked(
+                        pending.droppedEvidenceCount == 0
+                            ? .active(.complete)
+                            : .incomplete("pre-recorder-staging-overflow")
+                    )
+                    return ([], pending.droppedEvidenceCount)
+                }
+                let evidence = pending.evidence
+                pending.evidence.removeAll(keepingCapacity: true)
+                pendingSession = pending
+                return (evidence, pending.droppedEvidenceCount)
+            }
+            guard let next else {
+                session.requestCancellation()
+                return
+            }
+            if next.0.isEmpty {
+                if next.1 > 0 {
+                    session.emitStagingLoss(count: next.1)
+                }
+                refreshStatus(from: session)
+                return
+            }
+            for evidence in next.0 {
+                session.replay(evidence)
+            }
+        }
+    }
+
+    private func sessionStartFailed(_ error: Error, generation: UInt64) {
+        withLock {
+            guard self.generation == generation else { return }
+            pendingSession = nil
+            setStatusLocked(.unavailable("session-start-failed:\(Self.errorCode(error))"))
+        }
+    }
+
+    private func sessionFinished(_ result: TelemetryFinishResult, generation: UInt64) {
+        withLock {
+            guard self.generation == generation else { return }
+            switch result.completeness {
+            case .complete:
+                setStatusLocked(.idle)
+            case .incomplete, .failed, .cancelled:
+                setStatusLocked(.incomplete(result.completeness.rawValue))
+            }
+        }
+    }
+
+    private func currentActiveSession() -> TelemetryV2ActiveSession? {
+        withLock { activeSession }
+    }
+
+    private func bufferDisposition(
+        _ evidence: PendingEvidence
+    ) -> TelemetryYieldDisposition? {
+        withLock {
+            guard var pending = pendingSession else { return nil }
+            guard pending.evidence.count < Self.pendingEvidenceCapacity else {
+                pending.droppedEvidenceCount &+= 1
+                pendingSession = pending
+                setStatusLocked(.incomplete("pre-recorder-staging-overflow"))
+                return .lostNative
+            }
+            pending.evidence.append(evidence)
+            pendingSession = pending
+            return .enqueued
+        }
+    }
+
+    private func refreshStatus(from session: TelemetryV2ActiveSession) {
+        let operationalState = session.operationalState
+        withLock {
+            guard activeSession === session else { return }
+            if session.hasStagingLoss {
+                setStatusLocked(.incomplete("pre-recorder-staging-overflow"))
+                return
+            }
+            switch operationalState.lifecycleState {
+            case .failed, .cancelled, .incomplete:
+                setStatusLocked(.incomplete(operationalState.lifecycleState.rawValue))
+            default:
+                setStatusLocked(.active(operationalState.completeness))
+            }
+        }
+    }
+
+    private func setStatusLocked(_ status: TelemetryV2RuntimeStatus) {
+        guard storedStatus != status else { return }
+        storedStatus = status
+        if let statusHandler {
+            DispatchQueue.main.async {
+                statusHandler(status)
+            }
+        }
+    }
+
+    private func withLock<T>(_ operation: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return operation()
+    }
+
+    private static func heartRateDisposition(
+        _ disposition: TelemetryYieldDisposition
+    ) -> HeartRateTelemetrySinkDisposition {
+        switch disposition {
+        case .enqueued, .coalescedFrame: .accepted
+        case .droppedFrame, .lostNative, .lostCritical: .degraded
+        case .rejectedAfterFinish, .rejectedTerminal, .sequenceExhausted: .rejected
+        }
+    }
+
+    private static func treadmillDisposition(
+        _ disposition: TelemetryYieldDisposition
+    ) -> TreadmillTelemetrySinkDisposition {
+        switch disposition {
+        case .enqueued, .coalescedFrame: .accepted
+        case .droppedFrame, .lostNative, .lostCritical: .degraded
+        case .rejectedAfterFinish, .rejectedTerminal, .sequenceExhausted: .rejected
+        }
+    }
+
+    private static func errorCode(_ error: Error) -> String {
+        String(describing: type(of: error))
+    }
+}
+
+private final class TelemetryV2ActiveSession: @unchecked Sendable {
+    private let descriptor: TelemetryV2SessionDescriptor
+    private let recorder: TelemetryRecorder
+    private let runtimeClock: any TelemetryV2RuntimeClock
+    private let startedMonotonic: Duration
+    private let lock = NSLock()
+    private var emittedSourceIDs: Set<SourceID> = []
+    private var latestHeartRate: HeartRateObservation?
+    private var latestTreadmill: TreadmillObservation?
+    private var lastObservedFrameSecond: Int64?
+    private var firstMissingFrameSecond: Int64?
+    private var currentWorkoutPhase: WorkoutPhase?
+    private var ending = false
+    private var stagingLostEvidenceCount: UInt64 = 0
+
+    init(
+        descriptor: TelemetryV2SessionDescriptor,
+        recorder: TelemetryRecorder,
+        runtimeClock: any TelemetryV2RuntimeClock,
+        startedMonotonic: Duration
+    ) {
+        self.descriptor = descriptor
+        self.recorder = recorder
+        self.runtimeClock = runtimeClock
+        self.startedMonotonic = startedMonotonic
+    }
+
+    var operationalState: TelemetryRecorderOperationalState {
+        recorder.operationalState
+    }
+
+    var hasStagingLoss: Bool {
+        withLock { stagingLostEvidenceCount > 0 }
+    }
+
+    func activate() {
+        _ = yieldEvent(
+            .sessionLifecycle(
+                SessionLifecycleEvent(previous: nil, current: .running, reason: "authorized-start")
+            ),
+            occurredAt: descriptor.startedAt,
+            sourceID: nil
+        )
+        _ = observeWorkoutPhase(.main, occurredAt: descriptor.startedAt)
+    }
+
+    func replay(_ evidence: TelemetryV2RuntimeCoordinator.PendingEvidence) {
+        switch evidence {
+        case let .heartRate(result):
+            _ = observeHeartRate(result)
+        case let .sourceLifecycle(sourceLifecycle):
+            _ = observeHeartRateRuntime(.sourceLifecycle(sourceLifecycle))
+        case let .controlUse(controlUse):
+            _ = observeHeartRateRuntime(.controlUse(controlUse))
+        case let .treadmill(treadmill):
+            _ = observeTreadmill(treadmill)
+        case let .event(payload, occurredAt):
+            _ = observeEvent(payload, occurredAt: occurredAt)
+        case let .workoutPhase(phase, occurredAt):
+            _ = observeWorkoutPhase(phase, occurredAt: occurredAt)
+        }
+    }
+
+    func emitStagingLoss(count: UInt64) {
+        withLock { stagingLostEvidenceCount = count }
+        _ = yieldEvent(
+            .recorderHealth(
+                RecorderHealthEvent(
+                    kind: .loss,
+                    affectedRecordClass: "native-evidence",
+                    count: count,
+                    detailCode: "pre-recorder-staging-overflow"
+                )
+            ),
+            occurredAt: runtimeClock.nowDate(),
+            sourceID: nil
+        )
+        _ = recorder.requestFailure(reason: "pre-recorder-staging-overflow")
+    }
+
+    func requestCancellation() {
+        _ = recorder.requestCancellation()
+    }
+
+    func emitSessionEnd(reason: String) {
+        let shouldEmit: Bool = withLock {
+            guard !ending else { return false }
+            ending = true
+            return true
+        }
+        guard shouldEmit else { return }
+        if reason == "manual_stop" {
+            _ = observeEvent(
+                .manualStop(ManualStopEvent(reason: reason)),
+                occurredAt: runtimeClock.nowDate()
+            )
+        }
+        _ = observeWorkoutPhase(.finished, occurredAt: runtimeClock.nowDate())
+        _ = yieldEvent(
+            .sessionLifecycle(
+                SessionLifecycleEvent(previous: .running, current: .completed, reason: reason)
+            ),
+            occurredAt: runtimeClock.nowDate(),
+            sourceID: nil
+        )
+    }
+
+    func finish() async -> TelemetryFinishResult {
+        await recorder.finish(endedAt: runtimeClock.nowDate(), endedElapsed: elapsed())
+    }
+
+    func observeHeartRate(_ result: HeartRateNormalizationResult) -> TelemetryYieldDisposition {
+        let exactEvent = observeHeartRateRuntime(.delivery(result))
+        guard let scientific = result.canonicalObservation,
+              scientific.beatsPerMinute >= 0,
+              scientific.beatsPerMinute <= Int(UInt16.max) else {
+            return exactEvent
+        }
+
+        let source = heartRateSource(scientific.source)
+        emitSourceIfNeeded(source, observedAt: scientific.recordedAt)
+        let measuredElapsed = scientific.measuredAt.map(elapsed(at:))
+        let receivedElapsed = elapsed(at: scientific.receivedAt)
+        let recordedElapsed = elapsed(at: scientific.recordedAt)
+        let quality = heartRateQuality(scientific.quality)
+        let observation = HeartRateObservation(
+            recordID: RecordID(),
+            observationID: ObservationID(rawValue: scientific.canonicalObservationID.rawValue),
+            sessionID: descriptor.sessionID,
+            source: source,
+            beatsPerMinute: UInt16(scientific.beatsPerMinute),
+            arrivalOrder: result.delivery.arrivalOrder,
+            providerSequence: scientific.providerSequence,
+            providerSampleIdentity: scientific.providerNativeIdentity.flatMap {
+                ProviderNativeSampleIdentity(identifier: $0.identifier)
+            },
+            timestamp: ObservationTimestamp(
+                measuredAt: scientific.measuredAt,
+                receivedAt: scientific.receivedAt,
+                recordedAt: scientific.recordedAt,
+                measuredElapsed: measuredElapsed,
+                receivedElapsed: receivedElapsed,
+                recordedElapsed: recordedElapsed
+            ),
+            provenance: scientific.measuredAt == nil ? .reportedByProvider : .measuredByProvider,
+            freshness: EvidenceFreshness(
+                state: .fresh,
+                evaluatedAt: RecordTimestamp(
+                    recordedAt: scientific.recordedAt,
+                    elapsed: recordedElapsed
+                ),
+                age: .zero,
+                policyVersion: descriptor.versions.safetyPolicy
+            ),
+            quality: quality,
+            controlUse: result.delivery.acceptedIntoLegacyControllerState
+                ? .acceptedNotUsed
+                : .rejected
+        )
+        let receipt = recorder.ingress.yield(.heartRate(observation))
+        if receipt.disposition == .enqueued {
+            withLock { latestHeartRate = observation }
+        }
+        return Self.moreSevere(exactEvent, receipt.disposition)
+    }
+
+    func observeHeartRateRuntime(
+        _ evidence: HeartRateRuntimeEvidence
+    ) -> TelemetryYieldDisposition {
+        let occurredAt: Date
+        let source: HeartRateProviderIdentity
+        switch evidence {
+        case let .delivery(result):
+            occurredAt = result.delivery.recordedAt
+            source = result.delivery.source
+        case let .sourceLifecycle(lifecycle):
+            occurredAt = lifecycle.occurredAt
+            source = lifecycle.source
+        case let .controlUse(controlUse):
+            occurredAt = controlUse.occurredAt
+            source = HeartRateProviderIdentity(
+                kind: .legacyWatchWorkoutStream,
+                stableLocalKey: descriptor.configuration.heartRateProviderStableLocalKey
+            )
+        }
+        let sourceIdentity = heartRateSource(source)
+        emitSourceIfNeeded(sourceIdentity, observedAt: occurredAt)
+        return yieldEvent(
+            .heartRateEvidence(evidence),
+            occurredAt: occurredAt,
+            sourceID: sourceIdentity.id
+        )
+    }
+
+    func observeTreadmill(
+        _ evidence: TreadmillTelemetryEvidence
+    ) -> TelemetryYieldDisposition {
+        let source = treadmillSource(for: evidence)
+        if let source {
+            emitSourceIfNeeded(source, observedAt: evidence.occurredAt)
+        }
+        let eventDisposition = yieldEvent(
+            .treadmillEvidence(evidence),
+            occurredAt: evidence.occurredAt,
+            sourceID: source?.id
+        )
+        guard case let .observation(observed) = evidence,
+              let native = observed.nativeSpeed,
+              let source else {
+            return eventDisposition
+        }
+        let measuredElapsed = observed.measuredAt.map(elapsed(at:))
+        let receivedElapsed = elapsed(at: observed.receivedAt)
+        let recordedElapsed = elapsed(at: observed.recordedAt)
+        guard let observation = TreadmillObservation(
+            recordID: RecordID(),
+            sessionID: descriptor.sessionID,
+            source: source,
+            observedEvidence: observed,
+            nativeUnit: Self.nativeUnit(native, protocolKind: observed.protocolKind),
+            timestamp: ObservationTimestamp(
+                measuredAt: observed.measuredAt,
+                receivedAt: observed.receivedAt,
+                recordedAt: observed.recordedAt,
+                measuredElapsed: measuredElapsed,
+                receivedElapsed: receivedElapsed,
+                recordedElapsed: recordedElapsed
+            ),
+            freshness: EvidenceFreshness(
+                state: observed.freshness == .freshAtReceipt ? .fresh : .unknown,
+                evaluatedAt: RecordTimestamp(
+                    recordedAt: observed.recordedAt,
+                    elapsed: recordedElapsed
+                ),
+                age: .zero,
+                policyVersion: descriptor.versions.safetyPolicy
+            ),
+            quality: treadmillQuality(observed.quality)
+        ) else { return eventDisposition }
+        let receipt = recorder.ingress.yield(.treadmill(observation))
+        if receipt.disposition == .enqueued {
+            withLock { latestTreadmill = observation }
+        }
+        return Self.moreSevere(eventDisposition, receipt.disposition)
+    }
+
+    func observeEvent(
+        _ payload: WorkoutEventPayload,
+        occurredAt: Date
+    ) -> TelemetryYieldDisposition {
+        yieldEvent(payload, occurredAt: occurredAt, sourceID: nil)
+    }
+
+    func observeWorkoutPhase(
+        _ phase: WorkoutPhase,
+        occurredAt: Date
+    ) -> TelemetryYieldDisposition {
+        let previous: WorkoutPhase? = withLock {
+            let previous = currentWorkoutPhase
+            if previous != phase {
+                currentWorkoutPhase = phase
+            }
+            return previous
+        }
+        guard previous != phase else { return .coalescedFrame }
+        return yieldEvent(
+            .workoutPhase(WorkoutPhaseTransition(previous: previous, current: phase)),
+            occurredAt: occurredAt,
+            sourceID: nil
+        )
+    }
+
+    func observeCurrentElapsedSecond() -> TelemetryYieldDisposition {
+        let now = runtimeClock.nowDate()
+        let currentElapsed = elapsed()
+        let currentSecond = max(0, currentElapsed.microseconds / 1_000_000)
+        let frame: CanonicalFrame? = withLock {
+            guard !ending,
+                  lastObservedFrameSecond != currentSecond else { return nil }
+            let gap: CanonicalGapBoundary?
+            if let firstMissingFrameSecond {
+                gap = CanonicalGapBoundary(
+                    missingSinceElapsedSecond: firstMissingFrameSecond,
+                    kind: .recorderOutageOrLoss
+                )
+            } else if let lastObservedFrameSecond,
+                      currentSecond > lastObservedFrameSecond + 1 {
+                gap = CanonicalGapBoundary(
+                    missingSinceElapsedSecond: lastObservedFrameSecond + 1,
+                    kind: .runtimeSuspensionOrStall
+                )
+            } else if lastObservedFrameSecond == nil, currentSecond > 0 {
+                gap = CanonicalGapBoundary(
+                    missingSinceElapsedSecond: 0,
+                    kind: .recorderOutageOrLoss
+                )
+            } else {
+                gap = nil
+            }
+            lastObservedFrameSecond = currentSecond
+            return CanonicalFrame(
+                frameID: FrameID(),
+                recordID: RecordID(),
+                sessionID: descriptor.sessionID,
+                canonicalElapsedSecond: currentSecond,
+                materializedAt: RecordTimestamp(recordedAt: now, elapsed: currentElapsed),
+                heartRateEvidence: latestHeartRate.map {
+                    heartRateFrame($0, materializedAt: now, elapsed: currentElapsed)
+                },
+                treadmillEvidence: latestTreadmill.map {
+                    treadmillFrame($0, materializedAt: now, elapsed: currentElapsed)
+                },
+                precedingGap: gap
+            )
+        }
+        guard let frame else { return .coalescedFrame }
+        let disposition = recorder.ingress.yield(.frame(frame)).disposition
+        withLock {
+            if disposition == .enqueued || disposition == .coalescedFrame {
+                firstMissingFrameSecond = nil
+            } else if firstMissingFrameSecond == nil {
+                firstMissingFrameSecond = currentSecond
+            }
+        }
+        return disposition
+    }
+
+    private func yieldEvent(
+        _ payload: WorkoutEventPayload,
+        occurredAt: Date,
+        sourceID: SourceID?
+    ) -> TelemetryYieldDisposition {
+        let currentElapsed = elapsed()
+        let event = WorkoutEvent(
+            recordID: RecordID(),
+            sessionID: descriptor.sessionID,
+            timestamp: EventTimestamp(
+                occurredAt: occurredAt,
+                recordedAt: runtimeClock.nowDate(),
+                occurredElapsed: elapsed(at: occurredAt),
+                recordedElapsed: currentElapsed
+            ),
+            sourceID: sourceID,
+            payload: EventPayloadEnvelope(schemaVersion: 1, payload: payload)
+        )
+        return recorder.ingress.yield(.event(event)).disposition
+    }
+
+    private func emitSourceIfNeeded(_ source: SignalSourceIdentity, observedAt: Date) {
+        let shouldEmit: Bool = withLock {
+            emittedSourceIDs.insert(source.id).inserted
+        }
+        guard shouldEmit else { return }
+        _ = recorder.ingress.yield(
+            .source(TelemetrySourceRecord(identity: source, firstSeen: observedAt, lastSeen: observedAt))
+        )
+    }
+
+    private func heartRateSource(_ source: HeartRateProviderIdentity) -> SignalSourceIdentity {
+        let stableKey = "hr:\(source.stableLocalKey)"
+        return SignalSourceIdentity(
+            id: SourceID(rawValue: TelemetryV2SessionDescriptor.deterministicUUID(key: stableKey)),
+            providerKind: Self.providerKind(source.kind),
+            stableLocalKey: stableKey
+        )
+    }
+
+    private func treadmillSource(
+        for evidence: TreadmillTelemetryEvidence
+    ) -> SignalSourceIdentity? {
+        guard let stableDevice = descriptor.configuration.treadmill.stableLocalIdentifier,
+              !stableDevice.isEmpty else { return nil }
+        let protocolKind = evidence.protocolKind.rawValue
+        let stableKey = "treadmill:\(stableDevice):\(protocolKind)"
+        return SignalSourceIdentity(
+            id: SourceID(rawValue: TelemetryV2SessionDescriptor.deterministicUUID(key: stableKey)),
+            providerKind: .treadmillProtocol,
+            stableLocalKey: stableKey,
+            knownDevice: KnownDeviceMetadata(
+                manufacturer: nil,
+                model: descriptor.configuration.treadmill.model,
+                hardwareVersion: nil
+            )
+        )
+    }
+
+    private func heartRateFrame(
+        _ observation: HeartRateObservation,
+        materializedAt: Date,
+        elapsed: ElapsedDuration
+    ) -> HeartRateFrameEvidence {
+        let age = Self.nonnegativeAge(from: observation.timestamp.recordedElapsed, to: elapsed)
+        return HeartRateFrameEvidence(
+            observationID: observation.observationID,
+            recordID: observation.recordID,
+            sourceID: observation.source.id,
+            beatsPerMinute: observation.beatsPerMinute,
+            measuredAt: observation.timestamp.measuredAt,
+            receivedAt: observation.timestamp.receivedAt,
+            evidenceElapsed: observation.timestamp.recordedElapsed,
+            ageAtMaterialization: age,
+            freshness: age.seconds <= descriptor.heartRateFreshnessLimitSeconds ? .fresh : .stale,
+            provenance: observation.provenance
+        )
+    }
+
+    private func treadmillFrame(
+        _ observation: TreadmillObservation,
+        materializedAt: Date,
+        elapsed: ElapsedDuration
+    ) -> TreadmillFrameEvidence {
+        let age = Self.nonnegativeAge(from: observation.timestamp.recordedElapsed, to: elapsed)
+        return TreadmillFrameEvidence(
+            observationID: observation.observationID,
+            recordID: observation.recordID,
+            sourceID: observation.source.id,
+            nativeSpeed: observation.nativeSpeed,
+            factualSpeed: observation.factualSpeed,
+            deviceState: observation.deviceState,
+            measuredAt: observation.timestamp.measuredAt,
+            receivedAt: observation.timestamp.receivedAt,
+            evidenceElapsed: observation.timestamp.recordedElapsed,
+            ageAtMaterialization: age,
+            freshness: age.seconds <= descriptor.treadmillFreshnessLimitSeconds ? .fresh : .stale,
+            provenance: observation.provenance
+        )
+    }
+
+    private func elapsed() -> ElapsedDuration {
+        Self.elapsedDuration(runtimeClock.now() - startedMonotonic)
+    }
+
+    private func elapsed(at date: Date) -> ElapsedDuration {
+        let microseconds = date.timeIntervalSince(descriptor.startedAt) * 1_000_000
+        guard microseconds.isFinite else { return .zero }
+        return ElapsedDuration(
+            microseconds: Int64(max(0, min(microseconds, Double(Int64.max))))
+        )
+    }
+
+    private func withLock<T>(_ operation: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return operation()
+    }
+
+    private static func elapsedDuration(_ duration: Duration) -> ElapsedDuration {
+        let components = duration.components
+        let seconds = components.seconds.multipliedReportingOverflow(by: 1_000_000)
+        guard !seconds.overflow else {
+            return ElapsedDuration(microseconds: Int64.max)
+        }
+        let fractional = components.attoseconds / 1_000_000_000_000
+        let total = seconds.partialValue.addingReportingOverflow(fractional)
+        return ElapsedDuration(microseconds: total.overflow ? Int64.max : max(0, total.partialValue))
+    }
+
+    private static func nonnegativeAge(
+        from evidence: ElapsedDuration,
+        to current: ElapsedDuration
+    ) -> ElapsedDuration {
+        ElapsedDuration(microseconds: max(0, current.microseconds - evidence.microseconds))
+    }
+
+    private static func providerKind(_ kind: HeartRateProviderKind) -> SignalProviderKind {
+        switch kind {
+        case .legacyWatchWorkoutStream, .mirroredWatchWorkout: .watchMediated
+        case .healthKitSelected: .healthKitSelected
+        case .phoneHealthKit: .phoneLocal
+        case .bluetooth: .bluetooth
+        case .unknown: .unknown
+        case let .other(value): .other(value)
+        }
+    }
+
+    private static func nativeUnit(
+        _ speed: ReportedTreadmillNativeSpeed,
+        protocolKind: TreadmillProtocolKind
+    ) -> TreadmillNativeSpeedUnit {
+        switch speed.unit {
+        case .kilometresPerHour: .kilometresPerHour
+        case .milesPerHour: .milesPerHour
+        case .controllerUnit:
+            .controllerNative(code: "\(protocolKind.rawValue)-\(speed.resolution.rawValue)")
+        }
+    }
+
+    private static func moreSevere(
+        _ lhs: TelemetryYieldDisposition,
+        _ rhs: TelemetryYieldDisposition
+    ) -> TelemetryYieldDisposition {
+        let order: [TelemetryYieldDisposition] = [
+            .enqueued, .coalescedFrame, .droppedFrame, .lostNative, .lostCritical,
+            .rejectedAfterFinish, .rejectedTerminal, .sequenceExhausted,
+        ]
+        return (order.firstIndex(of: lhs) ?? 0) >= (order.firstIndex(of: rhs) ?? 0)
+            ? lhs
+            : rhs
+    }
+
+    private func heartRateQuality(
+        _ quality: HeartRateNormalizationQualityFlags
+    ) -> QualityFlags {
+        var mapped: QualityFlags = []
+        if quality.contains(.missingMeasurementTime) { mapped.insert(.missingMeasurementTime) }
+        if quality.contains(.duplicateProviderIdentity) { mapped.insert(.duplicateProviderIdentity) }
+        if quality.contains(.duplicateProviderSequence) { mapped.insert(.duplicateProviderSequence) }
+        if quality.contains(.providerSequenceOutOfOrder)
+            || quality.contains(.sourceObservationOutOfArrivalOrder)
+        {
+            mapped.insert(.measurementOutOfArrivalOrder)
+        }
+        return mapped
+    }
+
+    private func treadmillQuality(_ quality: TreadmillObservationQualityFlags) -> QualityFlags {
+        var mapped: QualityFlags = []
+        if quality.contains(.missingMeasurementTime) { mapped.insert(.missingMeasurementTime) }
+        if quality.contains(.missingSpeed) { mapped.insert(.unknownFreshness) }
+        if quality.contains(.invalidNativeValue) || quality.contains(.invalidChecksum) {
+            mapped.insert(.invalidNativeValue)
+        }
+        if quality.contains(.unitsNotRead) || quality.contains(.unitsUnknown)
+            || quality.contains(.unitsStale) || quality.contains(.unitsMalformed)
+            || quality.contains(.unitsInvalidChecksum) || quality.contains(.unitsEpochMismatch)
+        {
+            mapped.insert(.unknownFreshness)
+        }
+        return mapped
+    }
+}
+
+private extension TreadmillTelemetryEvidence {
+    var occurredAt: Date {
+        switch self {
+        case let .observation(evidence): evidence.recordedAt
+        case let .unitsTruth(evidence): evidence.observedAt
+        case let .decision(evidence): evidence.occurredAt
+        case let .commandEnqueued(evidence): evidence.enqueuedAt
+        case let .commandQueueDelay(evidence): evidence.sentAt
+        case let .sendAttempt(evidence): evidence.sentAt
+        case let .unassociatedWrite(evidence): evidence.sentAt
+        case let .acknowledgement(evidence): evidence.recordedAt
+        case let .writeResult(evidence): evidence.occurredAt
+        case let .commandTimeout(evidence): evidence.occurredAt
+        case let .commandFailed(evidence): evidence.occurredAt
+        case let .commandCancelled(evidence): evidence.occurredAt
+        case let .stopEvidence(evidence): evidence.evaluatedAt
+        }
+    }
+
+    var protocolKind: TreadmillProtocolKind {
+        switch self {
+        case let .observation(evidence): return evidence.protocolKind
+        case let .unitsTruth(evidence):
+            switch evidence.truth {
+            case .valid, .notRead, .unknown, .invalidChecksum, .malformed:
+                return .walkingPad
+            }
+        case let .decision(evidence):
+            _ = evidence
+            return .unknown
+        case let .commandEnqueued(evidence): return evidence.protocolKind
+        case .commandQueueDelay: return .unknown
+        case let .sendAttempt(evidence): return evidence.protocolKind
+        case let .unassociatedWrite(evidence): return evidence.protocolKind
+        case let .acknowledgement(evidence): return evidence.protocolKind
+        case let .writeResult(evidence): return evidence.protocolKind
+        case let .commandTimeout(evidence): return evidence.protocolKind
+        case .commandFailed, .commandCancelled: return .unknown
+        case let .stopEvidence(evidence): return evidence.protocolKind
+        }
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
@@ -27,10 +27,29 @@ public enum TelemetryV2WriterLifecycle: String, Equatable, Sendable {
     case incomplete
 }
 
+public enum TelemetryV2WriterRecorderLifecycle: String, Equatable, Sendable {
+    case beginning
+    case active
+    case finishing
+    case failing
+    case cancelling
+    case complete
+    case incomplete
+    case failed
+    case cancelled
+}
+
+public enum TelemetryV2WriterCompleteness: String, Equatable, Sendable {
+    case complete
+    case incomplete
+    case failed
+    case cancelled
+}
+
 public struct TelemetryV2WriterHealthSnapshot: Equatable, Sendable {
     public let runtimeLifecycle: TelemetryV2WriterLifecycle
-    public let recorderLifecycle: TelemetryRecorderLifecycleState?
-    public let completeness: TelemetryRecorderCompleteness?
+    public let recorderLifecycle: TelemetryV2WriterRecorderLifecycle?
+    public let completeness: TelemetryV2WriterCompleteness?
     public let queueDepth: Int
     public let peakQueueDepth: Int
     public let coalescedFrameCount: UInt64
@@ -68,11 +87,32 @@ public struct TelemetryV2WriterHealthSnapshot: Equatable, Sendable {
         case .incomplete:
             runtimeLifecycle = .incomplete
         }
-        recorderLifecycle = operationalState?.lifecycleState
+        switch operationalState?.lifecycleState {
+        case .beginning: recorderLifecycle = .beginning
+        case .active: recorderLifecycle = .active
+        case .finishing: recorderLifecycle = .finishing
+        case .failing: recorderLifecycle = .failing
+        case .cancelling: recorderLifecycle = .cancelling
+        case .complete: recorderLifecycle = .complete
+        case .incomplete: recorderLifecycle = .incomplete
+        case .failed: recorderLifecycle = .failed
+        case .cancelled: recorderLifecycle = .cancelled
+        case nil: recorderLifecycle = nil
+        }
         if let operationalState {
-            completeness = operationalState.completeness
+            switch operationalState.completeness {
+            case .complete: completeness = .complete
+            case .incomplete: completeness = .incomplete
+            case .failed: completeness = .failed
+            case .cancelled: completeness = .cancelled
+            }
         } else if case let .active(runtimeCompleteness) = runtimeStatus {
-            completeness = runtimeCompleteness
+            switch runtimeCompleteness {
+            case .complete: completeness = .complete
+            case .incomplete: completeness = .incomplete
+            case .failed: completeness = .failed
+            case .cancelled: completeness = .cancelled
+            }
         } else {
             completeness = nil
         }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
@@ -336,27 +336,60 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         var seenSourceIDs: Set<SourceID>
     }
 
+    private struct ActiveSession {
+        let generation: UInt64
+        let session: TelemetryV2ActiveSession
+    }
+
     private static let pendingEvidenceCapacity = 256
     private let lock = NSLock()
     private let persistenceFactory: PersistenceFactory
     private let statusHandler: StatusHandler?
     private let runtimeClock: any TelemetryV2RuntimeClock
+    private let installationDidPublishForTesting: (@Sendable (SessionID) -> Void)?
     private var persistence: (any TelemetryRecorderPersistence)?
     private var preparationStarted = false
     private var preparationFailed = false
     private var generation: UInt64 = 0
     private var pendingSession: PendingSession?
-    private var activeSession: TelemetryV2ActiveSession?
+    private var activeSession: ActiveSession?
     private var storedStatus: TelemetryV2RuntimeStatus = .idle
 
-    public init(
+    public convenience init(
         persistenceFactory: @escaping PersistenceFactory,
         runtimeClock: any TelemetryV2RuntimeClock = ContinuousTelemetryV2RuntimeClock(),
         statusHandler: StatusHandler? = nil
     ) {
+        self.init(
+            persistenceFactory: persistenceFactory,
+            runtimeClock: runtimeClock,
+            statusHandler: statusHandler,
+            installationDidPublishForTesting: nil
+        )
+    }
+
+    init(
+        persistenceFactory: @escaping PersistenceFactory,
+        runtimeClock: any TelemetryV2RuntimeClock = ContinuousTelemetryV2RuntimeClock(),
+        statusHandler: StatusHandler? = nil,
+        installationDidPublishForTesting: @escaping @Sendable (SessionID) -> Void
+    ) {
         self.persistenceFactory = persistenceFactory
         self.runtimeClock = runtimeClock
         self.statusHandler = statusHandler
+        self.installationDidPublishForTesting = installationDidPublishForTesting
+    }
+
+    private init(
+        persistenceFactory: @escaping PersistenceFactory,
+        runtimeClock: any TelemetryV2RuntimeClock,
+        statusHandler: StatusHandler?,
+        installationDidPublishForTesting: (@Sendable (SessionID) -> Void)?
+    ) {
+        self.persistenceFactory = persistenceFactory
+        self.runtimeClock = runtimeClock
+        self.statusHandler = statusHandler
+        self.installationDidPublishForTesting = installationDidPublishForTesting
     }
 
     public var status: TelemetryV2RuntimeStatus {
@@ -387,7 +420,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
     public func beginSession(_ descriptor: TelemetryV2SessionDescriptor) {
         let state: (TelemetryV2ActiveSession?, Bool) = withLock {
             generation &+= 1
-            let previous = activeSession
+            let previous = activeSession?.session
             activeSession = nil
             guard !preparationFailed else {
                 pendingSession = nil
@@ -420,7 +453,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
             }
             generation &+= 1
             pendingSession = nil
-            let session = activeSession
+            let session = activeSession?.session
             activeSession = nil
             setStatusLocked(session == nil ? .incomplete("ended-before-recorder-ready") : .finishing)
             return (session, generation, true)
@@ -583,7 +616,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
                       pending.generation == generation else { return nil }
                 if pending.evidence.isEmpty {
                     pendingSession = nil
-                    activeSession = session
+                    activeSession = ActiveSession(generation: generation, session: session)
                     setStatusLocked(
                         !pending.lossSummary.hasLoss
                             ? .active(.complete)
@@ -601,9 +634,8 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
                 return
             }
             if next.0.isEmpty {
-                if next.1.hasLoss {
-                    session.emitStagingLoss(next.1)
-                }
+                installationDidPublishForTesting?(session.sessionID)
+                session.completeInstallation(stagingLoss: next.1)
                 refreshStatus(from: session)
                 return
             }
@@ -634,7 +666,17 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
     }
 
     private func currentActiveSession() -> TelemetryV2ActiveSession? {
-        withLock { activeSession }
+        withLock {
+            guard activeSession?.generation == generation else { return nil }
+            return activeSession?.session
+        }
+    }
+
+    var activeSessionIDForTesting: SessionID? {
+        withLock {
+            guard activeSession?.generation == generation else { return nil }
+            return activeSession?.session.sessionID
+        }
     }
 
     private func bufferDisposition(
@@ -684,7 +726,8 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
     private func refreshStatus(from session: TelemetryV2ActiveSession) {
         let operationalState = session.operationalState
         withLock {
-            guard activeSession === session else { return }
+            guard activeSession?.generation == generation,
+                  activeSession?.session === session else { return }
             if session.hasStagingLoss {
                 setStatusLocked(.incomplete("pre-recorder-staging-overflow"))
                 return
@@ -751,6 +794,12 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
 }
 
 private final class TelemetryV2ActiveSession: @unchecked Sendable {
+    private enum InstallationState {
+        case installing
+        case installed
+        case invalidated
+    }
+
     private let descriptor: TelemetryV2SessionDescriptor
     private let recorder: TelemetryRecorder
     private let runtimeClock: any TelemetryV2RuntimeClock
@@ -764,6 +813,8 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
     private var currentWorkoutPhase: WorkoutPhase?
     private var ending = false
     private var stagingLossSummary = TelemetryV2RuntimeCoordinator.PendingLossSummary()
+    private var installationState = InstallationState.installing
+    private var installationWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(
         descriptor: TelemetryV2SessionDescriptor,
@@ -779,6 +830,10 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
 
     var operationalState: TelemetryRecorderOperationalState {
         recorder.operationalState
+    }
+
+    var sessionID: SessionID {
+        descriptor.sessionID
     }
 
     var hasStagingLoss: Bool {
@@ -813,7 +868,30 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
         }
     }
 
-    func emitStagingLoss(_ summary: TelemetryV2RuntimeCoordinator.PendingLossSummary) {
+    func completeInstallation(
+        stagingLoss summary: TelemetryV2RuntimeCoordinator.PendingLossSummary
+    ) {
+        let canComplete: Bool = withLock {
+            if case .installing = installationState { return true }
+            return false
+        }
+        guard canComplete else { return }
+        if summary.hasLoss {
+            emitStagingLoss(summary)
+        }
+        let waiters: [CheckedContinuation<Void, Never>] = withLock {
+            guard case .installing = installationState else { return [] }
+            installationState = .installed
+            let waiters = installationWaiters
+            installationWaiters.removeAll(keepingCapacity: false)
+            return waiters
+        }
+        waiters.forEach { $0.resume() }
+    }
+
+    private func emitStagingLoss(
+        _ summary: TelemetryV2RuntimeCoordinator.PendingLossSummary
+    ) {
         withLock { stagingLossSummary = summary }
         let occurredAt = runtimeClock.nowDate()
         if summary.lostCriticalRecordCount > 0 {
@@ -875,7 +953,14 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
     }
 
     func requestCancellation() {
+        let waiters: [CheckedContinuation<Void, Never>] = withLock {
+            installationState = .invalidated
+            let waiters = installationWaiters
+            installationWaiters.removeAll(keepingCapacity: false)
+            return waiters
+        }
         _ = recorder.requestCancellation()
+        waiters.forEach { $0.resume() }
     }
 
     func emitSessionEnd(reason: String) {
@@ -902,7 +987,30 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
     }
 
     func finish() async -> TelemetryFinishResult {
-        await recorder.finish(endedAt: runtimeClock.nowDate(), endedElapsed: elapsed())
+        // Product stop schedules this work detached. Only the recorder task waits so
+        // staging loss/incomplete intent wins before persistence can finalize.
+        await waitForInstallationResolution()
+        return await recorder.finish(
+            endedAt: runtimeClock.nowDate(),
+            endedElapsed: elapsed()
+        )
+    }
+
+    private func waitForInstallationResolution() async {
+        await withCheckedContinuation { continuation in
+            let resumeImmediately: Bool = withLock {
+                switch installationState {
+                case .installing:
+                    installationWaiters.append(continuation)
+                    return false
+                case .installed, .invalidated:
+                    return true
+                }
+            }
+            if resumeImmediately {
+                continuation.resume()
+            }
+        }
     }
 
     func observeHeartRate(_ result: HeartRateNormalizationResult) -> TelemetryYieldDisposition {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
@@ -17,6 +17,79 @@ public enum TelemetryV2RuntimeStatus: Equatable, Sendable {
     case incomplete(String)
 }
 
+public enum TelemetryV2WriterLifecycle: String, Equatable, Sendable {
+    case idle
+    case preparing
+    case starting
+    case active
+    case finishing
+    case unavailable
+    case incomplete
+}
+
+public struct TelemetryV2WriterHealthSnapshot: Equatable, Sendable {
+    public let runtimeLifecycle: TelemetryV2WriterLifecycle
+    public let recorderLifecycle: TelemetryRecorderLifecycleState?
+    public let completeness: TelemetryRecorderCompleteness?
+    public let queueDepth: Int
+    public let peakQueueDepth: Int
+    public let coalescedFrameCount: UInt64
+    public let droppedFrameCount: UInt64
+    public let lostNativeCount: UInt64
+    public let lostCriticalCount: UInt64
+    public let writerFailureCount: UInt64
+    public let retryCount: UInt64
+    public let successfulFlushCount: UInt64
+    public let lastCommittedRecorderSequence: UInt64?
+    public let mostRecentFlushDuration: Duration?
+
+    public static let idle = TelemetryV2WriterHealthSnapshot(
+        runtimeStatus: .idle,
+        operationalState: nil
+    )
+
+    init(
+        runtimeStatus: TelemetryV2RuntimeStatus,
+        operationalState: TelemetryRecorderOperationalState?
+    ) {
+        switch runtimeStatus {
+        case .idle:
+            runtimeLifecycle = .idle
+        case .preparing:
+            runtimeLifecycle = .preparing
+        case .starting:
+            runtimeLifecycle = .starting
+        case .active:
+            runtimeLifecycle = .active
+        case .finishing:
+            runtimeLifecycle = .finishing
+        case .unavailable:
+            runtimeLifecycle = .unavailable
+        case .incomplete:
+            runtimeLifecycle = .incomplete
+        }
+        recorderLifecycle = operationalState?.lifecycleState
+        if let operationalState {
+            completeness = operationalState.completeness
+        } else if case let .active(runtimeCompleteness) = runtimeStatus {
+            completeness = runtimeCompleteness
+        } else {
+            completeness = nil
+        }
+        queueDepth = operationalState?.queueDepth ?? 0
+        peakQueueDepth = operationalState?.peakQueueDepth ?? 0
+        coalescedFrameCount = operationalState?.coalescedFrameCount ?? 0
+        droppedFrameCount = operationalState?.droppedFrameCount ?? 0
+        lostNativeCount = operationalState?.lostNativeCount ?? 0
+        lostCriticalCount = operationalState?.lostCriticalCount ?? 0
+        writerFailureCount = operationalState?.writerFailureCount ?? 0
+        retryCount = operationalState?.retryCount ?? 0
+        successfulFlushCount = operationalState?.successfulFlushCount ?? 0
+        lastCommittedRecorderSequence = operationalState?.lastCommittedRecorderSequence
+        mostRecentFlushDuration = operationalState?.mostRecentFlushDuration
+    }
+}
+
 public protocol TelemetryV2RuntimeClock: AnyObject, Sendable {
     func nowDate() -> Date
     func now() -> Duration
@@ -222,6 +295,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
 {
     public typealias PersistenceFactory = @Sendable () throws -> any TelemetryRecorderPersistence
     public typealias StatusHandler = @Sendable (TelemetryV2RuntimeStatus) -> Void
+    public typealias WriterHealthHandler = @Sendable (TelemetryV2WriterHealthSnapshot) -> Void
 
     fileprivate enum PendingEvidence: Sendable {
         case heartRate(HeartRateNormalizationResult)
@@ -345,6 +419,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
     private let lock = NSLock()
     private let persistenceFactory: PersistenceFactory
     private let statusHandler: StatusHandler?
+    private let writerHealthHandler: WriterHealthHandler?
     private let runtimeClock: any TelemetryV2RuntimeClock
     private let installationDidPublishForTesting: (@Sendable (SessionID) -> Void)?
     private var persistence: (any TelemetryRecorderPersistence)?
@@ -354,16 +429,20 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
     private var pendingSession: PendingSession?
     private var activeSession: ActiveSession?
     private var storedStatus: TelemetryV2RuntimeStatus = .idle
+    private var storedOperationalState: TelemetryRecorderOperationalState?
+    private var storedWriterHealthSnapshot: TelemetryV2WriterHealthSnapshot = .idle
 
     public convenience init(
         persistenceFactory: @escaping PersistenceFactory,
         runtimeClock: any TelemetryV2RuntimeClock = ContinuousTelemetryV2RuntimeClock(),
-        statusHandler: StatusHandler? = nil
+        statusHandler: StatusHandler? = nil,
+        writerHealthHandler: WriterHealthHandler? = nil
     ) {
         self.init(
             persistenceFactory: persistenceFactory,
             runtimeClock: runtimeClock,
             statusHandler: statusHandler,
+            writerHealthHandler: writerHealthHandler,
             installationDidPublishForTesting: nil
         )
     }
@@ -372,11 +451,13 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         persistenceFactory: @escaping PersistenceFactory,
         runtimeClock: any TelemetryV2RuntimeClock = ContinuousTelemetryV2RuntimeClock(),
         statusHandler: StatusHandler? = nil,
+        writerHealthHandler: WriterHealthHandler? = nil,
         installationDidPublishForTesting: @escaping @Sendable (SessionID) -> Void
     ) {
         self.persistenceFactory = persistenceFactory
         self.runtimeClock = runtimeClock
         self.statusHandler = statusHandler
+        self.writerHealthHandler = writerHealthHandler
         self.installationDidPublishForTesting = installationDidPublishForTesting
     }
 
@@ -384,16 +465,22 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         persistenceFactory: @escaping PersistenceFactory,
         runtimeClock: any TelemetryV2RuntimeClock,
         statusHandler: StatusHandler?,
+        writerHealthHandler: WriterHealthHandler?,
         installationDidPublishForTesting: (@Sendable (SessionID) -> Void)?
     ) {
         self.persistenceFactory = persistenceFactory
         self.runtimeClock = runtimeClock
         self.statusHandler = statusHandler
+        self.writerHealthHandler = writerHealthHandler
         self.installationDidPublishForTesting = installationDidPublishForTesting
     }
 
     public var status: TelemetryV2RuntimeStatus {
         withLock { storedStatus }
+    }
+
+    public var writerHealthSnapshot: TelemetryV2WriterHealthSnapshot {
+        withLock { storedWriterHealthSnapshot }
     }
 
     public func prepareStoreAndRecover() {
@@ -422,6 +509,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
             generation &+= 1
             let previous = activeSession?.session
             activeSession = nil
+            storedOperationalState = nil
             guard !preparationFailed else {
                 pendingSession = nil
                 setStatusLocked(.unavailable("store-unavailable"))
@@ -463,7 +551,11 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         session.emitSessionEnd(reason: reason)
         Task.detached(priority: .utility) { [weak self] in
             let result = await session.finish()
-            self?.sessionFinished(result, generation: ending.1)
+            self?.sessionFinished(
+                result,
+                operationalState: session.operationalState,
+                generation: ending.1
+            )
         }
     }
 
@@ -573,6 +665,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         withLock {
             preparationFailed = true
             pendingSession = nil
+            storedOperationalState = nil
             setStatusLocked(.unavailable("store-or-recovery-failed:\(Self.errorCode(error))"))
         }
     }
@@ -649,13 +742,19 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         withLock {
             guard self.generation == generation else { return }
             pendingSession = nil
+            storedOperationalState = nil
             setStatusLocked(.unavailable("session-start-failed:\(Self.errorCode(error))"))
         }
     }
 
-    private func sessionFinished(_ result: TelemetryFinishResult, generation: UInt64) {
+    private func sessionFinished(
+        _ result: TelemetryFinishResult,
+        operationalState: TelemetryRecorderOperationalState,
+        generation: UInt64
+    ) {
         withLock {
             guard self.generation == generation else { return }
+            storedOperationalState = operationalState
             switch result.completeness {
             case .complete:
                 setStatusLocked(.idle)
@@ -728,6 +827,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         withLock {
             guard activeSession?.generation == generation,
                   activeSession?.session === session else { return }
+            storedOperationalState = operationalState
             if session.hasStagingLoss {
                 setStatusLocked(.incomplete("pre-recorder-staging-overflow"))
                 return
@@ -742,9 +842,21 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
     }
 
     private func setStatusLocked(_ status: TelemetryV2RuntimeStatus) {
-        guard storedStatus != status else { return }
+        let statusChanged = storedStatus != status
         storedStatus = status
-        if let statusHandler {
+        let writerHealthSnapshot = TelemetryV2WriterHealthSnapshot(
+            runtimeStatus: status,
+            operationalState: storedOperationalState
+        )
+        if writerHealthSnapshot != storedWriterHealthSnapshot {
+            storedWriterHealthSnapshot = writerHealthSnapshot
+            if let writerHealthHandler {
+                DispatchQueue.main.async {
+                    writerHealthHandler(writerHealthSnapshot)
+                }
+            }
+        }
+        if statusChanged, let statusHandler {
             DispatchQueue.main.async {
                 statusHandler(status)
             }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetrySchemaAndBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetrySchemaAndBoundaryTests.swift
@@ -65,7 +65,7 @@ final class TelemetrySchemaAndBoundaryTests: XCTestCase {
         )
     }
 
-    func testStoreBoundaryDisablesAutosaveAndProductionSourcesDoNotInstantiateV2() async throws {
+    func testStoreBoundaryDisablesAutosaveAndProductionWiringIsSingleCoordinatorFactory() async throws {
         let store = try TelemetryStoreFactory.make(.inMemory)
         let autosaveEnabled = await store.isAutosaveEnabled()
         XCTAssertFalse(autosaveEnabled)
@@ -83,8 +83,23 @@ final class TelemetrySchemaAndBoundaryTests: XCTestCase {
 
         for url in sourceURLs {
             let source = try String(contentsOf: url, encoding: .utf8)
-            XCTAssertFalse(source.contains("TelemetryStoreFactory"), "Unexpected V2 store wiring in \(url.lastPathComponent)")
-            XCTAssertFalse(source.contains("TelemetryPersistence"), "Unexpected V2 import in \(url.lastPathComponent)")
+            if url.lastPathComponent == "BluetoothManager.swift" {
+                XCTAssertEqual(
+                    source.components(separatedBy: "TelemetryStoreFactory.make").count - 1,
+                    1
+                )
+                XCTAssertTrue(source.contains("import TelemetryPersistence"))
+                XCTAssertTrue(source.contains("TelemetryV2RuntimeCoordinator("))
+            } else {
+                XCTAssertFalse(
+                    source.contains("TelemetryStoreFactory"),
+                    "Unexpected V2 store wiring in \(url.lastPathComponent)"
+                )
+                XCTAssertFalse(
+                    source.contains("TelemetryPersistence"),
+                    "Unexpected V2 import in \(url.lastPathComponent)"
+                )
+            }
         }
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreRoundTripTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreRoundTripTests.swift
@@ -4,6 +4,73 @@ import TelemetryPersistence
 import XCTest
 
 final class TelemetryStoreRoundTripTests: XCTestCase {
+    func testUnknownTreadmillCausalityRemainsNilAfterPersistenceReplay() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = TelemetryPersistenceFixtures.session(seed: 30)
+        try await store.insertSession(session)
+        let epoch = TreadmillConnectionEpoch(rawValue: UUID())
+        let date = TelemetryPersistenceFixtures.baseDate
+        let payloads: [WorkoutEventPayload] = [
+            .treadmillEvidence(
+                .acknowledgement(
+                    .unresolved(
+                        protocolKind: .walkingPad,
+                        connectionEpoch: epoch,
+                        receivedAt: date,
+                        recordedAt: date
+                    )
+                )
+            ),
+            .treadmillEvidence(
+                .commandTimeout(
+                    LegacyCommandTimeoutObservation(
+                        protocolKind: .walkingPad,
+                        connectionEpoch: epoch,
+                        occurredAt: date
+                    )
+                )
+            ),
+            .treadmillEvidence(
+                .writeResult(
+                    LegacyWriteResultObservation(
+                        protocolKind: .walkingPad,
+                        connectionEpoch: epoch,
+                        occurredAt: date,
+                        status: .succeeded
+                    )
+                )
+            ),
+        ]
+        for (offset, payload) in payloads.enumerated() {
+            let elapsed = ElapsedDuration(microseconds: Int64(offset + 1) * 1_000_000)
+            try await store.insertEvent(
+                WorkoutEvent(
+                    recordID: RecordID(),
+                    sessionID: session.sessionID,
+                    timestamp: EventTimestamp(
+                        occurredAt: date.addingTimeInterval(TimeInterval(offset)),
+                        recordedAt: date.addingTimeInterval(TimeInterval(offset)),
+                        occurredElapsed: elapsed,
+                        recordedElapsed: elapsed
+                    ),
+                    sourceID: nil,
+                    payload: EventPayloadEnvelope(schemaVersion: 1, payload: payload)
+                )
+            )
+        }
+
+        let replayed = try await store.fetchEvents(
+            sessionID: session.sessionID,
+            kind: .treadmillEvidence
+        )
+        XCTAssertEqual(replayed.count, 3)
+        for event in replayed {
+            XCTAssertNil(event.decisionID)
+            XCTAssertNil(event.commandID)
+            XCTAssertNil(event.attemptID)
+        }
+    }
+
     func testInsertFetchOrderAndFilterAllConceptualRecords() async throws {
         let store = try TelemetryStoreFactory.make(.inMemory)
         let sharedConfiguration = TelemetryPersistenceFixtures.configuration(seed: 1)

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreRoundTripTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryStoreRoundTripTests.swift
@@ -1,9 +1,116 @@
 import Foundation
 import TelemetryDomain
 import TelemetryPersistence
+import TelemetryRecorder
 import XCTest
 
 final class TelemetryStoreRoundTripTests: XCTestCase {
+    func testRecorderReusesExactGlobalSourceAcrossWorkoutSessions() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let source = TelemetryPersistenceFixtures.source(seed: 30, kind: .watchMediated)
+        let firstSeen = TelemetryPersistenceFixtures.baseDate
+        let laterSeen = firstSeen.addingTimeInterval(600)
+
+        try await store.insertRecorderBatch([
+            SequencedTelemetryRecord(
+                recorderSequence: 1,
+                record: .source(
+                    TelemetrySourceRecord(
+                        identity: source,
+                        firstSeen: firstSeen,
+                        lastSeen: firstSeen
+                    )
+                )
+            ),
+        ])
+        try await store.insertRecorderBatch([
+            SequencedTelemetryRecord(
+                recorderSequence: 1,
+                record: .source(
+                    TelemetrySourceRecord(
+                        identity: source,
+                        firstSeen: laterSeen,
+                        lastSeen: laterSeen
+                    )
+                )
+            ),
+        ])
+
+        let stored = try await store.fetchSources()
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored.first?.identity, source)
+        XCTAssertEqual(stored.first?.firstSeen, firstSeen)
+        XCTAssertEqual(stored.first?.lastSeen, laterSeen)
+    }
+
+    func testControllerNativeFactualTreadmillRoundTripsInMemoryAndOnDisk() async throws {
+        let session = TelemetryPersistenceFixtures.session(seed: 31)
+        let source = TelemetryPersistenceFixtures.source(seed: 31, kind: .treadmillProtocol)
+        let receivedAt = TelemetryPersistenceFixtures.baseDate.addingTimeInterval(1)
+        let recordedAt = receivedAt.addingTimeInterval(0.01)
+        let epoch = TreadmillConnectionEpoch(rawValue: UUID())
+        var normalizer = TreadmillObservationNormalizer()
+        let evidence = normalizer.normalize(
+            .walkingPad(
+                speedRawTenths: 37,
+                rawState: 1,
+                deviceState: .moving,
+                checksumValid: true,
+                connectionEpoch: epoch,
+                receivedAt: receivedAt
+            ),
+            unitsTruth: .valid(
+                unit: .kilometresPerHour,
+                connectionEpoch: epoch,
+                observedAt: receivedAt.addingTimeInterval(-1)
+            ),
+            observationID: ObservationID(),
+            recordedAt: recordedAt
+        )
+        let observation = try XCTUnwrap(
+            TreadmillObservation(
+                recordID: RecordID(),
+                sessionID: session.sessionID,
+                source: source,
+                observedEvidence: evidence,
+                nativeUnit: .controllerNative(code: "walkingPad-tenths"),
+                timestamp: TelemetryPersistenceFixtures.timestamp(elapsedMicroseconds: 1_000_000),
+                freshness: TelemetryPersistenceFixtures.freshness(elapsedMicroseconds: 1_000_000),
+                quality: []
+            )
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(observation.factualSpeed).value,
+            3.7,
+            accuracy: 0.000_001
+        )
+
+        let inMemory = try TelemetryStoreFactory.make(.inMemory)
+        try await inMemory.insertSession(session)
+        try await inMemory.insertSource(source, firstSeen: receivedAt, lastSeen: receivedAt)
+        try await inMemory.insertTreadmill(observation)
+        let inMemoryObservations = try await inMemory.fetchTreadmill(
+            sessionID: session.sessionID
+        )
+        XCTAssertEqual(inMemoryObservations, [observation])
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("telemetry-controller-native-\(UUID().uuidString)", isDirectory: true)
+        let storeURL = directory.appendingPathComponent("TelemetryV2.store")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        var writer: TelemetryStore? = try TelemetryStoreFactory.make(.onDisk(storeURL))
+        try await writer?.insertSession(session)
+        try await writer?.insertSource(source, firstSeen: receivedAt, lastSeen: receivedAt)
+        try await writer?.insertTreadmill(observation)
+        writer = nil
+
+        let reopened = try TelemetryStoreFactory.make(.onDisk(storeURL))
+        let reopenedObservations = try await reopened.fetchTreadmill(
+            sessionID: session.sessionID
+        )
+        XCTAssertEqual(reopenedObservations, [observation])
+    }
+
     func testUnknownTreadmillCausalityRemainsNilAfterPersistenceReplay() async throws {
         let store = try TelemetryStoreFactory.make(.inMemory)
         let session = TelemetryPersistenceFixtures.session(seed: 30)

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/TelemetryRecorderBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRecorderTests/TelemetryRecorderBoundaryTests.swift
@@ -36,14 +36,22 @@ final class TelemetryRecorderBoundaryTests: XCTestCase {
         XCTAssertEqual(recorder.components(separatedBy: "Task.detached").count - 1, 1)
     }
 
-    func testProductionApplicationSourcesDoNotWireRecorder() throws {
+    func testProductionApplicationWiresRecorderOnlyThroughRuntimeCoordinator() throws {
         let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
         let runtimeSources = try swiftSources(in: root.appendingPathComponent("WalkingPadRemote"))
+        let coordinator = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift"
+            ),
+            encoding: .utf8
+        )
 
         XCTAssertFalse(runtimeSources.contains("import TelemetryRecorder"))
         XCTAssertFalse(runtimeSources.contains("TelemetryIngress"))
         XCTAssertFalse(runtimeSources.contains("TelemetryRecorder("))
-        XCTAssertFalse(runtimeSources.contains("TelemetryStoreFactory.make"))
+        XCTAssertTrue(runtimeSources.contains("TelemetryV2RuntimeCoordinator("))
+        XCTAssertTrue(coordinator.contains("let recorder = TelemetryRecorder("))
+        XCTAssertTrue(coordinator.contains("Task.detached(priority: .utility)"))
     }
 
     func testPackageDependencyDirectionKeepsRecorderAboveDomainAndBelowPersistence() throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
@@ -256,15 +256,19 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
     func testPendingEvidenceOverflowDurablyFailsOnlyTelemetrySession() async throws {
         let persistence = RuntimePersistence()
         let factoryGate = DispatchSemaphore(value: 0)
-        let coordinator = TelemetryV2RuntimeCoordinator {
-            factoryGate.wait()
-            return persistence
-        }
+        let clock = ManualRuntimeClock(date: Date(timeIntervalSince1970: 25_000))
+        let coordinator = TelemetryV2RuntimeCoordinator(
+            persistenceFactory: {
+                factoryGate.wait()
+                return persistence
+            },
+            runtimeClock: clock
+        )
         let evidence = TreadmillTelemetryEvidence.unassociatedWrite(
             UnassociatedLegacyWriteObservation(
                 protocolKind: .walkingPad,
                 connectionEpoch: TreadmillConnectionEpoch(rawValue: UUID()),
-                sentAt: Date(),
+                sentAt: clock.nowDate(),
                 writeType: .withoutResponse
             )
         )
@@ -273,7 +277,37 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
         for _ in 0..<256 {
             XCTAssertEqual(coordinator.observeTreadmillEvidence(evidence), .accepted)
         }
+        clock.advance(by: .seconds(2))
+        let firstDropBegan = ContinuousClock.now
         XCTAssertEqual(coordinator.observeTreadmillEvidence(evidence), .degraded)
+        XCTAssertLessThan(firstDropBegan.duration(to: .now), .milliseconds(50))
+
+        clock.advance(by: .seconds(3))
+        let epoch = TreadmillConnectionEpoch(rawValue: UUID())
+        var normalizer = TreadmillObservationNormalizer()
+        let observation = normalizer.normalize(
+            .walkingPad(
+                speedRawTenths: 37,
+                rawState: 1,
+                deviceState: .moving,
+                checksumValid: true,
+                connectionEpoch: epoch,
+                receivedAt: clock.nowDate()
+            ),
+            unitsTruth: .valid(
+                unit: .kilometresPerHour,
+                connectionEpoch: epoch,
+                observedAt: clock.nowDate().addingTimeInterval(-1)
+            ),
+            observationID: ObservationID(),
+            recordedAt: clock.nowDate()
+        )
+        let secondDropBegan = ContinuousClock.now
+        XCTAssertEqual(
+            coordinator.observeTreadmillEvidence(.observation(observation)),
+            .degraded
+        )
+        XCTAssertLessThan(secondDropBegan.duration(to: .now), .milliseconds(50))
 
         factoryGate.signal()
         try await eventually { await persistence.finalizations.count == 1 }
@@ -282,6 +316,30 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
         XCTAssertEqual(finalization.lifecycleState, .incomplete)
         XCTAssertEqual(finalization.incompleteReason, "pre-recorder-staging-overflow")
         XCTAssertFalse(finalization.recorderHealth.isComplete)
+        XCTAssertEqual(finalization.recorderHealth.lostCriticalRecordCount, 2)
+        XCTAssertEqual(finalization.recorderHealth.lostNativeRecordCount, 1)
+        let acceptedPrefix = snapshot.records.compactMap { record -> WorkoutEvent? in
+            guard case let .event(event) = record,
+                  event.kind == .treadmillEvidence else { return nil }
+            return event
+        }
+        XCTAssertEqual(acceptedPrefix.count, 256)
+        let lossEvents = snapshot.records.compactMap { record -> RecorderHealthEvent? in
+            guard case let .event(event) = record,
+                  case let .recorderHealth(health) = event.payload.payload,
+                  health.kind == .loss else { return nil }
+            return health
+        }
+        XCTAssertEqual(lossEvents.map(\.affectedRecordClass), ["critical", "native"])
+        XCTAssertEqual(lossEvents.map(\.count), [2, 1])
+        XCTAssertEqual(
+            lossEvents.map(\.firstAffectedElapsed),
+            [ElapsedDuration(microseconds: 2_000_000), ElapsedDuration(microseconds: 5_000_000)]
+        )
+        XCTAssertEqual(
+            lossEvents.map(\.lastAffectedElapsed),
+            [ElapsedDuration(microseconds: 5_000_000), ElapsedDuration(microseconds: 5_000_000)]
+        )
         if case .incomplete("pre-recorder-staging-overflow") = coordinator.status {
             // The telemetry failure is visible and does not require product-path coordination.
         } else {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
@@ -1,0 +1,511 @@
+import CryptoKit
+import Dispatch
+import Foundation
+import TelemetryDomain
+import TelemetryRecorder
+@testable import TelemetryRuntime
+import XCTest
+
+final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
+    func testStoreConstructionAndImmediateStopNeverBlockOrResurrectSession() async throws {
+        let persistence = RuntimePersistence()
+        let factoryGate = DispatchSemaphore(value: 0)
+        let factoryEntered = DispatchSemaphore(value: 0)
+        let coordinator = TelemetryV2RuntimeCoordinator {
+            factoryEntered.signal()
+            factoryGate.wait()
+            return persistence
+        }
+
+        let startBegan = ContinuousClock.now
+        coordinator.beginSession(Self.descriptor())
+        let startDuration = startBegan.duration(to: .now)
+        XCTAssertLessThan(startDuration, .milliseconds(50))
+        XCTAssertEqual(factoryEntered.wait(timeout: .now() + 1), .success)
+
+        let stopBegan = ContinuousClock.now
+        coordinator.endSession(reason: "immediate-stop")
+        let stopDuration = stopBegan.duration(to: .now)
+        XCTAssertLessThan(stopDuration, .milliseconds(50))
+
+        factoryGate.signal()
+        try await eventually { await persistence.unfinishedCallCount == 1 }
+        let snapshot = await persistence.snapshot()
+        XCTAssertEqual(snapshot.beginCallCount, 0)
+        XCTAssertTrue(snapshot.headers.isEmpty)
+        XCTAssertTrue(snapshot.finalizations.isEmpty)
+        XCTAssertEqual(coordinator.status, .incomplete("ended-before-recorder-ready"))
+    }
+
+    func testDelayedHeaderAndFinalizationNeverBlockProductLifecycle() async throws {
+        let persistence = RuntimePersistence(suspendBegin: true, suspendFinalize: true)
+        let coordinator = TelemetryV2RuntimeCoordinator { persistence }
+        coordinator.beginSession(Self.descriptor())
+        try await eventually { await persistence.beginCallCount == 1 }
+        try await eventually {
+            if case .active = coordinator.status { return true }
+            return false
+        }
+
+        let stopBegan = ContinuousClock.now
+        coordinator.endSession(reason: "manual-stop")
+        XCTAssertLessThan(stopBegan.duration(to: .now), .milliseconds(50))
+
+        await persistence.resumeBegin()
+        try await eventually { await persistence.finalizeCallCount == 1 }
+        XCTAssertEqual(coordinator.status, .finishing)
+        await persistence.resumeFinalize()
+        try await eventually { await persistence.finalizations.count == 1 }
+        try await eventually { coordinator.status == .idle }
+    }
+
+    func testObservedFramesAreUniqueAllowGapsAndNeverBackfill() async throws {
+        let persistence = RuntimePersistence()
+        let clock = ManualRuntimeClock(date: Date(timeIntervalSince1970: 10_000))
+        let legacyID = UUID(uuidString: "10000000-0000-0000-0000-000000000030")!
+        let coordinator = TelemetryV2RuntimeCoordinator(
+            persistenceFactory: { persistence },
+            runtimeClock: clock
+        )
+        let descriptor = Self.descriptor(
+            legacySessionID: legacyID,
+            startedAt: clock.nowDate()
+        )
+        coordinator.beginSession(descriptor)
+        try await eventually { await persistence.headers.count == 1 }
+        try await eventually {
+            if case .active = coordinator.status { return true }
+            return false
+        }
+
+        XCTAssertEqual(coordinator.observeCurrentElapsedSecond(), .enqueued)
+        XCTAssertEqual(coordinator.observeCurrentElapsedSecond(), .coalescedFrame)
+        clock.advance(by: .seconds(3))
+        XCTAssertEqual(coordinator.observeCurrentElapsedSecond(), .enqueued)
+        coordinator.endSession(reason: "complete")
+        try await eventually { await persistence.finalizations.count == 1 }
+
+        let snapshot = await persistence.snapshot()
+        let header = try XCTUnwrap(snapshot.headers.first)
+        XCTAssertEqual(header.sessionID.rawValue, legacyID)
+        XCTAssertEqual(header.profileLocalIdentifier, descriptor.configuration.profileLocalIdentifier)
+        XCTAssertEqual(header.workoutMode, descriptor.configuration.workoutMode)
+        XCTAssertEqual(header.appContext, descriptor.appContext)
+        XCTAssertEqual(header.versions, descriptor.versions)
+        XCTAssertEqual(
+            header.treadmill?.protocolName,
+            descriptor.configuration.treadmill.protocolName
+        )
+        XCTAssertEqual(
+            try JSONDecoder().decode(
+                TelemetryV2ConfigurationInput.self,
+                from: header.configuration.canonicalPayload
+            ),
+            descriptor.configuration
+        )
+        XCTAssertEqual(
+            header.configuration.contentHash.lowercaseHexDigest,
+            SHA256.hash(data: header.configuration.canonicalPayload)
+                .map { String(format: "%02x", $0) }
+                .joined()
+        )
+        let frames = snapshot.records.compactMap { record -> CanonicalFrame? in
+            guard case let .frame(frame) = record else { return nil }
+            return frame
+        }
+        XCTAssertEqual(frames.map(\.canonicalElapsedSecond), [0, 3])
+        XCTAssertNil(frames[0].precedingGap)
+        XCTAssertEqual(frames[1].precedingGap?.missingSinceElapsedSecond, 1)
+        XCTAssertEqual(frames[1].precedingGap?.kind, .runtimeSuspensionOrStall)
+        XCTAssertNil(frames[0].heartRateEvidence)
+        XCTAssertNil(frames[0].treadmillEvidence)
+        XCTAssertNil(frames[1].heartRateEvidence)
+        XCTAssertNil(frames[1].treadmillEvidence)
+    }
+
+    func testSessionPhaseCooldownManualStopAndConnectionEventsPersistInOrder() async throws {
+        let persistence = RuntimePersistence()
+        let clock = ManualRuntimeClock(date: Date(timeIntervalSince1970: 15_000))
+        let coordinator = TelemetryV2RuntimeCoordinator(
+            persistenceFactory: { persistence },
+            runtimeClock: clock
+        )
+        coordinator.beginSession(Self.descriptor(startedAt: clock.nowDate()))
+        try await eventually {
+            if case .active = coordinator.status { return true }
+            return false
+        }
+
+        clock.advance(by: .seconds(1))
+        XCTAssertEqual(
+            coordinator.observeWorkoutPhase(.cooldown, occurredAt: clock.nowDate()),
+            .enqueued
+        )
+        XCTAssertEqual(
+            coordinator.observeEvent(
+                .cooldown(CooldownEvent(lifecycle: .started, targetHeartRate: 100)),
+                occurredAt: clock.nowDate()
+            ),
+            .enqueued
+        )
+        XCTAssertEqual(
+            coordinator.observeEvent(
+                .connectionTransition(
+                    ConnectionTransition(
+                        previous: .connected,
+                        current: .disconnected,
+                        reason: "disconnect_user"
+                    )
+                ),
+                occurredAt: clock.nowDate()
+            ),
+            .enqueued
+        )
+        coordinator.endSession(reason: "manual_stop")
+        try await eventually { await persistence.finalizations.count == 1 }
+
+        let events = await persistence.snapshot().records.compactMap { record -> WorkoutEvent? in
+            guard case let .event(event) = record else { return nil }
+            return event
+        }
+        XCTAssertEqual(
+            events.map(\.kind),
+            [
+                .sessionLifecycle,
+                .workoutPhase,
+                .workoutPhase,
+                .cooldown,
+                .connectionTransition,
+                .manualStop,
+                .workoutPhase,
+                .sessionLifecycle,
+            ]
+        )
+        let phases = events.compactMap { event -> WorkoutPhaseTransition? in
+            guard case let .workoutPhase(transition) = event.payload.payload else { return nil }
+            return transition
+        }
+        XCTAssertEqual(phases.map(\.current), [.main, .cooldown, .finished])
+    }
+
+    func testPendingUnknownCausalityReplaysWithoutInventingIdentifiers() async throws {
+        let persistence = RuntimePersistence()
+        let factoryGate = DispatchSemaphore(value: 0)
+        let coordinator = TelemetryV2RuntimeCoordinator {
+            factoryGate.wait()
+            return persistence
+        }
+        let epoch = TreadmillConnectionEpoch(rawValue: UUID())
+        let date = Date(timeIntervalSince1970: 20_000)
+        let evidence: [TreadmillTelemetryEvidence] = [
+            .acknowledgement(
+                .unresolved(
+                    protocolKind: .walkingPad,
+                    connectionEpoch: epoch,
+                    receivedAt: date,
+                    recordedAt: date
+                )
+            ),
+            .commandTimeout(
+                LegacyCommandTimeoutObservation(
+                    protocolKind: .walkingPad,
+                    connectionEpoch: epoch,
+                    occurredAt: date
+                )
+            ),
+            .writeResult(
+                LegacyWriteResultObservation(
+                    protocolKind: .walkingPad,
+                    connectionEpoch: epoch,
+                    occurredAt: date,
+                    status: .succeeded
+                )
+            ),
+        ]
+        coordinator.beginSession(Self.descriptor())
+        for item in evidence {
+            XCTAssertEqual(coordinator.observeTreadmillEvidence(item), .accepted)
+        }
+        factoryGate.signal()
+        try await eventually { await persistence.headers.count == 1 }
+        try await eventually {
+            if case .active = coordinator.status { return true }
+            return false
+        }
+        coordinator.endSession(reason: "complete")
+        try await eventually { await persistence.finalizations.count == 1 }
+
+        let stored = await persistence.snapshot().records.compactMap { record -> WorkoutEvent? in
+            guard case let .event(event) = record,
+                  event.kind == .treadmillEvidence else { return nil }
+            return event
+        }
+        XCTAssertEqual(stored.count, 3)
+        for event in stored {
+            XCTAssertNil(event.decisionID)
+            XCTAssertNil(event.commandID)
+            XCTAssertNil(event.attemptID)
+            let encoded = try JSONEncoder().encode(event)
+            let replayed = try JSONDecoder().decode(WorkoutEvent.self, from: encoded)
+            XCTAssertNil(replayed.decisionID)
+            XCTAssertNil(replayed.commandID)
+            XCTAssertNil(replayed.attemptID)
+        }
+    }
+
+    func testPendingEvidenceOverflowDurablyFailsOnlyTelemetrySession() async throws {
+        let persistence = RuntimePersistence()
+        let factoryGate = DispatchSemaphore(value: 0)
+        let coordinator = TelemetryV2RuntimeCoordinator {
+            factoryGate.wait()
+            return persistence
+        }
+        let evidence = TreadmillTelemetryEvidence.unassociatedWrite(
+            UnassociatedLegacyWriteObservation(
+                protocolKind: .walkingPad,
+                connectionEpoch: TreadmillConnectionEpoch(rawValue: UUID()),
+                sentAt: Date(),
+                writeType: .withoutResponse
+            )
+        )
+
+        coordinator.beginSession(Self.descriptor())
+        for _ in 0..<256 {
+            XCTAssertEqual(coordinator.observeTreadmillEvidence(evidence), .accepted)
+        }
+        XCTAssertEqual(coordinator.observeTreadmillEvidence(evidence), .degraded)
+
+        factoryGate.signal()
+        try await eventually { await persistence.finalizations.count == 1 }
+        let snapshot = await persistence.snapshot()
+        let finalization = try XCTUnwrap(snapshot.finalizations.first)
+        XCTAssertEqual(finalization.lifecycleState, .incomplete)
+        XCTAssertEqual(finalization.incompleteReason, "pre-recorder-staging-overflow")
+        XCTAssertFalse(finalization.recorderHealth.isComplete)
+        if case .incomplete("pre-recorder-staging-overflow") = coordinator.status {
+            // The telemetry failure is visible and does not require product-path coordination.
+        } else {
+            XCTFail("Expected durable telemetry-only incomplete status")
+        }
+    }
+
+    func testStoreAndFinalizationFailuresRemainTelemetryOnly() async throws {
+        enum FactoryFailure: Error { case unavailable }
+        let failedFactoryCoordinator = TelemetryV2RuntimeCoordinator {
+            throw FactoryFailure.unavailable
+        }
+        let began = ContinuousClock.now
+        failedFactoryCoordinator.beginSession(Self.descriptor())
+        XCTAssertLessThan(began.duration(to: .now), .milliseconds(50))
+        try await eventually {
+            if case .unavailable = failedFactoryCoordinator.status { return true }
+            return false
+        }
+        XCTAssertEqual(
+            failedFactoryCoordinator.observeTreadmillEvidence(
+                .unassociatedWrite(
+                    UnassociatedLegacyWriteObservation(
+                        protocolKind: .walkingPad,
+                        connectionEpoch: TreadmillConnectionEpoch(rawValue: UUID()),
+                        sentAt: Date(),
+                        writeType: .withoutResponse
+                    )
+                )
+            ),
+            .unavailable
+        )
+
+        let persistence = RuntimePersistence(finalizeFailure: true)
+        let finalizeFailureCoordinator = TelemetryV2RuntimeCoordinator { persistence }
+        finalizeFailureCoordinator.beginSession(Self.descriptor())
+        try await eventually { await persistence.headers.count == 1 }
+        try await eventually {
+            if case .active = finalizeFailureCoordinator.status { return true }
+            return false
+        }
+        let ended = ContinuousClock.now
+        finalizeFailureCoordinator.endSession(reason: "manual-stop")
+        XCTAssertLessThan(ended.duration(to: .now), .milliseconds(50))
+        try await eventually {
+            if case .incomplete = finalizeFailureCoordinator.status { return true }
+            return false
+        }
+    }
+
+    private static func descriptor(
+        legacySessionID: UUID? = UUID(uuidString: "10000000-0000-0000-0000-000000000030"),
+        startedAt: Date = Date(timeIntervalSince1970: 1_000)
+    ) -> TelemetryV2SessionDescriptor {
+        TelemetryV2SessionDescriptor(
+            sessionID: TelemetryV2SessionDescriptor.sessionID(
+                deterministicallyLinkedTo: legacySessionID
+            ),
+            deterministicLegacySessionID: legacySessionID,
+            startedAt: startedAt,
+            appContext: AppRuntimeContext(
+                appVersion: "test",
+                buildNumber: "30",
+                operatingSystemVersion: "test",
+                deviceModel: "test"
+            ),
+            configuration: TelemetryV2ConfigurationInput(
+                profileLocalIdentifier: "profile-30",
+                workoutMode: .heartRateControlled,
+                targetHeartRate: 120,
+                durationMinutes: 30,
+                decisionIntervalSeconds: 10,
+                adaptiveStepEnabled: true,
+                maximumStepKilometresPerHour: 0.4,
+                heartRateZones: [100, 120, 140, 160],
+                cooldownTargetHeartRate: 100,
+                cooldownMinimumSpeedKilometresPerHour: 1,
+                cooldownMaximumMinutes: 5,
+                heartRateProviderKind: "legacyWatchWorkoutStream",
+                heartRateProviderStableLocalKey: "watch-session",
+                treadmill: TelemetryV2TreadmillContext(
+                    stableLocalIdentifier: "treadmill-30",
+                    model: "test",
+                    protocolName: "walkingPad",
+                    protocolVersion: nil,
+                    minimumSpeedKilometresPerHour: 0.5,
+                    maximumSpeedKilometresPerHour: 6,
+                    speedIncrementKilometresPerHour: 0.1
+                )
+            ),
+            versions: RuntimeVersionContext(
+                telemetrySchema: TelemetrySchemaVersion(rawValue: "1"),
+                algorithm: AlgorithmVersion(rawValue: "legacy"),
+                safetyPolicy: SafetyPolicyVersion(rawValue: "test"),
+                workoutProtocol: WorkoutProtocolVersion(rawValue: "test")
+            ),
+            heartRateFreshnessLimitSeconds: 5,
+            treadmillFreshnessLimitSeconds: 30
+        )
+    }
+}
+
+private final class ManualRuntimeClock: TelemetryV2RuntimeClock, @unchecked Sendable {
+    private let lock = NSLock()
+    private var date: Date
+    private var elapsed: Duration = .zero
+
+    init(date: Date) {
+        self.date = date
+    }
+
+    func nowDate() -> Date {
+        lock.withLock { date }
+    }
+
+    func now() -> Duration {
+        lock.withLock { elapsed }
+    }
+
+    func advance(by duration: Duration) {
+        lock.withLock {
+            elapsed += duration
+            date = date.addingTimeInterval(duration.seconds)
+        }
+    }
+}
+
+private actor RuntimePersistence: TelemetryRecorderPersistence {
+    struct Snapshot: Sendable {
+        let headers: [WorkoutSessionRecord]
+        let records: [TelemetryPersistenceRecord]
+        let finalizations: [TelemetrySessionFinalization]
+        let beginCallCount: Int
+    }
+
+    private(set) var headers: [WorkoutSessionRecord] = []
+    private(set) var records: [TelemetryPersistenceRecord] = []
+    private(set) var finalizations: [TelemetrySessionFinalization] = []
+    private(set) var beginCallCount = 0
+    private(set) var finalizeCallCount = 0
+    private(set) var unfinishedCallCount = 0
+    private let suspendBegin: Bool
+    private let suspendFinalize: Bool
+    private let finalizeFailure: Bool
+    private var beginContinuation: CheckedContinuation<Void, Never>?
+    private var finalizeContinuation: CheckedContinuation<Void, Never>?
+
+    init(
+        suspendBegin: Bool = false,
+        suspendFinalize: Bool = false,
+        finalizeFailure: Bool = false
+    ) {
+        self.suspendBegin = suspendBegin
+        self.suspendFinalize = suspendFinalize
+        self.finalizeFailure = finalizeFailure
+    }
+
+    func beginSession(_ header: WorkoutSessionRecord) async throws {
+        beginCallCount += 1
+        if suspendBegin {
+            await withCheckedContinuation { beginContinuation = $0 }
+        }
+        headers.append(header)
+    }
+
+    func persistBatch(_ records: [SequencedTelemetryRecord]) async throws {
+        self.records.append(contentsOf: records.map(\.record))
+    }
+
+    func finalizeSession(_ finalization: TelemetrySessionFinalization) async throws {
+        finalizeCallCount += 1
+        if suspendFinalize {
+            await withCheckedContinuation { finalizeContinuation = $0 }
+        }
+        if finalizeFailure {
+            throw TelemetryPersistenceOperationError.terminal(code: "test-finalize")
+        }
+        finalizations.append(finalization)
+    }
+
+    func unfinishedSessions() async throws -> [WorkoutSessionRecord] {
+        unfinishedCallCount += 1
+        return []
+    }
+
+    func resumeBegin() {
+        beginContinuation?.resume()
+        beginContinuation = nil
+    }
+
+    func resumeFinalize() {
+        finalizeContinuation?.resume()
+        finalizeContinuation = nil
+    }
+
+    func snapshot() -> Snapshot {
+        Snapshot(
+            headers: headers,
+            records: records,
+            finalizations: finalizations,
+            beginCallCount: beginCallCount
+        )
+    }
+}
+
+private enum EventuallyFailure: Error {
+    case timedOut
+}
+
+private func eventually(
+    attempts: Int = 10_000,
+    _ predicate: @escaping @Sendable () async -> Bool
+) async throws {
+    for _ in 0..<attempts {
+        if await predicate() { return }
+        await Task.yield()
+    }
+    throw EventuallyFailure.timedOut
+}
+
+private extension Duration {
+    var seconds: TimeInterval {
+        let components = self.components
+        return TimeInterval(components.seconds)
+            + TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
@@ -264,22 +264,27 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
             },
             runtimeClock: clock
         )
-        let evidence = TreadmillTelemetryEvidence.unassociatedWrite(
-            UnassociatedLegacyWriteObservation(
-                protocolKind: .walkingPad,
-                connectionEpoch: TreadmillConnectionEpoch(rawValue: UUID()),
-                sentAt: clock.nowDate(),
-                writeType: .withoutResponse
-            )
+        let criticalEvent = WorkoutEventPayload.manualStop(
+            ManualStopEvent(reason: "staging-pressure")
         )
 
         coordinator.beginSession(Self.descriptor())
+        let frameDropBegan = ContinuousClock.now
+        XCTAssertEqual(coordinator.observeCurrentElapsedSecond(), .droppedFrame)
+        XCTAssertLessThan(frameDropBegan.duration(to: .now), .milliseconds(50))
+        XCTAssertEqual(coordinator.observeCurrentElapsedSecond(), .coalescedFrame)
         for _ in 0..<256 {
-            XCTAssertEqual(coordinator.observeTreadmillEvidence(evidence), .accepted)
+            XCTAssertEqual(
+                coordinator.observeEvent(criticalEvent, occurredAt: clock.nowDate()),
+                .enqueued
+            )
         }
         clock.advance(by: .seconds(2))
         let firstDropBegan = ContinuousClock.now
-        XCTAssertEqual(coordinator.observeTreadmillEvidence(evidence), .degraded)
+        XCTAssertEqual(
+            coordinator.observeEvent(criticalEvent, occurredAt: clock.nowDate()),
+            .lostCritical
+        )
         XCTAssertLessThan(firstDropBegan.duration(to: .now), .milliseconds(50))
 
         clock.advance(by: .seconds(3))
@@ -316,30 +321,61 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
         XCTAssertEqual(finalization.lifecycleState, .incomplete)
         XCTAssertEqual(finalization.incompleteReason, "pre-recorder-staging-overflow")
         XCTAssertFalse(finalization.recorderHealth.isComplete)
-        XCTAssertEqual(finalization.recorderHealth.lostCriticalRecordCount, 2)
+        XCTAssertEqual(finalization.recorderHealth.lostCriticalRecordCount, 3)
         XCTAssertEqual(finalization.recorderHealth.lostNativeRecordCount, 1)
         let acceptedPrefix = snapshot.records.compactMap { record -> WorkoutEvent? in
             guard case let .event(event) = record,
-                  event.kind == .treadmillEvidence else { return nil }
+                  event.kind == .manualStop else { return nil }
             return event
         }
         XCTAssertEqual(acceptedPrefix.count, 256)
+        XCTAssertTrue(
+            zip(snapshot.recorderSequences, snapshot.recorderSequences.dropFirst())
+                .allSatisfy(<)
+        )
         let lossEvents = snapshot.records.compactMap { record -> RecorderHealthEvent? in
             guard case let .event(event) = record,
                   case let .recorderHealth(health) = event.payload.payload,
                   health.kind == .loss else { return nil }
             return health
         }
-        XCTAssertEqual(lossEvents.map(\.affectedRecordClass), ["critical", "native"])
-        XCTAssertEqual(lossEvents.map(\.count), [2, 1])
+        XCTAssertEqual(
+            lossEvents.map(\.affectedRecordClass),
+            ["critical", "native", "bulkFrame"]
+        )
+        XCTAssertEqual(lossEvents.map(\.count), [3, 1, 1])
         XCTAssertEqual(
             lossEvents.map(\.firstAffectedElapsed),
-            [ElapsedDuration(microseconds: 2_000_000), ElapsedDuration(microseconds: 5_000_000)]
+            [
+                ElapsedDuration(microseconds: 2_000_000),
+                ElapsedDuration(microseconds: 5_000_000),
+                ElapsedDuration(microseconds: 0),
+            ]
         )
         XCTAssertEqual(
             lossEvents.map(\.lastAffectedElapsed),
-            [ElapsedDuration(microseconds: 5_000_000), ElapsedDuration(microseconds: 5_000_000)]
+            [
+                ElapsedDuration(microseconds: 5_000_000),
+                ElapsedDuration(microseconds: 5_000_000),
+                ElapsedDuration(microseconds: 0),
+            ]
         )
+        let lastAcceptedPrefixIndex = try XCTUnwrap(
+            snapshot.records.lastIndex { record in
+                guard case let .event(event) = record else { return false }
+                return event.kind == .manualStop
+            }
+        )
+        let firstLossIndex = try XCTUnwrap(
+            snapshot.records.firstIndex { record in
+                guard case let .event(event) = record,
+                      case let .recorderHealth(health) = event.payload.payload else {
+                    return false
+                }
+                return health.kind == .loss
+            }
+        )
+        XCTAssertLessThan(lastAcceptedPrefixIndex, firstLossIndex)
         if case .incomplete("pre-recorder-staging-overflow") = coordinator.status {
             // The telemetry failure is visible and does not require product-path coordination.
         } else {
@@ -471,12 +507,14 @@ private actor RuntimePersistence: TelemetryRecorderPersistence {
     struct Snapshot: Sendable {
         let headers: [WorkoutSessionRecord]
         let records: [TelemetryPersistenceRecord]
+        let recorderSequences: [UInt64]
         let finalizations: [TelemetrySessionFinalization]
         let beginCallCount: Int
     }
 
     private(set) var headers: [WorkoutSessionRecord] = []
     private(set) var records: [TelemetryPersistenceRecord] = []
+    private(set) var recorderSequences: [UInt64] = []
     private(set) var finalizations: [TelemetrySessionFinalization] = []
     private(set) var beginCallCount = 0
     private(set) var finalizeCallCount = 0
@@ -507,6 +545,7 @@ private actor RuntimePersistence: TelemetryRecorderPersistence {
 
     func persistBatch(_ records: [SequencedTelemetryRecord]) async throws {
         self.records.append(contentsOf: records.map(\.record))
+        recorderSequences.append(contentsOf: records.map(\.recorderSequence))
     }
 
     func finalizeSession(_ finalization: TelemetrySessionFinalization) async throws {
@@ -539,6 +578,7 @@ private actor RuntimePersistence: TelemetryRecorderPersistence {
         Snapshot(
             headers: headers,
             records: records,
+            recorderSequences: recorderSequences,
             finalizations: finalizations,
             beginCallCount: beginCallCount
         )

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
@@ -7,6 +7,49 @@ import TelemetryRecorder
 import XCTest
 
 final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
+    func testWriterHealthSnapshotMapsOnlyTypedOperationalDiagnostics() {
+        let snapshot = TelemetryV2WriterHealthSnapshot(
+            runtimeStatus: .active(.incomplete),
+            operationalState: TelemetryRecorderOperationalState(
+                queueDepth: 1,
+                peakQueueDepth: 2,
+                coalescedFrameCount: 3,
+                droppedFrameCount: 4,
+                lostNativeCount: 5,
+                lostCriticalCount: 6,
+                writerFailureCount: 7,
+                retryCount: 8,
+                successfulFlushCount: 9,
+                lastCommittedRecorderSequence: 10,
+                mostRecentFlushDuration: .milliseconds(11),
+                lifecycleState: .active,
+                completeness: .incomplete
+            )
+        )
+
+        XCTAssertEqual(snapshot.runtimeLifecycle, .active)
+        XCTAssertEqual(snapshot.recorderLifecycle, .active)
+        XCTAssertEqual(snapshot.completeness, .incomplete)
+        XCTAssertEqual(snapshot.queueDepth, 1)
+        XCTAssertEqual(snapshot.peakQueueDepth, 2)
+        XCTAssertEqual(snapshot.coalescedFrameCount, 3)
+        XCTAssertEqual(snapshot.droppedFrameCount, 4)
+        XCTAssertEqual(snapshot.lostNativeCount, 5)
+        XCTAssertEqual(snapshot.lostCriticalCount, 6)
+        XCTAssertEqual(snapshot.writerFailureCount, 7)
+        XCTAssertEqual(snapshot.retryCount, 8)
+        XCTAssertEqual(snapshot.successfulFlushCount, 9)
+        XCTAssertEqual(snapshot.lastCommittedRecorderSequence, 10)
+        XCTAssertEqual(snapshot.mostRecentFlushDuration, .milliseconds(11))
+
+        let labels = Set(Mirror(reflecting: snapshot).children.compactMap(\.label))
+        XCTAssertFalse(labels.contains("beatsPerMinute"))
+        XCTAssertFalse(labels.contains("profileLocalIdentifier"))
+        XCTAssertFalse(labels.contains("stableLocalIdentifier"))
+        XCTAssertFalse(labels.contains("sessionID"))
+        XCTAssertFalse(labels.contains("rawPayload"))
+    }
+
     func testStoreConstructionAndImmediateStopNeverBlockOrResurrectSession() async throws {
         let persistence = RuntimePersistence()
         let factoryGate = DispatchSemaphore(value: 0)

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
@@ -37,6 +37,209 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.status, .incomplete("ended-before-recorder-ready"))
     }
 
+    func testFinalizeWinsPublishedInstallWithStagingLossAndCannotComplete() async throws {
+        let persistence = RuntimePersistence(suspendFinalize: true)
+        let factoryGate = DispatchSemaphore(value: 0)
+        let installationPublished = DispatchSemaphore(value: 0)
+        let allowInstallationCompletion = DispatchSemaphore(value: 0)
+        let legacyID = UUID(uuidString: "10000000-0000-0000-0000-000000000031")!
+        let descriptor = Self.descriptor(legacySessionID: legacyID)
+        let coordinator = TelemetryV2RuntimeCoordinator(
+            persistenceFactory: {
+                factoryGate.wait()
+                return persistence
+            },
+            installationDidPublishForTesting: { sessionID in
+                guard sessionID == descriptor.sessionID else { return }
+                installationPublished.signal()
+                allowInstallationCompletion.wait()
+            }
+        )
+
+        coordinator.beginSession(descriptor)
+        XCTAssertEqual(coordinator.observeCurrentElapsedSecond(), .droppedFrame)
+        factoryGate.signal()
+        XCTAssertEqual(installationPublished.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(coordinator.activeSessionIDForTesting, descriptor.sessionID)
+
+        let stopBegan = ContinuousClock.now
+        DispatchQueue.concurrentPerform(iterations: 2) { _ in
+            coordinator.endSession(reason: "manual_stop")
+        }
+        XCTAssertLessThan(stopBegan.duration(to: .now), .milliseconds(50))
+        XCTAssertNil(coordinator.activeSessionIDForTesting)
+        XCTAssertNil(
+            coordinator.observeEvent(
+                .manualStop(ManualStopEvent(reason: "after-stop")),
+                occurredAt: Date()
+            )
+        )
+
+        allowInstallationCompletion.signal()
+        try await eventually { await persistence.finalizeCallCount == 1 }
+        await persistence.resumeFinalize()
+        try await eventually { await persistence.finalizations.count == 1 }
+        try await eventually {
+            if case .incomplete = coordinator.status { return true }
+            return false
+        }
+
+        let snapshot = await persistence.snapshot()
+        let finalization = try XCTUnwrap(snapshot.finalizations.first)
+        XCTAssertEqual(finalization.sessionID, descriptor.sessionID)
+        XCTAssertEqual(finalization.lifecycleState, .incomplete)
+        XCTAssertEqual(finalization.incompleteReason, "pre-recorder-staging-overflow")
+        XCTAssertFalse(finalization.recorderHealth.isComplete)
+        XCTAssertEqual(snapshot.finalizeCallCount, 1)
+        XCTAssertTrue(
+            snapshot.records.contains { record in
+                guard case let .event(event) = record,
+                      event.sessionID == descriptor.sessionID,
+                      case let .recorderHealth(health) = event.payload.payload else {
+                    return false
+                }
+                return health.kind == .loss && health.affectedRecordClass == "bulkFrame"
+            }
+        )
+        coordinator.endSession(reason: "repeated-stop")
+        let repeatedFinalizeCallCount = await persistence.finalizeCallCount
+        XCTAssertEqual(repeatedFinalizeCallCount, 1)
+        XCTAssertNil(coordinator.activeSessionIDForTesting)
+    }
+
+    func testDelayedSessionAInstallationCannotAttachToOrMutateSessionB() async throws {
+        let persistence = RuntimePersistence()
+        let factoryGate = DispatchSemaphore(value: 0)
+        let sessionAPublished = DispatchSemaphore(value: 0)
+        let allowSessionACompletion = DispatchSemaphore(value: 0)
+        let sessionA = Self.descriptor(
+            legacySessionID: UUID(uuidString: "10000000-0000-0000-0000-000000000032")!
+        )
+        let sessionB = Self.descriptor(
+            legacySessionID: UUID(uuidString: "10000000-0000-0000-0000-000000000033")!
+        )
+        let coordinator = TelemetryV2RuntimeCoordinator(
+            persistenceFactory: {
+                factoryGate.wait()
+                return persistence
+            },
+            installationDidPublishForTesting: { sessionID in
+                guard sessionID == sessionA.sessionID else { return }
+                sessionAPublished.signal()
+                allowSessionACompletion.wait()
+            }
+        )
+
+        coordinator.beginSession(sessionA)
+        XCTAssertEqual(coordinator.observeCurrentElapsedSecond(), .droppedFrame)
+        factoryGate.signal()
+        XCTAssertEqual(sessionAPublished.wait(timeout: .now() + 1), .success)
+        coordinator.endSession(reason: "session-a-stop")
+        XCTAssertNil(coordinator.activeSessionIDForTesting)
+
+        coordinator.beginSession(sessionB)
+        try await eventually { coordinator.activeSessionIDForTesting == sessionB.sessionID }
+        XCTAssertEqual(
+            coordinator.observeEvent(
+                .cooldown(CooldownEvent(lifecycle: .started, targetHeartRate: 100)),
+                occurredAt: Date()
+            ),
+            .enqueued
+        )
+
+        allowSessionACompletion.signal()
+        try await eventually {
+            await persistence.finalizations.contains { $0.sessionID == sessionA.sessionID }
+        }
+        XCTAssertEqual(coordinator.activeSessionIDForTesting, sessionB.sessionID)
+        if case .active = coordinator.status {
+            // Stale completion from A cannot replace B's active state.
+        } else {
+            XCTFail("Session B must remain active after session A finalizes")
+        }
+
+        coordinator.endSession(reason: "session-b-stop")
+        try await eventually { await persistence.finalizations.count == 2 }
+        let snapshot = await persistence.snapshot()
+        let finalizations = Dictionary(
+            uniqueKeysWithValues: snapshot.finalizations.map { ($0.sessionID, $0) }
+        )
+        XCTAssertEqual(finalizations[sessionA.sessionID]?.lifecycleState, .incomplete)
+        XCTAssertEqual(
+            finalizations[sessionA.sessionID]?.incompleteReason,
+            "pre-recorder-staging-overflow"
+        )
+        XCTAssertEqual(finalizations[sessionB.sessionID]?.lifecycleState, .completed)
+        XCTAssertTrue(
+            snapshot.records.contains { record in
+                guard case let .event(event) = record,
+                      event.sessionID == sessionB.sessionID else { return false }
+                if case .cooldown = event.payload.payload { return true }
+                return false
+            }
+        )
+        XCTAssertFalse(
+            snapshot.records.contains { record in
+                guard case let .event(event) = record,
+                      event.sessionID == sessionB.sessionID,
+                      case let .recorderHealth(health) = event.payload.payload else {
+                    return false
+                }
+                return health.detailCode == "pre-recorder-staging-overflow"
+            }
+        )
+        XCTAssertNil(coordinator.activeSessionIDForTesting)
+    }
+
+    func testSupersedingSessionCancelsDelayedInstallWithoutReplacingNewSession() async throws {
+        let persistence = RuntimePersistence()
+        let sessionAPublished = DispatchSemaphore(value: 0)
+        let allowSessionACompletion = DispatchSemaphore(value: 0)
+        let sessionA = Self.descriptor(
+            legacySessionID: UUID(uuidString: "10000000-0000-0000-0000-000000000034")!
+        )
+        let sessionB = Self.descriptor(
+            legacySessionID: UUID(uuidString: "10000000-0000-0000-0000-000000000035")!
+        )
+        let coordinator = TelemetryV2RuntimeCoordinator(
+            persistenceFactory: { persistence },
+            installationDidPublishForTesting: { sessionID in
+                guard sessionID == sessionA.sessionID else { return }
+                sessionAPublished.signal()
+                allowSessionACompletion.wait()
+            }
+        )
+
+        coordinator.beginSession(sessionA)
+        XCTAssertEqual(sessionAPublished.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(coordinator.activeSessionIDForTesting, sessionA.sessionID)
+
+        coordinator.beginSession(sessionB)
+        try await eventually { coordinator.activeSessionIDForTesting == sessionB.sessionID }
+        allowSessionACompletion.signal()
+        try await eventually {
+            await persistence.finalizations.contains {
+                $0.sessionID == sessionA.sessionID && $0.lifecycleState == .cancelled
+            }
+        }
+        XCTAssertEqual(coordinator.activeSessionIDForTesting, sessionB.sessionID)
+        if case .active = coordinator.status {
+            // Cancellation of A is generation-scoped and cannot replace B's state.
+        } else {
+            XCTFail("Session B must remain active after session A cancellation")
+        }
+
+        coordinator.endSession(reason: "session-b-stop")
+        try await eventually {
+            await persistence.finalizations.contains {
+                $0.sessionID == sessionB.sessionID && $0.lifecycleState == .completed
+            }
+        }
+        let snapshot = await persistence.snapshot()
+        XCTAssertEqual(snapshot.finalizations.count, 2)
+        XCTAssertNil(coordinator.activeSessionIDForTesting)
+    }
+
     func testDelayedHeaderAndFinalizationNeverBlockProductLifecycle() async throws {
         let persistence = RuntimePersistence(suspendBegin: true, suspendFinalize: true)
         let coordinator = TelemetryV2RuntimeCoordinator { persistence }
@@ -510,6 +713,7 @@ private actor RuntimePersistence: TelemetryRecorderPersistence {
         let recorderSequences: [UInt64]
         let finalizations: [TelemetrySessionFinalization]
         let beginCallCount: Int
+        let finalizeCallCount: Int
     }
 
     private(set) var headers: [WorkoutSessionRecord] = []
@@ -580,7 +784,8 @@ private actor RuntimePersistence: TelemetryRecorderPersistence {
             records: records,
             recorderSequences: recorderSequences,
             finalizations: finalizations,
-            beginCallCount: beginCallCount
+            beginCallCount: beginCallCount,
+            finalizeCallCount: finalizeCallCount
         )
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateBoundaryTests.swift
@@ -53,6 +53,5 @@ final class TelemetryGateBoundaryTests: XCTestCase {
         XCTAssertFalse(runtimeSources.contains("TelemetryGateCrashWorker"))
         XCTAssertFalse(runtimeSources.contains("insertGateBatch"))
         XCTAssertFalse(runtimeSources.contains("gateStageUncommittedHeartRate"))
-        XCTAssertFalse(runtimeSources.contains("TelemetryStoreFactory.make"))
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj/project.pbxproj
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj/project.pbxproj
@@ -7,14 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		A28000012F80000000000001 /* HeartRateNormalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28000022F80000000000002 /* HeartRateNormalization.swift */; };
-		A29000012F90000000000001 /* TreadmillTruth.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29000022F90000000000002 /* TreadmillTruth.swift */; };
-		A29100012F90000000000001 /* Identifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100022F90000000000002 /* Identifiers.swift */; };
-		A29200012F90000000000001 /* Observations.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29200022F90000000000002 /* Observations.swift */; };
-		A29300012F90000000000001 /* Provenance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29300022F90000000000002 /* Provenance.swift */; };
-		A29400012F90000000000001 /* Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29400022F90000000000002 /* Time.swift */; };
-		A29500012F90000000000001 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29500022F90000000000002 /* Configuration.swift */; };
-		A29600012F90000000000001 /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29600022F90000000000002 /* Events.swift */; };
+		C30000012FA0000000000001 /* TelemetryDomain in Frameworks */ = {isa = PBXBuildFile; productRef = C30000022FA0000000000002 /* TelemetryDomain */; };
+		C30100012FA0000000000001 /* TelemetryPersistence in Frameworks */ = {isa = PBXBuildFile; productRef = C30100022FA0000000000002 /* TelemetryPersistence */; };
+		C30200012FA0000000000001 /* TelemetryRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = C30200022FA0000000000002 /* TelemetryRuntime */; };
 		E31F57CB2F293B5600C6C470 /* WorkoutSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31F57CA2F293B5500C6C470 /* WorkoutSessionController.swift */; };
 		E31F57CD2F293B7100C6C470 /* TreadmillStatsPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31F57CC2F293B7100C6C470 /* TreadmillStatsPublisher.swift */; };
 		E37051C22F233FC100D2FA22 /* WalkingPadRemoteWatch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = E37051B82F233FBE00D2FA22 /* WalkingPadRemoteWatch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -45,14 +40,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		A28000022F80000000000002 /* HeartRateNormalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/HeartRateNormalization.swift; sourceTree = "<group>"; };
-		A29000022F90000000000002 /* TreadmillTruth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/TreadmillTruth.swift; sourceTree = "<group>"; };
-		A29100022F90000000000002 /* Identifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/Identifiers.swift; sourceTree = "<group>"; };
-		A29200022F90000000000002 /* Observations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/Observations.swift; sourceTree = "<group>"; };
-		A29300022F90000000000002 /* Provenance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/Provenance.swift; sourceTree = "<group>"; };
-		A29400022F90000000000002 /* Time.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/Time.swift; sourceTree = "<group>"; };
-		A29500022F90000000000002 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/Configuration.swift; sourceTree = "<group>"; };
-		A29600022F90000000000002 /* Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TelemetryDomain/Events.swift; sourceTree = "<group>"; };
 		E31F57CA2F293B5500C6C470 /* WorkoutSessionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSessionController.swift; sourceTree = "<group>"; };
 		E31F57CC2F293B7100C6C470 /* TreadmillStatsPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreadmillStatsPublisher.swift; sourceTree = "<group>"; };
 		E37051762F22AB0C00D2FA22 /* WalkingPadRemote.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WalkingPadRemote.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -77,6 +64,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C30000012FA0000000000001 /* TelemetryDomain in Frameworks */,
+				C30100012FA0000000000001 /* TelemetryPersistence in Frameworks */,
+				C30200012FA0000000000001 /* TelemetryRuntime in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -95,14 +85,6 @@
 			children = (
 				E37051782F22AB0C00D2FA22 /* WalkingPadRemote */,
 				E37051B92F233FBE00D2FA22 /* WalkingPadRemoteWatch Watch App */,
-				A28000022F80000000000002 /* HeartRateNormalization.swift */,
-				A29000022F90000000000002 /* TreadmillTruth.swift */,
-				A29100022F90000000000002 /* Identifiers.swift */,
-				A29200022F90000000000002 /* Observations.swift */,
-				A29300022F90000000000002 /* Provenance.swift */,
-				A29400022F90000000000002 /* Time.swift */,
-				A29500022F90000000000002 /* Configuration.swift */,
-				A29600022F90000000000002 /* Events.swift */,
 				E37051772F22AB0C00D2FA22 /* Products */,
 				E31F57CA2F293B5500C6C470 /* WorkoutSessionController.swift */,
 				E31F57CC2F293B7100C6C470 /* TreadmillStatsPublisher.swift */,
@@ -140,6 +122,9 @@
 			);
 			name = WalkingPadRemote;
 			packageProductDependencies = (
+				C30000022FA0000000000002 /* TelemetryDomain */,
+				C30100022FA0000000000002 /* TelemetryPersistence */,
+				C30200022FA0000000000002 /* TelemetryRuntime */,
 			);
 			productName = WalkingPadRemote;
 			productReference = E37051762F22AB0C00D2FA22 /* WalkingPadRemote.app */;
@@ -196,6 +181,9 @@
 			minimizedProjectReferenceProxies = 1;
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E37051772F22AB0C00D2FA22 /* Products */;
+			packageReferences = (
+				C30300012FA0000000000001 /* XCLocalSwiftPackageReference "." */,
+			);
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -227,14 +215,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A28000012F80000000000001 /* HeartRateNormalization.swift in Sources */,
-				A29000012F90000000000001 /* TreadmillTruth.swift in Sources */,
-				A29100012F90000000000001 /* Identifiers.swift in Sources */,
-				A29200012F90000000000001 /* Observations.swift in Sources */,
-				A29300012F90000000000001 /* Provenance.swift in Sources */,
-				A29400012F90000000000001 /* Time.swift in Sources */,
-				A29500012F90000000000001 /* Configuration.swift in Sources */,
-				A29600012F90000000000001 /* Events.swift in Sources */,
 				E31F57CB2F293B5600C6C470 /* WorkoutSessionController.swift in Sources */,
 				E31F57CD2F293B7100C6C470 /* TreadmillStatsPublisher.swift in Sources */,
 			);
@@ -256,6 +236,31 @@
 			targetProxy = E37051C02F233FC100D2FA22 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		C30300012FA0000000000001 /* XCLocalSwiftPackageReference "." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = .;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		C30000022FA0000000000002 /* TelemetryDomain */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C30300012FA0000000000001 /* XCLocalSwiftPackageReference "." */;
+			productName = TelemetryDomain;
+		};
+		C30100022FA0000000000002 /* TelemetryPersistence */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C30300012FA0000000000001 /* XCLocalSwiftPackageReference "." */;
+			productName = TelemetryPersistence;
+		};
+		C30200022FA0000000000002 /* TelemetryRuntime */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C30300012FA0000000000001 /* XCLocalSwiftPackageReference "." */;
+			productName = TelemetryRuntime;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCBuildConfiguration section */
 		E370517F2F22AB0F00D2FA22 /* Debug */ = {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -200,6 +200,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     )
     private var treadmillTelemetrySink: (any TreadmillTelemetrySink)?
     @Published private(set) var telemetryV2StatusText: String = "idle"
+    @Published private(set) var telemetryV2WriterHealthSnapshot: TelemetryV2WriterHealthSnapshot = .idle
     private lazy var telemetryV2Coordinator = TelemetryV2RuntimeCoordinator(
         persistenceFactory: {
             let appIdentifier = Bundle.main.bundleIdentifier ?? "sw.WalkingPadRemote"
@@ -211,6 +212,11 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         statusHandler: { [weak self] status in
             Task { @MainActor [weak self] in
                 self?.telemetryV2StatusText = String(describing: status)
+            }
+        },
+        writerHealthHandler: { [weak self] snapshot in
+            Task { @MainActor [weak self] in
+                self?.telemetryV2WriterHealthSnapshot = snapshot
             }
         }
     )

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -3,6 +3,9 @@ import SwiftUI
 import Combine
 import CoreBluetooth
 import HealthKit
+import TelemetryDomain
+import TelemetryPersistence
+import TelemetryRuntime
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -196,6 +199,21 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         controllerUnitsFreshnessInterval: ControllerUnitsSafetyPolicy.freshnessInterval
     )
     private var treadmillTelemetrySink: (any TreadmillTelemetrySink)?
+    @Published private(set) var telemetryV2StatusText: String = "idle"
+    private lazy var telemetryV2Coordinator = TelemetryV2RuntimeCoordinator(
+        persistenceFactory: {
+            let appIdentifier = Bundle.main.bundleIdentifier ?? "sw.WalkingPadRemote"
+            let storeURL = try TelemetryStoreLocation.applicationSupportStoreURL(
+                appIdentifier: appIdentifier
+            )
+            return try TelemetryStoreFactory.make(.onDisk(storeURL))
+        },
+        statusHandler: { [weak self] status in
+            Task { @MainActor [weak self] in
+                self?.telemetryV2StatusText = String(describing: status)
+            }
+        }
+    )
     private var latestTreadmillObservationEvidence: TreadmillObservationEvidence?
     private var treadmillCommandTelemetrySidecar = TreadmillCommandTelemetrySidecar()
     private var treadmillCommandAttemptNumbers: [CommandID: UInt16] = [:]
@@ -1184,10 +1202,41 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             if completionEffect.shouldStopBelt {
                 stopBeltWithToggle(reason: "hr_cooldown_done")
             }
+            if completionEffect.shouldStopSession {
+                endTelemetryV2Session(reason: completionEffect.structuredLogReason)
+            }
         }
     }
 
     private func logCooldownTelemetry(_ effect: CooldownRuntimeEngine.TelemetryEffect) {
+        defer {
+            let now = Date()
+            switch effect {
+            case let .start(telemetry):
+                _ = telemetryV2Coordinator.observeWorkoutPhase(.cooldown, occurredAt: now)
+                _ = telemetryV2Coordinator.observeEvent(
+                    .cooldown(
+                        CooldownEvent(
+                            lifecycle: .started,
+                            targetHeartRate: UInt16(exactly: telemetry.targetBpm)
+                        )
+                    ),
+                    occurredAt: now
+                )
+            case .complete:
+                _ = telemetryV2Coordinator.observeEvent(
+                    .cooldown(CooldownEvent(lifecycle: .completed)),
+                    occurredAt: now
+                )
+            case .insufficient:
+                _ = telemetryV2Coordinator.observeEvent(
+                    .cooldown(CooldownEvent(lifecycle: .insufficient)),
+                    occurredAt: now
+                )
+            case .speedSet, .state, .analysis:
+                break
+            }
+        }
         switch effect {
         case .start(let telemetry):
             appendLog(
@@ -1452,9 +1501,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
     }
 
-    private func startTrainingStructuredLog(trigger: String) {
+    @discardableResult
+    private func startTrainingStructuredLog(trigger: String) -> UUID? {
         stopTrainingStructuredLog(reason: "restart_before_new_session")
-        guard let dir = trainingLogsDirectoryURL() else { return }
+        guard let dir = trainingLogsDirectoryURL() else { return nil }
         pruneTrainingLogs(in: dir)
 
         let sessionId = UUID().uuidString
@@ -1488,8 +1538,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 "zone_bounds": [hrZone1Max, hrZone2Max, hrZone3Max, hrZone4Max]
             ].merging(controllerUnitsTelemetryFields(action: "session_start")) { current, _ in current })
             scheduleTrainingLogsInventoryRefresh()
+            return UUID(uuidString: sessionId)
         } catch {
             appendLog("Training log file open error: \(error.localizedDescription)")
+            return nil
         }
     }
 
@@ -1836,6 +1888,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         loadZonePlan()
         loadWorkoutHistory()
         refreshTrainingLogsInventory()
+        setHeartRateTelemetrySink(telemetryV2Coordinator)
+        setTreadmillTelemetrySink(telemetryV2Coordinator)
+        telemetryV2Coordinator.prepareStoreAndRecover()
 #if canImport(WatchConnectivity)
         startWatchConnectivity()
 #endif
@@ -2195,6 +2250,17 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             self.connectTimeoutWorkItem?.cancel()
             self.connectTimeoutWorkItem = nil
             self.manualModeSet = false
+            _ = self.telemetryV2Coordinator.observeEvent(
+                .connectionTransition(
+                    ConnectionTransition(
+                        previous: .connected,
+                        current: .disconnected,
+                        reason: "ble_disconnected"
+                    )
+                ),
+                occurredAt: Date()
+            )
+            self.endTelemetryV2Session(reason: "ble_disconnected")
         }
         if shouldBeScanning, central.state == .poweredOn {
             central.scanForPeripherals(withServices: supportedServiceUuids,
@@ -2249,6 +2315,19 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             self.resetSessionStats()
             self.stopTelemetry()
             self.isHrControlRunning = false
+            _ = self.telemetryV2Coordinator.observeEvent(
+                .connectionTransition(
+                    ConnectionTransition(
+                        previous: .connected,
+                        current: .disconnected,
+                        reason: userInitiated ? "disconnect_user" : "disconnect"
+                    )
+                ),
+                occurredAt: Date()
+            )
+            self.endTelemetryV2Session(
+                reason: userInitiated ? "disconnect_user" : "disconnect"
+            )
         }
     }
     func connectToKnownPeripheral(id: UUID) {
@@ -3593,7 +3672,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             appendLog("HR start: target=\(hrTargetBPM) duration=\(hrDurationMinutes)m interval=\(hrDecisionIntervalSeconds)s \(adaptiveStepDescription)")
             // Reset all per-session counters before writing session_start telemetry snapshot.
             resetSessionStats()
-            startTrainingStructuredLog(trigger: "start_hr")
+            let legacySessionID = startTrainingStructuredLog(trigger: "start_hr")
             isHrControlRunning = true
             hrStatusLine = "HR‑контроль запущен"
             hrSessionTotalSeconds = max(60, hrDurationMinutes * 60)
@@ -3622,6 +3701,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 "start_speed_kmh": speedKmh,
                 "device_target_kmh": deviceTargetSpeedKmh
             ].merging(controllerUnitsTelemetryFields(action: "hr_control_start")) { current, _ in current })
+            beginTelemetryV2Session(legacySessionID: legacySessionID)
             if deviceTargetSpeedKmh <= 0.1 && speedKmh <= 0.2 {
                 hrControlStartedBelt = true
                 startWithSpeed(3.0)
@@ -3656,6 +3736,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         hrControlStartedBelt = false
         stopBeltWithToggle(reason: "hr")
         sendWatchCommand("stop_hr")
+        endTelemetryV2Session(reason: "manual_stop")
     }
 
     func clearHrFailureReports() { hrFailureReports.removeAll() }
@@ -3795,6 +3876,11 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     private func tickTelemetry() {
+        defer {
+            if isHrControlRunning {
+                _ = telemetryV2Coordinator.observeCurrentElapsedSecond()
+            }
+        }
         // Move actual speed towards desired speed
         let target = deviceTargetSpeedKmh
         let diff = target - speedKmh
@@ -3895,6 +3981,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                         hrControlStartedBelt = false
                         sendWatchCommand("stop_hr")
                         stopBeltWithToggle(reason: "hr_no_connection")
+                        endTelemetryV2Session(reason: "hr_no_connection")
                         return
                     }
                     guard hrStreamingActive, heartRateBPM > 0 else {
@@ -3941,6 +4028,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                         hrControlStartedBelt = false
                         sendWatchCommand("stop_hr")
                         stopBeltWithToggle(reason: "hr_no_signal")
+                        endTelemetryV2Session(reason: "hr_no_signal")
                         return
                     }
 
@@ -5278,6 +5366,70 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     func setTreadmillTelemetrySink(_ sink: (any TreadmillTelemetrySink)?) {
         treadmillTelemetrySink = sink
+    }
+
+    private func beginTelemetryV2Session(legacySessionID: UUID?) {
+        guard isHrControlRunning, let startedAt = hrControlStartedAt else { return }
+        let sessionID = TelemetryV2SessionDescriptor.sessionID(
+            deterministicallyLinkedTo: legacySessionID
+        )
+#if canImport(UIKit)
+        let deviceModel: String? = UIDevice.current.model
+#else
+        let deviceModel: String? = nil
+#endif
+        let descriptor = TelemetryV2SessionDescriptor(
+            sessionID: sessionID,
+            deterministicLegacySessionID: legacySessionID,
+            startedAt: startedAt,
+            appContext: AppRuntimeContext(
+                appVersion: Bundle.main.object(
+                    forInfoDictionaryKey: "CFBundleShortVersionString"
+                ) as? String ?? "unknown",
+                buildNumber: Bundle.main.object(
+                    forInfoDictionaryKey: "CFBundleVersion"
+                ) as? String ?? "unknown",
+                operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+                deviceModel: deviceModel
+            ),
+            configuration: TelemetryV2ConfigurationInput(
+                profileLocalIdentifier: activeUserProfile?.id.uuidString ?? "unknown",
+                workoutMode: .heartRateControlled,
+                targetHeartRate: hrTargetBPM,
+                durationMinutes: hrDurationMinutes,
+                decisionIntervalSeconds: hrDecisionIntervalSeconds,
+                adaptiveStepEnabled: hrAdaptiveStepEnabled,
+                maximumStepKilometresPerHour: hrSpeedStepKmh,
+                heartRateZones: [hrZone1Max, hrZone2Max, hrZone3Max, hrZone4Max],
+                cooldownTargetHeartRate: hrCooldownTargetBpm,
+                cooldownMinimumSpeedKilometresPerHour: hrCooldownMinSpeed,
+                cooldownMaximumMinutes: hrCooldownMaxMinutes,
+                heartRateProviderKind: "legacyWatchWorkoutStream",
+                heartRateProviderStableLocalKey: legacyWatchHeartRateSource.stableLocalKey,
+                treadmill: TelemetryV2TreadmillContext(
+                    stableLocalIdentifier: connectedPeripheralId?.uuidString,
+                    model: displayDeviceName ?? (deviceName.isEmpty ? nil : deviceName),
+                    protocolName: treadmillProtocol.rawValue,
+                    protocolVersion: nil,
+                    minimumSpeedKilometresPerHour: treadmillMinSpeedKmh,
+                    maximumSpeedKilometresPerHour: treadmillMaxSpeedKmh,
+                    speedIncrementKilometresPerHour: treadmillSpeedIncrementKmh
+                )
+            ),
+            versions: RuntimeVersionContext(
+                telemetrySchema: TelemetrySchemaVersion(rawValue: "1.0.0"),
+                algorithm: AlgorithmVersion(rawValue: "legacy-hr-control-2026-08"),
+                safetyPolicy: SafetyPolicyVersion(rawValue: "walkingpad-runtime-safety-2026-08"),
+                workoutProtocol: WorkoutProtocolVersion(rawValue: "hr-workout-v1")
+            ),
+            heartRateFreshnessLimitSeconds: TimeInterval(hrStaleThresholdSeconds),
+            treadmillFreshnessLimitSeconds: ControllerUnitsSafetyPolicy.freshnessInterval
+        )
+        telemetryV2Coordinator.beginSession(descriptor)
+    }
+
+    private func endTelemetryV2Session(reason: String) {
+        telemetryV2Coordinator.endSession(reason: reason)
     }
 
     private var treadmillTelemetryConnectionEpoch: TreadmillConnectionEpoch? {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -1,4 +1,10 @@
 import SwiftUI
+#if canImport(TelemetryRecorder)
+import TelemetryRecorder
+#endif
+#if canImport(TelemetryRuntime)
+import TelemetryRuntime
+#endif
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -2772,6 +2778,33 @@ private struct DebugView: View {
         }
     }
 
+    private var telemetryV2WriterHealthMetrics: [DebugTrainingLogsCard.Presentation.Metric] {
+        let snapshot = manager.telemetryV2WriterHealthSnapshot
+        let lifecycle = [
+            snapshot.runtimeLifecycle.rawValue,
+            snapshot.recorderLifecycle?.rawValue,
+            snapshot.completeness?.rawValue,
+        ].compactMap { $0 }.joined(separator: " / ")
+
+        return [
+            .init(id: "v2_lifecycle", title: "State", value: lifecycle, tint: .accentColor),
+            .init(id: "v2_queue", title: "Queue / peak", value: "\(snapshot.queueDepth) / \(snapshot.peakQueueDepth)", tint: .blue),
+            .init(id: "v2_frames", title: "Frame C / D", value: "\(snapshot.coalescedFrameCount) / \(snapshot.droppedFrameCount)", tint: .secondary),
+            .init(id: "v2_loss", title: "Loss N / C", value: "\(snapshot.lostNativeCount) / \(snapshot.lostCriticalCount)", tint: .orange),
+            .init(id: "v2_writer", title: "Fail / retry", value: "\(snapshot.writerFailureCount) / \(snapshot.retryCount)", tint: .red),
+            .init(id: "v2_flush", title: "Flush / seq", value: "\(snapshot.successfulFlushCount) / \(snapshot.lastCommittedRecorderSequence.map(String.init) ?? "—")", tint: .green),
+        ]
+    }
+
+    private var telemetryV2WriterHealthDetailLines: [String] {
+        let duration = manager.telemetryV2WriterHealthSnapshot.mostRecentFlushDuration
+        guard let duration else { return ["Latest flush: —"] }
+        let components = duration.components
+        let milliseconds = (Double(components.seconds) * 1_000)
+            + (Double(components.attoseconds) / 1_000_000_000_000_000)
+        return ["Latest flush: \(String(format: "%.1f", milliseconds)) ms"]
+    }
+
     private var trainingLogsCardPresentation: DebugTrainingLogsCard.Presentation {
         let inventory = manager.trainingLogsInventory
         let lastLogName = manager.lastTrainingLogPath.isEmpty
@@ -2815,6 +2848,8 @@ private struct DebugView: View {
                 .init(id: "device_completed", title: "Все тр.", value: "\(inventory.completedWorkoutFiles)", tint: .secondary),
                 .init(id: "device_size", title: "Память", value: formattedByteCount(inventory.totalBytes), tint: .secondary)
             ],
+            writerHealthMetrics: telemetryV2WriterHealthMetrics,
+            writerHealthDetailLines: telemetryV2WriterHealthDetailLines,
             rawExportOptions: rawExportOptions,
             rawExportSubtitle: inventory.matchingProfileSessionFiles > 0
                 ? "\(inventory.matchingProfileSessionFiles) raw сессий доступно"

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -1,7 +1,4 @@
 import SwiftUI
-#if canImport(TelemetryRecorder)
-import TelemetryRecorder
-#endif
 #if canImport(TelemetryRuntime)
 import TelemetryRuntime
 #endif

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DebugTrainingLogsCard.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DebugTrainingLogsCard.swift
@@ -21,6 +21,8 @@ struct DebugTrainingLogsCard: View {
         let subtitle: String
         let profileMetrics: [Metric]
         let deviceMetrics: [Metric]
+        let writerHealthMetrics: [Metric]
+        let writerHealthDetailLines: [String]
         let rawExportOptions: [ExportOption]
         let rawExportSubtitle: String
         let canExportRaw: Bool
@@ -80,6 +82,21 @@ struct DebugTrainingLogsCard: View {
 
                 metricsSection(title: "Активный профиль", items: presentation.profileMetrics)
                 metricsSection(title: "Всё устройство", items: presentation.deviceMetrics)
+                metricsSection(
+                    title: "Telemetry V2 Writer",
+                    items: presentation.writerHealthMetrics
+                )
+
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(
+                        Array(presentation.writerHealthDetailLines.enumerated()),
+                        id: \.offset
+                    ) { _, line in
+                        Text(line)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
 
                 LazyVGrid(columns: actionColumns, spacing: 10) {
                     Menu {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TreadmillCommandTelemetrySidecar.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TreadmillCommandTelemetrySidecar.swift
@@ -1,7 +1,5 @@
 import Foundation
-#if SWIFT_PACKAGE
 import TelemetryDomain
-#endif
 
 /// Observational metadata that mirrors the legacy queue without participating in
 /// command equality, admission, ordering, coalescing, or transport decisions.

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -8,6 +8,12 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
     private lazy var contentViewSource = source(
         relativePath: "WalkingPadRemote/ContentView.swift"
     )
+    private lazy var trainingLogsCardSource = source(
+        relativePath: "WalkingPadRemote/DebugTrainingLogsCard.swift"
+    )
+    private lazy var telemetryRuntimeSource = source(
+        relativePath: "Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift"
+    )
     private lazy var watchSource = source(
         relativePath: "WalkingPadRemoteWatch Watch App/WatchHeartRateManager.swift"
     )
@@ -107,6 +113,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
             XCTAssertFalse(body.contains("TelemetryRecorder"))
             XCTAssertFalse(body.contains("TelemetryPersistence"))
             XCTAssertFalse(body.contains("telemetry health"))
+            XCTAssertFalse(body.contains("telemetryV2WriterHealthSnapshot"))
         }
 
         XCTAssertTrue(affordance.contains("HRDomainService.heartRateStartAffordanceAvailable"))
@@ -115,6 +122,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         XCTAssertFalse(affordance.contains("watchReachable"))
         XCTAssertFalse(affordance.contains("controllerUnits"))
         XCTAssertFalse(affordance.contains("telemetry"))
+        XCTAssertFalse(affordance.contains("telemetryV2WriterHealthSnapshot"))
 
         XCTAssertTrue(
             contentViewSource.contains(
@@ -143,6 +151,77 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
             ],
             in: start
         )
+    }
+
+    func testTelemetryV2WriterHealthIsWiredOnlyIntoDeveloperDiagnostics() throws {
+        let metrics = try functionBody(
+            "private var telemetryV2WriterHealthMetrics",
+            in: contentViewSource
+        )
+        let details = try functionBody(
+            "private var telemetryV2WriterHealthDetailLines",
+            in: contentViewSource
+        )
+        let presentation = try functionBody(
+            "private var trainingLogsCardPresentation",
+            in: contentViewSource
+        )
+        let cardBody = try functionBody("var body: some View", in: trainingLogsCardSource)
+
+        XCTAssertTrue(metrics.contains("manager.telemetryV2WriterHealthSnapshot"))
+        XCTAssertTrue(metrics.contains("snapshot.queueDepth"))
+        XCTAssertTrue(metrics.contains("snapshot.lostCriticalCount"))
+        XCTAssertTrue(metrics.contains("snapshot.writerFailureCount"))
+        XCTAssertTrue(metrics.contains("snapshot.successfulFlushCount"))
+        XCTAssertTrue(details.contains("mostRecentFlushDuration"))
+        XCTAssertTrue(presentation.contains("writerHealthMetrics: telemetryV2WriterHealthMetrics"))
+        XCTAssertTrue(
+            presentation.contains("writerHealthDetailLines: telemetryV2WriterHealthDetailLines")
+        )
+        XCTAssertTrue(cardBody.contains("Telemetry V2 Writer"))
+        XCTAssertTrue(cardBody.contains("presentation.writerHealthMetrics"))
+        XCTAssertTrue(cardBody.contains("presentation.writerHealthDetailLines"))
+    }
+
+    func testTelemetryV2WriterHealthDiagnosticSurfaceExcludesPrivateWorkoutData() throws {
+        let snapshot = try functionBody(
+            "public struct TelemetryV2WriterHealthSnapshot",
+            in: telemetryRuntimeSource
+        )
+        let metrics = try functionBody(
+            "private var telemetryV2WriterHealthMetrics",
+            in: contentViewSource
+        )
+        let details = try functionBody(
+            "private var telemetryV2WriterHealthDetailLines",
+            in: contentViewSource
+        )
+        let diagnosticSurface = snapshot + metrics + details
+
+        for forbidden in [
+            "beatsPerMinute", "heartRate", "speed", "profileLocalIdentifier",
+            "stableLocalIdentifier", "sessionID", "rawBLE", "rawPayload",
+            "healthPayload", "workoutExport",
+        ] {
+            XCTAssertFalse(
+                diagnosticSurface.contains(forbidden),
+                "Writer-health diagnostic surface contains \(forbidden)"
+            )
+        }
+
+        let recompute = try functionBody(
+            "private func recomputeHrStartAllowed()",
+            in: managerSource
+        )
+        let start = try functionBody("func startHrControl()", in: managerSource)
+        let affordance = try functionBody(
+            "var isHrControlStartAffordanceAvailable: Bool",
+            in: managerSource
+        )
+        for controlPath in [recompute, start, affordance] {
+            XCTAssertFalse(controlPath.contains("telemetryV2WriterHealthSnapshot"))
+            XCTAssertFalse(controlPath.contains("writerHealthSnapshot"))
+        }
     }
 
     func testTelemetryV2LifecycleHooksCannotPerformPersistenceOnControlPaths() throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -136,9 +136,85 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
                 "guard unitsDecision.allowed",
                 "persistBlockedControllerUnitsStart(decision: unitsDecision)",
                 "retryControllerUnitsQueryAfterBlockedStart()",
+                "let legacySessionID = startTrainingStructuredLog(trigger: \"start_hr\")",
+                "isHrControlRunning = true",
+                "beginTelemetryV2Session(legacySessionID: legacySessionID)",
                 "startWithSpeed",
             ],
             in: start
+        )
+    }
+
+    func testTelemetryV2LifecycleHooksCannotPerformPersistenceOnControlPaths() throws {
+        let start = try functionBody("func startHrControl()", in: managerSource)
+        let begin = try functionBody(
+            "private func beginTelemetryV2Session(legacySessionID: UUID?)",
+            in: managerSource
+        )
+        let end = try functionBody(
+            "private func endTelemetryV2Session(reason: String)",
+            in: managerSource
+        )
+        let forbidden = [
+            "TelemetryStore",
+            "TelemetryRecorder",
+            "FileManager",
+            "FileHandle",
+            "trainingLogQueue.sync",
+            "await ",
+            ".finish(",
+            ".finalize",
+        ]
+        for body in [start, begin, end] {
+            for token in forbidden {
+                XCTAssertFalse(body.contains(token), "Control path contains \(token)")
+            }
+        }
+        XCTAssertTrue(begin.contains("telemetryV2Coordinator.beginSession(descriptor)"))
+        XCTAssertTrue(end.contains("telemetryV2Coordinator.endSession(reason: reason)"))
+        XCTAssertFalse(start.contains("telemetryV2Status"))
+    }
+
+    func testTelemetryV2FinalizationIsAfterExistingProductStopEffects() throws {
+        let manual = try functionBody("func stopHrControl()", in: managerSource)
+        assertOrdered(
+            [
+                "stopTrainingStructuredLog(reason: \"manual_stop\")",
+                "isHrControlRunning = false",
+                "stopBeltWithToggle(reason: \"hr\")",
+                "sendWatchCommand(\"stop_hr\")",
+                "endTelemetryV2Session(reason: \"manual_stop\")",
+            ],
+            in: manual
+        )
+
+        let cooldown = try functionBody(
+            "private func executeCooldownEffect(",
+            in: managerSource
+        )
+        assertOrdered(
+            [
+                "stopTrainingStructuredLog(reason: completionEffect.structuredLogReason)",
+                "sendWatchCommand(\"stop_hr\")",
+                "stopBeltWithToggle(reason: \"hr_cooldown_done\")",
+                "endTelemetryV2Session(reason: completionEffect.structuredLogReason)",
+            ],
+            in: cooldown
+        )
+
+        let disconnect = try functionBody(
+            "private func disconnect(userInitiated: Bool = false)",
+            in: managerSource
+        )
+        assertOrdered(
+            [
+                "stopTrainingStructuredLog(reason:",
+                "central.cancelPeripheralConnection(p)",
+                "self.stopTelemetry()",
+                "self.isHrControlRunning = false",
+                "self.endTelemetryV2Session(",
+            ],
+            in: disconnect
         )
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -218,6 +218,53 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         )
     }
 
+    func testTelemetryV2LifecycleRaceCannotBranchProductOrLegacyOutputs() throws {
+        let start = try functionBody("func startHrControl()", in: managerSource)
+        let stop = try functionBody("func stopHrControl()", in: managerSource)
+        let begin = try functionBody(
+            "private func beginTelemetryV2Session(legacySessionID: UUID?)",
+            in: managerSource
+        )
+        let end = try functionBody(
+            "private func endTelemetryV2Session(reason: String)",
+            in: managerSource
+        )
+
+        for productPath in [start, stop] {
+            for forbiddenBranch in [
+                "if telemetryV2",
+                "guard telemetryV2",
+                "telemetryV2Status",
+                "telemetryV2Coordinator.status",
+            ] {
+                XCTAssertFalse(productPath.contains(forbiddenBranch))
+            }
+        }
+        assertOrdered(
+            [
+                "let legacySessionID = startTrainingStructuredLog(trigger: \"start_hr\")",
+                "isHrControlRunning = true",
+                "beginTelemetryV2Session(legacySessionID: legacySessionID)",
+                "startWithSpeed",
+            ],
+            in: start
+        )
+        assertOrdered(
+            [
+                "stopTrainingStructuredLog(reason: \"manual_stop\")",
+                "isHrControlRunning = false",
+                "stopBeltWithToggle(reason: \"hr\")",
+                "sendWatchCommand(\"stop_hr\")",
+                "endTelemetryV2Session(reason: \"manual_stop\")",
+            ],
+            in: stop
+        )
+        XCTAssertTrue(begin.contains("telemetryV2Coordinator.beginSession(descriptor)"))
+        XCTAssertTrue(end.contains("telemetryV2Coordinator.endSession(reason: reason)"))
+        XCTAssertFalse(begin.contains("return telemetryV2Coordinator"))
+        XCTAssertFalse(end.contains("return telemetryV2Coordinator"))
+    }
+
     func testControlSafetyAuthorityIsOutsideTelemetryNormalization() throws {
         XCTAssertTrue(managerSource.contains("private let hrStartGraceSeconds: Int = 15"))
         XCTAssertTrue(managerSource.contains("private let hrNoDataMaxSeconds: Int = 60"))


### PR DESCRIPTION
## Summary

- add passive Telemetry V2 domain, recorder, persistence, and runtime dual-write integration
- preserve deterministic legacy workout identity, unknown causal associations, observed-only frames, and unchanged legacy JSONL/workoutHistory behavior
- make setup, installation, cancellation, and finalization exact-generation scoped so delayed completion cannot resurrect or cross-contaminate sessions
- surface a compact typed privacy-safe V2 writer-health snapshot in the existing Debug → Training Logs diagnostics
- keep all Telemetry V2 persistence, diagnostics, and finalization work detached from HR control, sensor/control callbacks, and product stop completion
- keep production UI above the recorder boundary by exposing only TelemetryRuntime-owned diagnostic types

Closes #30

## Verification

- `swift test --disable-sandbox --filter 'TelemetryV2RuntimeCoordinatorTests/testWriterHealthSnapshotMapsOnlyTypedOperationalDiagnostics|HeartRateLegacyBehaviorContractTests/testTelemetryV2WriterHealth|HeartRateLegacyBehaviorContractTests/testStartAffordanceIsSeparateFromRuntimeAuthorization'` (4 tests)
- `swift test --disable-sandbox --filter 'TelemetryV2RuntimeCoordinatorTests|HeartRateLegacyBehaviorContractTests'` (22 tests)
- `swift test --disable-sandbox --filter 'TelemetryRecorderBoundaryTests/testProductionApplicationWiresRecorderOnlyThroughRuntimeCoordinator|TelemetryV2RuntimeCoordinatorTests/testWriterHealthSnapshotMapsOnlyTypedOperationalDiagnostics|HeartRateLegacyBehaviorContractTests/testTelemetryV2WriterHealth|HeartRateLegacyBehaviorContractTests/testStartAffordanceIsSeparateFromRuntimeAuthorization'` (5 tests)
- `swift test --disable-sandbox` and final exact-CI-style `swift test` (306 tests each)
- `python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py`
- `xcodebuild -quiet -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
  - first diagnostic-readout build failed because `ContentView` lacked explicit module visibility
  - after importing only `TelemetryRuntime`, the unsigned generic iOS/watchOS build passed
- first exact-head Swift Package CI on `babf58c` failed the production app→recorder dependency boundary; the final correction replaced recorder-owned UI types with exhaustive TelemetryRuntime-owned diagnostic enums, and the exact failed boundary test plus full local suite now pass
- `git diff --check`
- complete `2f5bc78ee3c80db080042eb862d8d83cd57d3d40...d9372e00b07a946ccaadd454e66c8ca40a2c54d9` scope/safety diff inspection
- fresh independent Terra/high final and safety/scope review, plus supplemental exact-delta review after the CI boundary correction: no P0, P1, or material P2 findings

## Risks / Notes

- Telemetry V2 is passive and failure-independent; product control and legacy persistence remain authoritative and behaviorally unchanged.
- The writer-health snapshot contains only lifecycle/completeness and bounded recorder operational counters; SwiftUI receives neither the recorder nor workout, health, profile, device, session, BLE, or export data.
- No migration, entitlement, deployment, or runtime configuration change is required. The SwiftData store remains additive and fail-closed.
- Generic unsigned iOS/watchOS compilation was verified; no install, launch, BLE connection, treadmill command, hardware experiment, or physical-device validation was performed.
- Hosted/device-only SwiftData behavior remains outside host verification and must not be inferred from CI.
- Rollback is a revert of this PR; legacy persistence remains available throughout dual-write rollout.
