### PR TITLE
Persist semantic HR control decisions in Telemetry V2

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Events.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Events.swift
@@ -46,11 +46,14 @@ public enum ControlDecisionReason: Codable, Hashable, Sendable {
     case withinTarget
     case belowTarget
     case aboveTarget
-    case inertiaHold
-    case speedLimit
     case safetyGate(String)
     case manual
     case other(String)
+}
+
+public extension ControlDecisionReason {
+    static let heartRateInertiaHold = Self.other("inertiaHold")
+    static let heartRateSpeedLimit = Self.other("speedLimit")
 }
 
 public struct ControlDecision: Codable, Hashable, Sendable {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Events.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/Events.swift
@@ -46,6 +46,8 @@ public enum ControlDecisionReason: Codable, Hashable, Sendable {
     case withinTarget
     case belowTarget
     case aboveTarget
+    case inertiaHold
+    case speedLimit
     case safetyGate(String)
     case manual
     case other(String)

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
@@ -370,10 +370,20 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
     public typealias StatusHandler = @Sendable (TelemetryV2RuntimeStatus) -> Void
     public typealias WriterHealthHandler = @Sendable (TelemetryV2WriterHealthSnapshot) -> Void
 
+    fileprivate struct PendingHeartRateControlDecision: Sendable {
+        let decisionID: DecisionID
+        let targetBeatsPerMinute: UInt16
+        let action: ControlAction
+        let reason: ControlDecisionReason
+        let heartRateInputs: [HeartRateCausalReference]
+        let occurredAt: Date
+    }
+
     fileprivate enum PendingEvidence: Sendable {
         case heartRate(HeartRateNormalizationResult)
         case sourceLifecycle(HeartRateSourceLifecycleEvidence)
         case controlUse(HeartRateControlUseEvidence)
+        case heartRateControlDecision(PendingHeartRateControlDecision)
         case treadmill(TreadmillTelemetryEvidence)
         case event(WorkoutEventPayload, Date)
         case workoutPhase(WorkoutPhase, Date)
@@ -390,7 +400,8 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
                 } else {
                     (1, 0)
                 }
-            case .sourceLifecycle, .controlUse, .event, .workoutPhase:
+            case .sourceLifecycle, .controlUse, .heartRateControlDecision,
+                 .event, .workoutPhase:
                 (1, 0)
             }
         }
@@ -402,7 +413,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
                 stableKey = "hr:\(result.delivery.source.stableLocalKey)"
             case let .sourceLifecycle(evidence):
                 stableKey = "hr:\(evidence.source.stableLocalKey)"
-            case .controlUse:
+            case .controlUse, .heartRateControlDecision:
                 stableKey = "hr:\(descriptor.configuration.heartRateProviderStableLocalKey)"
             case let .treadmill(evidence):
                 guard let stableDevice = descriptor.configuration.treadmill.stableLocalIdentifier,
@@ -684,6 +695,31 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         return Self.heartRateDisposition(disposition)
     }
 
+    @discardableResult
+    public func observeHeartRateControlDecision(
+        decisionID: DecisionID = DecisionID(),
+        targetBeatsPerMinute: UInt16,
+        action: ControlAction,
+        reason: ControlDecisionReason,
+        heartRateInputs: [HeartRateCausalReference],
+        occurredAt: Date
+    ) -> TelemetryYieldDisposition? {
+        let evidence = PendingHeartRateControlDecision(
+            decisionID: decisionID,
+            targetBeatsPerMinute: targetBeatsPerMinute,
+            action: action,
+            reason: reason,
+            heartRateInputs: heartRateInputs,
+            occurredAt: occurredAt
+        )
+        guard let session = currentActiveSession() else {
+            return bufferDisposition(.heartRateControlDecision(evidence))
+        }
+        let disposition = session.observeHeartRateControlDecision(evidence)
+        refreshStatus(from: session)
+        return disposition
+    }
+
     public func observeTreadmillEvidence(
         _ evidence: TreadmillTelemetryEvidence
     ) -> TreadmillTelemetrySinkDisposition {
@@ -762,6 +798,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
                 )
                 let session = TelemetryV2ActiveSession(
                     descriptor: work.0.descriptor,
+                    configurationSnapshotID: header.configuration.id,
                     recorder: recorder,
                     runtimeClock: self?.runtimeClock ?? ContinuousTelemetryV2RuntimeClock(),
                     startedMonotonic: work.0.startedMonotonic
@@ -986,6 +1023,7 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
     }
 
     private let descriptor: TelemetryV2SessionDescriptor
