### PR TITLE
Add semantic Telemetry V2 parity validation

### DIFF
--- a/docs/telemetry-v2/index.md
+++ b/docs/telemetry-v2/index.md
@@ -37,6 +37,7 @@ resolve a concrete remaining ambiguity.
 | Performance targets, soak measurements, privacy-safe instrumentation, or tuning evidence | [`performance-budget.md`](performance-budget.md) |
 | Issue #31 host measurements, A/B recorder decision, signpost catalog, or soak commands | [`issue-31-performance-report.md`](issue-31-performance-report.md) |
 | Dual-write, parity, migration, cutover, physical gate, rollback, or retirement | [`rollout-and-migration.md`](rollout-and-migration.md) |
+| Issue #32 parity categories, read-only inputs, report schema, or deterministic replay scenarios | [`issue-32-parity-validator.md`](issue-32-parity-validator.md) |
 
 ## Durable cross-Issue decisions
 

--- a/docs/telemetry-v2/issue-32-parity-validator.md
+++ b/docs/telemetry-v2/issue-32-parity-validator.md
@@ -47,9 +47,10 @@ Known legacy modelled speed, synthetic steps, sample-count-derived seconds, and
 missing runtime version fields are not V2 targets. Comparable explicit facts are
 still checked. When the legacy source cannot establish a category, that category
 is `INCONCLUSIVE`; absence is not converted to zero, equality, or failure.
-Invalid-checksum speed remains native evidence without being promoted to factual
-speed. The legacy ACK-association limitation excludes only ACK/response ownership;
-explicit timeout and write-result counts remain comparable.
+Invalid-checksum speed remains native evidence without promoting its speed or
+device state to factual truth. The legacy ACK-association limitation excludes
+only ACK/response ownership; explicit timeout and write-result counts remain
+comparable.
 
 The immutable-array V2 reader checks source event order before applying its
 deterministic comparison sort, while typed HR/treadmill arrival order and frame

--- a/docs/telemetry-v2/issue-32-parity-validator.md
+++ b/docs/telemetry-v2/issue-32-parity-validator.md
@@ -1,0 +1,108 @@
+# Telemetry V2 semantic parity and replay validator
+
+Status: Issue #32 implementation note. The normative contracts in this directory
+remain authoritative.
+
+## Boundary
+
+`TelemetryParity` is a read-only comparison layer above the legacy JSONL and
+Telemetry V2 evidence stores. It never writes, repairs, reorders, backfills, or
+deletes either source. It is not a controller, analyzer, migration tool, read
+cutover, or physical-device qualification path.
+
+The V2 reader consumes an already-open `TelemetryStore` through fetch-only APIs,
+or immutable domain arrays supplied by a caller. The legacy reader consumes a
+`Data` value or reads a JSONL URL without rewriting it. A caller validating an
+offline production artifact must work from a copy rather than open the only
+source artifact through a write-capable store factory.
+
+## Semantic/asymmetric categories
+
+The validator emits one deterministic result for each category:
+
+- lifecycle;
+- HR observations;
+- phase and cooldown boundaries;
+- configuration and versions;
+- control decisions;
+- factual treadmill observations;
+- command lifecycle;
+- timestamp-derived aggregates;
+- stop and safety evidence;
+- record integrity;
+- causal association;
+- physical-device truth.
+
+Each category is `PASS`, `FAIL`, or `INCONCLUSIVE`. Findings retain one of these
+separate classes rather than becoming a generic mismatch:
+
+- `sourceLegacyLimitation`;
+- `v2RecorderOrDataLoss`;
+- `protocolRuntimeCausalAmbiguity`;
+- `actualSemanticMismatch`;
+- `unsupportedCausalEdge`;
+- `deviceOnlyUnverified`.
+
+Known legacy modelled speed, synthetic steps, sample-count-derived seconds, and
+missing runtime version fields are not V2 targets. Comparable explicit facts are
+still checked. When the legacy source cannot establish a category, that category
+is `INCONCLUSIVE`; absence is not converted to zero, equality, or failure.
+
+Physical-device truth is always reported `INCONCLUSIVE` by this hosted gate and
+does not downgrade an otherwise passing automated parity result. Issue #37 owns
+physical evidence.
+
+## Causal proof rule
+
+ACK, timeout, write-result, and observed-response evidence remains factual even
+when its command/attempt association is unknown. Honest unknown association has
+nil command and attempt IDs and may pass factual integrity. Association coverage
+is reported separately from factual outcome count.
+
+The accepted runtime persists no independently verifiable proof token for a
+specific outcome/command/attempt tuple. Therefore this validator accepts no
+caller-supplied boolean or ID set as proof: every persisted specific ACK,
+timeout, write-result, or observed-response edge currently fails as
+`unsupportedCausalEdge`. A future protocol decoder would need its own reviewed,
+independently verifiable proof representation before the validator could accept
+such an edge. Timing, queue position, target or modelled speed, a frame, and
+nearest/latest/oldest command are never proof.
+
+## Timestamp-derived comparison
+
+The Issue #32 gate recalculates only the bounded parity aggregates needed for the
+comparison. It uses ordered HR evidence, explicit phase boundaries, configured
+zone bounds, a five-second maximum freshness hold, and one-second default
+rounding tolerance. It does not implement the Issue #33 analyzer or write an
+analysis record.
+
+## Deterministic replay
+
+`DeterministicControlReplay.run(scenario:telemetryObserver:)` feeds the same
+normalized harness observations through existing pure HR, speed-bound, and
+cooldown helpers with the observer absent or present. The observer is write-only;
+its state and disposition are never read by the replay decision. The harness has
+no production transport and cannot reach BLE.
+
+Required scenarios are:
+
+- normal HR control;
+- delayed HR;
+- missing HR;
+- overshoot/prediction;
+- speed limits;
+- disconnect;
+- cooldown;
+- stop;
+- Start HR Control affordance versus post-tap runtime authorization.
+
+Production formulas and branching remain inline in `BluetoothManager`. The
+replay harness is test evidence assembled from the existing pure helpers, not a
+new production controller authority.
+
+## Output API
+
+`TelemetrySemanticParityValidator.validate(legacy:telemetryV2:tolerance:)`
+returns `TelemetrySemanticParityReport`. Use `machineReadableJSON()` for sorted,
+versioned JSON and `humanReadableText()` for the deterministic review summary.
+Neither renderer includes raw BLE payloads or mutates source evidence.

--- a/docs/telemetry-v2/issue-32-parity-validator.md
+++ b/docs/telemetry-v2/issue-32-parity-validator.md
@@ -47,6 +47,13 @@ Known legacy modelled speed, synthetic steps, sample-count-derived seconds, and
 missing runtime version fields are not V2 targets. Comparable explicit facts are
 still checked. When the legacy source cannot establish a category, that category
 is `INCONCLUSIVE`; absence is not converted to zero, equality, or failure.
+Invalid-checksum speed remains native evidence without being promoted to factual
+speed. The legacy ACK-association limitation excludes only ACK/response ownership;
+explicit timeout and write-result counts remain comparable.
+
+The immutable-array V2 reader checks source event order before applying its
+deterministic comparison sort, while typed HR/treadmill arrival order and frame
+identity/gaps are checked independently.
 
 Physical-device truth is always reported `INCONCLUSIVE` by this hosted gate and
 does not downgrade an otherwise passing automated parity result. Issue #37 owns
@@ -98,7 +105,11 @@ Required scenarios are:
 
 Production formulas and branching remain inline in `BluetoothManager`. The
 replay harness is test evidence assembled from the existing pure helpers, not a
-new production controller authority.
+new production controller authority. A source-contract regression anchors the
+harness composition to the current inline prediction, deadband, adaptive-step,
+inertia, speed-clamp, missing-HR, cooldown, and Start authorization branches; it
+fails if those production branches drift away from the shared pure rules used by
+the replay.
 
 ## Output API
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -34,6 +34,10 @@ let package = Package(
             targets: ["TelemetryRuntime"]
         ),
         .library(
+            name: "TelemetryParity",
+            targets: ["TelemetryParity"]
+        ),
+        .library(
             name: "TelemetrySoak",
             targets: ["TelemetrySoak"]
         ),