+    private let configurationSnapshotID: ConfigurationSnapshotID
     private let recorder: TelemetryRecorder
     private let runtimeClock: any TelemetryV2RuntimeClock
     private let startedMonotonic: Duration
@@ -1003,11 +1041,13 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
 
     init(
         descriptor: TelemetryV2SessionDescriptor,
+        configurationSnapshotID: ConfigurationSnapshotID,
         recorder: TelemetryRecorder,
         runtimeClock: any TelemetryV2RuntimeClock,
         startedMonotonic: Duration
     ) {
         self.descriptor = descriptor
+        self.configurationSnapshotID = configurationSnapshotID
         self.recorder = recorder
         self.runtimeClock = runtimeClock
         self.startedMonotonic = startedMonotonic
@@ -1044,6 +1084,8 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
             _ = observeHeartRateRuntime(.sourceLifecycle(sourceLifecycle))
         case let .controlUse(controlUse):
             _ = observeHeartRateRuntime(.controlUse(controlUse))
+        case let .heartRateControlDecision(decision):
+            _ = observeHeartRateControlDecision(decision)
         case let .treadmill(treadmill):
             _ = observeTreadmill(treadmill)
         case let .event(payload, occurredAt):
@@ -1278,6 +1320,34 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
             .heartRateEvidence(evidence),
             occurredAt: occurredAt,
             sourceID: sourceIdentity.id
+        )
+    }
+
+    func observeHeartRateControlDecision(
+        _ evidence: TelemetryV2RuntimeCoordinator.PendingHeartRateControlDecision
+    ) -> TelemetryYieldDisposition {
+        let source = heartRateSource(
+            HeartRateProviderIdentity(
+                kind: .legacyWatchWorkoutStream,
+                stableLocalKey: descriptor.configuration.heartRateProviderStableLocalKey
+            )
+        )
+        emitSourceIfNeeded(source, observedAt: evidence.occurredAt)
+        let decision = ControlDecision(
+            decisionID: evidence.decisionID,
+            observationsUsed: evidence.heartRateInputs.map {
+                .heartRate(ObservationID(rawValue: $0.canonicalObservationID.rawValue))
+            },
+            target: .heartRate(beatsPerMinute: evidence.targetBeatsPerMinute),
+            action: evidence.action,
+            reason: evidence.reason,
+            versions: descriptor.versions,
+            configurationSnapshotID: configurationSnapshotID
+        )
+        return yieldEvent(
+            .controlDecision(decision),
+            occurredAt: evidence.occurredAt,
+            sourceID: source.id
         )
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/EventSessionAndAnalysisTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/EventSessionAndAnalysisTests.swift
@@ -11,6 +11,29 @@ final class EventSessionAndAnalysisTests: XCTestCase {
         try assertCodableRoundTrip(decision)
     }
 
+    func testHeartRateNoCommandReasonsPreserveVersionOneOtherWireRepresentation() throws {
+        let encoder = JSONEncoder()
+        let cases: [(ControlDecisionReason, ControlDecisionReason)] = [
+            (.heartRateInertiaHold, .other("inertiaHold")),
+            (.heartRateSpeedLimit, .other("speedLimit")),
+        ]
+
+        for (semanticReason, versionOneReason) in cases {
+            XCTAssertEqual(semanticReason, versionOneReason)
+            XCTAssertEqual(
+                try encoder.encode(semanticReason),
+                try encoder.encode(versionOneReason)
+            )
+            XCTAssertEqual(
+                try JSONDecoder().decode(
+                    ControlDecisionReason.self,
+                    from: encoder.encode(semanticReason)
+                ),
+                versionOneReason
+            )
+        }
+    }
+
     func testEveryCommandLifecycleCaseRoundTripsWithCausalIDs() throws {
         let commandID = CommandID()
         let decisionID = DecisionID()

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
@@ -434,6 +434,217 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
         XCTAssertEqual(phases.map(\.current), [.main, .cooldown, .finished])
     }
 
+    func testProductionShapedLegacyAndSemanticHrDecisionsPersistInOccurrenceOrder() async throws {
+        let fixture = Issue50ProductionDecisionFixture.fixture
+        let persistence = RuntimePersistence()
+        let factoryGate = DispatchSemaphore(value: 0)
+        let clock = ManualRuntimeClock(date: fixture.startedAt)
+        let descriptor = Self.descriptor(startedAt: fixture.startedAt)
+        let coordinator = TelemetryV2RuntimeCoordinator(
+            persistenceFactory: {
+                factoryGate.wait()
+                return persistence
+            },
+            runtimeClock: clock
+        )
+
+        coordinator.beginSession(descriptor)
+        for row in fixture.rows {
+            clock.advance(by: .seconds(1))
+            XCTAssertEqual(clock.nowDate(), row.occurredAt)
+            XCTAssertEqual(
+                coordinator.observeHeartRateControlDecision(
+                    decisionID: row.decisionID,
+                    targetBeatsPerMinute: fixture.targetBeatsPerMinute,
+                    action: row.action,
+                    reason: row.reason,
+                    heartRateInputs: [row.heartRateInput],
+                    occurredAt: row.occurredAt
+                ),
+                .enqueued
+            )
+        }
+
+        factoryGate.signal()
+        try await eventually {
+            if case .active = coordinator.status { return true }
+            return false
+        }
+        coordinator.endSession(reason: "fixture-complete")
+        try await eventually { await persistence.finalizations.count == 1 }
+
+        let snapshot = await persistence.snapshot()
+        let header = try XCTUnwrap(snapshot.headers.first)
+        let events = snapshot.records.compactMap { record -> WorkoutEvent? in
+            guard case let .event(event) = record,
+                  event.kind == .controlDecision else { return nil }
+            return event
+        }
+        XCTAssertEqual(events.count, fixture.rows.count)
+        XCTAssertEqual(
+            events.compactMap(Self.semanticHeartRateOutcome),
+            fixture.rows.map(\.semanticOutcome)
+        )
+        XCTAssertEqual(
+            fixture.rows.map(\.legacyOutcome),
+            ["set", "hold", "inertia_hold", "limit"]
+        )
+
+        for (event, row) in zip(events, fixture.rows) {
+            guard case let .controlDecision(decision) = event.payload.payload else {
+                XCTFail("Expected typed controlDecision payload")
+                continue
+            }
+            XCTAssertEqual(decision.decisionID, row.decisionID)
+            XCTAssertEqual(decision.target, .heartRate(beatsPerMinute: 120))
+            XCTAssertEqual(decision.action, row.action)
+            XCTAssertEqual(decision.reason, row.reason)
+            XCTAssertEqual(
+                decision.observationsUsed,
+                [
+                    .heartRate(
+                        ObservationID(
+                            rawValue: row.heartRateInput.canonicalObservationID.rawValue
+                        )
+                    ),
+                ]
+            )
+            XCTAssertEqual(decision.versions, descriptor.versions)
+            XCTAssertEqual(decision.configurationSnapshotID, header.configuration.id)
+            XCTAssertEqual(event.sourceID, events.first?.sourceID)
+            XCTAssertNotNil(event.sourceID)
+            XCTAssertEqual(event.timestamp.occurredAt, row.occurredAt)
+            XCTAssertEqual(
+                event.timestamp.occurredElapsed,
+                ElapsedDuration(microseconds: row.elapsedSeconds * 1_000_000)
+            )
+            XCTAssertNil(event.commandID)
+            XCTAssertNil(event.attemptID)
+        }
+    }
+
+    func testDecisionTelemetryDispositionCannotChangeAlreadySelectedControlOutput() async throws {
+        let fixture = Issue50ProductionDecisionFixture.fixture
+        let row = fixture.rows[0]
+        let expectedOutput = Issue50ProductionDecisionFixture.ControlOutput(
+            desiredSpeedKilometresPerHour: 4.1,
+            deviceTargetSpeedKilometresPerHour: 4.1,
+            commandLabel: "SPEED 4.1 km/h (HR)"
+        )
+
+        let unavailable = TelemetryV2RuntimeCoordinator { RuntimePersistence() }
+        var unavailableDisposition: TelemetryYieldDisposition?
+        let unavailableOutput = Self.alreadySelectedControlOutput(expectedOutput) {
+            unavailableDisposition = unavailable.observeHeartRateControlDecision(
+                decisionID: row.decisionID,
+                targetBeatsPerMinute: fixture.targetBeatsPerMinute,
+                action: row.action,
+                reason: row.reason,
+                heartRateInputs: [row.heartRateInput],
+                occurredAt: row.occurredAt
+            )
+            return unavailableDisposition
+        }
+        XCTAssertNil(unavailableDisposition)
+        XCTAssertEqual(unavailableOutput, expectedOutput)
+
+        enum FactoryFailure: Error { case unavailable }
+        let failing = TelemetryV2RuntimeCoordinator { throw FactoryFailure.unavailable }
+        failing.beginSession(Self.descriptor(startedAt: fixture.startedAt))
+        try await eventually {
+            if case .unavailable = failing.status { return true }
+            return false
+        }
+        var failingDisposition: TelemetryYieldDisposition?
+        let failingOutput = Self.alreadySelectedControlOutput(expectedOutput) {
+            failingDisposition = failing.observeHeartRateControlDecision(
+                decisionID: row.decisionID,
+                targetBeatsPerMinute: fixture.targetBeatsPerMinute,
+                action: row.action,
+                reason: row.reason,
+                heartRateInputs: [row.heartRateInput],
+                occurredAt: row.occurredAt
+            )
+            return failingDisposition
+        }
+        XCTAssertNil(failingDisposition)
+        XCTAssertEqual(failingOutput, expectedOutput)
+
+        let enabledPersistence = RuntimePersistence()
+        let enabled = TelemetryV2RuntimeCoordinator { enabledPersistence }
+        enabled.beginSession(Self.descriptor(startedAt: fixture.startedAt))
+        try await eventually {
+            if case .active = enabled.status { return true }
+            return false
+        }
+        var enabledDisposition: TelemetryYieldDisposition?
+        let enabledOutput = Self.alreadySelectedControlOutput(expectedOutput) {
+            enabledDisposition = enabled.observeHeartRateControlDecision(
+                decisionID: row.decisionID,
+                targetBeatsPerMinute: fixture.targetBeatsPerMinute,
+                action: row.action,
+                reason: row.reason,
+                heartRateInputs: [row.heartRateInput],
+                occurredAt: row.occurredAt
+            )
+            return enabledDisposition
+        }
+        XCTAssertEqual(enabledDisposition, .enqueued)
+        XCTAssertEqual(enabledOutput, expectedOutput)
+        enabled.endSession(reason: "enabled-complete")
+        try await eventually { await enabledPersistence.finalizations.count == 1 }
+
+        let backpressuredPersistence = RuntimePersistence()
+        let factoryGate = DispatchSemaphore(value: 0)
+        let backpressured = TelemetryV2RuntimeCoordinator {
+            factoryGate.wait()
+            return backpressuredPersistence
+        }
+        backpressured.beginSession(Self.descriptor(startedAt: fixture.startedAt))
+        for offset in 0..<256 {
+            XCTAssertEqual(
+                backpressured.observeHeartRateControlDecision(
+                    decisionID: DecisionID(
+                        rawValue: UUID(
+                            uuidString: String(
+                                format: "50000000-0000-0000-0000-%012d",
+                                offset
+                            )
+                        )!
+                    ),
+                    targetBeatsPerMinute: fixture.targetBeatsPerMinute,
+                    action: row.action,
+                    reason: row.reason,
+                    heartRateInputs: [row.heartRateInput],
+                    occurredAt: row.occurredAt
+                ),
+                .enqueued
+            )
+        }
+        var backpressuredDisposition: TelemetryYieldDisposition?
+        let backpressuredOutput = Self.alreadySelectedControlOutput(expectedOutput) {
+            backpressuredDisposition = backpressured.observeHeartRateControlDecision(
+                decisionID: row.decisionID,
+                targetBeatsPerMinute: fixture.targetBeatsPerMinute,
+                action: row.action,
+                reason: row.reason,
+                heartRateInputs: [row.heartRateInput],
+                occurredAt: row.occurredAt
+            )
+            return backpressuredDisposition
+        }
+        XCTAssertEqual(backpressuredDisposition, .lostCritical)
+        XCTAssertEqual(backpressuredOutput, expectedOutput)
+
+        factoryGate.signal()
+        try await eventually { await backpressuredPersistence.finalizations.count == 1 }
+        if case .incomplete = backpressured.status {
+            // Recorder loss is visible only in telemetry state.
+        } else {
+            XCTFail("Expected telemetry-only incomplete status")
+        }
+    }
+
     func testPendingUnknownCausalityReplaysWithoutInventingIdentifiers() async throws {
         let persistence = RuntimePersistence()
         let factoryGate = DispatchSemaphore(value: 0)
@@ -687,6 +898,25 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
         XCTAssertEqual(enabledOutput, disabledOutput)
     }
 
+    private static func semanticHeartRateOutcome(_ event: WorkoutEvent) -> String? {
+        guard case let .controlDecision(decision) = event.payload.payload else { return nil }
+        switch (decision.action, decision.reason) {
+        case (.enqueueSpeed, _): return "setSpeed"
+        case (.noCommand, .withinTarget): return "hold"
+        case (.noCommand, .inertiaHold): return "inertiaHold"
+        case (.noCommand, .speedLimit): return "speedLimit"
+        default: return nil
+        }
+    }
+
+    private static func alreadySelectedControlOutput(
+        _ output: Issue50ProductionDecisionFixture.ControlOutput,
+        observe: () -> TelemetryYieldDisposition?
+    ) -> Issue50ProductionDecisionFixture.ControlOutput {
+        _ = observe()
+        return output
+    }
+
     private static func descriptor(
         legacySessionID: UUID? = UUID(uuidString: "10000000-0000-0000-0000-000000000030"),
         startedAt: Date = Date(timeIntervalSince1970: 1_000)
@@ -737,6 +967,85 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
             treadmillFreshnessLimitSeconds: 30
         )
     }