@@ -67,6 +71,14 @@ let package = Package(
                 "TelemetryDomain",
                 "TelemetryInstrumentation",
                 "TelemetryRecorder",
+            ]
+        ),
+        .target(
+            name: "TelemetryParity",
+            dependencies: [
+                "TelemetryDomain",
+                "TelemetryPersistence",
+                "TelemetryRuntime",
             ]
         ),
         .target(
@@ -148,6 +160,15 @@ let package = Package(
         .testTarget(
             name: "TelemetryRuntimeTests",
             dependencies: ["TelemetryDomain", "TelemetryRecorder", "TelemetryRuntime"]
+        ),
+        .testTarget(
+            name: "TelemetryParityTests",
+            dependencies: [
+                "TelemetryDomain",
+                "TelemetryParity",
+                "TelemetryPersistence",
+                "TelemetryRuntime",
+            ]
         ),
         .testTarget(
             name: "TelemetryInstrumentationTests",

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/LegacyTelemetryJSONLReader.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/LegacyTelemetryJSONLReader.swift
@@ -95,12 +95,15 @@ public enum LegacyTelemetryJSONLReader {
                     )
                 }
             case "hr_decision":
+                let action = normalizedDecision(payload)
                 decisions.append(
                     TelemetryParityDecisionEvidence(
                         domain: .heartRateControl,
                         source: "heartRateControl",
-                        action: normalizedDecision(payload),
-                        desiredSpeedKilometresPerHour: double(payload["speed_after_kmh"]),
+                        action: action,
+                        desiredSpeedKilometresPerHour: action == "setSpeed"
+                            ? double(payload["speed_after_kmh"])
+                            : nil,
                         elapsedMilliseconds: elapsedMilliseconds
                     )
                 )

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/LegacyTelemetryJSONLReader.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/LegacyTelemetryJSONLReader.swift
@@ -97,6 +97,7 @@ public enum LegacyTelemetryJSONLReader {
             case "hr_decision":
                 decisions.append(
                     TelemetryParityDecisionEvidence(
+                        domain: .heartRateControl,
                         source: "heartRateControl",
                         action: normalizedDecision(payload),
                         desiredSpeedKilometresPerHour: double(payload["speed_after_kmh"]),

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/LegacyTelemetryJSONLReader.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/LegacyTelemetryJSONLReader.swift
@@ -114,10 +114,12 @@ public enum LegacyTelemetryJSONLReader {
                             nativeUnit: "walkingpad_controller_tenths",
                             factualSpeedKilometresPerHour: unitsAreMetric
                                 && bool(payload["checksum_ok"]) == true ? reportedSpeed : nil,
-                            deviceState: normalizedWalkingPadState(
-                                speedKilometresPerHour: reportedSpeed,
-                                rawState: integer(payload["state"])
-                            )
+                            deviceState: bool(payload["checksum_ok"]) == true
+                                ? normalizedWalkingPadState(
+                                    speedKilometresPerHour: reportedSpeed,
+                                    rawState: integer(payload["state"])
+                                )
+                                : nil
                         )
                     )
                 }
@@ -143,7 +145,9 @@ public enum LegacyTelemetryJSONLReader {
                             factualSpeedKilometresPerHour: bool(payload["checksum_ok"]) == true
                                 ? reportedSpeed
                                 : nil,
-                            deviceState: string(payload["state"]) ?? "unknown"
+                            deviceState: bool(payload["checksum_ok"]) == true
+                                ? string(payload["state"])
+                                : nil
                         )
                     )
                 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/LegacyTelemetryJSONLReader.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/LegacyTelemetryJSONLReader.swift
@@ -1,0 +1,363 @@
+import Foundation
+
+public enum LegacyTelemetryJSONLReaderError: Error, Equatable, Sendable {
+    case unreadableUTF8
+    case noParseableRecords
+    case missingSessionIdentifier
+}
+
+public enum LegacyTelemetryJSONLReader {
+    public static func read(from url: URL) throws -> TelemetryParitySessionEvidence {
+        try read(data: Data(contentsOf: url, options: [.mappedIfSafe]))
+    }
+
+    public static func read(data: Data) throws -> TelemetryParitySessionEvidence {
+        guard let source = String(data: data, encoding: .utf8) else {
+            throw LegacyTelemetryJSONLReaderError.unreadableUTF8
+        }
+
+        var payloads: [[String: Any]] = []
+        var malformedRecordCount = 0
+        for rawLine in source.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let lineData = String(rawLine).data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: lineData),
+                  let payload = object as? [String: Any] else {
+                malformedRecordCount += 1
+                continue
+            }
+            payloads.append(payload)
+        }
+        guard !payloads.isEmpty else {
+            throw LegacyTelemetryJSONLReaderError.noParseableRecords
+        }
+        guard let sessionIdentifier = payloads.lazy.compactMap({ string($0["session_id"]) }).first,
+              !sessionIdentifier.isEmpty else {
+            throw LegacyTelemetryJSONLReaderError.missingSessionIdentifier
+        }
+
+        let datedPayloads = payloads.map { payload in
+            (payload, date(payload["ts"]))
+        }
+        let sessionStartPayload = datedPayloads.first { string($0.0["event"]) == "session_start" }
+        let sessionEndPayload = datedPayloads.last { string($0.0["event"]) == "session_end" }
+        let startedAt = sessionStartPayload?.1 ?? datedPayloads.compactMap(\.1).first
+        let endedAt = sessionEndPayload?.1
+        let durationMilliseconds = durationMilliseconds(startedAt: startedAt, endedAt: endedAt)
+        let elapsed: (Date?) -> Int64 = { eventDate in
+            guard let startedAt, let eventDate else { return 0 }
+            return max(0, Int64((eventDate.timeIntervalSince(startedAt) * 1_000).rounded()))
+        }
+
+        var arrivalOrder: UInt64 = 0
+        var heartRate: [TelemetryParityHeartRateEvidence] = []
+        var phases: [TelemetryParityPhaseEvidence] = []
+        var decisions: [TelemetryParityDecisionEvidence] = []
+        var treadmillFacts: [TelemetryParityTreadmillFact] = []
+        var commandEvidence: [TelemetryParityCommandEvidence] = []
+        var stopEvidence: [TelemetryParityStopEvidence] = []
+
+        for (payload, eventDate) in datedPayloads {
+            guard let event = string(payload["event"]) else { continue }
+            let elapsedMilliseconds = elapsed(eventDate)
+            switch event {
+            case "session_start":
+                phases.append(
+                    TelemetryParityPhaseEvidence(
+                        phase: "main",
+                        elapsedMilliseconds: elapsedMilliseconds
+                    )
+                )
+            case "session_end":
+                phases.append(
+                    TelemetryParityPhaseEvidence(
+                        phase: "finished",
+                        elapsedMilliseconds: elapsedMilliseconds
+                    )
+                )
+            case "cooldown_start":
+                phases.append(
+                    TelemetryParityPhaseEvidence(
+                        phase: "cooldown",
+                        elapsedMilliseconds: elapsedMilliseconds
+                    )
+                )
+            case "hr_sample":
+                if let beatsPerMinute = integer(payload["hr_bpm"]), let eventDate {
+                    arrivalOrder += 1
+                    heartRate.append(
+                        TelemetryParityHeartRateEvidence(
+                            elapsedMilliseconds: elapsedMilliseconds,
+                            receivedAt: eventDate,
+                            beatsPerMinute: beatsPerMinute,
+                            acceptedForControl: true,
+                            arrivalOrder: arrivalOrder
+                        )
+                    )
+                }
+            case "hr_decision":
+                decisions.append(
+                    TelemetryParityDecisionEvidence(
+                        source: "heartRateControl",
+                        action: normalizedDecision(payload),
+                        desiredSpeedKilometresPerHour: double(payload["speed_after_kmh"]),
+                        elapsedMilliseconds: elapsedMilliseconds
+                    )
+                )
+            case "notify_fe01":
+                if let reportedSpeed = double(payload["speed_kmh"]) {
+                    let unitsAreMetric = string(payload["controller_units"]) == "metric"
+                        && bool(payload["controller_units_fresh"]) == true
+                    treadmillFacts.append(
+                        TelemetryParityTreadmillFact(
+                            elapsedMilliseconds: elapsedMilliseconds,
+                            nativeValue: reportedSpeed,
+                            nativeUnit: "walkingpad_controller_tenths",
+                            factualSpeedKilometresPerHour: unitsAreMetric ? reportedSpeed : nil,
+                            deviceState: normalizedWalkingPadState(
+                                speedKilometresPerHour: reportedSpeed,
+                                rawState: integer(payload["state"])
+                            )
+                        )
+                    )
+                }
+            case "notify_ftms_treadmill_data":
+                if let reportedSpeed = double(payload["speed_kmh"]) {
+                    treadmillFacts.append(
+                        TelemetryParityTreadmillFact(
+                            elapsedMilliseconds: elapsedMilliseconds,
+                            nativeValue: reportedSpeed,
+                            nativeUnit: "kilometres_per_hour",
+                            factualSpeedKilometresPerHour: reportedSpeed,
+                            deviceState: bool(payload["moving"]) == true ? "moving" : "stopped"
+                        )
+                    )
+                }
+            case "notify_fitshow_speed", "notify_fitshow_status":
+                if let reportedSpeed = double(payload["speed_kmh"]) {
+                    treadmillFacts.append(
+                        TelemetryParityTreadmillFact(
+                            elapsedMilliseconds: elapsedMilliseconds,
+                            nativeValue: reportedSpeed,
+                            nativeUnit: "kilometres_per_hour",
+                            factualSpeedKilometresPerHour: reportedSpeed,
+                            deviceState: string(payload["state"]) ?? "unknown"
+                        )
+                    )
+                }
+            case "command_write":
+                commandEvidence.append(
+                    TelemetryParityCommandEvidence(
+                        outcomeKind: .sent,
+                        semanticCommand: semanticCommand(label: string(payload["label"])),
+                        elapsedMilliseconds: elapsedMilliseconds,
+                        association: .unknown,
+                        commandIdentifier: nil,
+                        attemptIdentifier: nil
+                    )
+                )
+            case "command_ack_timeout":
+                commandEvidence.append(
+                    unknownCommandOutcome(.timeout, elapsedMilliseconds: elapsedMilliseconds)
+                )
+            case "command_write_result":
+                commandEvidence.append(
+                    unknownCommandOutcome(.writeResult, elapsedMilliseconds: elapsedMilliseconds)
+                )
+            case "stop_observation_finished":
+                if let conclusion = string(payload["stop_final_result"]), !conclusion.isEmpty {
+                    stopEvidence.append(
+                        TelemetryParityStopEvidence(
+                            conclusion: normalizedStopConclusion(conclusion),
+                            factualObservationIdentifier: nil,
+                            elapsedMilliseconds: elapsedMilliseconds
+                        )
+                    )
+                }
+            default:
+                break
+            }
+        }
+
+        let timestamps = datedPayloads.compactMap(\.1)
+        let outOfOrderCount = zip(timestamps, timestamps.dropFirst()).filter {
+            pair in pair.0 > pair.1
+        }.count
+        var limitations = [
+            TelemetryParitySourceLimitation(
+                category: .commandLifecycle,
+                code: "legacy-jsonl-ack-acceptance-not-explicit",
+                detail: "Legacy JSONL notifications do not prove which signals the runtime accepted as ACK evidence."
+            )
+        ]
+        if malformedRecordCount > 0 {
+            limitations.append(
+                TelemetryParitySourceLimitation(
+                    category: .recordIntegrity,
+                    code: "legacy-malformed-records",
+                    detail: "Legacy JSONL contains \(malformedRecordCount) malformed record(s)."
+                )
+            )
+        }
+        let configuration = sessionStartPayload.map {
+            legacyConfiguration($0.0, limitations: &limitations)
+        }
+        let completeness: TelemetryParityCompleteness = malformedRecordCount == 0
+            && sessionEndPayload != nil ? .complete : .incomplete
+
+        return TelemetryParitySessionEvidence(
+            origin: .legacyJSONL,
+            sessionIdentifier: sessionIdentifier,
+            linkedLegacySessionIdentifier: sessionIdentifier,
+            completeness: completeness,
+            lifecycle: TelemetryParityLifecycleEvidence(
+                startedAt: startedAt,
+                endedAt: endedAt,
+                endReason: sessionEndPayload.flatMap { string($0.0["reason"]) },
+                durationMilliseconds: durationMilliseconds
+            ),
+            heartRate: heartRate,
+            phases: phases,
+            configuration: configuration,
+            decisions: decisions,
+            treadmillFacts: treadmillFacts,
+            commandEvidence: commandEvidence,
+            aggregates: nil,
+            stopEvidence: stopEvidence,
+            integrity: TelemetryParityIntegrityEvidence(
+                outOfOrderRecordCount: outOfOrderCount
+            ),
+            limitations: limitations
+        )
+    }
+
+    private static func legacyConfiguration(
+        _ payload: [String: Any],
+        limitations: inout [TelemetryParitySourceLimitation]
+    ) -> TelemetryParityConfigurationEvidence {
+        let telemetrySchemaVersion = string(payload["telemetry_schema_version"])
+        let algorithmVersion = string(payload["algorithm_version"])
+        let safetyPolicyVersion = string(payload["safety_policy_version"])
+        let workoutProtocolVersion = string(payload["workout_protocol_version"])
+        if telemetrySchemaVersion == nil || algorithmVersion == nil
+            || safetyPolicyVersion == nil || workoutProtocolVersion == nil {
+            limitations.append(
+                TelemetryParitySourceLimitation(
+                    category: .configurationAndVersions,
+                    code: "legacy-runtime-versions-not-recorded",
+                    detail: "Legacy JSONL does not expose the complete V2 runtime-version snapshot."
+                )
+            )
+        }
+        return TelemetryParityConfigurationEvidence(
+            targetHeartRate: integer(payload["target_bpm"]),
+            durationSeconds: integer(payload["duration_min"]).map { $0 * 60 },
+            decisionIntervalSeconds: integer(payload["decision_interval_s"]),
+            adaptiveStepEnabled: bool(payload["adaptive_step_enabled"]),
+            maximumStepKilometresPerHour: double(payload["max_step_kmh"]),
+            heartRateZoneUpperBounds: integerArray(payload["zone_bounds"]),
+            cooldownTargetHeartRate: integer(payload["cooldown_target_bpm"]),
+            cooldownMinimumSpeedKilometresPerHour: double(payload["cooldown_min_speed_kmh"]),
+            cooldownMaximumSeconds: integer(payload["cooldown_max_minutes"]).map { $0 * 60 },
+            telemetrySchemaVersion: telemetrySchemaVersion,
+            algorithmVersion: algorithmVersion,
+            safetyPolicyVersion: safetyPolicyVersion,
+            workoutProtocolVersion: workoutProtocolVersion
+        )
+    }
+
+    private static func normalizedDecision(_ payload: [String: Any]) -> String {
+        switch string(payload["decision"]) {
+        case "set": "setSpeed"
+        case "hold": "hold"
+        case "inertia_hold": "inertiaHold"
+        case "limit": "speedLimit"
+        case let value?: value
+        case nil: "unknown"
+        }
+    }
+
+    private static func semanticCommand(label: String?) -> String {
+        let lower = (label ?? "").lowercased()
+        if lower.contains("stop") || lower.contains("standby") { return "stop" }
+        if lower.contains("speed") { return "setSpeed" }
+        if lower.contains("start") || lower.contains("resume") { return "start" }
+        if lower.contains("request") || lower.contains("query") { return "maintenance" }
+        return "other"
+    }
+
+    private static func unknownCommandOutcome(
+        _ kind: TelemetryParityCommandOutcomeKind,
+        elapsedMilliseconds: Int64
+    ) -> TelemetryParityCommandEvidence {
+        TelemetryParityCommandEvidence(
+            outcomeKind: kind,
+            semanticCommand: nil,
+            elapsedMilliseconds: elapsedMilliseconds,
+            association: .unknown,
+            commandIdentifier: nil,
+            attemptIdentifier: nil
+        )
+    }
+
+    private static func normalizedWalkingPadState(
+        speedKilometresPerHour: Double,
+        rawState: Int?
+    ) -> String {
+        if speedKilometresPerHour > 0 { return "moving" }
+        if [0, 2, 5, 7, 9].contains(rawState) { return "stopped" }
+        return "unknown"
+    }
+
+    private static func normalizedStopConclusion(_ raw: String) -> String {
+        let lower = raw.lowercased()
+        if lower.contains("confirmed") && !lower.contains("unconfirmed") { return "confirmed" }
+        if lower.contains("contradict") { return "contradictory" }
+        return "unconfirmed"
+    }
+
+    private static func durationMilliseconds(startedAt: Date?, endedAt: Date?) -> Int64? {
+        guard let startedAt, let endedAt else { return nil }
+        return max(0, Int64((endedAt.timeIntervalSince(startedAt) * 1_000).rounded()))
+    }
+
+    private static func date(_ value: Any?) -> Date? {
+        guard let value = string(value) else { return nil }
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let parsed = fractional.date(from: value) { return parsed }
+        return ISO8601DateFormatter().date(from: value)
+    }
+
+    private static func string(_ value: Any?) -> String? {
+        if let value = value as? String { return value }
+        return nil
+    }
+
+    private static func integer(_ value: Any?) -> Int? {
+        if let value = value as? Int { return value }
+        if let value = value as? NSNumber { return value.intValue }
+        if let value = value as? String { return Int(value) }
+        return nil
+    }
+
+    private static func double(_ value: Any?) -> Double? {
+        if let value = value as? Double { return value }
+        if let value = value as? NSNumber { return value.doubleValue }
+        if let value = value as? String { return Double(value) }
+        return nil
+    }
+
+    private static func bool(_ value: Any?) -> Bool? {
+        if let value = value as? Bool { return value }
+        if let value = value as? NSNumber { return value.boolValue }
+        if let value = value as? String {
+            if value == "true" { return true }
+            if value == "false" { return false }
+        }
+        return nil
+    }
+
+    private static func integerArray(_ value: Any?) -> [Int] {
+        (value as? [Any] ?? []).compactMap(integer)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/LegacyTelemetryJSONLReader.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/LegacyTelemetryJSONLReader.swift
@@ -112,7 +112,8 @@ public enum LegacyTelemetryJSONLReader {
                             elapsedMilliseconds: elapsedMilliseconds,
                             nativeValue: reportedSpeed,
                             nativeUnit: "walkingpad_controller_tenths",
-                            factualSpeedKilometresPerHour: unitsAreMetric ? reportedSpeed : nil,
+                            factualSpeedKilometresPerHour: unitsAreMetric
+                                && bool(payload["checksum_ok"]) == true ? reportedSpeed : nil,
                             deviceState: normalizedWalkingPadState(
                                 speedKilometresPerHour: reportedSpeed,
                                 rawState: integer(payload["state"])
@@ -133,13 +134,15 @@ public enum LegacyTelemetryJSONLReader {
                     )
                 }
             case "notify_fitshow_speed", "notify_fitshow_status":
-                if let reportedSpeed = double(payload["speed_kmh"]) {
+                if let reportedSpeed = double(payload["speed_kmh"]), reportedSpeed >= 0 {
                     treadmillFacts.append(
                         TelemetryParityTreadmillFact(
                             elapsedMilliseconds: elapsedMilliseconds,
                             nativeValue: reportedSpeed,
                             nativeUnit: "kilometres_per_hour",
-                            factualSpeedKilometresPerHour: reportedSpeed,
+                            factualSpeedKilometresPerHour: bool(payload["checksum_ok"]) == true
+                                ? reportedSpeed
+                                : nil,
                             deviceState: string(payload["state"]) ?? "unknown"
                         )
                     )

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryParityModels.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryParityModels.swift
@@ -271,14 +271,14 @@ public struct TelemetryParityTreadmillFact: Codable, Equatable, Sendable {
     public let nativeValue: Double
     public let nativeUnit: String
     public let factualSpeedKilometresPerHour: Double?
-    public let deviceState: String
+    public let deviceState: String?
 
     public init(
         elapsedMilliseconds: Int64,
         nativeValue: Double,
         nativeUnit: String,
         factualSpeedKilometresPerHour: Double?,
-        deviceState: String
+        deviceState: String?
     ) {
         self.elapsedMilliseconds = elapsedMilliseconds
         self.nativeValue = nativeValue

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryParityModels.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryParityModels.swift
@@ -1,0 +1,442 @@
+import Foundation
+
+public enum TelemetryParityStatus: String, Codable, CaseIterable, Sendable {
+    case pass = "PASS"
+    case fail = "FAIL"
+    case inconclusive = "INCONCLUSIVE"
+}
+
+public enum TelemetryParityCategory: String, Codable, CaseIterable, Sendable {
+    case lifecycle
+    case heartRateObservations
+    case phaseAndCooldown
+    case configurationAndVersions
+    case controlDecisions
+    case treadmillFacts
+    case commandLifecycle
+    case timestampDerivedAggregates
+    case stopAndSafety
+    case recordIntegrity
+    case causalAssociation
+    case physicalDeviceTruth
+}
+
+public enum TelemetryParityFindingClass: String, Codable, Sendable {
+    case sourceLegacyLimitation
+    case v2RecorderOrDataLoss
+    case protocolRuntimeCausalAmbiguity
+    case actualSemanticMismatch
+    case unsupportedCausalEdge
+    case deviceOnlyUnverified
+}
+
+public struct TelemetryParityFinding: Codable, Equatable, Sendable {
+    public let code: String
+    public let classification: TelemetryParityFindingClass
+    public let impact: TelemetryParityStatus
+    public let detail: String
+
+    public init(
+        code: String,
+        classification: TelemetryParityFindingClass,
+        impact: TelemetryParityStatus,
+        detail: String
+    ) {
+        self.code = code
+        self.classification = classification
+        self.impact = impact
+        self.detail = detail
+    }
+}
+
+public struct TelemetryParityCategoryResult: Codable, Equatable, Sendable {
+    public let category: TelemetryParityCategory
+    public let status: TelemetryParityStatus
+    public let findings: [TelemetryParityFinding]
+
+    public init(
+        category: TelemetryParityCategory,
+        status: TelemetryParityStatus,
+        findings: [TelemetryParityFinding]
+    ) {
+        self.category = category
+        self.status = status
+        self.findings = findings
+    }
+}
+
+public struct TelemetryParityCausalCoverage: Codable, Equatable, Sendable {
+    public let factualOutcomeCount: Int
+    public let deterministicallyAssociatedCount: Int
+    public let honestlyUnknownCount: Int
+    public let unsupportedClaimCount: Int
+
+    public init(
+        factualOutcomeCount: Int,
+        deterministicallyAssociatedCount: Int,
+        honestlyUnknownCount: Int,
+        unsupportedClaimCount: Int
+    ) {
+        self.factualOutcomeCount = factualOutcomeCount
+        self.deterministicallyAssociatedCount = deterministicallyAssociatedCount
+        self.honestlyUnknownCount = honestlyUnknownCount
+        self.unsupportedClaimCount = unsupportedClaimCount
+    }
+}
+
+public struct TelemetrySemanticParityReport: Codable, Equatable, Sendable {
+    public let schemaVersion: Int
+    public let legacySessionIdentifier: String?
+    public let telemetryV2SessionIdentifier: String
+    public let overallStatus: TelemetryParityStatus
+    public let categories: [TelemetryParityCategoryResult]
+    public let causalCoverage: TelemetryParityCausalCoverage
+
+    public init(
+        schemaVersion: Int = 1,
+        legacySessionIdentifier: String?,
+        telemetryV2SessionIdentifier: String,
+        overallStatus: TelemetryParityStatus,
+        categories: [TelemetryParityCategoryResult],
+        causalCoverage: TelemetryParityCausalCoverage
+    ) {
+        self.schemaVersion = schemaVersion
+        self.legacySessionIdentifier = legacySessionIdentifier
+        self.telemetryV2SessionIdentifier = telemetryV2SessionIdentifier
+        self.overallStatus = overallStatus
+        self.categories = categories
+        self.causalCoverage = causalCoverage
+    }
+
+    public func machineReadableJSON() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(self)
+    }
+
+    public func humanReadableText() -> String {
+        var lines = [
+            "Telemetry V2 semantic parity: \(overallStatus.rawValue)",
+            "legacy_session=\(legacySessionIdentifier ?? "unknown")",
+            "v2_session=\(telemetryV2SessionIdentifier)",
+        ]
+        for result in categories {
+            lines.append("[\(result.status.rawValue)] \(result.category.rawValue)")
+            for finding in result.findings {
+                lines.append(
+                    "  - \(finding.classification.rawValue)/\(finding.code): \(finding.detail)"
+                )
+            }
+        }
+        lines.append(
+            "causal_coverage factual=\(causalCoverage.factualOutcomeCount) " +
+                "associated=\(causalCoverage.deterministicallyAssociatedCount) " +
+                "unknown=\(causalCoverage.honestlyUnknownCount) " +
+                "unsupported=\(causalCoverage.unsupportedClaimCount)"
+        )
+        return lines.joined(separator: "\n")
+    }
+}
+
+public enum TelemetryParityEvidenceOrigin: String, Codable, Sendable {
+    case legacyJSONL
+    case telemetryV2
+}
+
+public enum TelemetryParityCompleteness: String, Codable, Sendable {
+    case complete
+    case incomplete
+    case unknown
+}
+
+public struct TelemetryParityLifecycleEvidence: Codable, Equatable, Sendable {
+    public let startedAt: Date?
+    public let endedAt: Date?
+    public let endReason: String?
+    public let durationMilliseconds: Int64?
+
+    public init(
+        startedAt: Date?,
+        endedAt: Date?,
+        endReason: String?,
+        durationMilliseconds: Int64?
+    ) {
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.endReason = endReason
+        self.durationMilliseconds = durationMilliseconds
+    }
+}
+
+public struct TelemetryParityHeartRateEvidence: Codable, Equatable, Sendable {
+    public let elapsedMilliseconds: Int64
+    public let receivedAt: Date
+    public let beatsPerMinute: Int
+    public let acceptedForControl: Bool
+    public let arrivalOrder: UInt64
+
+    public init(
+        elapsedMilliseconds: Int64,
+        receivedAt: Date,
+        beatsPerMinute: Int,
+        acceptedForControl: Bool,
+        arrivalOrder: UInt64
+    ) {
+        self.elapsedMilliseconds = elapsedMilliseconds
+        self.receivedAt = receivedAt
+        self.beatsPerMinute = beatsPerMinute
+        self.acceptedForControl = acceptedForControl
+        self.arrivalOrder = arrivalOrder
+    }
+}
+
+public struct TelemetryParityPhaseEvidence: Codable, Equatable, Sendable {
+    public let phase: String
+    public let elapsedMilliseconds: Int64
+
+    public init(phase: String, elapsedMilliseconds: Int64) {
+        self.phase = phase
+        self.elapsedMilliseconds = elapsedMilliseconds
+    }
+}
+
+public struct TelemetryParityConfigurationEvidence: Codable, Equatable, Sendable {
+    public let targetHeartRate: Int?
+    public let durationSeconds: Int?
+    public let decisionIntervalSeconds: Int?
+    public let adaptiveStepEnabled: Bool?
+    public let maximumStepKilometresPerHour: Double?
+    public let heartRateZoneUpperBounds: [Int]
+    public let cooldownTargetHeartRate: Int?
+    public let cooldownMinimumSpeedKilometresPerHour: Double?
+    public let cooldownMaximumSeconds: Int?
+    public let telemetrySchemaVersion: String?
+    public let algorithmVersion: String?
+    public let safetyPolicyVersion: String?
+    public let workoutProtocolVersion: String?
+
+    public init(
+        targetHeartRate: Int?,
+        durationSeconds: Int?,
+        decisionIntervalSeconds: Int?,
+        adaptiveStepEnabled: Bool?,
+        maximumStepKilometresPerHour: Double?,
+        heartRateZoneUpperBounds: [Int],
+        cooldownTargetHeartRate: Int?,
+        cooldownMinimumSpeedKilometresPerHour: Double?,
+        cooldownMaximumSeconds: Int?,
+        telemetrySchemaVersion: String?,
+        algorithmVersion: String?,
+        safetyPolicyVersion: String?,
+        workoutProtocolVersion: String?
+    ) {
+        self.targetHeartRate = targetHeartRate
+        self.durationSeconds = durationSeconds
+        self.decisionIntervalSeconds = decisionIntervalSeconds
+        self.adaptiveStepEnabled = adaptiveStepEnabled
+        self.maximumStepKilometresPerHour = maximumStepKilometresPerHour
+        self.heartRateZoneUpperBounds = heartRateZoneUpperBounds
+        self.cooldownTargetHeartRate = cooldownTargetHeartRate
+        self.cooldownMinimumSpeedKilometresPerHour = cooldownMinimumSpeedKilometresPerHour
+        self.cooldownMaximumSeconds = cooldownMaximumSeconds
+        self.telemetrySchemaVersion = telemetrySchemaVersion
+        self.algorithmVersion = algorithmVersion
+        self.safetyPolicyVersion = safetyPolicyVersion
+        self.workoutProtocolVersion = workoutProtocolVersion
+    }
+}
+
+public struct TelemetryParityDecisionEvidence: Codable, Equatable, Sendable {
+    public let source: String
+    public let action: String
+    public let desiredSpeedKilometresPerHour: Double?
+    public let elapsedMilliseconds: Int64
+
+    public init(
+        source: String,
+        action: String,
+        desiredSpeedKilometresPerHour: Double?,
+        elapsedMilliseconds: Int64
+    ) {
+        self.source = source
+        self.action = action
+        self.desiredSpeedKilometresPerHour = desiredSpeedKilometresPerHour
+        self.elapsedMilliseconds = elapsedMilliseconds
+    }
+}
+
+public struct TelemetryParityTreadmillFact: Codable, Equatable, Sendable {
+    public let elapsedMilliseconds: Int64
+    public let nativeValue: Double
+    public let nativeUnit: String
+    public let factualSpeedKilometresPerHour: Double?
+    public let deviceState: String
+
+    public init(
+        elapsedMilliseconds: Int64,
+        nativeValue: Double,
+        nativeUnit: String,
+        factualSpeedKilometresPerHour: Double?,
+        deviceState: String
+    ) {
+        self.elapsedMilliseconds = elapsedMilliseconds
+        self.nativeValue = nativeValue
+        self.nativeUnit = nativeUnit
+        self.factualSpeedKilometresPerHour = factualSpeedKilometresPerHour
+        self.deviceState = deviceState
+    }
+}
+
+public enum TelemetryParityCommandOutcomeKind: String, Codable, Hashable, Sendable {
+    case sent
+    case acknowledgement
+    case timeout
+    case writeResult
+    case observedResponse
+}
+
+public enum TelemetryParityCausalAssociation: String, Codable, Sendable {
+    case unknown
+    case deterministicallyCorrelated
+}
+
+public struct TelemetryParityCommandEvidence: Codable, Equatable, Sendable {
+    public let outcomeKind: TelemetryParityCommandOutcomeKind
+    public let semanticCommand: String?
+    public let elapsedMilliseconds: Int64
+    public let association: TelemetryParityCausalAssociation
+    public let commandIdentifier: String?
+    public let attemptIdentifier: String?
+
+    public init(
+        outcomeKind: TelemetryParityCommandOutcomeKind,
+        semanticCommand: String?,
+        elapsedMilliseconds: Int64,
+        association: TelemetryParityCausalAssociation,
+        commandIdentifier: String?,
+        attemptIdentifier: String?
+    ) {
+        self.outcomeKind = outcomeKind
+        self.semanticCommand = semanticCommand
+        self.elapsedMilliseconds = elapsedMilliseconds
+        self.association = association
+        self.commandIdentifier = commandIdentifier
+        self.attemptIdentifier = attemptIdentifier
+    }
+}
+
+public struct TelemetryParityAggregateEvidence: Codable, Equatable, Sendable {
+    public let zoneSeconds: [Int]
+    public let cooldownCoveredSeconds: Int?
+
+    public init(zoneSeconds: [Int], cooldownCoveredSeconds: Int?) {
+        self.zoneSeconds = zoneSeconds
+        self.cooldownCoveredSeconds = cooldownCoveredSeconds
+    }
+}
+
+public struct TelemetryParityStopEvidence: Codable, Equatable, Sendable {
+    public let conclusion: String
+    public let factualObservationIdentifier: String?
+    public let elapsedMilliseconds: Int64
+
+    public init(
+        conclusion: String,
+        factualObservationIdentifier: String?,
+        elapsedMilliseconds: Int64
+    ) {
+        self.conclusion = conclusion
+        self.factualObservationIdentifier = factualObservationIdentifier
+        self.elapsedMilliseconds = elapsedMilliseconds
+    }
+}
+
+public struct TelemetryParityIntegrityEvidence: Codable, Equatable, Sendable {
+    public let duplicateRecordIdentifierCount: Int
+    public let outOfOrderRecordCount: Int
+    public let duplicateCanonicalSecondCount: Int
+    public let unexplainedFrameGapCount: Int
+    public let lostCriticalRecordCount: UInt64
+    public let lostNativeRecordCount: UInt64
+
+    public init(
+        duplicateRecordIdentifierCount: Int = 0,
+        outOfOrderRecordCount: Int = 0,
+        duplicateCanonicalSecondCount: Int = 0,
+        unexplainedFrameGapCount: Int = 0,
+        lostCriticalRecordCount: UInt64 = 0,
+        lostNativeRecordCount: UInt64 = 0
+    ) {
+        self.duplicateRecordIdentifierCount = duplicateRecordIdentifierCount
+        self.outOfOrderRecordCount = outOfOrderRecordCount
+        self.duplicateCanonicalSecondCount = duplicateCanonicalSecondCount
+        self.unexplainedFrameGapCount = unexplainedFrameGapCount
+        self.lostCriticalRecordCount = lostCriticalRecordCount
+        self.lostNativeRecordCount = lostNativeRecordCount
+    }
+}
+
+public struct TelemetryParitySourceLimitation: Codable, Equatable, Sendable {
+    public let category: TelemetryParityCategory
+    public let code: String
+    public let detail: String
+
+    public init(category: TelemetryParityCategory, code: String, detail: String) {
+        self.category = category
+        self.code = code
+        self.detail = detail
+    }
+}
+
+public struct TelemetryParitySessionEvidence: Codable, Equatable, Sendable {
+    public let origin: TelemetryParityEvidenceOrigin
+    public let sessionIdentifier: String
+    public let linkedLegacySessionIdentifier: String?
+    public let completeness: TelemetryParityCompleteness
+    public let lifecycle: TelemetryParityLifecycleEvidence
+    public let heartRate: [TelemetryParityHeartRateEvidence]
+    public let phases: [TelemetryParityPhaseEvidence]
+    public let configuration: TelemetryParityConfigurationEvidence?
+    public let decisions: [TelemetryParityDecisionEvidence]
+    public let treadmillFacts: [TelemetryParityTreadmillFact]
+    public let commandEvidence: [TelemetryParityCommandEvidence]
+    public let aggregates: TelemetryParityAggregateEvidence?
+    public let stopEvidence: [TelemetryParityStopEvidence]
+    public let integrity: TelemetryParityIntegrityEvidence
+    public let limitations: [TelemetryParitySourceLimitation]
+
+    public init(
+        origin: TelemetryParityEvidenceOrigin,
+        sessionIdentifier: String,
+        linkedLegacySessionIdentifier: String?,
+        completeness: TelemetryParityCompleteness,
+        lifecycle: TelemetryParityLifecycleEvidence,
+        heartRate: [TelemetryParityHeartRateEvidence] = [],
+        phases: [TelemetryParityPhaseEvidence] = [],
+        configuration: TelemetryParityConfigurationEvidence? = nil,
+        decisions: [TelemetryParityDecisionEvidence] = [],
+        treadmillFacts: [TelemetryParityTreadmillFact] = [],
+        commandEvidence: [TelemetryParityCommandEvidence] = [],
+        aggregates: TelemetryParityAggregateEvidence? = nil,
+        stopEvidence: [TelemetryParityStopEvidence] = [],
+        integrity: TelemetryParityIntegrityEvidence = TelemetryParityIntegrityEvidence(),
+        limitations: [TelemetryParitySourceLimitation] = []
+    ) {
+        self.origin = origin
+        self.sessionIdentifier = sessionIdentifier
+        self.linkedLegacySessionIdentifier = linkedLegacySessionIdentifier
+        self.completeness = completeness
+        self.lifecycle = lifecycle
+        self.heartRate = heartRate
+        self.phases = phases
+        self.configuration = configuration
+        self.decisions = decisions
+        self.treadmillFacts = treadmillFacts
+        self.commandEvidence = commandEvidence
+        self.aggregates = aggregates
+        self.stopEvidence = stopEvidence
+        self.integrity = integrity
+        self.limitations = limitations
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryParityModels.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryParityModels.swift
@@ -247,18 +247,27 @@ public struct TelemetryParityConfigurationEvidence: Codable, Equatable, Sendable
     }
 }
 
+public enum TelemetryParityDecisionDomain: String, Codable, Sendable {
+    case heartRateControl
+    case outsideHeartRateControl
+    case unclassified
+}
+
 public struct TelemetryParityDecisionEvidence: Codable, Equatable, Sendable {
+    public let domain: TelemetryParityDecisionDomain
     public let source: String
     public let action: String
     public let desiredSpeedKilometresPerHour: Double?
     public let elapsedMilliseconds: Int64
 
     public init(
+        domain: TelemetryParityDecisionDomain,
         source: String,
         action: String,
         desiredSpeedKilometresPerHour: Double?,
         elapsedMilliseconds: Int64
     ) {
+        self.domain = domain
         self.source = source
         self.action = action
         self.desiredSpeedKilometresPerHour = desiredSpeedKilometresPerHour

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetrySemanticParityValidator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetrySemanticParityValidator.swift
@@ -338,38 +338,90 @@ public enum TelemetrySemanticParityValidator {
         tolerance: TelemetryParityTolerance,
         add: FindingSink
     ) {
-        guard legacy.decisions.count == v2.decisions.count else {
-            addMissingOrExtra(
-                category: .controlDecisions,
-                code: "decision-count",
-                legacyCount: legacy.decisions.count,
-                v2Count: v2.decisions.count,
-                v2Completeness: v2.completeness,
-                add: add
-            )
-            return
+        let legacyHeartRateDecisions = legacy.decisions.filter {
+            $0.domain == .heartRateControl
         }
-        for (index, pair) in zip(legacy.decisions, v2.decisions).enumerated() {
-            let speedMatches: Bool
-            switch (pair.0.desiredSpeedKilometresPerHour, pair.1.desiredSpeedKilometresPerHour) {
-            case (nil, nil): speedMatches = true
-            case let (lhs?, rhs?):
-                speedMatches = abs(lhs - rhs) <= tolerance.speedKilometresPerHour
-            default: speedMatches = false
-            }
-            if pair.0.source != pair.1.source
-                || pair.0.action != pair.1.action
-                || !speedMatches
-                || abs(pair.0.elapsedMilliseconds - pair.1.elapsedMilliseconds) > tolerance.timestampMilliseconds {
-                add(
-                    .controlDecisions,
-                    "decision-mismatch-\(index)",
-                    .actualSemanticMismatch,
-                    .fail,
-                    "Control decision \(index) differs in source, action, speed target, or time."
+        let v2HeartRateDecisions = v2.decisions.filter {
+            $0.domain == .heartRateControl
+        }
+
+        let legacyActionOrder = legacyHeartRateDecisions.map(\.action)
+        let v2ActionOrder = v2HeartRateDecisions.map(\.action)
+        if legacyHeartRateDecisions.count == v2HeartRateDecisions.count,
+           legacyActionOrder != v2ActionOrder {
+            add(
+                .controlDecisions,
+                "heart-rate-control-decision-order",
+                .actualSemanticMismatch,
+                .fail,
+                "Comparable HR-control decision action order differs."
+            )
+        }
+
+        let actions = Set(legacyActionOrder + v2ActionOrder).sorted()
+        for action in actions {
+            let legacyActionDecisions = legacyHeartRateDecisions.filter { $0.action == action }
+            let v2ActionDecisions = v2HeartRateDecisions.filter { $0.action == action }
+
+            if legacyActionDecisions.count != v2ActionDecisions.count {
+                addHeartRateDecisionCountDifference(
+                    action: action,
+                    legacyCount: legacyActionDecisions.count,
+                    v2Count: v2ActionDecisions.count,
+                    v2Completeness: v2.completeness,
+                    add: add
                 )
             }
+
+            // Exact semantic action plus occurrence order is the identity rule.
+            // Speed and timestamp are compared only after that deterministic pairing.
+            for (index, pair) in zip(legacyActionDecisions, v2ActionDecisions).enumerated() {
+                let speedMatches: Bool
+                switch (pair.0.desiredSpeedKilometresPerHour, pair.1.desiredSpeedKilometresPerHour) {
+                case (nil, nil): speedMatches = true
+                case let (lhs?, rhs?):
+                    speedMatches = abs(lhs - rhs) <= tolerance.speedKilometresPerHour
+                default: speedMatches = false
+                }
+                if pair.0.source != pair.1.source
+                    || !speedMatches
+                    || abs(pair.0.elapsedMilliseconds - pair.1.elapsedMilliseconds) > tolerance.timestampMilliseconds {
+                    add(
+                        .controlDecisions,
+                        "heart-rate-control-decision-mismatch-\(action)-\(index)",
+                        .actualSemanticMismatch,
+                        .fail,
+                        "HR-control \(action) decision occurrence \(index) differs in source, speed target, or time."
+                    )
+                }
+            }
         }
+    }
+
+    private static func addHeartRateDecisionCountDifference(
+        action: String,
+        legacyCount: Int,
+        v2Count: Int,
+        v2Completeness: TelemetryParityCompleteness,
+        add: FindingSink
+    ) {
+        let v2IsMissingRequiredEvidence = v2Count < legacyCount
+        let classification: TelemetryParityFindingClass
+        let impact: TelemetryParityStatus
+        if v2IsMissingRequiredEvidence, v2Completeness != .complete {
+            classification = .v2RecorderOrDataLoss
+            impact = .inconclusive
+        } else {
+            classification = .actualSemanticMismatch
+            impact = .fail
+        }
+        add(
+            .controlDecisions,
+            "heart-rate-control-decision-count-\(action)",
+            classification,
+            impact,
+            "Comparable HR-control \(action) count: legacy=\(legacyCount), V2=\(v2Count)."
+        )
     }
 
     private static func compareTreadmillFacts(

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetrySemanticParityValidator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetrySemanticParityValidator.swift
@@ -1,0 +1,859 @@
+import Foundation
+
+public struct TelemetryParityTolerance: Equatable, Sendable {
+    public let timestampMilliseconds: Int64
+    public let speedKilometresPerHour: Double
+    public let aggregateSeconds: Int
+
+    public init(
+        timestampMilliseconds: Int64 = 1_000,
+        speedKilometresPerHour: Double = 0.001,
+        aggregateSeconds: Int = 1
+    ) {
+        self.timestampMilliseconds = timestampMilliseconds
+        self.speedKilometresPerHour = speedKilometresPerHour
+        self.aggregateSeconds = aggregateSeconds
+    }
+}
+
+public enum TelemetrySemanticParityValidator {
+    public static func validate(
+        legacy: TelemetryParitySessionEvidence,
+        telemetryV2: TelemetryParitySessionEvidence,
+        tolerance: TelemetryParityTolerance = TelemetryParityTolerance()
+    ) -> TelemetrySemanticParityReport {
+        var findings = Dictionary(
+            uniqueKeysWithValues: TelemetryParityCategory.allCases.map { ($0, [TelemetryParityFinding]()) }
+        )
+
+        func add(
+            _ category: TelemetryParityCategory,
+            _ code: String,
+            _ classification: TelemetryParityFindingClass,
+            _ impact: TelemetryParityStatus,
+            _ detail: String
+        ) {
+            findings[category, default: []].append(
+                TelemetryParityFinding(
+                    code: code,
+                    classification: classification,
+                    impact: impact,
+                    detail: detail
+                )
+            )
+        }
+
+        for limitation in legacy.limitations + telemetryV2.limitations {
+            add(
+                limitation.category,
+                limitation.code,
+                .sourceLegacyLimitation,
+                .inconclusive,
+                limitation.detail
+            )
+        }
+
+        compareLifecycle(legacy, telemetryV2, tolerance: tolerance, add: add)
+        compareHeartRate(legacy, telemetryV2, tolerance: tolerance, add: add)
+        comparePhases(legacy, telemetryV2, tolerance: tolerance, add: add)
+        compareConfiguration(legacy, telemetryV2, tolerance: tolerance, add: add)
+        compareDecisions(legacy, telemetryV2, tolerance: tolerance, add: add)
+        compareTreadmillFacts(legacy, telemetryV2, tolerance: tolerance, add: add)
+        compareCommands(legacy, telemetryV2, add: add)
+        compareAggregates(legacy, telemetryV2, tolerance: tolerance, add: add)
+        compareStopEvidence(legacy, telemetryV2, add: add)
+        inspectIntegrity(legacy, telemetryV2, add: add)
+        inspectCausality(telemetryV2, add: add)
+
+        add(
+            .physicalDeviceTruth,
+            "device-only-deferred-to-issue-37",
+            .deviceOnlyUnverified,
+            .inconclusive,
+            "Hosted parity and replay do not verify physical treadmill behavior."
+        )
+
+        let results = TelemetryParityCategory.allCases.map { category in
+            let categoryFindings = (findings[category] ?? []).sorted {
+                if $0.impact != $1.impact {
+                    return statusRank($0.impact) > statusRank($1.impact)
+                }
+                if $0.classification != $1.classification {
+                    return $0.classification.rawValue < $1.classification.rawValue
+                }
+                return $0.code < $1.code
+            }
+            return TelemetryParityCategoryResult(
+                category: category,
+                status: categoryFindings.map(\.impact).max(by: {
+                    statusRank($0) < statusRank($1)
+                }) ?? .pass,
+                findings: categoryFindings
+            )
+        }
+
+        let automatedResults = results.filter { $0.category != .physicalDeviceTruth }
+        let overallStatus = automatedResults.map(\.status).max(by: {
+            statusRank($0) < statusRank($1)
+        }) ?? .pass
+        let causalOutcomes = telemetryV2.commandEvidence.filter { $0.outcomeKind != .sent }
+        let coverage = TelemetryParityCausalCoverage(
+            factualOutcomeCount: causalOutcomes.count,
+            deterministicallyAssociatedCount: causalOutcomes.filter {
+                $0.association == .deterministicallyCorrelated && causalClaimIsSupported($0)
+            }.count,
+            honestlyUnknownCount: causalOutcomes.filter {
+                $0.association == .unknown
+                    && $0.commandIdentifier == nil
+                    && $0.attemptIdentifier == nil
+            }.count,
+            unsupportedClaimCount: causalOutcomes.filter { !causalClaimIsSupported($0) }.count
+        )
+
+        return TelemetrySemanticParityReport(
+            legacySessionIdentifier: legacy.sessionIdentifier,
+            telemetryV2SessionIdentifier: telemetryV2.sessionIdentifier,
+            overallStatus: overallStatus,
+            categories: results,
+            causalCoverage: coverage
+        )
+    }
+
+    private typealias FindingSink = (
+        TelemetryParityCategory,
+        String,
+        TelemetryParityFindingClass,
+        TelemetryParityStatus,
+        String
+    ) -> Void
+
+    private static func compareLifecycle(
+        _ legacy: TelemetryParitySessionEvidence,
+        _ v2: TelemetryParitySessionEvidence,
+        tolerance: TelemetryParityTolerance,
+        add: FindingSink
+    ) {
+        if let linked = v2.linkedLegacySessionIdentifier,
+           linked.caseInsensitiveCompare(legacy.sessionIdentifier) != .orderedSame {
+            add(
+                .lifecycle,
+                "cross-reference-mismatch",
+                .actualSemanticMismatch,
+                .fail,
+                "V2 session is linked to \(linked), not legacy session \(legacy.sessionIdentifier)."
+            )
+        }
+        compareRequiredDate(
+            legacy.lifecycle.startedAt,
+            v2.lifecycle.startedAt,
+            field: "start",
+            tolerance: tolerance,
+            v2Completeness: v2.completeness,
+            category: .lifecycle,
+            add: add
+        )
+        compareRequiredDate(
+            legacy.lifecycle.endedAt,
+            v2.lifecycle.endedAt,
+            field: "end",
+            tolerance: tolerance,
+            v2Completeness: v2.completeness,
+            category: .lifecycle,
+            add: add
+        )
+        compareOptional(
+            legacy.lifecycle.endReason,
+            v2.lifecycle.endReason,
+            field: "end-reason",
+            category: .lifecycle,
+            v2Completeness: v2.completeness,
+            add: add
+        )
+        compareOptionalInt64(
+            legacy.lifecycle.durationMilliseconds,
+            v2.lifecycle.durationMilliseconds,
+            field: "duration",
+            tolerance: tolerance.timestampMilliseconds,
+            category: .lifecycle,
+            v2Completeness: v2.completeness,
+            add: add
+        )
+    }
+
+    private static func compareHeartRate(
+        _ legacy: TelemetryParitySessionEvidence,
+        _ v2: TelemetryParitySessionEvidence,
+        tolerance: TelemetryParityTolerance,
+        add: FindingSink
+    ) {
+        guard legacy.heartRate.count == v2.heartRate.count else {
+            addMissingOrExtra(
+                category: .heartRateObservations,
+                code: "heart-rate-count",
+                legacyCount: legacy.heartRate.count,
+                v2Count: v2.heartRate.count,
+                v2Completeness: v2.completeness,
+                add: add
+            )
+            return
+        }
+        for (index, pair) in zip(legacy.heartRate, v2.heartRate).enumerated() {
+            let lhs = pair.0
+            let rhs = pair.1
+            if lhs.beatsPerMinute != rhs.beatsPerMinute
+                || lhs.acceptedForControl != rhs.acceptedForControl
+                || abs(lhs.elapsedMilliseconds - rhs.elapsedMilliseconds) > tolerance.timestampMilliseconds {
+                add(
+                    .heartRateObservations,
+                    "heart-rate-semantic-mismatch-\(index)",
+                    .actualSemanticMismatch,
+                    .fail,
+                    "HR observation \(index) differs in timestamp, BPM, or accepted-for-control state."
+                )
+            }
+        }
+        let v2Arrival = v2.heartRate.map(\.arrivalOrder)
+        if !strictlyIncreasing(v2Arrival) {
+            add(
+                .heartRateObservations,
+                "v2-arrival-order",
+                .actualSemanticMismatch,
+                .fail,
+                "V2 HR arrival order is not strictly increasing."
+            )
+        }
+    }
+
+    private static func comparePhases(
+        _ legacy: TelemetryParitySessionEvidence,
+        _ v2: TelemetryParitySessionEvidence,
+        tolerance: TelemetryParityTolerance,
+        add: FindingSink
+    ) {
+        guard legacy.phases.count == v2.phases.count else {
+            addMissingOrExtra(
+                category: .phaseAndCooldown,
+                code: "phase-count",
+                legacyCount: legacy.phases.count,
+                v2Count: v2.phases.count,
+                v2Completeness: v2.completeness,
+                add: add
+            )
+            return
+        }
+        for (index, pair) in zip(legacy.phases, v2.phases).enumerated() {
+            if pair.0.phase != pair.1.phase
+                || abs(pair.0.elapsedMilliseconds - pair.1.elapsedMilliseconds) > tolerance.timestampMilliseconds {
+                add(
+                    .phaseAndCooldown,
+                    "phase-mismatch-\(index)",
+                    .actualSemanticMismatch,
+                    .fail,
+                    "Phase boundary \(index) differs semantically."
+                )
+            }
+        }
+    }
+
+    private static func compareConfiguration(
+        _ legacy: TelemetryParitySessionEvidence,
+        _ v2: TelemetryParitySessionEvidence,
+        tolerance: TelemetryParityTolerance,
+        add: FindingSink
+    ) {
+        guard let lhs = legacy.configuration else {
+            add(
+                .configurationAndVersions,
+                "legacy-configuration-unavailable",
+                .sourceLegacyLimitation,
+                .inconclusive,
+                "Legacy source does not expose a configuration snapshot."
+            )
+            return
+        }
+        guard let rhs = v2.configuration else {
+            add(
+                .configurationAndVersions,
+                "v2-configuration-missing",
+                .v2RecorderOrDataLoss,
+                v2.completeness == .complete ? .fail : .inconclusive,
+                "V2 configuration snapshot is missing."
+            )
+            return
+        }
+
+        compareConfigurationValue(lhs.targetHeartRate, rhs.targetHeartRate, "target-heart-rate", add)
+        compareConfigurationValue(lhs.durationSeconds, rhs.durationSeconds, "duration", add)
+        compareConfigurationValue(
+            lhs.decisionIntervalSeconds,
+            rhs.decisionIntervalSeconds,
+            "decision-interval",
+            add
+        )
+        compareConfigurationValue(lhs.adaptiveStepEnabled, rhs.adaptiveStepEnabled, "adaptive-step", add)
+        compareConfigurationDouble(
+            lhs.maximumStepKilometresPerHour,
+            rhs.maximumStepKilometresPerHour,
+            "maximum-step",
+            tolerance.speedKilometresPerHour,
+            add
+        )
+        if lhs.heartRateZoneUpperBounds != rhs.heartRateZoneUpperBounds {
+            add(
+                .configurationAndVersions,
+                "zone-bounds",
+                .actualSemanticMismatch,
+                .fail,
+                "Heart-rate zone bounds differ."
+            )
+        }
+        compareConfigurationValue(
+            lhs.cooldownTargetHeartRate,
+            rhs.cooldownTargetHeartRate,
+            "cooldown-target",
+            add
+        )
+        compareConfigurationDouble(
+            lhs.cooldownMinimumSpeedKilometresPerHour,
+            rhs.cooldownMinimumSpeedKilometresPerHour,
+            "cooldown-minimum-speed",
+            tolerance.speedKilometresPerHour,
+            add
+        )
+        compareConfigurationValue(
+            lhs.cooldownMaximumSeconds,
+            rhs.cooldownMaximumSeconds,
+            "cooldown-maximum-duration",
+            add
+        )
+        compareVersion(lhs.telemetrySchemaVersion, rhs.telemetrySchemaVersion, "telemetry-schema", add)
+        compareVersion(lhs.algorithmVersion, rhs.algorithmVersion, "algorithm", add)
+        compareVersion(lhs.safetyPolicyVersion, rhs.safetyPolicyVersion, "safety-policy", add)
+        compareVersion(lhs.workoutProtocolVersion, rhs.workoutProtocolVersion, "workout-protocol", add)
+    }
+
+    private static func compareDecisions(
+        _ legacy: TelemetryParitySessionEvidence,
+        _ v2: TelemetryParitySessionEvidence,
+        tolerance: TelemetryParityTolerance,
+        add: FindingSink
+    ) {
+        guard legacy.decisions.count == v2.decisions.count else {
+            addMissingOrExtra(
+                category: .controlDecisions,
+                code: "decision-count",
+                legacyCount: legacy.decisions.count,
+                v2Count: v2.decisions.count,
+                v2Completeness: v2.completeness,
+                add: add
+            )
+            return
+        }
+        for (index, pair) in zip(legacy.decisions, v2.decisions).enumerated() {
+            let speedMatches: Bool
+            switch (pair.0.desiredSpeedKilometresPerHour, pair.1.desiredSpeedKilometresPerHour) {
+            case (nil, nil): speedMatches = true
+            case let (lhs?, rhs?):
+                speedMatches = abs(lhs - rhs) <= tolerance.speedKilometresPerHour
+            default: speedMatches = false
+            }
+            if pair.0.source != pair.1.source
+                || pair.0.action != pair.1.action
+                || !speedMatches
+                || abs(pair.0.elapsedMilliseconds - pair.1.elapsedMilliseconds) > tolerance.timestampMilliseconds {
+                add(
+                    .controlDecisions,
+                    "decision-mismatch-\(index)",
+                    .actualSemanticMismatch,
+                    .fail,
+                    "Control decision \(index) differs in source, action, speed target, or time."
+                )
+            }
+        }
+    }
+
+    private static func compareTreadmillFacts(
+        _ legacy: TelemetryParitySessionEvidence,
+        _ v2: TelemetryParitySessionEvidence,
+        tolerance: TelemetryParityTolerance,
+        add: FindingSink
+    ) {
+        if legacy.treadmillFacts.isEmpty {
+            add(
+                .treadmillFacts,
+                "legacy-factual-treadmill-evidence-unavailable",
+                .sourceLegacyLimitation,
+                .inconclusive,
+                "Legacy source contains no explicit device-reported treadmill fact to compare."
+            )
+            return
+        }
+        guard legacy.treadmillFacts.count == v2.treadmillFacts.count else {
+            addMissingOrExtra(
+                category: .treadmillFacts,
+                code: "treadmill-fact-count",
+                legacyCount: legacy.treadmillFacts.count,
+                v2Count: v2.treadmillFacts.count,
+                v2Completeness: v2.completeness,
+                add: add
+            )
+            return
+        }
+        for (index, pair) in zip(legacy.treadmillFacts, v2.treadmillFacts).enumerated() {
+            let factualSpeedMatches: Bool
+            switch (pair.0.factualSpeedKilometresPerHour, pair.1.factualSpeedKilometresPerHour) {
+            case (nil, _): factualSpeedMatches = true
+            case let (lhs?, rhs?):
+                factualSpeedMatches = abs(lhs - rhs) <= tolerance.speedKilometresPerHour
+            case (_, nil): factualSpeedMatches = false
+            }
+            if pair.0.nativeUnit != pair.1.nativeUnit
+                || abs(pair.0.nativeValue - pair.1.nativeValue) > tolerance.speedKilometresPerHour
+                || !factualSpeedMatches
+                || pair.0.deviceState != pair.1.deviceState
+                || abs(pair.0.elapsedMilliseconds - pair.1.elapsedMilliseconds) > tolerance.timestampMilliseconds {
+                add(
+                    .treadmillFacts,
+                    "treadmill-fact-mismatch-\(index)",
+                    .actualSemanticMismatch,
+                    .fail,
+                    "Explicit treadmill fact \(index) differs; desired or modelled speed was not substituted."
+                )
+            }
+        }
+    }
+
+    private static func compareCommands(
+        _ legacy: TelemetryParitySessionEvidence,
+        _ v2: TelemetryParitySessionEvidence,
+        add: FindingSink
+    ) {
+        let legacySent = legacy.commandEvidence.filter { $0.outcomeKind == .sent }.map(\.semanticCommand)
+        let v2Sent = v2.commandEvidence.filter { $0.outcomeKind == .sent }.map(\.semanticCommand)
+        if legacySent != v2Sent {
+            let isMissingV2Evidence = v2Sent.count < legacySent.count
+            add(
+                .commandLifecycle,
+                "sent-command-sequence",
+                isMissingV2Evidence ? .v2RecorderOrDataLoss : .actualSemanticMismatch,
+                isMissingV2Evidence && v2.completeness != .complete ? .inconclusive : .fail,
+                "Comparable sent-command sequence differs."
+            )
+        }
+
+        guard !legacy.limitations.contains(where: { $0.category == .commandLifecycle }) else {
+            return
+        }
+        for kind in [
+            TelemetryParityCommandOutcomeKind.acknowledgement,
+            .timeout,
+            .writeResult,
+            .observedResponse,
+        ] {
+            let legacyCount = legacy.commandEvidence.filter { $0.outcomeKind == kind }.count
+            let v2Count = v2.commandEvidence.filter { $0.outcomeKind == kind }.count
+            if legacyCount != v2Count {
+                addMissingOrExtra(
+                    category: .commandLifecycle,
+                    code: "\(kind.rawValue)-count",
+                    legacyCount: legacyCount,
+                    v2Count: v2Count,
+                    v2Completeness: v2.completeness,
+                    add: add
+                )
+            }
+        }
+    }
+
+    private static func compareAggregates(
+        _ legacy: TelemetryParitySessionEvidence,
+        _ v2: TelemetryParitySessionEvidence,
+        tolerance: TelemetryParityTolerance,
+        add: FindingSink
+    ) {
+        guard let lhs = derivedAggregates(legacy) ?? legacy.aggregates,
+              let rhs = derivedAggregates(v2) ?? v2.aggregates else {
+            add(
+                .timestampDerivedAggregates,
+                "aggregate-inputs-unavailable",
+                .sourceLegacyLimitation,
+                .inconclusive,
+                "Timestamped HR, phase, or zone inputs are insufficient for deterministic aggregate comparison."
+            )
+            return
+        }
+        if lhs.zoneSeconds.count != rhs.zoneSeconds.count
+            || zip(lhs.zoneSeconds, rhs.zoneSeconds).contains(where: {
+                abs($0.0 - $0.1) > tolerance.aggregateSeconds
+            }) {
+            add(
+                .timestampDerivedAggregates,
+                "zone-duration-mismatch",
+                .actualSemanticMismatch,
+                .fail,
+                "Timestamp-derived zone durations differ beyond \(tolerance.aggregateSeconds)s tolerance."
+            )
+        }
+        switch (lhs.cooldownCoveredSeconds, rhs.cooldownCoveredSeconds) {
+        case (nil, nil): break
+        case let (legacySeconds?, v2Seconds?) where
+            abs(legacySeconds - v2Seconds) <= tolerance.aggregateSeconds:
+            break
+        default:
+            add(
+                .timestampDerivedAggregates,
+                "cooldown-duration-mismatch",
+                .actualSemanticMismatch,
+                .fail,
+                "Timestamp-derived cooldown coverage differs beyond tolerance."
+            )
+        }
+    }
+
+    private static func compareStopEvidence(
+        _ legacy: TelemetryParitySessionEvidence,
+        _ v2: TelemetryParitySessionEvidence,
+        add: FindingSink
+    ) {
+        guard !legacy.stopEvidence.isEmpty else {
+            add(
+                .stopAndSafety,
+                "legacy-stop-truth-unavailable",
+                .sourceLegacyLimitation,
+                .inconclusive,
+                "Legacy source does not establish factual stop truth."
+            )
+            return
+        }
+        guard legacy.stopEvidence.count == v2.stopEvidence.count else {
+            addMissingOrExtra(
+                category: .stopAndSafety,
+                code: "stop-evidence-count",
+                legacyCount: legacy.stopEvidence.count,
+                v2Count: v2.stopEvidence.count,
+                v2Completeness: v2.completeness,
+                add: add
+            )
+            return
+        }
+        for (index, pair) in zip(legacy.stopEvidence, v2.stopEvidence).enumerated()
+        where pair.0.conclusion != pair.1.conclusion {
+            add(
+                .stopAndSafety,
+                "stop-conclusion-mismatch-\(index)",
+                .actualSemanticMismatch,
+                .fail,
+                "Stop conclusion \(index) differs."
+            )
+        }
+    }
+
+    private static func inspectIntegrity(
+        _ legacy: TelemetryParitySessionEvidence,
+        _ v2: TelemetryParitySessionEvidence,
+        add: FindingSink
+    ) {
+        if legacy.completeness != .complete {
+            add(
+                .recordIntegrity,
+                "legacy-session-incomplete",
+                .sourceLegacyLimitation,
+                .inconclusive,
+                "Legacy source is incomplete or its completion is unknown."
+            )
+        }
+        if legacy.integrity.duplicateRecordIdentifierCount > 0
+            || legacy.integrity.outOfOrderRecordCount > 0
+            || legacy.integrity.duplicateCanonicalSecondCount > 0
+            || legacy.integrity.unexplainedFrameGapCount > 0 {
+            add(
+                .recordIntegrity,
+                "legacy-record-order-or-integrity-limitation",
+                .sourceLegacyLimitation,
+                .inconclusive,
+                "Legacy source contains duplicate or out-of-order evidence that limits comparison."
+            )
+        }
+        if v2.completeness != .complete {
+            add(
+                .recordIntegrity,
+                "v2-session-incomplete",
+                .v2RecorderOrDataLoss,
+                .inconclusive,
+                "V2 session is not represented complete."
+            )
+        }
+        if v2.integrity.lostCriticalRecordCount > 0 || v2.integrity.lostNativeRecordCount > 0 {
+            add(
+                .recordIntegrity,
+                "v2-native-or-critical-loss",
+                .v2RecorderOrDataLoss,
+                .fail,
+                "V2 reports lost critical=\(v2.integrity.lostCriticalRecordCount), native=\(v2.integrity.lostNativeRecordCount)."
+            )
+        }
+        if v2.integrity.duplicateRecordIdentifierCount > 0
+            || v2.integrity.outOfOrderRecordCount > 0
+            || v2.integrity.duplicateCanonicalSecondCount > 0
+            || v2.integrity.unexplainedFrameGapCount > 0 {
+            add(
+                .recordIntegrity,
+                "v2-record-order-or-frame-integrity",
+                .actualSemanticMismatch,
+                .fail,
+                "V2 contains duplicate IDs, out-of-order records, duplicate frame seconds, or unexplained frame gaps."
+            )
+        }
+    }
+
+    private static func inspectCausality(
+        _ v2: TelemetryParitySessionEvidence,
+        add: FindingSink
+    ) {
+        let outcomes = v2.commandEvidence.filter { $0.outcomeKind != .sent }
+        for (index, outcome) in outcomes.enumerated() {
+            if !causalClaimIsSupported(outcome) {
+                add(
+                    .causalAssociation,
+                    "unsupported-causal-edge-\(index)",
+                    .unsupportedCausalEdge,
+                    .fail,
+                    "\(outcome.outcomeKind.rawValue) claims command/attempt ownership without independently sufficient evidence."
+                )
+            } else if outcome.association == .unknown {
+                add(
+                    .causalAssociation,
+                    "honest-unknown-association-\(index)",
+                    .protocolRuntimeCausalAmbiguity,
+                    .pass,
+                    "\(outcome.outcomeKind.rawValue) remains factual with nil command and attempt IDs."
+                )
+            }
+        }
+    }
+
+    private static func causalClaimIsSupported(
+        _ outcome: TelemetryParityCommandEvidence
+    ) -> Bool {
+        switch outcome.association {
+        case .unknown:
+            return outcome.commandIdentifier == nil
+                && outcome.attemptIdentifier == nil
+        case .deterministicallyCorrelated:
+            // The accepted runtime persists no independently verifiable proof
+            // token. A typed claim or matching IDs alone are not proof.
+            return false
+        }
+    }
+
+    private static func derivedAggregates(
+        _ evidence: TelemetryParitySessionEvidence,
+        freshnessMilliseconds: Int64 = 5_000
+    ) -> TelemetryParityAggregateEvidence? {
+        guard let configuration = evidence.configuration,
+              !configuration.heartRateZoneUpperBounds.isEmpty,
+              !evidence.heartRate.isEmpty else { return nil }
+        let ordered = evidence.heartRate.sorted {
+            if $0.elapsedMilliseconds != $1.elapsedMilliseconds {
+                return $0.elapsedMilliseconds < $1.elapsedMilliseconds
+            }
+            return $0.arrivalOrder < $1.arrivalOrder
+        }
+        var zoneMilliseconds = Array(
+            repeating: Int64(0),
+            count: configuration.heartRateZoneUpperBounds.count + 1
+        )
+        for index in ordered.indices {
+            let current = ordered[index]
+            let nextElapsed = index + 1 < ordered.count
+                ? ordered[index + 1].elapsedMilliseconds
+                : (evidence.lifecycle.durationMilliseconds ?? current.elapsedMilliseconds)
+            let interval = max(
+                0,
+                min(nextElapsed - current.elapsedMilliseconds, freshnessMilliseconds)
+            )
+            let zone = configuration.heartRateZoneUpperBounds.firstIndex {
+                current.beatsPerMinute <= $0
+            } ?? configuration.heartRateZoneUpperBounds.count
+            zoneMilliseconds[zone] += interval
+        }
+
+        let cooldownStart = evidence.phases.first { $0.phase == "cooldown" }?.elapsedMilliseconds
+        let finished = evidence.phases.first { $0.phase == "finished" }?.elapsedMilliseconds
+            ?? evidence.lifecycle.durationMilliseconds
+        let cooldownSeconds: Int?
+        if let cooldownStart, let finished, finished >= cooldownStart {
+            cooldownSeconds = Int(((Double(finished - cooldownStart) / 1_000.0).rounded()))
+        } else {
+            cooldownSeconds = nil
+        }
+        return TelemetryParityAggregateEvidence(
+            zoneSeconds: zoneMilliseconds.map {
+                Int((Double($0) / 1_000.0).rounded())
+            },
+            cooldownCoveredSeconds: cooldownSeconds
+        )
+    }
+
+    private static func compareRequiredDate(
+        _ legacy: Date?,
+        _ v2: Date?,
+        field: String,
+        tolerance: TelemetryParityTolerance,
+        v2Completeness: TelemetryParityCompleteness,
+        category: TelemetryParityCategory,
+        add: FindingSink
+    ) {
+        switch (legacy, v2) {
+        case let (lhs?, rhs?):
+            if abs(lhs.timeIntervalSince(rhs) * 1_000) > Double(tolerance.timestampMilliseconds) {
+                add(
+                    category,
+                    "\(field)-timestamp-mismatch",
+                    .actualSemanticMismatch,
+                    .fail,
+                    "Comparable \(field) timestamps differ beyond tolerance."
+                )
+            }
+        case (nil, _):
+            add(
+                category,
+                "legacy-\(field)-missing",
+                .sourceLegacyLimitation,
+                .inconclusive,
+                "Legacy \(field) timestamp is unavailable."
+            )
+        case (_, nil):
+            add(
+                category,
+                "v2-\(field)-missing",
+                .v2RecorderOrDataLoss,
+                v2Completeness == .complete ? .fail : .inconclusive,
+                "V2 \(field) timestamp is unavailable."
+            )
+        }
+    }
+
+    private static func compareOptional<T: Equatable>(
+        _ legacy: T?,
+        _ v2: T?,
+        field: String,
+        category: TelemetryParityCategory,
+        v2Completeness: TelemetryParityCompleteness,
+        add: FindingSink
+    ) {
+        switch (legacy, v2) {
+        case let (lhs?, rhs?) where lhs != rhs:
+            add(category, "\(field)-mismatch", .actualSemanticMismatch, .fail, "\(field) differs.")
+        case (nil, _):
+            add(category, "legacy-\(field)-missing", .sourceLegacyLimitation, .inconclusive, "Legacy \(field) is unavailable.")
+        case (_, nil):
+            add(category, "v2-\(field)-missing", .v2RecorderOrDataLoss, v2Completeness == .complete ? .fail : .inconclusive, "V2 \(field) is unavailable.")
+        default:
+            break
+        }
+    }
+
+    private static func compareOptionalInt64(
+        _ legacy: Int64?,
+        _ v2: Int64?,
+        field: String,
+        tolerance: Int64,
+        category: TelemetryParityCategory,
+        v2Completeness: TelemetryParityCompleteness,
+        add: FindingSink
+    ) {
+        switch (legacy, v2) {
+        case let (lhs?, rhs?) where abs(lhs - rhs) > tolerance:
+            add(category, "\(field)-mismatch", .actualSemanticMismatch, .fail, "\(field) differs beyond tolerance.")
+        case (nil, _):
+            add(category, "legacy-\(field)-missing", .sourceLegacyLimitation, .inconclusive, "Legacy \(field) is unavailable.")
+        case (_, nil):
+            add(category, "v2-\(field)-missing", .v2RecorderOrDataLoss, v2Completeness == .complete ? .fail : .inconclusive, "V2 \(field) is unavailable.")
+        default:
+            break
+        }
+    }
+
+    private static func addMissingOrExtra(
+        category: TelemetryParityCategory,
+        code: String,
+        legacyCount: Int,
+        v2Count: Int,
+        v2Completeness: TelemetryParityCompleteness,
+        add: FindingSink
+    ) {
+        let v2IsMissingEvidence = v2Count < legacyCount
+        let classification: TelemetryParityFindingClass = v2IsMissingEvidence
+            ? .v2RecorderOrDataLoss
+            : .actualSemanticMismatch
+        let impact: TelemetryParityStatus = v2IsMissingEvidence && v2Completeness != .complete
+            ? .inconclusive
+            : .fail
+        add(
+            category,
+            code,
+            classification,
+            impact,
+            "Legacy count=\(legacyCount), V2 count=\(v2Count)."
+        )
+    }
+
+    private static func compareConfigurationValue<T: Equatable>(
+        _ lhs: T?,
+        _ rhs: T?,
+        _ field: String,
+        _ add: FindingSink
+    ) {
+        switch (lhs, rhs) {
+        case let (lhs?, rhs?) where lhs != rhs:
+            add(.configurationAndVersions, field, .actualSemanticMismatch, .fail, "Configuration field \(field) differs.")
+        case (nil, _):
+            add(.configurationAndVersions, "legacy-\(field)-missing", .sourceLegacyLimitation, .inconclusive, "Legacy configuration field \(field) is unavailable.")
+        case (_, nil):
+            add(.configurationAndVersions, "v2-\(field)-missing", .v2RecorderOrDataLoss, .fail, "V2 configuration field \(field) is unavailable.")
+        default:
+            break
+        }
+    }
+
+    private static func compareConfigurationDouble(
+        _ lhs: Double?,
+        _ rhs: Double?,
+        _ field: String,
+        _ tolerance: Double,
+        _ add: FindingSink
+    ) {
+        switch (lhs, rhs) {
+        case let (lhs?, rhs?) where abs(lhs - rhs) > tolerance:
+            add(.configurationAndVersions, field, .actualSemanticMismatch, .fail, "Configuration field \(field) differs.")
+        case (nil, _):
+            add(.configurationAndVersions, "legacy-\(field)-missing", .sourceLegacyLimitation, .inconclusive, "Legacy configuration field \(field) is unavailable.")
+        case (_, nil):
+            add(.configurationAndVersions, "v2-\(field)-missing", .v2RecorderOrDataLoss, .fail, "V2 configuration field \(field) is unavailable.")
+        default:
+            break
+        }
+    }
+
+    private static func compareVersion(
+        _ lhs: String?,
+        _ rhs: String?,
+        _ field: String,
+        _ add: FindingSink
+    ) {
+        compareConfigurationValue(lhs, rhs, field, add)
+    }
+
+    private static func strictlyIncreasing<T: Comparable>(_ values: [T]) -> Bool {
+        zip(values, values.dropFirst()).allSatisfy(<)
+    }
+
+    private static func statusRank(_ status: TelemetryParityStatus) -> Int {
+        switch status {
+        case .pass: 0
+        case .inconclusive: 1
+        case .fail: 2
+        }
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetrySemanticParityValidator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetrySemanticParityValidator.swift
@@ -441,15 +441,20 @@ public enum TelemetrySemanticParityValidator {
             )
         }
 
-        guard !legacy.limitations.contains(where: { $0.category == .commandLifecycle }) else {
-            return
-        }
         for kind in [
             TelemetryParityCommandOutcomeKind.acknowledgement,
             .timeout,
             .writeResult,
             .observedResponse,
         ] {
+            let sourceCannotCompareAssociation = legacy.limitations.contains {
+                $0.category == .commandLifecycle
+                    && $0.code == "legacy-jsonl-ack-acceptance-not-explicit"
+            }
+            if sourceCannotCompareAssociation
+                && (kind == .acknowledgement || kind == .observedResponse) {
+                continue
+            }
             let legacyCount = legacy.commandEvidence.filter { $0.outcomeKind == kind }.count
             let v2Count = v2.commandEvidence.filter { $0.outcomeKind == kind }.count
             if legacyCount != v2Count {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetrySemanticParityValidator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetrySemanticParityValidator.swift
@@ -407,10 +407,16 @@ public enum TelemetrySemanticParityValidator {
                 factualSpeedMatches = abs(lhs - rhs) <= tolerance.speedKilometresPerHour
             case (_, nil): factualSpeedMatches = false
             }
+            let deviceStateMatches: Bool
+            switch (pair.0.deviceState, pair.1.deviceState) {
+            case (nil, _): deviceStateMatches = true
+            case let (lhs?, rhs?): deviceStateMatches = lhs == rhs
+            case (_, nil): deviceStateMatches = false
+            }
             if pair.0.nativeUnit != pair.1.nativeUnit
                 || abs(pair.0.nativeValue - pair.1.nativeValue) > tolerance.speedKilometresPerHour
                 || !factualSpeedMatches
-                || pair.0.deviceState != pair.1.deviceState
+                || !deviceStateMatches
                 || abs(pair.0.elapsedMilliseconds - pair.1.elapsedMilliseconds) > tolerance.timestampMilliseconds {
                 add(
                     .treadmillFacts,

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryV2ParityReader.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryV2ParityReader.swift
@@ -1,0 +1,460 @@
+import Foundation
+import TelemetryDomain
+import TelemetryPersistence
+import TelemetryRuntime
+
+public enum TelemetryV2ParityReaderError: Error, Equatable, Sendable {
+    case sessionNotFound(SessionID)
+    case invalidConfigurationSnapshot
+}
+
+public enum TelemetryV2ParityReader {
+    public static func read(
+        from store: TelemetryStore,
+        sessionID: SessionID
+    ) async throws -> TelemetryParitySessionEvidence {
+        let sessions = try await store.fetchSessions()
+        guard let session = sessions.first(where: { $0.sessionID == sessionID }) else {
+            throw TelemetryV2ParityReaderError.sessionNotFound(sessionID)
+        }
+        let heartRate = try await store.fetchHeartRate(sessionID: sessionID)
+        let treadmill = try await store.fetchTreadmill(sessionID: sessionID)
+        let events = try await store.fetchEvents(sessionID: sessionID)
+        let frames = try await store.fetchFrames(sessionID: sessionID)
+        return try read(
+            session: session,
+            heartRate: heartRate,
+            treadmill: treadmill,
+            events: events,
+            frames: frames
+        )
+    }
+
+    public static func read(
+        session: WorkoutSessionRecord,
+        heartRate: [HeartRateObservation],
+        treadmill: [TreadmillObservation],
+        events: [WorkoutEvent],
+        frames: [CanonicalFrame]
+    ) throws -> TelemetryParitySessionEvidence {
+        let decoder = JSONDecoder()
+        guard let configuration = try? decoder.decode(
+            TelemetryV2ConfigurationInput.self,
+            from: session.configuration.canonicalPayload
+        ) else {
+            throw TelemetryV2ParityReaderError.invalidConfigurationSnapshot
+        }
+
+        let orderedEvents = events.sorted {
+            if $0.timestamp.occurredElapsed != $1.timestamp.occurredElapsed {
+                return $0.timestamp.occurredElapsed < $1.timestamp.occurredElapsed
+            }
+            return $0.recordID.description < $1.recordID.description
+        }
+        let lifecycleEvents = orderedEvents.compactMap { event -> SessionLifecycleEvent? in
+            guard case let .sessionLifecycle(lifecycle) = event.payload.payload else { return nil }
+            return lifecycle
+        }
+        let endReason = lifecycleEvents.last(where: {
+            $0.current == .completed || $0.current == .incomplete || $0.current == .cancelled
+        })?.reason ?? lifecycleEvents.last?.incompleteReason ?? session.incompleteReason
+
+        let phases = orderedEvents.compactMap { event -> TelemetryParityPhaseEvidence? in
+            guard case let .workoutPhase(transition) = event.payload.payload else { return nil }
+            return TelemetryParityPhaseEvidence(
+                phase: phaseName(transition.current),
+                elapsedMilliseconds: milliseconds(event.timestamp.occurredElapsed)
+            )
+        }
+        let deliveryHeartRate = orderedEvents.compactMap { event -> TelemetryParityHeartRateEvidence? in
+            guard case let .heartRateEvidence(.delivery(result)) = event.payload.payload else {
+                return nil
+            }
+            return TelemetryParityHeartRateEvidence(
+                elapsedMilliseconds: milliseconds(event.timestamp.occurredElapsed),
+                receivedAt: result.delivery.receivedAt,
+                beatsPerMinute: result.delivery.beatsPerMinute,
+                acceptedForControl: result.delivery.acceptedIntoLegacyControllerState,
+                arrivalOrder: result.delivery.arrivalOrder
+            )
+        }
+        let mappedHeartRate = deliveryHeartRate.isEmpty ? heartRate.map {
+            TelemetryParityHeartRateEvidence(
+                elapsedMilliseconds: milliseconds($0.timestamp.receivedElapsed),
+                receivedAt: $0.timestamp.receivedAt,
+                beatsPerMinute: Int($0.beatsPerMinute),
+                acceptedForControl: $0.controlUse.acceptedForControl,
+                arrivalOrder: $0.arrivalOrder
+            )
+        } : deliveryHeartRate
+        let mappedTreadmill = treadmill.map {
+            TelemetryParityTreadmillFact(
+                elapsedMilliseconds: milliseconds($0.timestamp.receivedElapsed),
+                nativeValue: $0.nativeSpeed.value,
+                nativeUnit: nativeUnitName($0.nativeSpeed.unit),
+                factualSpeedKilometresPerHour: $0.factualSpeed?.value,
+                deviceState: $0.deviceState.rawValue
+            )
+        }
+        let decisions = orderedEvents.compactMap(decisionEvidence)
+        let commandEvidence = commandEvidence(from: orderedEvents)
+        let stops = orderedEvents.compactMap(stopEvidence)
+        let integrity = integrityEvidence(
+            session: session,
+            heartRate: heartRate,
+            treadmill: treadmill,
+            events: events,
+            frames: frames
+        )
+        let completeness: TelemetryParityCompleteness = session.lifecycleState == .completed
+            && session.recorderHealth.isComplete ? .complete : .incomplete
+
+        return TelemetryParitySessionEvidence(
+            origin: .telemetryV2,
+            sessionIdentifier: session.sessionID.description,
+            linkedLegacySessionIdentifier: session.sessionID.description,
+            completeness: completeness,
+            lifecycle: TelemetryParityLifecycleEvidence(
+                startedAt: session.startedAt,
+                endedAt: session.endedAt,
+                endReason: endReason,
+                durationMilliseconds: session.endedElapsed.map(milliseconds)
+            ),
+            heartRate: mappedHeartRate,
+            phases: phases,
+            configuration: TelemetryParityConfigurationEvidence(
+                targetHeartRate: configuration.targetHeartRate,
+                durationSeconds: configuration.durationMinutes * 60,
+                decisionIntervalSeconds: configuration.decisionIntervalSeconds,
+                adaptiveStepEnabled: configuration.adaptiveStepEnabled,
+                maximumStepKilometresPerHour: configuration.maximumStepKilometresPerHour,
+                heartRateZoneUpperBounds: configuration.heartRateZones,
+                cooldownTargetHeartRate: configuration.cooldownTargetHeartRate,
+                cooldownMinimumSpeedKilometresPerHour: configuration.cooldownMinimumSpeedKilometresPerHour,
+                cooldownMaximumSeconds: configuration.cooldownMaximumMinutes * 60,
+                telemetrySchemaVersion: session.versions.telemetrySchema.rawValue,
+                algorithmVersion: session.versions.algorithm.rawValue,
+                safetyPolicyVersion: session.versions.safetyPolicy.rawValue,
+                workoutProtocolVersion: session.versions.workoutProtocol.rawValue
+            ),
+            decisions: decisions,
+            treadmillFacts: mappedTreadmill,
+            commandEvidence: commandEvidence,
+            aggregates: nil,
+            stopEvidence: stops,
+            integrity: integrity,
+            limitations: []
+        )
+    }
+
+    private static func decisionEvidence(
+        _ event: WorkoutEvent
+    ) -> TelemetryParityDecisionEvidence? {
+        switch event.payload.payload {
+        case let .treadmillEvidence(.decision(decision)):
+            let mapped = mappedDecisionIntent(decision.intent)
+            return TelemetryParityDecisionEvidence(
+                source: decision.source.rawValue,
+                action: mapped.action,
+                desiredSpeedKilometresPerHour: mapped.speed,
+                elapsedMilliseconds: milliseconds(event.timestamp.occurredElapsed)
+            )
+        case let .controlDecision(decision):
+            let mapped = mappedControlAction(decision.action)
+            return TelemetryParityDecisionEvidence(
+                source: "controlDecision",
+                action: mapped.action,
+                desiredSpeedKilometresPerHour: mapped.speed,
+                elapsedMilliseconds: milliseconds(event.timestamp.occurredElapsed)
+            )
+        default:
+            return nil
+        }
+    }
+
+    private static func commandEvidence(
+        from events: [WorkoutEvent]
+    ) -> [TelemetryParityCommandEvidence] {
+        var semanticCommands: [String: String] = [:]
+        for event in events {
+            switch event.payload.payload {
+            case let .treadmillEvidence(.commandEnqueued(enqueued)):
+                semanticCommands[enqueued.commandID.description] = semanticCommand(enqueued.kind)
+            case let .commandLifecycle(record):
+                if case let .enqueued(kind) = record.lifecycle {
+                    semanticCommands[record.commandID.description] = semanticCommand(kind)
+                }
+            default:
+                break
+            }
+        }
+
+        var result: [TelemetryParityCommandEvidence] = []
+
+        for event in events {
+            let elapsedMilliseconds = milliseconds(event.timestamp.occurredElapsed)
+            switch event.payload.payload {
+            case let .treadmillEvidence(.commandEnqueued(enqueued)):
+                semanticCommands[enqueued.commandID.description] = semanticCommand(enqueued.kind)
+            case let .treadmillEvidence(.sendAttempt(attempt)):
+                result.append(
+                    TelemetryParityCommandEvidence(
+                        outcomeKind: .sent,
+                        semanticCommand: semanticCommands[attempt.commandID.description],
+                        elapsedMilliseconds: elapsedMilliseconds,
+                        association: .deterministicallyCorrelated,
+                        commandIdentifier: attempt.commandID.description,
+                        attemptIdentifier: attempt.attemptID.description
+                    )
+                )
+            case let .treadmillEvidence(.acknowledgement(acknowledgement)):
+                result.append(
+                    causalOutcome(
+                        kind: .acknowledgement,
+                        association: acknowledgement.association,
+                        elapsedMilliseconds: elapsedMilliseconds
+                    )
+                )
+            case let .treadmillEvidence(.commandTimeout(timeout)):
+                result.append(
+                    causalOutcome(
+                        kind: .timeout,
+                        association: timeout.association,
+                        elapsedMilliseconds: elapsedMilliseconds
+                    )
+                )
+            case let .treadmillEvidence(.writeResult(writeResult)):
+                result.append(
+                    causalOutcome(
+                        kind: .writeResult,
+                        association: writeResult.association,
+                        elapsedMilliseconds: elapsedMilliseconds
+                    )
+                )
+            case let .treadmillEvidence(.observation(observation)):
+                if case let .deterministicallyCorrelated(commandID, attemptID) = observation.responseAssociation {
+                    result.append(
+                        TelemetryParityCommandEvidence(
+                            outcomeKind: .observedResponse,
+                            semanticCommand: semanticCommands[commandID.description],
+                            elapsedMilliseconds: elapsedMilliseconds,
+                            association: .deterministicallyCorrelated,
+                            commandIdentifier: commandID.description,
+                            attemptIdentifier: attemptID.description
+                        )
+                    )
+                }
+            case let .commandLifecycle(record):
+                result.append(
+                    contentsOf: genericCommandEvidence(
+                        record,
+                        semanticCommand: semanticCommands[record.commandID.description],
+                        elapsedMilliseconds: elapsedMilliseconds
+                    )
+                )
+            default:
+                break
+            }
+        }
+        return result
+    }
+
+    private static func causalOutcome(
+        kind: TelemetryParityCommandOutcomeKind,
+        association: LegacyAcknowledgementAssociation,
+        elapsedMilliseconds: Int64
+    ) -> TelemetryParityCommandEvidence {
+        switch association {
+        case .unresolvedByLegacyRuntime:
+            return TelemetryParityCommandEvidence(
+                outcomeKind: kind,
+                semanticCommand: nil,
+                elapsedMilliseconds: elapsedMilliseconds,
+                association: .unknown,
+                commandIdentifier: nil,
+                attemptIdentifier: nil
+            )
+        case let .deterministicallyCorrelated(commandID, attemptID):
+            return TelemetryParityCommandEvidence(
+                outcomeKind: kind,
+                semanticCommand: nil,
+                elapsedMilliseconds: elapsedMilliseconds,
+                association: .deterministicallyCorrelated,
+                commandIdentifier: commandID.description,
+                attemptIdentifier: attemptID.description
+            )
+        }
+    }
+
+    private static func genericCommandEvidence(
+        _ record: CommandLifecycleRecord,
+        semanticCommand: String?,
+        elapsedMilliseconds: Int64
+    ) -> [TelemetryParityCommandEvidence] {
+        switch record.lifecycle {
+        case .enqueued:
+            return []
+        case let .sendAttempt(attemptID, _):
+            return [
+                TelemetryParityCommandEvidence(
+                    outcomeKind: .sent,
+                    semanticCommand: semanticCommand,
+                    elapsedMilliseconds: elapsedMilliseconds,
+                    association: .deterministicallyCorrelated,
+                    commandIdentifier: record.commandID.description,
+                    attemptIdentifier: attemptID.description
+                )
+            ]
+        case let .acknowledged(attemptID):
+            return [unsupportedGenericOutcome(.acknowledgement, record, attemptID, elapsedMilliseconds)]
+        case let .timedOut(attemptID):
+            return [unsupportedGenericOutcome(.timeout, record, attemptID, elapsedMilliseconds)]
+        default:
+            return []
+        }
+    }
+
+    private static func unsupportedGenericOutcome(
+        _ kind: TelemetryParityCommandOutcomeKind,
+        _ record: CommandLifecycleRecord,
+        _ attemptID: CommandAttemptID,
+        _ elapsedMilliseconds: Int64
+    ) -> TelemetryParityCommandEvidence {
+        TelemetryParityCommandEvidence(
+            outcomeKind: kind,
+            semanticCommand: nil,
+            elapsedMilliseconds: elapsedMilliseconds,
+            association: .deterministicallyCorrelated,
+            commandIdentifier: record.commandID.description,
+            attemptIdentifier: attemptID.description
+        )
+    }
+
+    private static func stopEvidence(_ event: WorkoutEvent) -> TelemetryParityStopEvidence? {
+        let conclusion: StopEvidenceConclusion
+        switch event.payload.payload {
+        case let .treadmillEvidence(.stopEvidence(stop)):
+            conclusion = stop.conclusion
+        case let .stopEvidence(stop):
+            conclusion = stop.conclusion
+        default:
+            return nil
+        }
+        switch conclusion {
+        case let .confirmedByFreshFactualObservation(observationID):
+            return TelemetryParityStopEvidence(
+                conclusion: "confirmed",
+                factualObservationIdentifier: observationID.description,
+                elapsedMilliseconds: milliseconds(event.timestamp.occurredElapsed)
+            )
+        case .unconfirmed:
+            return TelemetryParityStopEvidence(
+                conclusion: "unconfirmed",
+                factualObservationIdentifier: nil,
+                elapsedMilliseconds: milliseconds(event.timestamp.occurredElapsed)
+            )
+        case .contradictory:
+            return TelemetryParityStopEvidence(
+                conclusion: "contradictory",
+                factualObservationIdentifier: nil,
+                elapsedMilliseconds: milliseconds(event.timestamp.occurredElapsed)
+            )
+        }
+    }
+
+    private static func integrityEvidence(
+        session: WorkoutSessionRecord,
+        heartRate: [HeartRateObservation],
+        treadmill: [TreadmillObservation],
+        events: [WorkoutEvent],
+        frames: [CanonicalFrame]
+    ) -> TelemetryParityIntegrityEvidence {
+        let identifiers = [session.recordID.description]
+            + heartRate.map { $0.recordID.description }
+            + treadmill.map { $0.recordID.description }
+            + events.map { $0.recordID.description }
+            + frames.map { $0.recordID.description }
+        let duplicateIdentifiers = identifiers.count - Set(identifiers).count
+        let outOfOrder = outOfOrderCount(heartRate.map(\.arrivalOrder))
+            + outOfOrderCount(treadmill.map(\.arrivalOrder))
+        let frameSeconds = frames.map(\.canonicalElapsedSecond)
+        let duplicateSeconds = frameSeconds.count - Set(frameSeconds).count
+        let sortedFrames = frames.sorted { $0.canonicalElapsedSecond < $1.canonicalElapsedSecond }
+        var unexplainedGaps = 0
+        for (index, frame) in sortedFrames.enumerated() {
+            let expected = index == 0 ? 0 : sortedFrames[index - 1].canonicalElapsedSecond + 1
+            if frame.canonicalElapsedSecond > expected && frame.precedingGap == nil {
+                unexplainedGaps += 1
+            }
+        }
+        return TelemetryParityIntegrityEvidence(
+            duplicateRecordIdentifierCount: duplicateIdentifiers,
+            outOfOrderRecordCount: outOfOrder,
+            duplicateCanonicalSecondCount: duplicateSeconds,
+            unexplainedFrameGapCount: unexplainedGaps,
+            lostCriticalRecordCount: session.recorderHealth.lostCriticalRecordCount,
+            lostNativeRecordCount: session.recorderHealth.lostNativeRecordCount
+        )
+    }
+
+    private static func mappedDecisionIntent(
+        _ intent: TreadmillControlDecisionIntent
+    ) -> (action: String, speed: Double?) {
+        switch intent {
+        case let .startAtDesiredSpeed(speed): ("start", speed.value)
+        case let .setDesiredSpeed(speed): ("setSpeed", speed.value)
+        case .stop: ("stop", nil)
+        case .hold: ("hold", nil)
+        case .requestControl: ("requestControl", nil)
+        case .queryControllerUnits: ("queryControllerUnits", nil)
+        case let .other(value): (value, nil)
+        }
+    }
+
+    private static func mappedControlAction(_ action: ControlAction) -> (action: String, speed: Double?) {
+        switch action {
+        case .noCommand: ("hold", nil)
+        case let .enqueueSpeed(speed): ("setSpeed", speed.value)
+        case .enqueueStop: ("stop", nil)
+        }
+    }
+
+    private static func semanticCommand(_ kind: CommandKind) -> String {
+        switch kind {
+        case .setSpeed: "setSpeed"
+        case .stop: "stop"
+        case let .other(value): value
+        }
+    }
+
+    private static func phaseName(_ phase: WorkoutPhase) -> String {
+        switch phase {
+        case .warmup: "warmup"
+        case .main: "main"
+        case .cooldown: "cooldown"
+        case .finished: "finished"
+        case .unknown: "unknown"
+        case let .other(value): value
+        }
+    }
+
+    private static func nativeUnitName(_ unit: TreadmillNativeSpeedUnit) -> String {
+        switch unit {
+        case .kilometresPerHour: "kilometres_per_hour"
+        case .milesPerHour: "miles_per_hour"
+        case let .controllerNative(code):
+            code == "walkingPad-tenths"
+                ? "walkingpad_controller_tenths"
+                : code.map { "controller_native:\($0)" } ?? "controller_native"
+        case .unknown: "unknown"
+        }
+    }
+
+    private static func outOfOrderCount<T: Comparable>(_ values: [T]) -> Int {
+        zip(values, values.dropFirst()).filter { pair in pair.0 >= pair.1 }.count
+    }
+
+    private static func milliseconds(_ elapsed: ElapsedDuration) -> Int64 {
+        elapsed.microseconds / 1_000
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryV2ParityReader.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryV2ParityReader.swift
@@ -232,7 +232,19 @@ public enum TelemetryV2ParityReader {
                     )
                 )
             case let .treadmillEvidence(.observation(observation)):
-                if case let .deterministicallyCorrelated(commandID, attemptID) = observation.responseAssociation {
+                switch observation.responseAssociation {
+                case .unassociated:
+                    result.append(
+                        TelemetryParityCommandEvidence(
+                            outcomeKind: .observedResponse,
+                            semanticCommand: nil,
+                            elapsedMilliseconds: elapsedMilliseconds,
+                            association: .unknown,
+                            commandIdentifier: nil,
+                            attemptIdentifier: nil
+                        )
+                    )
+                case let .deterministicallyCorrelated(commandID, attemptID):
                     result.append(
                         TelemetryParityCommandEvidence(
                             outcomeKind: .observedResponse,

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryV2ParityReader.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryV2ParityReader.swift
@@ -377,6 +377,9 @@ public enum TelemetryV2ParityReader {
         let duplicateIdentifiers = identifiers.count - Set(identifiers).count
         let outOfOrder = outOfOrderCount(heartRate.map(\.arrivalOrder))
             + outOfOrderCount(treadmill.map(\.arrivalOrder))
+            + zip(events, events.dropFirst()).filter {
+                $0.timestamp.occurredElapsed > $1.timestamp.occurredElapsed
+            }.count
         let frameSeconds = frames.map(\.canonicalElapsedSecond)
         let duplicateSeconds = frameSeconds.count - Set(frameSeconds).count
         let sortedFrames = frames.sorted { $0.canonicalElapsedSecond < $1.canonicalElapsedSecond }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryV2ParityReader.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryV2ParityReader.swift
@@ -154,6 +154,9 @@ public enum TelemetryV2ParityReader {
         case let .treadmillEvidence(.decision(decision)):
             let mapped = mappedDecisionIntent(decision.intent)
             return TelemetryParityDecisionEvidence(
+                domain: decision.source == .heartRateControl
+                    ? .heartRateControl
+                    : .outsideHeartRateControl,
                 source: decision.source.rawValue,
                 action: mapped.action,
                 desiredSpeedKilometresPerHour: mapped.speed,
@@ -162,6 +165,7 @@ public enum TelemetryV2ParityReader {
         case let .controlDecision(decision):
             let mapped = mappedControlAction(decision.action)
             return TelemetryParityDecisionEvidence(
+                domain: .unclassified,
                 source: "controlDecision",
                 action: mapped.action,
                 desiredSpeedKilometresPerHour: mapped.speed,

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryV2ParityReader.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryParity/TelemetryV2ParityReader.swift
@@ -154,19 +154,27 @@ public enum TelemetryV2ParityReader {
         case let .treadmillEvidence(.decision(decision)):
             let mapped = mappedDecisionIntent(decision.intent)
             return TelemetryParityDecisionEvidence(
-                domain: decision.source == .heartRateControl
-                    ? .heartRateControl
-                    : .outsideHeartRateControl,
+                domain: .outsideHeartRateControl,
                 source: decision.source.rawValue,
                 action: mapped.action,
                 desiredSpeedKilometresPerHour: mapped.speed,
                 elapsedMilliseconds: milliseconds(event.timestamp.occurredElapsed)
             )
         case let .controlDecision(decision):
-            let mapped = mappedControlAction(decision.action)
+            guard case .heartRate = decision.target else {
+                let mapped = mappedControlAction(decision.action)
+                return TelemetryParityDecisionEvidence(
+                    domain: .unclassified,
+                    source: "controlDecision",
+                    action: mapped.action,
+                    desiredSpeedKilometresPerHour: mapped.speed,
+                    elapsedMilliseconds: milliseconds(event.timestamp.occurredElapsed)
+                )
+            }
+            let mapped = mappedSemanticHeartRateDecision(decision)
             return TelemetryParityDecisionEvidence(
-                domain: .unclassified,
-                source: "controlDecision",
+                domain: .heartRateControl,
+                source: "heartRateControl",
                 action: mapped.action,
                 desiredSpeedKilometresPerHour: mapped.speed,
                 elapsedMilliseconds: milliseconds(event.timestamp.occurredElapsed)
@@ -435,6 +443,23 @@ public enum TelemetryV2ParityReader {
         case .noCommand: ("hold", nil)
         case let .enqueueSpeed(speed): ("setSpeed", speed.value)
         case .enqueueStop: ("stop", nil)
+        }
+    }
+
+    private static func mappedSemanticHeartRateDecision(
+        _ decision: ControlDecision
+    ) -> (action: String, speed: Double?) {
+        switch (decision.action, decision.reason) {
+        case let (.enqueueSpeed(speed), _):
+            ("setSpeed", speed.value)
+        case (.noCommand, .withinTarget):
+            ("hold", nil)
+        case let (.noCommand, .other(value)) where value == "inertiaHold":
+            ("inertiaHold", nil)
+        case let (.noCommand, .other(value)) where value == "speedLimit":
+            ("speedLimit", nil)
+        default:
+            ("unsupportedHeartRateControlDecision", nil)
         }
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryParityTests/TelemetrySemanticParityValidatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryParityTests/TelemetrySemanticParityValidatorTests.swift
@@ -48,26 +48,35 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
         XCTAssertEqual(control.findings.first?.classification, .actualSemanticMismatch)
     }
 
-    func testProductionShapedHeartRateDecisionDomainReportsMissingRequiredOutcomes() throws {
+    func testProductionShapedHeartRateDecisionDomainUsesGenericEventsWithoutDuplicates() throws {
         let fixture = try productionShapedDecisionDomainFixture()
 
         XCTAssertEqual(fixture.legacy.decisions.count, 4)
-        XCTAssertEqual(fixture.telemetryV2.decisions.count, 4)
+        XCTAssertEqual(fixture.telemetryV2.decisions.count, 8)
         XCTAssertTrue(fixture.legacy.decisions.allSatisfy {
             $0.domain == .heartRateControl
         })
         XCTAssertEqual(
-            fixture.telemetryV2.decisions.map(\.domain),
-            [
-                .outsideHeartRateControl,
-                .heartRateControl,
-                .outsideHeartRateControl,
-                .outsideHeartRateControl,
-            ]
+            fixture.legacy.decisions.map(\.desiredSpeedKilometresPerHour),
+            [4.1, nil, nil, nil]
+        )
+        let semanticDecisions = fixture.telemetryV2.decisions.filter {
+            $0.domain == .heartRateControl
+        }
+        XCTAssertEqual(
+            semanticDecisions.map(\.action),
+            ["setSpeed", "hold", "inertiaHold", "speedLimit"]
         )
         XCTAssertEqual(
-            fixture.telemetryV2.decisions.filter { $0.domain == .heartRateControl }.count,
-            1
+            semanticDecisions.map(\.desiredSpeedKilometresPerHour),
+            [4.1, nil, nil, nil]
+        )
+        let outsideDecisions = fixture.telemetryV2.decisions.filter {
+            $0.domain == .outsideHeartRateControl
+        }
+        XCTAssertEqual(
+            outsideDecisions.map(\.source),
+            ["start", "heartRateControl", "cooldown", "stop"]
         )
 
         let report = TelemetrySemanticParityValidator.validate(
@@ -76,24 +85,33 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
         )
         let control = result(.controlDecisions, in: report)
 
-        XCTAssertEqual(control.status, .fail)
-        XCTAssertEqual(
-            control.findings.map(\.code),
-            [
-                "heart-rate-control-decision-count-hold",
-                "heart-rate-control-decision-count-inertiaHold",
-                "heart-rate-control-decision-count-speedLimit",
-            ]
+        XCTAssertEqual(control.status, .pass)
+        XCTAssertTrue(control.findings.isEmpty)
+    }
+
+    func testCompleteV2SessionMissingSemanticHeartRateDecisionStillFails() throws {
+        let fixture = try productionShapedDecisionDomainFixture(
+            omittingSemanticOutcome: "inertiaHold"
         )
-        XCTAssertTrue(control.findings.allSatisfy {
-            $0.classification == .actualSemanticMismatch && $0.impact == .fail
-        })
-        XCTAssertFalse(control.findings.contains {
-            $0.code.contains("setSpeed")
-                || $0.detail.contains("start")
-                || $0.detail.contains("cooldown")
-                || $0.detail.contains("stop")
-        })
+
+        XCTAssertEqual(
+            fixture.telemetryV2.decisions.filter { $0.domain == .heartRateControl }.map(\.action),
+            ["setSpeed", "hold", "speedLimit"]
+        )
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: fixture.legacy,
+            telemetryV2: fixture.telemetryV2
+        )
+        let control = result(.controlDecisions, in: report)
+
+        XCTAssertEqual(control.status, .fail)
+        XCTAssertEqual(control.findings.count, 1)
+        XCTAssertEqual(
+            control.findings.first?.code,
+            "heart-rate-control-decision-count-inertiaHold"
+        )
+        XCTAssertEqual(control.findings.first?.classification, .actualSemanticMismatch)
+        XCTAssertEqual(control.findings.first?.impact, .fail)
     }
 
     func testHeartRateDecisionOrderMismatchFailsWithoutFuzzyPairing() {
@@ -514,6 +532,55 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
         XCTAssertEqual(read.integrity.outOfOrderRecordCount, 1)
     }
 
+    func testV2ReaderUsesHeartRateTargetAndFlagsUnsupportedSemanticCombination() throws {
+        let sessionID = SessionID(
+            rawValue: UUID(uuidString: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")!
+        )
+        let start = Date(timeIntervalSince1970: 1_000)
+        let session = try makeV2Session(sessionID: sessionID, start: start)
+        let events = [
+            makeControlDecisionEvent(
+                session: session,
+                start: start,
+                elapsedMicroseconds: 1_000_000,
+                target: .desiredSpeed(DesiredSpeedKilometresPerHour(value: 4.2)),
+                action: .enqueueSpeed(DesiredSpeedKilometresPerHour(value: 4.2)),
+                reason: .manual
+            ),
+            makeControlDecisionEvent(
+                session: session,
+                start: start,
+                elapsedMicroseconds: 2_000_000,
+                action: .noCommand,
+                reason: .other("unexpected")
+            ),
+            makeControlDecisionEvent(
+                session: session,
+                start: start,
+                elapsedMicroseconds: 3_000_000,
+                action: .noCommand,
+                reason: .withinTarget
+            ),
+        ]
+
+        let read = try TelemetryV2ParityReader.read(
+            session: session,
+            heartRate: [],
+            treadmill: [],
+            events: events,
+            frames: []
+        )
+
+        XCTAssertEqual(
+            read.decisions.map(\.domain),
+            [.unclassified, .heartRateControl, .heartRateControl]
+        )
+        XCTAssertEqual(
+            read.decisions.map(\.action),
+            ["setSpeed", "unsupportedHeartRateControlDecision", "hold"]
+        )
+    }
+
     func testV2ReaderPreservesUnassociatedObservedResponseWithNilCausalIDs() throws {
         let sessionID = SessionID(
             rawValue: UUID(uuidString: "66666666-6666-6666-6666-666666666666")!
@@ -632,7 +699,9 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
         )
     }
 
-    private func productionShapedDecisionDomainFixture() throws -> (
+    private func productionShapedDecisionDomainFixture(
+        omittingSemanticOutcome: String? = nil
+    ) throws -> (
         legacy: TelemetryParitySessionEvidence,
         telemetryV2: TelemetryParitySessionEvidence
     ) {
@@ -652,7 +721,34 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
         let connectionEpoch = TreadmillConnectionEpoch(
             rawValue: UUID(uuidString: "99999999-9999-9999-9999-999999999999")!
         )
-        let v2Events = [
+        let v2Session = try makeV2Session(sessionID: sessionID, start: start)
+        let semanticRows: [(
+            outcome: String,
+            elapsedMicroseconds: Int64,
+            action: ControlAction,
+            reason: ControlDecisionReason
+        )] = [
+            (
+                "setSpeed",
+                1_000_000,
+                .enqueueSpeed(DesiredSpeedKilometresPerHour(value: 4.1)),
+                .belowTarget
+            ),
+            ("hold", 2_000_000, .noCommand, .withinTarget),
+            ("inertiaHold", 3_000_000, .noCommand, .heartRateInertiaHold),
+            ("speedLimit", 4_000_000, .noCommand, .heartRateSpeedLimit),
+        ]
+        let semanticEvents = semanticRows.compactMap { row -> WorkoutEvent? in
+            guard row.outcome != omittingSemanticOutcome else { return nil }
+            return makeControlDecisionEvent(
+                session: v2Session,
+                start: start,
+                elapsedMicroseconds: row.elapsedMicroseconds,
+                action: row.action,
+                reason: row.reason
+            )
+        }
+        var v2Events = [
             makeTreadmillDecisionEvent(
                 sessionID: sessionID,
                 start: start,
@@ -661,18 +757,23 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
                 intent: .startAtDesiredSpeed(DesiredSpeedKilometresPerHour(value: 4.0)),
                 connectionEpoch: connectionEpoch
             ),
+        ]
+        v2Events.append(contentsOf: semanticEvents)
+        v2Events.append(
             makeTreadmillDecisionEvent(
                 sessionID: sessionID,
                 start: start,
-                elapsedMicroseconds: 1_000_000,
+                elapsedMicroseconds: 1_100_000,
                 source: .heartRateControl,
                 intent: .setDesiredSpeed(DesiredSpeedKilometresPerHour(value: 4.1)),
                 connectionEpoch: connectionEpoch
-            ),
+            )
+        )
+        v2Events.append(contentsOf: [
             makeTreadmillDecisionEvent(
                 sessionID: sessionID,
                 start: start,
-                elapsedMicroseconds: 2_500_000,
+                elapsedMicroseconds: 4_500_000,
                 source: .cooldown,
                 intent: .setDesiredSpeed(DesiredSpeedKilometresPerHour(value: 3.5)),
                 connectionEpoch: connectionEpoch
@@ -680,20 +781,46 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
             makeTreadmillDecisionEvent(
                 sessionID: sessionID,
                 start: start,
-                elapsedMicroseconds: 4_500_000,
+                elapsedMicroseconds: 5_000_000,
                 source: .stop,
                 intent: .stop,
                 connectionEpoch: connectionEpoch
             ),
-        ]
+        ])
         let telemetryV2 = try TelemetryV2ParityReader.read(
-            session: makeV2Session(sessionID: sessionID, start: start),
+            session: v2Session,
             heartRate: [],
             treadmill: [],
             events: v2Events,
             frames: []
         )
         return (legacy, telemetryV2)
+    }
+
+    private func makeControlDecisionEvent(
+        session: WorkoutSessionRecord,
+        start: Date,
+        elapsedMicroseconds: Int64,
+        target: ControlTarget = .heartRate(beatsPerMinute: 110),
+        action: ControlAction,
+        reason: ControlDecisionReason
+    ) -> WorkoutEvent {
+        makeEvent(
+            sessionID: session.sessionID,
+            start: start,
+            elapsedMicroseconds: elapsedMicroseconds,
+            payload: .controlDecision(
+                ControlDecision(
+                    decisionID: DecisionID(),
+                    observationsUsed: [],
+                    target: target,
+                    action: action,
+                    reason: reason,
+                    versions: session.versions,
+                    configurationSnapshotID: session.configuration.id
+                )
+            )
+        )
     }
 
     private func makeTreadmillDecisionEvent(

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryParityTests/TelemetrySemanticParityValidatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryParityTests/TelemetrySemanticParityValidatorTests.swift
@@ -29,6 +29,7 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
     func testActualControlMismatchFailsWithoutBeingCalledRecorderLoss() {
         let legacy = evidence(origin: .legacyJSONL)
         let mismatchedDecision = TelemetryParityDecisionEvidence(
+            domain: .heartRateControl,
             source: "heartRateControl",
             action: "setSpeed",
             desiredSpeedKilometresPerHour: 4.8,
@@ -45,6 +46,84 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
         XCTAssertEqual(report.overallStatus, .fail)
         XCTAssertEqual(control.status, .fail)
         XCTAssertEqual(control.findings.first?.classification, .actualSemanticMismatch)
+    }
+
+    func testProductionShapedHeartRateDecisionDomainReportsMissingRequiredOutcomes() throws {
+        let fixture = try productionShapedDecisionDomainFixture()
+
+        XCTAssertEqual(fixture.legacy.decisions.count, 4)
+        XCTAssertEqual(fixture.telemetryV2.decisions.count, 4)
+        XCTAssertTrue(fixture.legacy.decisions.allSatisfy {
+            $0.domain == .heartRateControl
+        })
+        XCTAssertEqual(
+            fixture.telemetryV2.decisions.map(\.domain),
+            [
+                .outsideHeartRateControl,
+                .heartRateControl,
+                .outsideHeartRateControl,
+                .outsideHeartRateControl,
+            ]
+        )
+        XCTAssertEqual(
+            fixture.telemetryV2.decisions.filter { $0.domain == .heartRateControl }.count,
+            1
+        )
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: fixture.legacy,
+            telemetryV2: fixture.telemetryV2
+        )
+        let control = result(.controlDecisions, in: report)
+
+        XCTAssertEqual(control.status, .fail)
+        XCTAssertEqual(
+            control.findings.map(\.code),
+            [
+                "heart-rate-control-decision-count-hold",
+                "heart-rate-control-decision-count-inertiaHold",
+                "heart-rate-control-decision-count-speedLimit",
+            ]
+        )
+        XCTAssertTrue(control.findings.allSatisfy {
+            $0.classification == .actualSemanticMismatch && $0.impact == .fail
+        })
+        XCTAssertFalse(control.findings.contains {
+            $0.code.contains("setSpeed")
+                || $0.detail.contains("start")
+                || $0.detail.contains("cooldown")
+                || $0.detail.contains("stop")
+        })
+    }
+
+    func testHeartRateDecisionOrderMismatchFailsWithoutFuzzyPairing() {
+        let set = TelemetryParityDecisionEvidence(
+            domain: .heartRateControl,
+            source: "heartRateControl",
+            action: "setSpeed",
+            desiredSpeedKilometresPerHour: 4.1,
+            elapsedMilliseconds: 1_000
+        )
+        let hold = TelemetryParityDecisionEvidence(
+            domain: .heartRateControl,
+            source: "heartRateControl",
+            action: "hold",
+            desiredSpeedKilometresPerHour: 4.1,
+            elapsedMilliseconds: 2_000
+        )
+        let legacy = evidence(origin: .legacyJSONL, decisions: [set, hold])
+        let v2 = evidence(origin: .telemetryV2, decisions: [hold, set])
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: legacy,
+            telemetryV2: v2
+        )
+
+        XCTAssertTrue(result(.controlDecisions, in: report).findings.contains {
+            $0.code == "heart-rate-control-decision-order"
+                && $0.classification == .actualSemanticMismatch
+                && $0.impact == .fail
+        })
     }
 
     func testKnownRecorderLossFailsAsRecorderDataLoss() {
@@ -553,6 +632,99 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
         )
     }
 
+    private func productionShapedDecisionDomainFixture() throws -> (
+        legacy: TelemetryParitySessionEvidence,
+        telemetryV2: TelemetryParitySessionEvidence
+    ) {
+        let sessionID = SessionID(
+            rawValue: UUID(uuidString: "88888888-8888-8888-8888-888888888888")!
+        )
+        let start = Date(timeIntervalSince1970: 1_000)
+        let legacyJSONL = """
+        {"ts":"1970-01-01T00:16:40.000Z","event":"session_start","session_id":"\(sessionID.description)","target_bpm":110,"duration_min":1,"decision_interval_s":10,"adaptive_step_enabled":true,"max_step_kmh":0.5,"zone_bounds":[100,120,140,160],"cooldown_target_bpm":105,"cooldown_min_speed_kmh":3.5,"cooldown_max_minutes":2,"telemetry_schema_version":"1","algorithm_version":"a","safety_policy_version":"s","workout_protocol_version":"w"}
+        {"ts":"1970-01-01T00:16:41.000Z","event":"hr_decision","session_id":"\(sessionID.description)","decision":"set","speed_after_kmh":4.1}
+        {"ts":"1970-01-01T00:16:42.000Z","event":"hr_decision","session_id":"\(sessionID.description)","decision":"hold","speed_after_kmh":4.1}
+        {"ts":"1970-01-01T00:16:43.000Z","event":"hr_decision","session_id":"\(sessionID.description)","decision":"inertia_hold","speed_after_kmh":4.1}
+        {"ts":"1970-01-01T00:16:44.000Z","event":"hr_decision","session_id":"\(sessionID.description)","decision":"limit","speed_after_kmh":4.1}
+        {"ts":"1970-01-01T00:16:50.000Z","event":"session_end","session_id":"\(sessionID.description)","reason":"manual_stop"}
+        """
+        let legacy = try LegacyTelemetryJSONLReader.read(data: Data(legacyJSONL.utf8))
+        let connectionEpoch = TreadmillConnectionEpoch(
+            rawValue: UUID(uuidString: "99999999-9999-9999-9999-999999999999")!
+        )
+        let v2Events = [
+            makeTreadmillDecisionEvent(
+                sessionID: sessionID,
+                start: start,
+                elapsedMicroseconds: 500_000,
+                source: .start,
+                intent: .startAtDesiredSpeed(DesiredSpeedKilometresPerHour(value: 4.0)),
+                connectionEpoch: connectionEpoch
+            ),
+            makeTreadmillDecisionEvent(
+                sessionID: sessionID,
+                start: start,
+                elapsedMicroseconds: 1_000_000,
+                source: .heartRateControl,
+                intent: .setDesiredSpeed(DesiredSpeedKilometresPerHour(value: 4.1)),
+                connectionEpoch: connectionEpoch
+            ),
+            makeTreadmillDecisionEvent(
+                sessionID: sessionID,
+                start: start,
+                elapsedMicroseconds: 2_500_000,
+                source: .cooldown,
+                intent: .setDesiredSpeed(DesiredSpeedKilometresPerHour(value: 3.5)),
+                connectionEpoch: connectionEpoch
+            ),
+            makeTreadmillDecisionEvent(
+                sessionID: sessionID,
+                start: start,
+                elapsedMicroseconds: 4_500_000,
+                source: .stop,
+                intent: .stop,
+                connectionEpoch: connectionEpoch
+            ),
+        ]
+        let telemetryV2 = try TelemetryV2ParityReader.read(
+            session: makeV2Session(sessionID: sessionID, start: start),
+            heartRate: [],
+            treadmill: [],
+            events: v2Events,
+            frames: []
+        )
+        return (legacy, telemetryV2)
+    }
+
+    private func makeTreadmillDecisionEvent(
+        sessionID: SessionID,
+        start: Date,
+        elapsedMicroseconds: Int64,
+        source: TreadmillControlDecisionSource,
+        intent: TreadmillControlDecisionIntent,
+        connectionEpoch: TreadmillConnectionEpoch
+    ) -> WorkoutEvent {
+        makeEvent(
+            sessionID: sessionID,
+            start: start,
+            elapsedMicroseconds: elapsedMicroseconds,
+            payload: .treadmillEvidence(
+                .decision(
+                    TreadmillControlDecisionEvidence(
+                        decisionID: DecisionID(),
+                        source: source,
+                        intent: intent,
+                        heartRateInputs: [],
+                        occurredAt: start.addingTimeInterval(
+                            Double(elapsedMicroseconds) / 1_000_000
+                        ),
+                        connectionEpoch: connectionEpoch
+                    )
+                )
+            )
+        )
+    }
+
     private func makeEvent(
         sessionID: SessionID,
         start: Date,
@@ -639,6 +811,7 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
             ),
             decisions: decisions ?? [
                 TelemetryParityDecisionEvidence(
+                    domain: .heartRateControl,
                     source: "heartRateControl",
                     action: "setSpeed",
                     desiredSpeedKilometresPerHour: 4.1,

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryParityTests/TelemetrySemanticParityValidatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryParityTests/TelemetrySemanticParityValidatorTests.swift
@@ -1,0 +1,545 @@
+import Foundation
+import TelemetryDomain
+import TelemetryParity
+import TelemetryPersistence
+import TelemetryRuntime
+import XCTest
+
+final class TelemetrySemanticParityValidatorTests: XCTestCase {
+    func testCompleteSemanticEvidencePassesWhileDeviceTruthStaysInconclusive() throws {
+        let legacy = evidence(origin: .legacyJSONL)
+        let v2 = evidence(origin: .telemetryV2)
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: legacy,
+            telemetryV2: v2
+        )
+
+        XCTAssertEqual(report.overallStatus, .pass)
+        XCTAssertEqual(result(.causalAssociation, in: report).status, .pass)
+        XCTAssertEqual(result(.physicalDeviceTruth, in: report).status, .inconclusive)
+        XCTAssertEqual(report.causalCoverage.honestlyUnknownCount, 1)
+        XCTAssertEqual(report.causalCoverage.unsupportedClaimCount, 0)
+        let firstJSON = try report.machineReadableJSON()
+        let secondJSON = try report.machineReadableJSON()
+        XCTAssertEqual(firstJSON, secondJSON)
+        XCTAssertTrue(report.humanReadableText().contains("deviceOnlyUnverified"))
+    }
+
+    func testActualControlMismatchFailsWithoutBeingCalledRecorderLoss() {
+        let legacy = evidence(origin: .legacyJSONL)
+        let mismatchedDecision = TelemetryParityDecisionEvidence(
+            source: "heartRateControl",
+            action: "setSpeed",
+            desiredSpeedKilometresPerHour: 4.8,
+            elapsedMilliseconds: 1_000
+        )
+        let v2 = evidence(origin: .telemetryV2, decisions: [mismatchedDecision])
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: legacy,
+            telemetryV2: v2
+        )
+        let control = result(.controlDecisions, in: report)
+
+        XCTAssertEqual(report.overallStatus, .fail)
+        XCTAssertEqual(control.status, .fail)
+        XCTAssertEqual(control.findings.first?.classification, .actualSemanticMismatch)
+    }
+
+    func testKnownRecorderLossFailsAsRecorderDataLoss() {
+        let legacy = evidence(origin: .legacyJSONL)
+        let v2 = evidence(
+            origin: .telemetryV2,
+            completeness: .incomplete,
+            integrity: TelemetryParityIntegrityEvidence(lostNativeRecordCount: 1)
+        )
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: legacy,
+            telemetryV2: v2
+        )
+        let integrity = result(.recordIntegrity, in: report)
+
+        XCTAssertEqual(report.overallStatus, .fail)
+        XCTAssertTrue(integrity.findings.contains {
+            $0.classification == .v2RecorderOrDataLoss && $0.impact == .fail
+        })
+    }
+
+    func testIncompleteEvidenceWithoutProvenLossIsInconclusive() {
+        let legacy = evidence(origin: .legacyJSONL)
+        let v2 = evidence(origin: .telemetryV2, completeness: .incomplete)
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: legacy,
+            telemetryV2: v2
+        )
+
+        XCTAssertEqual(report.overallStatus, .inconclusive)
+        XCTAssertEqual(result(.recordIntegrity, in: report).status, .inconclusive)
+    }
+
+    func testLegacySourceLimitationRemainsDistinctAndInconclusive() {
+        let limitation = TelemetryParitySourceLimitation(
+            category: .treadmillFacts,
+            code: "legacy-modelled-speed",
+            detail: "Legacy value is modelled, not factual."
+        )
+        let legacy = evidence(origin: .legacyJSONL, limitations: [limitation])
+        let v2 = evidence(origin: .telemetryV2)
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: legacy,
+            telemetryV2: v2
+        )
+        let treadmill = result(.treadmillFacts, in: report)
+
+        XCTAssertEqual(treadmill.status, .inconclusive)
+        XCTAssertEqual(treadmill.findings.first?.classification, .sourceLegacyLimitation)
+    }
+
+    func testHonestUnknownCausalOutcomePassesFactualIntegrity() {
+        let legacy = evidence(origin: .legacyJSONL)
+        let v2 = evidence(origin: .telemetryV2)
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: legacy,
+            telemetryV2: v2
+        )
+        let causal = result(.causalAssociation, in: report)
+
+        XCTAssertEqual(causal.status, .pass)
+        XCTAssertEqual(causal.findings.first?.classification, .protocolRuntimeCausalAmbiguity)
+        XCTAssertEqual(causal.findings.first?.impact, .pass)
+    }
+
+    func testFabricatedCausalEdgeFailsEvenWhenCountsMatch() {
+        let legacy = evidence(origin: .legacyJSONL)
+        let fabricated = TelemetryParityCommandEvidence(
+            outcomeKind: .acknowledgement,
+            semanticCommand: nil,
+            elapsedMilliseconds: 2_100,
+            association: .deterministicallyCorrelated,
+            commandIdentifier: "command-nearest-in-time",
+            attemptIdentifier: "attempt-nearest-in-time"
+        )
+        let v2 = evidence(
+            origin: .telemetryV2,
+            commandEvidence: [sentCommand(), fabricated]
+        )
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: legacy,
+            telemetryV2: v2
+        )
+        let causal = result(.causalAssociation, in: report)
+
+        XCTAssertEqual(report.overallStatus, .fail)
+        XCTAssertEqual(causal.status, .fail)
+        XCTAssertEqual(causal.findings.first?.classification, .unsupportedCausalEdge)
+        XCTAssertEqual(report.causalCoverage.unsupportedClaimCount, 1)
+    }
+
+    func testCompleteSessionWithMissingRequiredHeartRateFails() {
+        let legacy = evidence(origin: .legacyJSONL)
+        let v2 = evidence(origin: .telemetryV2, heartRate: [])
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: legacy,
+            telemetryV2: v2
+        )
+
+        let heartRate = result(.heartRateObservations, in: report)
+        XCTAssertEqual(heartRate.status, .fail)
+        XCTAssertEqual(heartRate.findings.first?.classification, .v2RecorderOrDataLoss)
+    }
+
+    func testIncompleteSessionWithMissingHeartRateIsRecorderInconclusive() {
+        let legacy = evidence(origin: .legacyJSONL)
+        let v2 = evidence(origin: .telemetryV2, completeness: .incomplete, heartRate: [])
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: legacy,
+            telemetryV2: v2
+        )
+        let heartRate = result(.heartRateObservations, in: report)
+
+        XCTAssertEqual(heartRate.status, .inconclusive)
+        XCTAssertEqual(heartRate.findings.first?.classification, .v2RecorderOrDataLoss)
+    }
+
+    func testTimestampDerivedAggregatesAreRecalculatedDeterministically() {
+        let legacy = evidence(origin: .legacyJSONL, useDerivedAggregates: true)
+        let v2 = evidence(origin: .telemetryV2, useDerivedAggregates: true)
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: legacy,
+            telemetryV2: v2
+        )
+
+        XCTAssertEqual(result(.timestampDerivedAggregates, in: report).status, .pass)
+    }
+
+    func testTimestampDerivedAggregatesIgnoreLegacySampleCountSummary() {
+        let sampleCountSummary = TelemetryParityAggregateEvidence(
+            zoneSeconds: [2, 0, 0, 0, 0],
+            cooldownCoveredSeconds: 99
+        )
+        let legacy = evidence(
+            origin: .legacyJSONL,
+            aggregateOverride: sampleCountSummary
+        )
+        let v2 = evidence(origin: .telemetryV2)
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: legacy,
+            telemetryV2: v2
+        )
+
+        XCTAssertEqual(result(.timestampDerivedAggregates, in: report).status, .pass)
+    }
+
+    func testOutOfOrderV2EvidenceFailsRecordIntegrity() {
+        let legacy = evidence(origin: .legacyJSONL)
+        let v2 = evidence(
+            origin: .telemetryV2,
+            integrity: TelemetryParityIntegrityEvidence(outOfOrderRecordCount: 1)
+        )
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: legacy,
+            telemetryV2: v2
+        )
+
+        XCTAssertEqual(result(.recordIntegrity, in: report).status, .fail)
+    }
+
+    func testLegacyReaderDoesNotMutateInputAndPreservesKnownLimitations() throws {
+        let jsonl = """
+        {"ts":"2026-08-20T10:00:00.000Z","event":"session_start","session_id":"11111111-1111-1111-1111-111111111111","target_bpm":110,"duration_min":1,"decision_interval_s":10,"adaptive_step_enabled":true,"max_step_kmh":0.5,"zone_bounds":[100,120,140,160],"cooldown_target_bpm":105,"cooldown_min_speed_kmh":3.5,"cooldown_max_minutes":2,"telemetry_schema_version":"1","algorithm_version":"a","safety_policy_version":"s","workout_protocol_version":"w"}
+        {"ts":"2026-08-20T10:00:01.000Z","event":"hr_sample","session_id":"11111111-1111-1111-1111-111111111111","hr_bpm":90}
+        {"ts":"2026-08-20T10:00:01.500Z","event":"notify_fe01","session_id":"11111111-1111-1111-1111-111111111111","speed_kmh":4.2,"state":0,"controller_units":"metric","controller_units_fresh":true}
+        {"ts":"2026-08-20T10:00:02.000Z","event":"session_end","session_id":"11111111-1111-1111-1111-111111111111","reason":"manual_stop"}
+        """
+        let data = Data(jsonl.utf8)
+        let original = data
+
+        let evidence = try LegacyTelemetryJSONLReader.read(data: data)
+
+        XCTAssertEqual(data, original)
+        XCTAssertEqual(evidence.sessionIdentifier, "11111111-1111-1111-1111-111111111111")
+        XCTAssertEqual(evidence.heartRate.map(\.beatsPerMinute), [90])
+        XCTAssertEqual(evidence.treadmillFacts.first?.nativeUnit, "walkingpad_controller_tenths")
+        XCTAssertEqual(evidence.treadmillFacts.first?.deviceState, "moving")
+        XCTAssertTrue(evidence.limitations.contains {
+            $0.code == "legacy-jsonl-ack-acceptance-not-explicit"
+        })
+    }
+
+    func testV2StoreReaderIsReadOnly() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let sessionID = SessionID(rawValue: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!)
+        let start = Date(timeIntervalSince1970: 1_000)
+        let configuration = TelemetryV2ConfigurationInput(
+            profileLocalIdentifier: "profile",
+            workoutMode: .heartRateControlled,
+            targetHeartRate: 110,
+            durationMinutes: 1,
+            decisionIntervalSeconds: 10,
+            adaptiveStepEnabled: true,
+            maximumStepKilometresPerHour: 0.5,
+            heartRateZones: [100, 120, 140, 160],
+            cooldownTargetHeartRate: 105,
+            cooldownMinimumSpeedKilometresPerHour: 3.5,
+            cooldownMaximumMinutes: 2,
+            heartRateProviderKind: "legacyWatchWorkoutStream",
+            heartRateProviderStableLocalKey: "watch",
+            treadmill: TelemetryV2TreadmillContext(
+                stableLocalIdentifier: nil,
+                model: nil,
+                protocolName: "walkingPad",
+                protocolVersion: nil,
+                minimumSpeedKilometresPerHour: 0.5,
+                maximumSpeedKilometresPerHour: 12,
+                speedIncrementKilometresPerHour: 0.1
+            )
+        )
+        let payload = try JSONEncoder().encode(configuration)
+        let session = WorkoutSessionRecord(
+            recordID: RecordID(),
+            sessionID: sessionID,
+            profileLocalIdentifier: "profile",
+            lifecycleState: .completed,
+            workoutMode: .heartRateControlled,
+            startedAt: start,
+            endedAt: start.addingTimeInterval(10),
+            endedElapsed: ElapsedDuration(microseconds: 10_000_000),
+            incompleteReason: nil,
+            appContext: AppRuntimeContext(
+                appVersion: "1",
+                buildNumber: "1",
+                operatingSystemVersion: "test"
+            ),
+            versions: RuntimeVersionContext(
+                telemetrySchema: TelemetrySchemaVersion(rawValue: "1"),
+                algorithm: AlgorithmVersion(rawValue: "a"),
+                safetyPolicy: SafetyPolicyVersion(rawValue: "s"),
+                workoutProtocol: WorkoutProtocolVersion(rawValue: "w")
+            ),
+            configuration: ImmutableConfigurationSnapshot(
+                id: ConfigurationSnapshotID(),
+                formatVersion: 1,
+                format: .canonicalJSON,
+                canonicalPayload: payload,
+                contentHash: ContentHash(algorithm: .sha256, lowercaseHexDigest: "00")
+            ),
+            healthKitWorkoutIdentifier: nil,
+            treadmill: nil,
+            recorderHealth: RecorderHealthSummary(
+                isComplete: true,
+                lostCriticalRecordCount: 0,
+                lostNativeRecordCount: 0,
+                lastPersistedElapsed: ElapsedDuration(microseconds: 10_000_000)
+            )
+        )
+        try await store.insertSession(session)
+        let commandID = CommandID(
+            rawValue: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+        )
+        let attemptID = CommandAttemptID(
+            rawValue: UUID(uuidString: "44444444-4444-4444-4444-444444444444")!
+        )
+        let eventTimestamp = EventTimestamp(
+            occurredAt: start.addingTimeInterval(1),
+            recordedAt: start.addingTimeInterval(1),
+            occurredElapsed: ElapsedDuration(microseconds: 1_000_000),
+            recordedElapsed: ElapsedDuration(microseconds: 1_000_000)
+        )
+        try await store.insertEvent(
+            WorkoutEvent(
+                recordID: RecordID(
+                    rawValue: UUID(uuidString: "ffffffff-ffff-ffff-ffff-ffffffffffff")!
+                ),
+                sessionID: sessionID,
+                timestamp: eventTimestamp,
+                payload: EventPayloadEnvelope(
+                    schemaVersion: 1,
+                    payload: .commandLifecycle(
+                        CommandLifecycleRecord(
+                            commandID: commandID,
+                            decisionID: nil,
+                            lifecycle: .enqueued(
+                                kind: .setSpeed(
+                                    CommandedSpeed(
+                                        nativeValue: 4.2,
+                                        nativeUnit: .kilometresPerHour
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        try await store.insertEvent(
+            WorkoutEvent(
+                recordID: RecordID(
+                    rawValue: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+                ),
+                sessionID: sessionID,
+                timestamp: eventTimestamp,
+                payload: EventPayloadEnvelope(
+                    schemaVersion: 1,
+                    payload: .commandLifecycle(
+                        CommandLifecycleRecord(
+                            commandID: commandID,
+                            decisionID: nil,
+                            lifecycle: .sendAttempt(attemptID: attemptID, attemptNumber: 1)
+                        )
+                    )
+                )
+            )
+        )
+        let treadmillSource = SignalSourceIdentity(
+            id: SourceID(),
+            providerKind: .bluetooth,
+            stableLocalKey: "walkingpad-test",
+            savingSource: nil,
+            knownDevice: nil
+        )
+        try await store.insertSource(
+            treadmillSource,
+            firstSeen: start,
+            lastSeen: start.addingTimeInterval(1.5)
+        )
+        try await store.insertTreadmill(
+            TreadmillObservation(
+                recordID: RecordID(),
+                observationID: ObservationID(),
+                sessionID: sessionID,
+                source: treadmillSource,
+                nativeSpeed: NativeTreadmillSpeed(
+                    value: 4.2,
+                    unit: .controllerNative(code: "walkingPad-tenths")
+                ),
+                deviceState: .moving,
+                arrivalOrder: 1,
+                timestamp: ObservationTimestamp(
+                    measuredAt: nil,
+                    receivedAt: start.addingTimeInterval(1.5),
+                    recordedAt: start.addingTimeInterval(1.5),
+                    measuredElapsed: nil,
+                    receivedElapsed: ElapsedDuration(microseconds: 1_500_000),
+                    recordedElapsed: ElapsedDuration(microseconds: 1_500_000)
+                ),
+                provenance: .decodedDeviceReport,
+                freshness: EvidenceFreshness(
+                    state: .fresh,
+                    evaluatedAt: RecordTimestamp(
+                        recordedAt: start.addingTimeInterval(1.5),
+                        elapsed: ElapsedDuration(microseconds: 1_500_000)
+                    ),
+                    age: .zero,
+                    policyVersion: session.versions.safetyPolicy
+                ),
+                quality: []
+            )
+        )
+        let before = try await store.counts()
+
+        let read = try await TelemetryV2ParityReader.read(from: store, sessionID: sessionID)
+        let after = try await store.counts()
+
+        XCTAssertEqual(read.sessionIdentifier, sessionID.description)
+        XCTAssertEqual(read.commandEvidence.count, 1)
+        XCTAssertEqual(read.commandEvidence.first?.semanticCommand, "setSpeed")
+        XCTAssertEqual(read.treadmillFacts.first?.nativeUnit, "walkingpad_controller_tenths")
+        XCTAssertEqual(read.treadmillFacts.first?.deviceState, "moving")
+        XCTAssertEqual(before, after)
+    }
+
+    private func result(
+        _ category: TelemetryParityCategory,
+        in report: TelemetrySemanticParityReport
+    ) -> TelemetryParityCategoryResult {
+        report.categories.first { $0.category == category }!
+    }
+
+    private func evidence(
+        origin: TelemetryParityEvidenceOrigin,
+        completeness: TelemetryParityCompleteness = .complete,
+        heartRate: [TelemetryParityHeartRateEvidence]? = nil,
+        decisions: [TelemetryParityDecisionEvidence]? = nil,
+        commandEvidence: [TelemetryParityCommandEvidence]? = nil,
+        integrity: TelemetryParityIntegrityEvidence = TelemetryParityIntegrityEvidence(),
+        limitations: [TelemetryParitySourceLimitation] = [],
+        aggregateOverride: TelemetryParityAggregateEvidence? = nil,
+        useDerivedAggregates: Bool = false
+    ) -> TelemetryParitySessionEvidence {
+        let start = Date(timeIntervalSince1970: 1_000)
+        let defaultHeartRate = [
+            TelemetryParityHeartRateEvidence(
+                elapsedMilliseconds: 0,
+                receivedAt: start,
+                beatsPerMinute: 90,
+                acceptedForControl: true,
+                arrivalOrder: 1
+            ),
+            TelemetryParityHeartRateEvidence(
+                elapsedMilliseconds: 5_000,
+                receivedAt: start.addingTimeInterval(5),
+                beatsPerMinute: 100,
+                acceptedForControl: true,
+                arrivalOrder: 2
+            ),
+        ]
+        return TelemetryParitySessionEvidence(
+            origin: origin,
+            sessionIdentifier: "11111111-1111-1111-1111-111111111111",
+            linkedLegacySessionIdentifier: "11111111-1111-1111-1111-111111111111",
+            completeness: completeness,
+            lifecycle: TelemetryParityLifecycleEvidence(
+                startedAt: start,
+                endedAt: start.addingTimeInterval(10),
+                endReason: "manual_stop",
+                durationMilliseconds: 10_000
+            ),
+            heartRate: heartRate ?? defaultHeartRate,
+            phases: [
+                TelemetryParityPhaseEvidence(phase: "main", elapsedMilliseconds: 0),
+                TelemetryParityPhaseEvidence(phase: "cooldown", elapsedMilliseconds: 8_000),
+                TelemetryParityPhaseEvidence(phase: "finished", elapsedMilliseconds: 10_000),
+            ],
+            configuration: TelemetryParityConfigurationEvidence(
+                targetHeartRate: 110,
+                durationSeconds: 60,
+                decisionIntervalSeconds: 10,
+                adaptiveStepEnabled: true,
+                maximumStepKilometresPerHour: 0.5,
+                heartRateZoneUpperBounds: [100, 120, 140, 160],
+                cooldownTargetHeartRate: 105,
+                cooldownMinimumSpeedKilometresPerHour: 3.5,
+                cooldownMaximumSeconds: 120,
+                telemetrySchemaVersion: "1",
+                algorithmVersion: "a",
+                safetyPolicyVersion: "s",
+                workoutProtocolVersion: "w"
+            ),
+            decisions: decisions ?? [
+                TelemetryParityDecisionEvidence(
+                    source: "heartRateControl",
+                    action: "setSpeed",
+                    desiredSpeedKilometresPerHour: 4.1,
+                    elapsedMilliseconds: 1_000
+                ),
+            ],
+            treadmillFacts: [
+                TelemetryParityTreadmillFact(
+                    elapsedMilliseconds: 2_000,
+                    nativeValue: 4,
+                    nativeUnit: "walkingpad_controller_tenths",
+                    factualSpeedKilometresPerHour: 4,
+                    deviceState: "moving"
+                ),
+            ],
+            commandEvidence: commandEvidence ?? [sentCommand(), unknownAcknowledgement()],
+            aggregates: useDerivedAggregates ? nil : aggregateOverride
+                ?? TelemetryParityAggregateEvidence(
+                    zoneSeconds: [10, 0, 0, 0, 0],
+                    cooldownCoveredSeconds: 2
+                ),
+            stopEvidence: [
+                TelemetryParityStopEvidence(
+                    conclusion: "unconfirmed",
+                    factualObservationIdentifier: nil,
+                    elapsedMilliseconds: 10_000
+                ),
+            ],
+            integrity: integrity,
+            limitations: limitations
+        )
+    }
+
+    private func sentCommand() -> TelemetryParityCommandEvidence {
+        TelemetryParityCommandEvidence(
+            outcomeKind: .sent,
+            semanticCommand: "setSpeed",
+            elapsedMilliseconds: 2_000,
+            association: .deterministicallyCorrelated,
+            commandIdentifier: "command-1",
+            attemptIdentifier: "attempt-1"
+        )
+    }
+
+    private func unknownAcknowledgement() -> TelemetryParityCommandEvidence {
+        TelemetryParityCommandEvidence(
+            outcomeKind: .acknowledgement,
+            semanticCommand: nil,
+            elapsedMilliseconds: 2_100,
+            association: .unknown,
+            commandIdentifier: nil,
+            attemptIdentifier: nil
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryParityTests/TelemetrySemanticParityValidatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryParityTests/TelemetrySemanticParityValidatorTests.swift
@@ -141,6 +141,39 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
         XCTAssertEqual(report.causalCoverage.unsupportedClaimCount, 1)
     }
 
+    func testExplicitLegacyTimeoutRemainsComparableDespiteAckLimitation() {
+        let limitation = TelemetryParitySourceLimitation(
+            category: .commandLifecycle,
+            code: "legacy-jsonl-ack-acceptance-not-explicit",
+            detail: "Legacy ACK ownership is unavailable."
+        )
+        let timeout = TelemetryParityCommandEvidence(
+            outcomeKind: .timeout,
+            semanticCommand: nil,
+            elapsedMilliseconds: 2_200,
+            association: .unknown,
+            commandIdentifier: nil,
+            attemptIdentifier: nil
+        )
+        let legacy = evidence(
+            origin: .legacyJSONL,
+            commandEvidence: [sentCommand(), timeout],
+            limitations: [limitation]
+        )
+        let v2 = evidence(origin: .telemetryV2, commandEvidence: [sentCommand()])
+
+        let report = TelemetrySemanticParityValidator.validate(
+            legacy: legacy,
+            telemetryV2: v2
+        )
+        let commands = result(.commandLifecycle, in: report)
+
+        XCTAssertEqual(commands.status, .fail)
+        XCTAssertTrue(commands.findings.contains {
+            $0.code == "timeout-count" && $0.classification == .v2RecorderOrDataLoss
+        })
+    }
+
     func testCompleteSessionWithMissingRequiredHeartRateFails() {
         let legacy = evidence(origin: .legacyJSONL)
         let v2 = evidence(origin: .telemetryV2, heartRate: [])
@@ -219,7 +252,7 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
         let jsonl = """
         {"ts":"2026-08-20T10:00:00.000Z","event":"session_start","session_id":"11111111-1111-1111-1111-111111111111","target_bpm":110,"duration_min":1,"decision_interval_s":10,"adaptive_step_enabled":true,"max_step_kmh":0.5,"zone_bounds":[100,120,140,160],"cooldown_target_bpm":105,"cooldown_min_speed_kmh":3.5,"cooldown_max_minutes":2,"telemetry_schema_version":"1","algorithm_version":"a","safety_policy_version":"s","workout_protocol_version":"w"}
         {"ts":"2026-08-20T10:00:01.000Z","event":"hr_sample","session_id":"11111111-1111-1111-1111-111111111111","hr_bpm":90}
-        {"ts":"2026-08-20T10:00:01.500Z","event":"notify_fe01","session_id":"11111111-1111-1111-1111-111111111111","speed_kmh":4.2,"state":0,"controller_units":"metric","controller_units_fresh":true}
+        {"ts":"2026-08-20T10:00:01.500Z","event":"notify_fe01","session_id":"11111111-1111-1111-1111-111111111111","speed_kmh":4.2,"state":0,"controller_units":"metric","controller_units_fresh":true,"checksum_ok":true}
         {"ts":"2026-08-20T10:00:02.000Z","event":"session_end","session_id":"11111111-1111-1111-1111-111111111111","reason":"manual_stop"}
         """
         let data = Data(jsonl.utf8)
@@ -231,78 +264,32 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
         XCTAssertEqual(evidence.sessionIdentifier, "11111111-1111-1111-1111-111111111111")
         XCTAssertEqual(evidence.heartRate.map(\.beatsPerMinute), [90])
         XCTAssertEqual(evidence.treadmillFacts.first?.nativeUnit, "walkingpad_controller_tenths")
+        XCTAssertEqual(evidence.treadmillFacts.first?.factualSpeedKilometresPerHour, 4.2)
         XCTAssertEqual(evidence.treadmillFacts.first?.deviceState, "moving")
         XCTAssertTrue(evidence.limitations.contains {
             $0.code == "legacy-jsonl-ack-acceptance-not-explicit"
         })
     }
 
+    func testLegacyReaderNeverPromotesInvalidChecksumSpeedToFactualTruth() throws {
+        let jsonl = """
+        {"ts":"2026-08-20T10:00:00.000Z","event":"session_start","session_id":"11111111-1111-1111-1111-111111111111"}
+        {"ts":"2026-08-20T10:00:01.000Z","event":"notify_fe01","session_id":"11111111-1111-1111-1111-111111111111","speed_kmh":4.2,"state":1,"controller_units":"metric","controller_units_fresh":true,"checksum_ok":false}
+        {"ts":"2026-08-20T10:00:02.000Z","event":"notify_fitshow_speed","session_id":"11111111-1111-1111-1111-111111111111","speed_kmh":4.3,"checksum_ok":false}
+        {"ts":"2026-08-20T10:00:03.000Z","event":"session_end","session_id":"11111111-1111-1111-1111-111111111111","reason":"manual_stop"}
+        """
+
+        let read = try LegacyTelemetryJSONLReader.read(data: Data(jsonl.utf8))
+
+        XCTAssertEqual(read.treadmillFacts.map(\.nativeValue), [4.2, 4.3])
+        XCTAssertEqual(read.treadmillFacts.map(\.factualSpeedKilometresPerHour), [nil, nil])
+    }
+
     func testV2StoreReaderIsReadOnly() async throws {
         let store = try TelemetryStoreFactory.make(.inMemory)
         let sessionID = SessionID(rawValue: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!)
         let start = Date(timeIntervalSince1970: 1_000)
-        let configuration = TelemetryV2ConfigurationInput(
-            profileLocalIdentifier: "profile",
-            workoutMode: .heartRateControlled,
-            targetHeartRate: 110,
-            durationMinutes: 1,
-            decisionIntervalSeconds: 10,
-            adaptiveStepEnabled: true,
-            maximumStepKilometresPerHour: 0.5,
-            heartRateZones: [100, 120, 140, 160],
-            cooldownTargetHeartRate: 105,
-            cooldownMinimumSpeedKilometresPerHour: 3.5,
-            cooldownMaximumMinutes: 2,
-            heartRateProviderKind: "legacyWatchWorkoutStream",
-            heartRateProviderStableLocalKey: "watch",
-            treadmill: TelemetryV2TreadmillContext(
-                stableLocalIdentifier: nil,
-                model: nil,
-                protocolName: "walkingPad",
-                protocolVersion: nil,
-                minimumSpeedKilometresPerHour: 0.5,
-                maximumSpeedKilometresPerHour: 12,
-                speedIncrementKilometresPerHour: 0.1
-            )
-        )
-        let payload = try JSONEncoder().encode(configuration)
-        let session = WorkoutSessionRecord(
-            recordID: RecordID(),
-            sessionID: sessionID,
-            profileLocalIdentifier: "profile",
-            lifecycleState: .completed,
-            workoutMode: .heartRateControlled,
-            startedAt: start,
-            endedAt: start.addingTimeInterval(10),
-            endedElapsed: ElapsedDuration(microseconds: 10_000_000),
-            incompleteReason: nil,
-            appContext: AppRuntimeContext(
-                appVersion: "1",
-                buildNumber: "1",
-                operatingSystemVersion: "test"
-            ),
-            versions: RuntimeVersionContext(
-                telemetrySchema: TelemetrySchemaVersion(rawValue: "1"),
-                algorithm: AlgorithmVersion(rawValue: "a"),
-                safetyPolicy: SafetyPolicyVersion(rawValue: "s"),
-                workoutProtocol: WorkoutProtocolVersion(rawValue: "w")
-            ),
-            configuration: ImmutableConfigurationSnapshot(
-                id: ConfigurationSnapshotID(),
-                formatVersion: 1,
-                format: .canonicalJSON,
-                canonicalPayload: payload,
-                contentHash: ContentHash(algorithm: .sha256, lowercaseHexDigest: "00")
-            ),
-            healthKitWorkoutIdentifier: nil,
-            treadmill: nil,
-            recorderHealth: RecorderHealthSummary(
-                isComplete: true,
-                lostCriticalRecordCount: 0,
-                lostNativeRecordCount: 0,
-                lastPersistedElapsed: ElapsedDuration(microseconds: 10_000_000)
-            )
-        )
+        let session = try makeV2Session(sessionID: sessionID, start: start)
         try await store.insertSession(session)
         let commandID = CommandID(
             rawValue: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
@@ -419,11 +406,129 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
         XCTAssertEqual(before, after)
     }
 
+    func testV2ArrayReaderReportsOutOfOrderEventsBeforeSortingForComparison() throws {
+        let sessionID = SessionID(
+            rawValue: UUID(uuidString: "55555555-5555-5555-5555-555555555555")!
+        )
+        let start = Date(timeIntervalSince1970: 1_000)
+        let session = try makeV2Session(sessionID: sessionID, start: start)
+        let later = makeEvent(
+            sessionID: sessionID,
+            start: start,
+            elapsedMicroseconds: 2_000_000
+        )
+        let earlier = makeEvent(
+            sessionID: sessionID,
+            start: start,
+            elapsedMicroseconds: 1_000_000
+        )
+
+        let read = try TelemetryV2ParityReader.read(
+            session: session,
+            heartRate: [],
+            treadmill: [],
+            events: [later, earlier],
+            frames: []
+        )
+
+        XCTAssertEqual(read.integrity.outOfOrderRecordCount, 1)
+    }
+
     private func result(
         _ category: TelemetryParityCategory,
         in report: TelemetrySemanticParityReport
     ) -> TelemetryParityCategoryResult {
         report.categories.first { $0.category == category }!
+    }
+
+    private func makeV2Session(
+        sessionID: SessionID,
+        start: Date
+    ) throws -> WorkoutSessionRecord {
+        let configuration = TelemetryV2ConfigurationInput(
+            profileLocalIdentifier: "profile",
+            workoutMode: .heartRateControlled,
+            targetHeartRate: 110,
+            durationMinutes: 1,
+            decisionIntervalSeconds: 10,
+            adaptiveStepEnabled: true,
+            maximumStepKilometresPerHour: 0.5,
+            heartRateZones: [100, 120, 140, 160],
+            cooldownTargetHeartRate: 105,
+            cooldownMinimumSpeedKilometresPerHour: 3.5,
+            cooldownMaximumMinutes: 2,
+            heartRateProviderKind: "legacyWatchWorkoutStream",
+            heartRateProviderStableLocalKey: "watch",
+            treadmill: TelemetryV2TreadmillContext(
+                stableLocalIdentifier: nil,
+                model: nil,
+                protocolName: "walkingPad",
+                protocolVersion: nil,
+                minimumSpeedKilometresPerHour: 0.5,
+                maximumSpeedKilometresPerHour: 12,
+                speedIncrementKilometresPerHour: 0.1
+            )
+        )
+        return WorkoutSessionRecord(
+            recordID: RecordID(),
+            sessionID: sessionID,
+            profileLocalIdentifier: "profile",
+            lifecycleState: .completed,
+            workoutMode: .heartRateControlled,
+            startedAt: start,
+            endedAt: start.addingTimeInterval(10),
+            endedElapsed: ElapsedDuration(microseconds: 10_000_000),
+            incompleteReason: nil,
+            appContext: AppRuntimeContext(
+                appVersion: "1",
+                buildNumber: "1",
+                operatingSystemVersion: "test"
+            ),
+            versions: RuntimeVersionContext(
+                telemetrySchema: TelemetrySchemaVersion(rawValue: "1"),
+                algorithm: AlgorithmVersion(rawValue: "a"),
+                safetyPolicy: SafetyPolicyVersion(rawValue: "s"),
+                workoutProtocol: WorkoutProtocolVersion(rawValue: "w")
+            ),
+            configuration: ImmutableConfigurationSnapshot(
+                id: ConfigurationSnapshotID(),
+                formatVersion: 1,
+                format: .canonicalJSON,
+                canonicalPayload: try JSONEncoder().encode(configuration),
+                contentHash: ContentHash(algorithm: .sha256, lowercaseHexDigest: "00")
+            ),
+            healthKitWorkoutIdentifier: nil,
+            treadmill: nil,
+            recorderHealth: RecorderHealthSummary(
+                isComplete: true,
+                lostCriticalRecordCount: 0,
+                lostNativeRecordCount: 0,
+                lastPersistedElapsed: ElapsedDuration(microseconds: 10_000_000)
+            )
+        )
+    }
+
+    private func makeEvent(
+        sessionID: SessionID,
+        start: Date,
+        elapsedMicroseconds: Int64
+    ) -> WorkoutEvent {
+        let elapsed = ElapsedDuration(microseconds: elapsedMicroseconds)
+        let occurredAt = start.addingTimeInterval(Double(elapsedMicroseconds) / 1_000_000)
+        return WorkoutEvent(
+            recordID: RecordID(),
+            sessionID: sessionID,
+            timestamp: EventTimestamp(
+                occurredAt: occurredAt,
+                recordedAt: occurredAt,
+                occurredElapsed: elapsed,
+                recordedElapsed: elapsed
+            ),
+            payload: EventPayloadEnvelope(
+                schemaVersion: 1,
+                payload: .manualStop(ManualStopEvent(reason: "test"))
+            )
+        )
     }
 
     private func evidence(

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryParityTests/TelemetrySemanticParityValidatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryParityTests/TelemetrySemanticParityValidatorTests.swift
@@ -283,6 +283,7 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
 
         XCTAssertEqual(read.treadmillFacts.map(\.nativeValue), [4.2, 4.3])
         XCTAssertEqual(read.treadmillFacts.map(\.factualSpeedKilometresPerHour), [nil, nil])
+        XCTAssertEqual(read.treadmillFacts.map(\.deviceState), [nil, nil])
     }
 
     func testV2StoreReaderIsReadOnly() async throws {
@@ -434,6 +435,50 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
         XCTAssertEqual(read.integrity.outOfOrderRecordCount, 1)
     }
 
+    func testV2ReaderPreservesUnassociatedObservedResponseWithNilCausalIDs() throws {
+        let sessionID = SessionID(
+            rawValue: UUID(uuidString: "66666666-6666-6666-6666-666666666666")!
+        )
+        let start = Date(timeIntervalSince1970: 1_000)
+        let session = try makeV2Session(sessionID: sessionID, start: start)
+        let receivedAt = start.addingTimeInterval(1)
+        var normalizer = TreadmillObservationNormalizer()
+        let observation = normalizer.normalize(
+            .ftms(
+                speedRawHundredthsKmh: 420,
+                rawState: 1,
+                deviceState: .moving,
+                connectionEpoch: TreadmillConnectionEpoch(
+                    rawValue: UUID(uuidString: "77777777-7777-7777-7777-777777777777")!
+                ),
+                receivedAt: receivedAt
+            ),
+            unitsTruth: nil,
+            observationID: ObservationID(),
+            recordedAt: receivedAt
+        )
+        let event = makeEvent(
+            sessionID: sessionID,
+            start: start,
+            elapsedMicroseconds: 1_000_000,
+            payload: .treadmillEvidence(.observation(observation))
+        )
+
+        let read = try TelemetryV2ParityReader.read(
+            session: session,
+            heartRate: [],
+            treadmill: [],
+            events: [event],
+            frames: []
+        )
+
+        XCTAssertEqual(read.commandEvidence.count, 1)
+        XCTAssertEqual(read.commandEvidence.first?.outcomeKind, .observedResponse)
+        XCTAssertEqual(read.commandEvidence.first?.association, .unknown)
+        XCTAssertNil(read.commandEvidence.first?.commandIdentifier)
+        XCTAssertNil(read.commandEvidence.first?.attemptIdentifier)
+    }
+
     private func result(
         _ category: TelemetryParityCategory,
         in report: TelemetrySemanticParityReport
@@ -511,7 +556,8 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
     private func makeEvent(
         sessionID: SessionID,
         start: Date,
-        elapsedMicroseconds: Int64
+        elapsedMicroseconds: Int64,
+        payload: WorkoutEventPayload = .manualStop(ManualStopEvent(reason: "test"))
     ) -> WorkoutEvent {
         let elapsed = ElapsedDuration(microseconds: elapsedMicroseconds)
         let occurredAt = start.addingTimeInterval(Double(elapsedMicroseconds) / 1_000_000)
@@ -526,7 +572,7 @@ final class TelemetrySemanticParityValidatorTests: XCTestCase {
             ),
             payload: EventPayloadEnvelope(
                 schemaVersion: 1,
-                payload: .manualStop(ManualStopEvent(reason: "test"))
+                payload: payload
             )
         )
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DeterministicControlReplay.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DeterministicControlReplay.swift
@@ -229,3 +229,311 @@ public enum DeterministicControlReplay {
         return updateChecksum(result, bytes: reference.branch.utf8)
     }
 }
+
+public enum SemanticControlReplayScenario: String, Codable, CaseIterable, Sendable {
+    case normalHeartRateControl
+    case delayedHeartRate
+    case missingHeartRate
+    case overshootPrediction
+    case speedLimits
+    case disconnect
+    case cooldown
+    case stop
+    case startAffordanceRuntimeAuthorization
+}
+
+public enum SemanticControlReplayOutput: Codable, Equatable, Sendable {
+    case start(speedKilometresPerHour: Double)
+    case setSpeed(kilometresPerHour: Double)
+    case hold(reason: String)
+    case waitForHeartRate
+    case stop(reason: String)
+    case runtimeAuthorizationBlocked
+}
+
+public struct SemanticControlReplayResult: Codable, Equatable, Sendable {
+    public let scenario: SemanticControlReplayScenario
+    public let startAffordanceAvailable: Bool
+    public let runtimeAuthorizationAllowed: Bool
+    public let outputs: [SemanticControlReplayOutput]
+
+    public init(
+        scenario: SemanticControlReplayScenario,
+        startAffordanceAvailable: Bool,
+        runtimeAuthorizationAllowed: Bool,
+        outputs: [SemanticControlReplayOutput]
+    ) {
+        self.scenario = scenario
+        self.startAffordanceAvailable = startAffordanceAvailable
+        self.runtimeAuthorizationAllowed = runtimeAuthorizationAllowed
+        self.outputs = outputs
+    }
+}
+
+public struct SemanticControlReplayObservation: Codable, Equatable, Sendable {
+    public let scenario: SemanticControlReplayScenario
+    public let step: String
+    public let heartRateBpm: Int?
+    public let targetHeartRateBpm: Int
+    public let controllerSpeedKilometresPerHour: Double
+
+    public init(
+        scenario: SemanticControlReplayScenario,
+        step: String,
+        heartRateBpm: Int?,
+        targetHeartRateBpm: Int,
+        controllerSpeedKilometresPerHour: Double
+    ) {
+        self.scenario = scenario
+        self.step = step
+        self.heartRateBpm = heartRateBpm
+        self.targetHeartRateBpm = targetHeartRateBpm
+        self.controllerSpeedKilometresPerHour = controllerSpeedKilometresPerHour
+    }
+}
+
+public protocol SemanticControlReplayTelemetryObserver: AnyObject, Sendable {
+    func observe(_ observation: SemanticControlReplayObservation)
+}
+
+public extension DeterministicControlReplay {
+    /// Replays normalized harness observations through the current pure controller
+    /// helpers. The optional observer is write-only: no telemetry-derived value is
+    /// read while choosing outputs, and the harness never reaches BLE transport.
+    static func run(
+        scenario: SemanticControlReplayScenario,
+        telemetryObserver: (any SemanticControlReplayTelemetryObserver)? = nil
+    ) -> SemanticControlReplayResult {
+        let treadmillConnected = scenario != .disconnect
+        let currentHeartRateVisible = scenario != .missingHeartRate
+        let watchReachable = scenario != .startAffordanceRuntimeAuthorization
+        let affordance = HRDomainService.heartRateStartAffordanceAvailable(
+            treadmillConnected: treadmillConnected,
+            currentHeartRateVisible: currentHeartRateVisible
+        )
+        let runtimeAuthorization = HRDomainService.heartRateRuntimePrerequisitesAllowStart(
+            treadmillConnected: treadmillConnected,
+            watchReachable: watchReachable,
+            currentHeartRateVisible: currentHeartRateVisible
+        )
+
+        let outputs: [SemanticControlReplayOutput]
+        switch scenario {
+        case .normalHeartRateControl:
+            outputs = [heartRateOutput(
+                scenario: scenario,
+                heartRateBpm: 90,
+                predictedBpm: nil,
+                currentSpeed: 4.0,
+                observer: telemetryObserver
+            )]
+
+        case .delayedHeartRate:
+            telemetryObserver?.observe(
+                observation(
+                    scenario: scenario,
+                    step: "within_initial_grace",
+                    heartRateBpm: nil,
+                    speed: 4.0
+                )
+            )
+            outputs = [
+                .waitForHeartRate,
+                heartRateOutput(
+                    scenario: scenario,
+                    heartRateBpm: 92,
+                    predictedBpm: nil,
+                    currentSpeed: 4.0,
+                    observer: telemetryObserver
+                ),
+            ]
+
+        case .missingHeartRate:
+            let missingSeconds = HRDomainService.missingHeartRateSignalSeconds(
+                lastReceivedAt: nil,
+                now: Date(timeIntervalSince1970: 100),
+                noDataMaximumSeconds: 30
+            )
+            telemetryObserver?.observe(
+                observation(
+                    scenario: scenario,
+                    step: "missing_heart_rate",
+                    heartRateBpm: nil,
+                    speed: 4.0
+                )
+            )
+            outputs = HRDomainService.shouldStopForMissingHeartRateSignal(
+                missingSeconds: missingSeconds,
+                noDataMaximumSeconds: 30
+            ) ? [.stop(reason: "missingHeartRate")] : [.hold(reason: "missingHeartRate")]
+
+        case .overshootPrediction:
+            outputs = [heartRateOutput(
+                scenario: scenario,
+                heartRateBpm: 108,
+                predictedBpm: 116,
+                currentSpeed: 6.0,
+                observer: telemetryObserver
+            )]
+
+        case .speedLimits:
+            outputs = [heartRateOutput(
+                scenario: scenario,
+                heartRateBpm: 80,
+                predictedBpm: nil,
+                currentSpeed: 12.0,
+                observer: telemetryObserver
+            )]
+
+        case .disconnect:
+            telemetryObserver?.observe(
+                observation(
+                    scenario: scenario,
+                    step: "connection_lost",
+                    heartRateBpm: 105,
+                    speed: 5.0
+                )
+            )
+            outputs = [.stop(reason: "disconnect")]
+
+        case .cooldown:
+            let config = CooldownRuntimeEngine.Config(
+                targetBpm: 110,
+                minSpeedKmh: 3.5,
+                maxMinutes: 2,
+                holdSeconds: 8,
+                baseStepKmh: 0.5,
+                stepIntervalSeconds: 10
+            )
+            let aggregates = CooldownRuntimeEngine.SessionAggregates(
+                sessionPeakBpm: 168,
+                mainAvgBpm: 148,
+                mainPeakBpm: 171,
+                zoneSeconds: [10, 20, 30, 40, 50],
+                zone4PlusSeconds: 90
+            )
+            telemetryObserver?.observe(
+                observation(
+                    scenario: scenario,
+                    step: "cooldown_start",
+                    heartRateBpm: 145,
+                    speed: 6.0
+                )
+            )
+            let cooldown = CooldownRuntimeEngine.start(
+                config: config,
+                input: CooldownRuntimeEngine.StartInput(
+                    currentBpm: 145,
+                    deviceTargetSpeedKmh: 6.0,
+                    actualSpeedKmh: 6.0,
+                    sessionAggregates: aggregates
+                )
+            )
+            outputs = cooldown.effects.compactMap { effect in
+                guard case let .setSpeed(speed) = effect else { return nil }
+                return .setSpeed(kilometresPerHour: speed.targetKmh)
+            }
+
+        case .stop:
+            telemetryObserver?.observe(
+                observation(
+                    scenario: scenario,
+                    step: "manual_stop",
+                    heartRateBpm: 105,
+                    speed: 5.0
+                )
+            )
+            outputs = [.stop(reason: "manualStop")]
+
+        case .startAffordanceRuntimeAuthorization:
+            telemetryObserver?.observe(
+                observation(
+                    scenario: scenario,
+                    step: "post_tap_runtime_authorization",
+                    heartRateBpm: 100,
+                    speed: 0
+                )
+            )
+            outputs = runtimeAuthorization
+                ? [.start(speedKilometresPerHour: 3.0)]
+                : [.runtimeAuthorizationBlocked]
+        }
+
+        return SemanticControlReplayResult(
+            scenario: scenario,
+            startAffordanceAvailable: affordance,
+            runtimeAuthorizationAllowed: runtimeAuthorization,
+            outputs: outputs
+        )
+    }
+
+    private static func heartRateOutput(
+        scenario: SemanticControlReplayScenario,
+        heartRateBpm: Int,
+        predictedBpm: Int?,
+        currentSpeed: Double,
+        observer: (any SemanticControlReplayTelemetryObserver)?
+    ) -> SemanticControlReplayOutput {
+        let targetBpm = 110
+        observer?.observe(
+            observation(
+                scenario: scenario,
+                step: "heart_rate_decision",
+                heartRateBpm: heartRateBpm,
+                speed: currentSpeed
+            )
+        )
+        let effectiveBpm = max(heartRateBpm, predictedBpm ?? heartRateBpm)
+        let diff = effectiveBpm - targetBpm
+        let thresholds = HRDomainService.AdaptiveThresholdPercents(
+            deadband: 3.0,
+            downLevel2Start: 8.0,
+            downLevel3Start: 15.0,
+            downLevel4Start: 23.0,
+            upLevel2Start: 23.0,
+            upLevel3Start: 31.0,
+            upLevel4Start: 46.0
+        )
+        let deadband = HRDomainService.deadbandBpm(
+            targetBpm: targetBpm,
+            thresholds: thresholds
+        )
+        guard abs(diff) > deadband else { return .hold(reason: "deadband") }
+        let increasing = diff < 0
+        let selection = HRDomainService.stepFromDiff(
+            diffPercent: HRDomainService.diffPercent(
+                absDiff: abs(diff),
+                targetBpm: targetBpm
+            ),
+            isIncreasingSpeed: increasing,
+            thresholds: thresholds
+        )
+        let direction = increasing ? 1.0 : -1.0
+        let bounds = TreadmillSpeedBoundsService.normalized(
+            min: 0.5,
+            max: 12.0,
+            increment: 0.1
+        )
+        let next = TreadmillSpeedBoundsService.clampRunningSpeed(
+            currentSpeed + direction * selection.stepKmh,
+            bounds: bounds
+        )
+        guard next != currentSpeed else { return .hold(reason: "speedLimit") }
+        return .setSpeed(kilometresPerHour: next)
+    }
+
+    private static func observation(
+        scenario: SemanticControlReplayScenario,
+        step: String,
+        heartRateBpm: Int?,
+        speed: Double
+    ) -> SemanticControlReplayObservation {
+        SemanticControlReplayObservation(
+            scenario: scenario,
+            step: step,
+            heartRateBpm: heartRateBpm,
+            targetHeartRateBpm: 110,
+            controllerSpeedKilometresPerHour: speed
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/DeterministicSemanticControlReplayTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/DeterministicSemanticControlReplayTests.swift
@@ -69,6 +69,93 @@ final class DeterministicSemanticControlReplayTests: XCTestCase {
             return false
         })
     }
+
+    func testReplayCompositionIsAnchoredToCurrentInlineProductionBranches() throws {
+        let manager = source(relativePath: "WalkingPadRemote/BluetoothManager.swift")
+        let replay = source(relativePath: "WalkingPadRemote/DeterministicControlReplay.swift")
+        let tick = try functionBody("private func tickTelemetry()", in: manager)
+
+        assertOrdered(
+            [
+                "let predictedValue = trend.map",
+                "let effectiveBpm = max(heartRateBPM, predictedBpm ?? heartRateBPM)",
+                "let diff = effectiveBpm - hrTargetBPM",
+                "let absDiffPercent = adaptiveDiffPercent",
+                "let deadbandBpm = adaptiveDeadbandBpm",
+                "let stepSelection: AdaptiveStepSelection",
+                "adaptiveStepFromDiff(",
+                "if absDiff <= deadbandBpm",
+                "if direction > 0, let trend, trend > 0, let predictedValue",
+                "let nextSpeed = clampRunningSpeedKmh(currentTarget + direction * step)",
+            ],
+            in: tick
+        )
+        for sharedRule in [
+            "HRDomainService.diffPercent(",
+            "HRDomainService.deadbandBpm(",
+            "HRDomainService.stepFromDiff(",
+            "TreadmillSpeedBoundsService.clampRunningSpeed(",
+            "HRDomainService.shouldStopForMissingHeartRateSignal(",
+            "CooldownRuntimeEngine.start(",
+            "HRDomainService.heartRateStartAffordanceAvailable(",
+            "HRDomainService.heartRateRuntimePrerequisitesAllowStart(",
+        ] {
+            XCTAssertTrue(replay.contains(sharedRule), "Replay missing shared rule: \(sharedRule)")
+        }
+        XCTAssertFalse(manager.contains("SemanticControlReplayScenario"))
+        XCTAssertFalse(replay.contains("BluetoothManager"))
+        XCTAssertFalse(replay.contains("CoreBluetooth"))
+        XCTAssertFalse(replay.contains("writeValue"))
+    }
+
+    private func source(relativePath: String) -> String {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let root = testsDirectory.deletingLastPathComponent()
+        return (try? String(
+            contentsOf: root.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )) ?? ""
+    }
+
+    private func functionBody(_ signature: String, in source: String) throws -> String {
+        guard let signatureRange = source.range(of: signature),
+              let openingBrace = source[signatureRange.upperBound...].firstIndex(of: "{")
+        else {
+            throw NSError(domain: "DeterministicSemanticControlReplayTests", code: 1)
+        }
+        var depth = 0
+        var index = openingBrace
+        while index < source.endIndex {
+            switch source[index] {
+            case "{": depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 { return String(source[openingBrace...index]) }
+            default: break
+            }
+            index = source.index(after: index)
+        }
+        throw NSError(domain: "DeterministicSemanticControlReplayTests", code: 2)
+    }
+
+    private func assertOrdered(
+        _ fragments: [String],
+        in source: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        var lowerBound = source.startIndex
+        for fragment in fragments {
+            guard let range = source.range(
+                of: fragment,
+                range: lowerBound..<source.endIndex
+            ) else {
+                XCTFail("Missing or out-of-order fragment: \(fragment)", file: file, line: line)
+                return
+            }
+            lowerBound = range.upperBound
+        }
+    }
 }
 
 private final class ReplayObservationCollector: SemanticControlReplayTelemetryObserver,

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/DeterministicSemanticControlReplayTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/DeterministicSemanticControlReplayTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+@testable import WalkingPadCoreLogic
+import XCTest
+
+final class DeterministicSemanticControlReplayTests: XCTestCase {
+    func testTelemetryOnAndOffProduceIdenticalOutputsForEveryRequiredScenario() {
+        for scenario in SemanticControlReplayScenario.allCases {
+            let collector = ReplayObservationCollector()
+
+            let disabled = DeterministicControlReplay.run(scenario: scenario)
+            let enabled = DeterministicControlReplay.run(
+                scenario: scenario,
+                telemetryObserver: collector
+            )
+
+            XCTAssertEqual(disabled, enabled, "scenario=\(scenario.rawValue)")
+            XCTAssertFalse(collector.observations.isEmpty, "scenario=\(scenario.rawValue)")
+        }
+    }
+
+    func testNormalDelayedAndPredictionScenariosPreserveExpectedBranches() {
+        let normal = DeterministicControlReplay.run(scenario: .normalHeartRateControl)
+        let delayed = DeterministicControlReplay.run(scenario: .delayedHeartRate)
+        let prediction = DeterministicControlReplay.run(scenario: .overshootPrediction)
+
+        XCTAssertEqual(normal.outputs, [.setSpeed(kilometresPerHour: 4.1)])
+        XCTAssertEqual(
+            delayed.outputs,
+            [.waitForHeartRate, .setSpeed(kilometresPerHour: 4.1)]
+        )
+        guard case let .setSpeed(predictedSpeed) = prediction.outputs.first else {
+            return XCTFail("Prediction scenario must produce a speed decision")
+        }
+        XCTAssertLessThan(predictedSpeed, 6.0)
+    }
+
+    func testMissingHeartRateDisconnectAndManualStopFailSafe() {
+        let missing = DeterministicControlReplay.run(scenario: .missingHeartRate)
+        let disconnect = DeterministicControlReplay.run(scenario: .disconnect)
+        let stop = DeterministicControlReplay.run(scenario: .stop)
+
+        XCTAssertEqual(missing.outputs, [.stop(reason: "missingHeartRate")])
+        XCTAssertEqual(disconnect.outputs, [.stop(reason: "disconnect")])
+        XCTAssertEqual(stop.outputs, [.stop(reason: "manualStop")])
+    }
+
+    func testSpeedLimitAndCooldownUseExistingPureHelpers() {
+        let speedLimit = DeterministicControlReplay.run(scenario: .speedLimits)
+        let cooldown = DeterministicControlReplay.run(scenario: .cooldown)
+
+        XCTAssertEqual(speedLimit.outputs, [.hold(reason: "speedLimit")])
+        guard case let .setSpeed(cooldownSpeed) = cooldown.outputs.first else {
+            return XCTFail("Cooldown must apply its immediate pure-engine speed step")
+        }
+        XCTAssertLessThan(cooldownSpeed, 6.0)
+        XCTAssertGreaterThanOrEqual(cooldownSpeed, 3.5)
+    }
+
+    func testStartAffordanceRemainsSeparateFromPostTapRuntimeAuthorization() {
+        let result = DeterministicControlReplay.run(
+            scenario: .startAffordanceRuntimeAuthorization
+        )
+
+        XCTAssertTrue(result.startAffordanceAvailable)
+        XCTAssertFalse(result.runtimeAuthorizationAllowed)
+        XCTAssertEqual(result.outputs, [.runtimeAuthorizationBlocked])
+        XCTAssertFalse(result.outputs.contains { output in
+            if case .start = output { return true }
+            return false
+        })
+    }
+}
+
+private final class ReplayObservationCollector: SemanticControlReplayTelemetryObserver,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var stored: [SemanticControlReplayObservation] = []
+
+    var observations: [SemanticControlReplayObservation] {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+
+    func observe(_ observation: SemanticControlReplayObservation) {
+        lock.lock()
+        stored.append(observation)
+        lock.unlock()
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/DeterministicSemanticControlReplayTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/DeterministicSemanticControlReplayTests.swift
@@ -74,6 +74,16 @@ final class DeterministicSemanticControlReplayTests: XCTestCase {
         let manager = source(relativePath: "WalkingPadRemote/BluetoothManager.swift")
         let replay = source(relativePath: "WalkingPadRemote/DeterministicControlReplay.swift")
         let tick = try functionBody("private func tickTelemetry()", in: manager)
+        let affordance = try functionBody(
+            "var isHrControlStartAffordanceAvailable: Bool",
+            in: manager
+        )
+        let start = try functionBody("func startHrControl()", in: manager)
+        let stop = try functionBody("func stopHrControl()", in: manager)
+        let disconnect = try functionBody(
+            "private func disconnect(userInitiated: Bool = false)",
+            in: manager
+        )
 
         assertOrdered(
             [
@@ -90,6 +100,25 @@ final class DeterministicSemanticControlReplayTests: XCTestCase {
             ],
             in: tick
         )
+        XCTAssertTrue(tick.contains(".missingHeartRateSignalSeconds("))
+        XCTAssertTrue(tick.contains("HRDomainService.shouldStopForMissingHeartRateSignal("))
+        XCTAssertTrue(tick.contains("CooldownRuntimeEngine.start("))
+        XCTAssertTrue(tick.contains("CooldownRuntimeEngine.tick("))
+        XCTAssertTrue(
+            affordance.contains("HRDomainService.heartRateStartAffordanceAvailable(")
+        )
+        assertOrdered(
+            [
+                "HRDomainService",
+                ".heartRateRuntimePrerequisitesAllowStart(",
+                "guard existingGatesAllowStart",
+                "isHrControlRunning = true",
+                "startWithSpeed",
+            ],
+            in: start
+        )
+        XCTAssertTrue(stop.contains("stopBeltWithToggle(reason: \"hr\")"))
+        XCTAssertTrue(disconnect.contains("self.isHrControlRunning = false"))
         for sharedRule in [
             "HRDomainService.diffPercent(",
             "HRDomainService.deadbandBpm(",


### PR DESCRIPTION
## Summary

- Add a read-only `TelemetryParity` package target with legacy JSONL and Telemetry V2 evidence readers, deterministic `PASS | FAIL | INCONCLUSIVE` reports, and harness-only replay coverage.
- Merge accepted Issue #50 production evidence from current `main` with a normal merge commit, preserving the published #32 branch history.
- Use typed generic `controlDecision` events with `ControlTarget.heartRate` as the authoritative V2 semantic HR-control domain and recognize `setSpeed`, `hold`, `inertiaHold`, and `speedLimit` deterministically.
- Keep the separate command-linked HR treadmill decision, plus start/manual/cooldown/stop treadmill decisions, outside the HR semantic comparison domain so they cannot duplicate or distort semantic parity.
- Compare HR decisions by semantic outcome and occurrence order, then accepted speed/time tolerances. No nearest-time, latest/oldest, queue, target-similarity, command-proximity, or canonical-frame matching is used.
- Update the production-shaped fixture so all four legacy/V2 semantic outcomes pass while unrelated treadmill evidence is present; retain a complete-session fixture where one missing semantic outcome fails honestly.
- Preserve unknown ACK/write-result/timeout/observed-response ownership with nil IDs and reject unsupported causal claims.

Closes #32

## Verification

- `swift test --filter 'TelemetrySemanticParityValidatorTests|DeterministicSemanticControlReplayTests'` — pass: 22 validator and 6 replay tests.
- Applicable treadmill truth, command-decision, Telemetry V2 runtime, HR legacy behavior, boundary, controller-unit, Stop, cooldown, and session-analysis regressions — pass.
- `swift test` — pass; the opt-in 1000-hour profile remains excluded unless `TELEMETRY_GATE_PROFILE=full`.
- `xcodebuild -list -project WalkingPadRemote.xcodeproj` — pass.
- Unsigned generic iOS build — pass with isolated DerivedData.
- Unsigned generic watchOS build — pass with isolated DerivedData.
- `git diff --check` — pass.
- Complete `c3e1687b1f2c9736dfdee6f7595bdea9da6eb55b..b27c77c7fe9bf19ff3398fdb54ffc555add0a0f1` scope, source-mutation, and causality inspection — pass; no #32 production controller/producer/recorder/BLE/start/stop/cooldown/watch/units mutation relative to new `main`.
- Fresh independent `gpt-5.6-terra/high` exact-diff review — CLEAN, no P0–P3 findings.
- Exact-head CI — pass on unchanged `b27c77c7fe9bf19ff3398fdb54ffc555add0a0f1`. The first Swift job hit one runner timing timeout in the merged #50 coordinator test; that exact test passed locally 5/5, and the unchanged exact-head rerun passed all 348 tests (1 expected skip). Python, metadata, and unsigned app-build gates passed.

## Risks / Notes

- PR remains Draft. Do not mark Ready or merge without PM authorization.
- Physical treadmill truth remains `INCONCLUSIVE` and is deferred to Issue #37.
- No deploy, install, device launch, BLE/treadmill connection, controller command, or hardware activity was performed.
- No migration, configuration, environment, deployment, or data rollback step is required. Rollback is a normal revert of this Draft PR's commits.