+}
+
+private struct Issue50ProductionDecisionFixture {
+    struct Row {
+        let legacyOutcome: String
+        let semanticOutcome: String
+        let decisionID: DecisionID
+        let action: ControlAction
+        let reason: ControlDecisionReason
+        let heartRateInput: HeartRateCausalReference
+        let occurredAt: Date
+        let elapsedSeconds: Int64
+    }
+
+    struct ControlOutput: Equatable {
+        let desiredSpeedKilometresPerHour: Double
+        let deviceTargetSpeedKilometresPerHour: Double
+        let commandLabel: String
+    }
+
+    let startedAt: Date
+    let targetBeatsPerMinute: UInt16
+    let rows: [Row]
+
+    static let fixture: Self = {
+        let startedAt = Date(timeIntervalSince1970: 30_000)
+        let legacyOutcomes = ["set", "hold", "inertia_hold", "limit"]
+        let semanticOutcomes = ["setSpeed", "hold", "inertiaHold", "speedLimit"]
+        let actions: [ControlAction] = [
+            .enqueueSpeed(DesiredSpeedKilometresPerHour(value: 4.1)),
+            .noCommand,
+            .noCommand,
+            .noCommand,
+        ]
+        let reasons: [ControlDecisionReason] = [
+            .belowTarget,
+            .withinTarget,
+            .inertiaHold,
+            .speedLimit,
+        ]
+        let rows = legacyOutcomes.indices.map { index in
+            let ordinal = index + 1
+            return Row(
+                legacyOutcome: legacyOutcomes[index],
+                semanticOutcome: semanticOutcomes[index],
+                decisionID: DecisionID(
+                    rawValue: UUID(
+                        uuidString: String(
+                            format: "51000000-0000-0000-0000-%012d",
+                            ordinal
+                        )
+                    )!
+                ),
+                action: actions[index],
+                reason: reasons[index],
+                heartRateInput: HeartRateCausalReference(
+                    deliveryID: HeartRateDeliveryID(
+                        rawValue: UUID(
+                            uuidString: String(
+                                format: "52000000-0000-0000-0000-%012d",
+                                ordinal
+                            )
+                        )!
+                    ),
+                    canonicalObservationID: HeartRateCanonicalObservationID(
+                        rawValue: UUID(
+                            uuidString: String(
+                                format: "53000000-0000-0000-0000-%012d",
+                                ordinal
+                            )
+                        )!
+                    )
+                ),
+                occurredAt: startedAt.addingTimeInterval(TimeInterval(ordinal)),
+                elapsedSeconds: Int64(ordinal)
+            )
+        }
+        return Self(startedAt: startedAt, targetBeatsPerMinute: 120, rows: rows)
+    }()
 }
 
 private final class ManualRuntimeClock: TelemetryV2RuntimeClock, @unchecked Sendable {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
@@ -903,8 +903,10 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
         switch (decision.action, decision.reason) {
         case (.enqueueSpeed, _): return "setSpeed"
         case (.noCommand, .withinTarget): return "hold"
-        case (.noCommand, .inertiaHold): return "inertiaHold"
-        case (.noCommand, .speedLimit): return "speedLimit"
+        case let (.noCommand, .other(value)) where value == "inertiaHold":
+            return "inertiaHold"
+        case let (.noCommand, .other(value)) where value == "speedLimit":
+            return "speedLimit"
         default: return nil
         }
     }
@@ -1004,8 +1006,8 @@ private struct Issue50ProductionDecisionFixture {
         let reasons: [ControlDecisionReason] = [
             .belowTarget,
             .withinTarget,
-            .inertiaHold,
-            .speedLimit,
+            .heartRateInertiaHold,
+            .heartRateSpeedLimit,
         ]
         let rows = legacyOutcomes.indices.map { index in
             let ordinal = index + 1

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -4138,7 +4138,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                             ])
                             observeSemanticHeartRateDecision(
                                 action: .noCommand,
-                                reason: .inertiaHold,
+                                reason: .heartRateInertiaHold,
                                 heartRateInputs: controlUseEvidence?.inputs ?? [],
                                 occurredAt: Date()
                             )
@@ -4206,7 +4206,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                         ])
                         observeSemanticHeartRateDecision(
                             action: .noCommand,
-                            reason: .speedLimit,
+                            reason: .heartRateSpeedLimit,
                             heartRateInputs: controlUseEvidence?.inputs ?? [],
                             occurredAt: Date()
                         )

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -4107,6 +4107,12 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                             "speed_before_kmh": currentTarget,
                             "speed_after_kmh": currentTarget
                         ])
+                        observeSemanticHeartRateDecision(
+                            action: .noCommand,
+                            reason: .withinTarget,
+                            heartRateInputs: controlUseEvidence?.inputs ?? [],
+                            occurredAt: Date()
+                        )
                         return
                     }
                     if direction > 0, let trend, trend > 0, let predictedValue {
@@ -4130,6 +4136,12 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                                 "speed_before_kmh": currentTarget,
                                 "speed_after_kmh": currentTarget
                             ])
+                            observeSemanticHeartRateDecision(
+                                action: .noCommand,
+                                reason: .inertiaHold,
+                                heartRateInputs: controlUseEvidence?.inputs ?? [],
+                                occurredAt: Date()
+                            )
                             return
                         }
                     }
@@ -4168,6 +4180,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                             "speed_before_kmh": currentTarget,
                             "speed_after_kmh": nextSpeed
                         ])
+                        observeSemanticHeartRateDecision(
+                            action: .enqueueSpeed(
+                                DesiredSpeedKilometresPerHour(value: nextSpeed)
+                            ),
+                            reason: diff < 0 ? .belowTarget : .aboveTarget,
+                            heartRateInputs: controlUseEvidence?.inputs ?? [],
+                            occurredAt: Date()
+                        )
                     } else {
                         hrStatusLine = "HR‑контроль: предел скорости"
                         hrDecisionDetails = "\(decisionPrefix) · шаг \(stepDebugLabel) \(String(format: "%.1f", step)) км/ч · скорость \(String(format: "%.1f", currentTarget)) → предел скорости"
@@ -4184,6 +4204,12 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                             "speed_before_kmh": currentTarget,
                             "speed_after_kmh": currentTarget
                         ])
+                        observeSemanticHeartRateDecision(
+                            action: .noCommand,
+                            reason: .speedLimit,
+                            heartRateInputs: controlUseEvidence?.inputs ?? [],
+                            occurredAt: Date()
+                        )
                     }
                 }
             } else if cooldownRuntimeState == nil {
@@ -5693,6 +5719,21 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private func observeHeartRateControlUse(_ evidence: HeartRateControlUseEvidence?) {
         guard let evidence else { return }
         _ = heartRateTelemetrySink?.observeControlUse(evidence)
+    }
+
+    private func observeSemanticHeartRateDecision(
+        action: ControlAction,
+        reason: ControlDecisionReason,
+        heartRateInputs: [HeartRateCausalReference],
+        occurredAt: Date
+    ) {
+        _ = telemetryV2Coordinator.observeHeartRateControlDecision(
+            targetBeatsPerMinute: UInt16(clamping: hrTargetBPM),
+            action: action,
+            reason: reason,
+            heartRateInputs: heartRateInputs,
+            occurredAt: occurredAt
+        )
     }
 
     private func currentHrTrendBpmPerSecond() -> Double? {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -119,6 +119,56 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         )
     }
 
+    func testEveryLegacyHrDecisionEmitsOnePassiveSemanticDecisionInBranchOrder() throws {
+        let tick = try functionBody("private func tickTelemetry()", in: managerSource)
+        let observer = try functionBody(
+            "private func observeSemanticHeartRateDecision(",
+            in: managerSource
+        )
+
+        XCTAssertEqual(
+            tick.components(separatedBy: "logTrainingEvent(\"hr_decision\"").count - 1,
+            4
+        )
+        XCTAssertEqual(
+            tick.components(separatedBy: "observeSemanticHeartRateDecision(").count - 1,
+            4
+        )
+        assertOrdered(
+            [
+                "if absDiff <= deadbandBpm",
+                "\"decision\": \"hold\"",
+                "reason: .withinTarget",
+                "if direction > 0, let trend, trend > 0, let predictedValue",
+                "\"decision\": \"inertia_hold\"",
+                "reason: .inertiaHold",
+                "let nextSpeed = clampRunningSpeedKmh(currentTarget + direction * step)",
+                "if nextSpeed != currentTarget",
+                "let telemetryDecision = makeTreadmillDecision(",
+                "defer { observeTreadmillDecision(telemetryDecision) }",
+                "sendTreadmillSetSpeed(",
+                "\"decision\": \"set\"",
+                "action: .enqueueSpeed(",
+                "\"decision\": \"limit\"",
+                "reason: .speedLimit",
+            ],
+            in: tick
+        )
+        XCTAssertFalse(tick.contains("if observeSemanticHeartRateDecision"))
+        XCTAssertFalse(tick.contains("guard observeSemanticHeartRateDecision"))
+        XCTAssertFalse(tick.contains("return observeSemanticHeartRateDecision"))
+
+        XCTAssertTrue(
+            observer.contains("_ = telemetryV2Coordinator.observeHeartRateControlDecision(")
+        )
+        for forbidden in [
+            "TelemetryStore", "TelemetryPersistence", "TelemetryRecorder", "FileManager",
+            "FileHandle", "Task", "await ", "logTrainingEvent", "sendTreadmill",
+        ] {
+            XCTAssertFalse(observer.contains(forbidden), "Decision observer contains \(forbidden)")
+        }
+    }
+
     func testStartAffordanceIsSeparateFromRuntimeAuthorization() throws {
         let recompute = try functionBody(
             "private func recomputeHrStartAllowed()",

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -141,7 +141,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
                 "reason: .withinTarget",
                 "if direction > 0, let trend, trend > 0, let predictedValue",
                 "\"decision\": \"inertia_hold\"",
-                "reason: .inertiaHold",
+                "reason: .heartRateInertiaHold",
                 "let nextSpeed = clampRunningSpeedKmh(currentTarget + direction * step)",
                 "if nextSpeed != currentTarget",
                 "let telemetryDecision = makeTreadmillDecision(",
@@ -150,7 +150,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
                 "\"decision\": \"set\"",
                 "action: .enqueueSpeed(",
                 "\"decision\": \"limit\"",
-                "reason: .speedLimit",
+                "reason: .heartRateSpeedLimit",
             ],
             in: tick
         )


### PR DESCRIPTION
## Summary

Adds one passive typed Telemetry V2 control-decision event after each existing legacy HR controller outcome: set, hold, inertia hold, and speed limit.

The semantic event preserves exact accepted HR observation references, the branch occurrence timestamp, target/action/reason context, and nil command/attempt causal IDs. The existing set-speed treadmill decision and command lifecycle remain distinct and unchanged.

Closes #50

## Why

Issue #50 requires semantic HR decision evidence without moving controller authority into telemetry or altering legacy control behavior. This keeps the inline controller, legacy JSONL, command queue, BLE, ACK, Stop, cooldown, Watch, and units paths unchanged.

## Verification

- [x] `swift test --filter EventSessionAndAnalysisTests` — 7 passed
- [x] `swift test --filter TelemetryV2RuntimeCoordinatorTests` — 14 passed
- [x] `swift test --filter HeartRateLegacyBehaviorContractTests` — 14 passed
- [x] `swift test` — exit 0; all top-level suites passed; expected 1000-hour profile skipped because `TELEMETRY_GATE_PROFILE=full` was not set
- [x] Fresh unsigned generic iOS build with isolated DerivedData:
  `xcodebuild -quiet -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination generic/platform=iOS -derivedDataPath <fresh-temp-dir> CODE_SIGNING_ALLOWED=NO build`
- [x] `git diff --check`
- [x] Fresh independent safety/code review: GO, no unresolved P0/P1/material P2
- [x] GitHub CI on exact head `d71b66e3f58bdb3183077726306609efdb53827e`: all four gates passed on an unchanged rerun
- [ ] Python compileall — not applicable; no Python changes

The first Swift Package CI attempt had one async waiter timeout in `testDecisionTelemetryDispositionCannotChangeAlreadySelectedControlOutput` after 0.28 seconds. The same exact head passed on the single rerun; the focused test also passed twice locally. No code changed between attempts.

The Xcode build emitted one pre-existing weak-capture warning at `BluetoothManager.swift:2147`.

## Hardware / environment

- Treadmill model: not exercised
- Protocol: not exercised
- iPhone / iOS: generic unsigned device build only
- Apple Watch / watchOS: embedded Watch app compiled; no device run
- Physical-device, BLE, deploy, and production proof: intentionally not performed

## Risks / Notes

- Risk area: additive telemetry at the HR decision boundary.
- Mitigation: disposition is discarded; regression coverage proves legacy branch order and outputs are unchanged across unavailable, rejected, degraded, and backpressured telemetry.
- V1 compatibility: new named semantics use existing `.other(String)` wire representation and have an explicit codec regression.
- Issue #32 validator and PR #49 are untouched.
- No migrations, configuration changes, deployment steps, or backward-incompatible payload changes.
- Rollback: revert the two focused commits; no persisted product state migration is involved.
- Follow-up work: none in this PR.
- Docs updated: none; existing Telemetry V2 contract remains authoritative.