### PR TITLE
Add resumable legacy telemetry migration

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/LegacyTelemetryMigrationCapability.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/LegacyTelemetryMigrationCapability.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+public struct LegacyJSONLSourceDescriptor: Hashable, Sendable {
+    public let url: URL
+    public let deterministicFallbackProfileLocalIdentifier: String?
+
+    public init(
+        url: URL,
+        deterministicFallbackProfileLocalIdentifier: String?
+    ) {
+        self.url = url
+        self.deterministicFallbackProfileLocalIdentifier =
+            deterministicFallbackProfileLocalIdentifier
+    }
+}
+
+public struct LegacyWorkoutHistorySourceDescriptor: Hashable, Sendable {
+    public let storageKey: String
+    public let representation: Data
+    public let exactProfileLocalIdentifier: String?
+
+    public init(
+        storageKey: String,
+        representation: Data,
+        exactProfileLocalIdentifier: String?
+    ) {
+        self.storageKey = storageKey
+        self.representation = representation
+        self.exactProfileLocalIdentifier = exactProfileLocalIdentifier
+    }
+}
+
+public struct LegacyTelemetryMigrationRequest: Sendable {
+    public let jsonlSources: [LegacyJSONLSourceDescriptor]
+    public let workoutHistorySources: [LegacyWorkoutHistorySourceDescriptor]
+    public let knownProfileLocalIdentifiers: Set<String>
+    public let maximumRecordsPerBatch: Int
+
+    public init(
+        jsonlSources: [LegacyJSONLSourceDescriptor],
+        workoutHistorySources: [LegacyWorkoutHistorySourceDescriptor],
+        knownProfileLocalIdentifiers: Set<String>,
+        maximumRecordsPerBatch: Int = 64
+    ) {
+        self.jsonlSources = jsonlSources
+        self.workoutHistorySources = workoutHistorySources
+        self.knownProfileLocalIdentifiers = knownProfileLocalIdentifiers
+        self.maximumRecordsPerBatch = maximumRecordsPerBatch
+    }
+}
+
+public enum LegacyTelemetryMigrationCompletion: String, Codable, Hashable, Sendable {
+    case completed
+    case partial
+    case failed
+}
+
+public struct LegacyTelemetryMigrationReport: Codable, Hashable, Sendable {
+    public let completion: LegacyTelemetryMigrationCompletion
+    public let completedSourceCount: Int
+    public let skippedSourceCount: Int
+    public let failedSourceCount: Int
+    public let importedRecordCount: Int
+    public let importedWorkoutCount: Int
+
+    public init(
+        completion: LegacyTelemetryMigrationCompletion,
+        completedSourceCount: Int,
+        skippedSourceCount: Int,
+        failedSourceCount: Int,
+        importedRecordCount: Int,
+        importedWorkoutCount: Int
+    ) {
+        self.completion = completion
+        self.completedSourceCount = completedSourceCount
+        self.skippedSourceCount = skippedSourceCount
+        self.failedSourceCount = failedSourceCount
+        self.importedRecordCount = importedRecordCount
+        self.importedWorkoutCount = importedWorkoutCount
+    }
+}
+
+/// Optional persistence capability used only for historical/background work.
+/// Runtime callers must ignore the result: migration completeness never owns
+/// application startup, workout startup, control, Stop, or safety policy.
+public protocol LegacyTelemetryMigrationCapability: Sendable {
+    func migrateLegacyTelemetry(
+        _ request: LegacyTelemetryMigrationRequest
+    ) async -> LegacyTelemetryMigrationReport
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrationModels.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrationModels.swift
@@ -1,0 +1,337 @@
+import Foundation
+
+public enum LegacyMigrationSourceKind: String, Codable, Hashable, Sendable {
+    case jsonl
+    case workoutHistory
+}
+
+public enum LegacyMigrationSourceStatus: String, Codable, Hashable, Sendable {
+    case pending
+    case inProgress
+    case paused
+    case completed
+    case failed
+}
+
+public enum LegacyWorkoutCandidateOrigin: String, Codable, Hashable, Sendable {
+    case jsonl
+    case workoutHistory
+}
+
+public enum LegacyIdentityStatus: String, Codable, Hashable, Sendable {
+    case exact
+    case uncertain
+    case conflict
+}
+
+public enum LegacyReconciliationOutcome: String, Codable, Hashable, Sendable {
+    case matched
+    case conflict
+}
+
+public enum LegacyReconciliationIdentityKind: String, Codable, Hashable, Sendable {
+    case workoutIdentifier
+    case healthKitWorkoutIdentifier
+    case stableLegacySessionIdentifier
+}
+
+public enum LegacyImportedSpeedEvidence: Codable, Hashable, Sendable {
+    case factualDeviceReported(kilometresPerHour: Double, source: String)
+    case legacyEstimated(kilometresPerHour: Double, field: String)
+    case legacyUnknown(value: Double, field: String, reason: String)
+}
+
+public enum LegacyCausalAssociation: String, Codable, Hashable, Sendable {
+    case notApplicable
+    case unknown
+    case unsupportedSpecificClaim
+}
+
+public struct LegacyImportedRecordPayload: Codable, Hashable, Sendable {
+    public let eventName: String
+    public let heartRateBeatsPerMinute: Int?
+    public let targetBeatsPerMinute: Int?
+    public let targetZoneIndex: Int?
+    public let speedEvidence: LegacyImportedSpeedEvidence?
+    public let desiredSpeedKilometresPerHour: Double?
+    public let legacySummaryDurationSeconds: Int?
+    public let legacySummaryAverageHeartRateBeatsPerMinute: Int?
+    public let ignoredStepFieldPresent: Bool
+    public let causalAssociation: LegacyCausalAssociation
+    public let warnings: [String]
+
+    public init(
+        eventName: String,
+        heartRateBeatsPerMinute: Int?,
+        targetBeatsPerMinute: Int?,
+        targetZoneIndex: Int?,
+        speedEvidence: LegacyImportedSpeedEvidence?,
+        desiredSpeedKilometresPerHour: Double?,
+        legacySummaryDurationSeconds: Int?,
+        legacySummaryAverageHeartRateBeatsPerMinute: Int?,
+        ignoredStepFieldPresent: Bool,
+        causalAssociation: LegacyCausalAssociation,
+        warnings: [String]
+    ) {
+        self.eventName = eventName
+        self.heartRateBeatsPerMinute = heartRateBeatsPerMinute
+        self.targetBeatsPerMinute = targetBeatsPerMinute
+        self.targetZoneIndex = targetZoneIndex
+        self.speedEvidence = speedEvidence
+        self.desiredSpeedKilometresPerHour = desiredSpeedKilometresPerHour
+        self.legacySummaryDurationSeconds = legacySummaryDurationSeconds
+        self.legacySummaryAverageHeartRateBeatsPerMinute =
+            legacySummaryAverageHeartRateBeatsPerMinute
+        self.ignoredStepFieldPresent = ignoredStepFieldPresent
+        self.causalAssociation = causalAssociation
+        self.warnings = warnings
+    }
+}
+
+public struct LegacySummaryConflict: Codable, Hashable, Sendable {
+    public let field: String
+    public let preferredProvenance: String?
+    public let observedProvenances: [String]
+
+    public init(
+        field: String,
+        preferredProvenance: String?,
+        observedProvenances: [String]
+    ) {
+        self.field = field
+        self.preferredProvenance = preferredProvenance
+        self.observedProvenances = observedProvenances
+    }
+}
+
+public struct LegacyWorkoutCandidateSummary: Codable, Hashable, Sendable {
+    public let timestampDerivedDurationMicroseconds: Int64?
+    public let legacySummaryDurationSeconds: Int?
+    public let targetBeatsPerMinute: Int?
+    public let timestampDerivedAverageHeartRateBeatsPerMinute: Double?
+    public let legacySummaryAverageHeartRateBeatsPerMinute: Int?
+    public let legacyEstimatedAverageSpeedKilometresPerHour: Double?
+    public let timestampDerivedZoneMicroseconds: [Int64?]?
+    public let legacySummaryZoneSeconds: [Int?]?
+    public let heartRateCoveredMicroseconds: Int64?
+    public let heartRateUncoveredMicroseconds: Int64?
+    public let heartRateSampleCount: Int
+    public let missingTimestampCount: Int
+    public let malformedRecordCount: Int
+    public let ignoredStepFieldCount: Int
+    public let legacySessionEvidenceComplete: Bool?
+    public let warnings: [String]
+    public let conflicts: [LegacySummaryConflict]
+
+    public init(
+        timestampDerivedDurationMicroseconds: Int64?,
+        legacySummaryDurationSeconds: Int?,
+        targetBeatsPerMinute: Int?,
+        timestampDerivedAverageHeartRateBeatsPerMinute: Double?,
+        legacySummaryAverageHeartRateBeatsPerMinute: Int?,
+        legacyEstimatedAverageSpeedKilometresPerHour: Double?,
+        timestampDerivedZoneMicroseconds: [Int64?]?,
+        legacySummaryZoneSeconds: [Int?]?,
+        heartRateCoveredMicroseconds: Int64?,
+        heartRateUncoveredMicroseconds: Int64?,
+        heartRateSampleCount: Int,
+        missingTimestampCount: Int,
+        malformedRecordCount: Int,
+        ignoredStepFieldCount: Int,
+        legacySessionEvidenceComplete: Bool?,
+        warnings: [String],
+        conflicts: [LegacySummaryConflict]
+    ) {
+        self.timestampDerivedDurationMicroseconds = timestampDerivedDurationMicroseconds
+        self.legacySummaryDurationSeconds = legacySummaryDurationSeconds
+        self.targetBeatsPerMinute = targetBeatsPerMinute
+        self.timestampDerivedAverageHeartRateBeatsPerMinute =
+            timestampDerivedAverageHeartRateBeatsPerMinute
+        self.legacySummaryAverageHeartRateBeatsPerMinute =
+            legacySummaryAverageHeartRateBeatsPerMinute
+        self.legacyEstimatedAverageSpeedKilometresPerHour =
+            legacyEstimatedAverageSpeedKilometresPerHour
+        self.timestampDerivedZoneMicroseconds = timestampDerivedZoneMicroseconds
+        self.legacySummaryZoneSeconds = legacySummaryZoneSeconds
+        self.heartRateCoveredMicroseconds = heartRateCoveredMicroseconds
+        self.heartRateUncoveredMicroseconds = heartRateUncoveredMicroseconds
+        self.heartRateSampleCount = heartRateSampleCount
+        self.missingTimestampCount = missingTimestampCount
+        self.malformedRecordCount = malformedRecordCount
+        self.ignoredStepFieldCount = ignoredStepFieldCount
+        self.legacySessionEvidenceComplete = legacySessionEvidenceComplete
+        self.warnings = warnings
+        self.conflicts = conflicts
+    }
+}
+
+public struct LegacySourcedValue<Value>: Codable, Hashable, Sendable
+where Value: Codable & Hashable & Sendable {
+    public let value: Value
+    public let provenance: String
+
+    public init(value: Value, provenance: String) {
+        self.value = value
+        self.provenance = provenance
+    }
+}
+
+public struct LegacyResolvedValue<Value>: Codable, Hashable, Sendable
+where Value: Codable & Hashable & Sendable {
+    public let selected: LegacySourcedValue<Value>?
+    public let alternatives: [LegacySourcedValue<Value>]
+    public let conflict: Bool
+
+    public init(
+        selected: LegacySourcedValue<Value>?,
+        alternatives: [LegacySourcedValue<Value>],
+        conflict: Bool
+    ) {
+        self.selected = selected
+        self.alternatives = alternatives
+        self.conflict = conflict
+    }
+}
+
+public struct LegacyResolvedWorkoutSummary: Codable, Hashable, Sendable {
+    public let durationMicroseconds: LegacyResolvedValue<Int64>
+    public let targetBeatsPerMinute: LegacyResolvedValue<Int>
+    public let averageHeartRateBeatsPerMinute: LegacyResolvedValue<Double>
+    public let estimatedAverageSpeedKilometresPerHour: LegacyResolvedValue<Double>
+    public let zoneMicroseconds: LegacyResolvedValue<[Int64?]>
+    public let warnings: [String]
+    public let conflicts: [LegacySummaryConflict]
+
+    public init(
+        durationMicroseconds: LegacyResolvedValue<Int64>,
+        targetBeatsPerMinute: LegacyResolvedValue<Int>,
+        averageHeartRateBeatsPerMinute: LegacyResolvedValue<Double>,
+        estimatedAverageSpeedKilometresPerHour: LegacyResolvedValue<Double>,
+        zoneMicroseconds: LegacyResolvedValue<[Int64?]>,
+        warnings: [String],
+        conflicts: [LegacySummaryConflict]
+    ) {
+        self.durationMicroseconds = durationMicroseconds
+        self.targetBeatsPerMinute = targetBeatsPerMinute
+        self.averageHeartRateBeatsPerMinute = averageHeartRateBeatsPerMinute
+        self.estimatedAverageSpeedKilometresPerHour =
+            estimatedAverageSpeedKilometresPerHour
+        self.zoneMicroseconds = zoneMicroseconds
+        self.warnings = warnings
+        self.conflicts = conflicts
+    }
+}
+
+public struct LegacyMigrationSourceSnapshot: Codable, Hashable, Sendable {
+    public let sourceID: String
+    public let kind: LegacyMigrationSourceKind
+    public let contentHashDigest: String
+    public let importerVersion: String
+    public let locator: String
+    public let exactProfileLocalIdentifier: String?
+    public let status: LegacyMigrationSourceStatus
+    public let checkpointByteOffset: Int64
+    public let checkpointRecordIndex: Int64
+    public let parsedRecordCount: Int64
+    public let malformedRecordCount: Int64
+    public let warningCount: Int64
+    public let errorCode: String?
+    public let errorDetail: String?
+}
+
+public struct LegacyImportedRecordSnapshot: Codable, Hashable, Sendable {
+    public let importedRecordID: String
+    public let sourceID: String
+    public let candidateID: String
+    public let sourceRecordIndex: Int64
+    public let eventKind: String
+    public let occurredAt: Date?
+    public let profileLocalIdentifier: String?
+    public let workoutIdentifier: String?
+    public let healthKitWorkoutIdentifier: String?
+    public let stableLegacySessionIdentifier: String?
+    public let payload: LegacyImportedRecordPayload
+    public let identityUncertain: Bool
+    public let adaptationQualityEligible: Bool
+}
+
+public struct LegacyWorkoutCandidateSnapshot: Codable, Hashable, Sendable {
+    public let candidateID: String
+    public let sourceID: String
+    public let origin: LegacyWorkoutCandidateOrigin
+    public let profileLocalIdentifier: String?
+    public let workoutIdentifier: String?
+    public let healthKitWorkoutIdentifier: String?
+    public let stableLegacySessionIdentifier: String?
+    public let startedAt: Date?
+    public let endedAt: Date?
+    public let identityUncertain: Bool
+    public let possibleDuplicate: Bool
+    public let summary: LegacyWorkoutCandidateSummary
+}
+
+public struct LegacyImportedWorkoutSnapshot: Codable, Hashable, Sendable {
+    public let importedWorkoutID: String
+    public let canonicalIdentityKey: String
+    public let profileLocalIdentifier: String?
+    public let startedAt: Date?
+    public let endedAt: Date?
+    public let identityStatus: LegacyIdentityStatus
+    public let possibleDuplicate: Bool
+    public let adaptationQualityEligible: Bool
+    public let candidateIDs: [String]
+    public let resolvedSummary: LegacyResolvedWorkoutSummary
+}
+
+public struct LegacyReconciliationSnapshot: Codable, Hashable, Sendable {
+    public let reconciliationID: String
+    public let leftCandidateID: String
+    public let rightCandidateID: String
+    public let outcome: LegacyReconciliationOutcome
+    public let identityKind: LegacyReconciliationIdentityKind?
+    public let identityValue: String?
+    public let importedWorkoutID: String?
+    public let detailCodes: [String]
+}
+
+struct LegacyMigrationSourceDefinition: Sendable {
+    let sourceID: String
+    let kind: LegacyMigrationSourceKind
+    let contentHashDigest: String
+    let locator: String
+    let exactProfileLocalIdentifier: String?
+}
+
+struct LegacyImportedRecordDraft: Sendable {
+    let importedRecordID: String
+    let sourceItemIdentityKey: String
+    let sourceID: String
+    let candidateID: String
+    let sourceRecordIndex: Int64
+    let sourceByteOffset: Int64
+    let eventKind: String
+    let occurredAt: Date?
+    let profileLocalIdentifier: String?
+    let workoutIdentifier: String?
+    let healthKitWorkoutIdentifier: String?
+    let stableLegacySessionIdentifier: String?
+    let provenanceKey: String
+    let payload: LegacyImportedRecordPayload
+    let identityUncertain: Bool
+}
+
+struct LegacyWorkoutCandidateDraft: Sendable {
+    let candidateID: String
+    let sourceItemIdentityKey: String
+    let sourceID: String
+    let origin: LegacyWorkoutCandidateOrigin
+    let profileLocalIdentifier: String?
+    let workoutIdentifier: String?
+    let healthKitWorkoutIdentifier: String?
+    let stableLegacySessionIdentifier: String?
+    let startedAt: Date?
+    let endedAt: Date?
+    let identityUncertain: Bool
+    let possibleDuplicate: Bool
+    let summary: LegacyWorkoutCandidateSummary
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrationParsing.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrationParsing.swift
@@ -1,0 +1,1141 @@
+import CryptoKit
+import CoreFoundation
+import Foundation
+
+enum LegacyMigrationParsingError: Error, Equatable {
+    case unreadableSource
+    case invalidWorkoutHistoryArray
+    case sourceOffsetOutOfBounds
+}
+
+enum LegacyMigrationHashing {
+    static func fileSHA256(_ url: URL, chunkSize: Int = 64 * 1_024) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while let chunk = try handle.read(upToCount: chunkSize), !chunk.isEmpty {
+            hasher.update(data: chunk)
+        }
+        return hex(hasher.finalize())
+    }
+
+    static func dataSHA256(_ data: Data) -> String {
+        hex(SHA256.hash(data: data))
+    }
+
+    static func deterministicIdentifier(_ key: String) -> String {
+        let digest = SHA256.hash(data: Data(key.utf8))
+        var bytes = Array(digest.prefix(16))
+        bytes[6] = (bytes[6] & 0x0f) | 0x80
+        bytes[8] = (bytes[8] & 0x3f) | 0x80
+        let parts = bytes.map { String(format: "%02x", $0) }
+        return [
+            parts[0...3].joined(),
+            parts[4...5].joined(),
+            parts[6...7].joined(),
+            parts[8...9].joined(),
+            parts[10...15].joined(),
+        ].joined(separator: "-")
+    }
+
+    private static func hex<S: Sequence>(_ bytes: S) -> String where S.Element == UInt8 {
+        bytes.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+struct LegacySourceElement: Sendable {
+    let data: Data?
+    let startOffset: Int64
+    let endOffset: Int64
+    let recordIndex: Int64
+    let structuralWarning: String?
+}
+
+final class LegacyJSONLLineReader {
+    private let handle: FileHandle
+    private let chunkSize: Int
+    private let maximumLineBytes: Int
+    private var buffer = Data()
+    private var bufferStartOffset: Int64
+    private var nextRecordIndex: Int64
+    private var reachedEOF = false
+    private var discardingOversizedLine = false
+
+    init(
+        url: URL,
+        startingAt byteOffset: Int64,
+        nextRecordIndex: Int64,
+        chunkSize: Int = 64 * 1_024,
+        maximumLineBytes: Int = 1 * 1_024 * 1_024
+    ) throws {
+        guard byteOffset >= 0 else {
+            throw LegacyMigrationParsingError.sourceOffsetOutOfBounds
+        }
+        handle = try FileHandle(forReadingFrom: url)
+        try handle.seek(toOffset: UInt64(byteOffset))
+        bufferStartOffset = byteOffset
+        self.nextRecordIndex = nextRecordIndex
+        self.chunkSize = max(1, chunkSize)
+        self.maximumLineBytes = max(1, maximumLineBytes)
+    }
+
+    deinit {
+        try? handle.close()
+    }
+
+    func next() throws -> LegacySourceElement? {
+        while true {
+            if let newline = buffer.firstIndex(of: 0x0a) {
+                let consumedCount = buffer.distance(
+                    from: buffer.startIndex,
+                    to: buffer.index(after: newline)
+                )
+                let start = bufferStartOffset
+                let end = start + Int64(consumedCount)
+                let rawLine = Data(buffer[..<newline])
+                buffer.removeFirst(consumedCount)
+                bufferStartOffset = end
+                nextRecordIndex += 1
+
+                if discardingOversizedLine {
+                    discardingOversizedLine = false
+                    return LegacySourceElement(
+                        data: nil,
+                        startOffset: start,
+                        endOffset: end,
+                        recordIndex: nextRecordIndex,
+                        structuralWarning: "line-too-large"
+                    )
+                }
+                return element(
+                    rawLine,
+                    start: start,
+                    end: end,
+                    recordIndex: nextRecordIndex
+                )
+            }
+
+            if reachedEOF {
+                guard !buffer.isEmpty || discardingOversizedLine else { return nil }
+                let start = bufferStartOffset
+                let end = start + Int64(buffer.count)
+                let rawLine = buffer
+                buffer.removeAll(keepingCapacity: false)
+                bufferStartOffset = end
+                nextRecordIndex += 1
+                if discardingOversizedLine {
+                    discardingOversizedLine = false
+                    return LegacySourceElement(
+                        data: nil,
+                        startOffset: start,
+                        endOffset: end,
+                        recordIndex: nextRecordIndex,
+                        structuralWarning: "line-too-large"
+                    )
+                }
+                return element(
+                    rawLine,
+                    start: start,
+                    end: end,
+                    recordIndex: nextRecordIndex
+                )
+            }
+
+            guard let chunk = try handle.read(upToCount: chunkSize), !chunk.isEmpty else {
+                reachedEOF = true
+                continue
+            }
+            if discardingOversizedLine {
+                if let newline = chunk.firstIndex(of: 0x0a) {
+                    let suffixStart = chunk.index(after: newline)
+                    bufferStartOffset += Int64(chunk.distance(
+                        from: chunk.startIndex,
+                        to: suffixStart
+                    ))
+                    buffer.append(contentsOf: chunk[suffixStart...])
+                    nextRecordIndex += 1
+                    discardingOversizedLine = false
+                    return LegacySourceElement(
+                        data: nil,
+                        startOffset: bufferStartOffset,
+                        endOffset: bufferStartOffset,
+                        recordIndex: nextRecordIndex,
+                        structuralWarning: "line-too-large"
+                    )
+                }
+                bufferStartOffset += Int64(chunk.count)
+                continue
+            }
+            buffer.append(chunk)
+            if buffer.count > maximumLineBytes, buffer.firstIndex(of: 0x0a) == nil {
+                bufferStartOffset += Int64(buffer.count)
+                buffer.removeAll(keepingCapacity: true)
+                discardingOversizedLine = true
+            }
+        }
+    }
+
+    private func element(
+        _ rawLine: Data,
+        start: Int64,
+        end: Int64,
+        recordIndex: Int64
+    ) -> LegacySourceElement {
+        var line = rawLine
+        if line.last == 0x0d {
+            line.removeLast()
+        }
+        return LegacySourceElement(
+            data: line.isEmpty ? nil : line,
+            startOffset: start,
+            endOffset: end,
+            recordIndex: recordIndex,
+            structuralWarning: nil
+        )
+    }
+}
+
+struct LegacyJSONArrayElementReader {
+    private let data: Data
+    private var cursor: Int
+    private var nextRecordIndex: Int64
+    private var opened = false
+
+    init(data: Data, startingAt byteOffset: Int64, nextRecordIndex: Int64) throws {
+        guard byteOffset >= 0, byteOffset <= data.count else {
+            throw LegacyMigrationParsingError.sourceOffsetOutOfBounds
+        }
+        self.data = data
+        cursor = Int(byteOffset)
+        self.nextRecordIndex = nextRecordIndex
+        opened = byteOffset > 0
+    }
+
+    mutating func next() throws -> LegacySourceElement? {
+        if !opened {
+            skipWhitespace()
+            guard cursor < data.count, data[cursor] == 0x5b else {
+                throw LegacyMigrationParsingError.invalidWorkoutHistoryArray
+            }
+            cursor += 1
+            opened = true
+        }
+        skipSeparators()
+        guard cursor < data.count else {
+            throw LegacyMigrationParsingError.invalidWorkoutHistoryArray
+        }
+        if data[cursor] == 0x5d {
+            cursor += 1
+            skipWhitespace()
+            guard cursor == data.count else {
+                throw LegacyMigrationParsingError.invalidWorkoutHistoryArray
+            }
+            return nil
+        }
+
+        let start = cursor
+        var depth = 0
+        var isInString = false
+        var isEscaped = false
+        while cursor < data.count {
+            let byte = data[cursor]
+            if isInString {
+                if isEscaped {
+                    isEscaped = false
+                } else if byte == 0x5c {
+                    isEscaped = true
+                } else if byte == 0x22 {
+                    isInString = false
+                }
+            } else {
+                switch byte {
+                case 0x22:
+                    isInString = true
+                case 0x7b, 0x5b:
+                    depth += 1
+                case 0x7d:
+                    depth -= 1
+                case 0x5d:
+                    if depth == 0 {
+                        return makeElement(start: start, end: cursor)
+                    }
+                    depth -= 1
+                case 0x2c where depth == 0:
+                    return makeElement(start: start, end: cursor)
+                default:
+                    break
+                }
+            }
+            cursor += 1
+        }
+        return makeElement(start: start, end: cursor)
+    }
+
+    private mutating func makeElement(start: Int, end: Int) -> LegacySourceElement {
+        let trimmed = data[start..<end].trimmingJSONWhitespace()
+        let result = LegacySourceElement(
+            data: trimmed.isEmpty ? nil : Data(trimmed),
+            startOffset: Int64(start),
+            endOffset: Int64(end),
+            recordIndex: nextRecordIndex + 1,
+            structuralWarning: nil
+        )
+        nextRecordIndex += 1
+        return result
+    }
+
+    private mutating func skipWhitespace() {
+        while cursor < data.count, data[cursor].isJSONWhitespace {
+            cursor += 1
+        }
+    }
+
+    private mutating func skipSeparators() {
+        while cursor < data.count {
+            if data[cursor].isJSONWhitespace || data[cursor] == 0x2c {
+                cursor += 1
+            } else {
+                break
+            }
+        }
+    }
+}
+
+private extension Data.SubSequence {
+    func trimmingJSONWhitespace() -> Data.SubSequence {
+        var lower = startIndex
+        var upper = endIndex
+        while lower < upper, self[lower].isJSONWhitespace {
+            lower = index(after: lower)
+        }
+        while lower < upper {
+            let previous = index(before: upper)
+            guard self[previous].isJSONWhitespace else { break }
+            upper = previous
+        }
+        return self[lower..<upper]
+    }
+}
+
+private extension UInt8 {
+    var isJSONWhitespace: Bool {
+        self == 0x20 || self == 0x09 || self == 0x0a || self == 0x0d
+    }
+}
+
+struct ParsedLegacyJSONLRecord {
+    let canonicalPayloadDigest: String
+    let draft: LegacyImportedRecordDraft
+}
+
+enum LegacyTelemetryMigrationParser {
+    static func canonicalObjectDigest(_ data: Data) throws -> String {
+        let object = try JSONSerialization.jsonObject(with: data)
+        guard JSONSerialization.isValidJSONObject(object) else {
+            throw LegacyMigrationParsingError.unreadableSource
+        }
+        let canonical = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        return LegacyMigrationHashing.dataSHA256(canonical)
+    }
+
+    static func parseJSONL(
+        _ data: Data,
+        sourceID: String,
+        candidateID: String,
+        element: LegacySourceElement,
+        knownProfiles: Set<String>,
+        deterministicFallbackProfile: String?
+    ) throws -> ParsedLegacyJSONLRecord {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw LegacyMigrationParsingError.unreadableSource
+        }
+        let canonical = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        let digest = LegacyMigrationHashing.dataSHA256(canonical)
+        let event = string(object, keys: ["event"]) ?? "unknown"
+        let timestamp = jsonlDate(object["ts"] ?? object["timestamp"])
+        let stableSession = stableIdentifier(object, keys: [
+            "session_id", "legacy_session_id", "session_uuid",
+        ])
+        let workoutIdentifier = stableIdentifier(object, keys: ["workout_id"])
+        let healthKitIdentifier = uuidIdentifier(object, keys: [
+            "healthkit_workout_uuid", "healthkitWorkoutUUID", "healthkit_uuid",
+            "workout_uuid",
+        ])
+        var warnings: [String] = []
+        let explicitProfile = stableIdentifier(
+            object,
+            keys: ["profile_id", "profileId"]
+        )?.lowercased()
+        let profile: String?
+        if let explicitProfile {
+            if knownProfiles.contains(explicitProfile) {
+                profile = explicitProfile
+            } else {
+                profile = nil
+                warnings.append("unknown-explicit-profile")
+            }
+        } else if let deterministicFallbackProfile,
+                  knownProfiles.contains(deterministicFallbackProfile) {
+            profile = deterministicFallbackProfile
+            warnings.append("deterministic-pre-profile-ownership-mapping")
+        } else {
+            profile = nil
+            warnings.append("profile-ownership-unknown")
+        }
+
+        let heartRate: Int? = event == "hr_sample"
+            ? positiveInteger(object, keys: ["hr_bpm", "bpm"], maximum: 300)
+            : nil
+        let target = positiveInteger(object, keys: ["target_bpm"], maximum: 300)
+        let targetZone = nonNegativeInteger(object, keys: ["target_zone_index", "zone_index"])
+        let speedEvidence = speedEvidence(object, event: event, warnings: &warnings)
+        let desiredSpeed = nonNegativeDouble(
+            object,
+            keys: ["speed_after_kmh", "speed_target_kmh"]
+        )
+        let summaryDuration = (event == "workout_saved" || event == "session_end")
+            ? positiveInteger(object, keys: ["workout_duration_s", "duration_s"])
+            : nil
+        let summaryAverageHeartRate = (event == "workout_saved" || event == "session_end")
+            ? nonNegativeInteger(object, keys: ["avg_bpm", "main_avg_bpm"])
+            : nil
+        let ignoredSteps = object["steps"] != nil
+        if ignoredSteps {
+            warnings.append("legacy-steps-ignored")
+        }
+        let hasSpecificCausalClaim = stableIdentifier(object, keys: [
+            "command_id", "commandID", "attempt_id", "attemptID",
+        ]) != nil || bool(object, keys: ["deterministically_correlated"]) == true
+        let isCommandEvidence = event.hasPrefix("command_")
+            || event == "notify_ftms_control_point"
+        let causalAssociation: LegacyCausalAssociation
+        if hasSpecificCausalClaim {
+            causalAssociation = .unsupportedSpecificClaim
+            warnings.append("unsupported-specific-causal-claim")
+        } else if isCommandEvidence {
+            causalAssociation = .unknown
+        } else {
+            causalAssociation = .notApplicable
+        }
+        if timestamp == nil {
+            warnings.append("missing-or-invalid-timestamp")
+        }
+
+        let sourceItemKey = "jsonl-item:\(sourceID):\(element.recordIndex):\(digest)"
+        let importedRecordID = LegacyMigrationHashing.deterministicIdentifier(sourceItemKey)
+        let identityUncertain = stableSession == nil
+            && workoutIdentifier == nil
+            && healthKitIdentifier == nil
+        let payload = LegacyImportedRecordPayload(
+            eventName: event,
+            heartRateBeatsPerMinute: heartRate,
+            targetBeatsPerMinute: target,
+            targetZoneIndex: targetZone,
+            speedEvidence: speedEvidence,
+            desiredSpeedKilometresPerHour: desiredSpeed,
+            legacySummaryDurationSeconds: summaryDuration,
+            legacySummaryAverageHeartRateBeatsPerMinute: summaryAverageHeartRate,
+            ignoredStepFieldPresent: ignoredSteps,
+            causalAssociation: causalAssociation,
+            warnings: warnings.sorted()
+        )
+        return ParsedLegacyJSONLRecord(
+            canonicalPayloadDigest: digest,
+            draft: LegacyImportedRecordDraft(
+                importedRecordID: importedRecordID,
+                sourceItemIdentityKey: sourceItemKey,
+                sourceID: sourceID,
+                candidateID: candidateID,
+                sourceRecordIndex: element.recordIndex,
+                sourceByteOffset: element.startOffset,
+                eventKind: event,
+                occurredAt: timestamp,
+                profileLocalIdentifier: profile,
+                workoutIdentifier: workoutIdentifier,
+                healthKitWorkoutIdentifier: healthKitIdentifier,
+                stableLegacySessionIdentifier: stableSession,
+                provenanceKey: "legacyJSONL",
+                payload: payload,
+                identityUncertain: identityUncertain
+            )
+        )
+    }
+
+    static func parseWorkoutHistory(
+        _ data: Data,
+        sourceID: String,
+        element: LegacySourceElement,
+        occurrence: Int,
+        exactProfile: String?
+    ) throws -> (record: LegacyImportedRecordDraft, candidate: LegacyWorkoutCandidateDraft) {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw LegacyMigrationParsingError.unreadableSource
+        }
+        let canonical = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        let digest = LegacyMigrationHashing.dataSHA256(canonical)
+        let workoutIdentifier = stableIdentifier(object, keys: ["id", "workout_id"])
+        let healthKitIdentifier = uuidIdentifier(object, keys: [
+            "healthkitWorkoutUUID", "healthkit_workout_uuid", "workout_uuid",
+        ])
+        let stableSession = stableIdentifier(object, keys: [
+            "session_id", "legacy_session_id", "session_uuid",
+        ])
+        let sourceItemKey = "history-item:\(sourceID):\(digest):\(occurrence)"
+        let candidateID = LegacyMigrationHashing.deterministicIdentifier(
+            "history-candidate:\(sourceItemKey)"
+        )
+        let importedRecordID = LegacyMigrationHashing.deterministicIdentifier(
+            "history-record:\(sourceItemKey)"
+        )
+        let endedAt = historyDate(object["date"] ?? object["ended_at"])
+        let duration = positiveInteger(object, keys: ["durationSeconds", "duration_s"])
+        let target = positiveInteger(object, keys: ["targetBpm", "target_bpm"], maximum: 300)
+        let averageHeartRate = nonNegativeInteger(object, keys: ["avgBpm", "avg_bpm"])
+        let averageSpeed = nonNegativeDouble(object, keys: ["avgSpeedKmh", "avg_speed_kmh"])
+        let zones = optionalNonNegativeIntegerArray(
+            object["zoneSeconds"] ?? object["zone_seconds"],
+            expectedCount: 5
+        )
+        var warnings: [String] = ["legacy-summary-not-native-evidence"]
+        if workoutIdentifier == nil, healthKitIdentifier == nil, stableSession == nil {
+            warnings.append("stable-identity-missing")
+        }
+        if exactProfile == nil {
+            warnings.append("profile-ownership-unknown")
+        }
+        let speedEvidence = averageSpeed.map {
+            LegacyImportedSpeedEvidence.legacyEstimated(
+                kilometresPerHour: $0,
+                field: "avgSpeedKmh"
+            )
+        }
+        let payload = LegacyImportedRecordPayload(
+            eventName: "workout_history_summary",
+            heartRateBeatsPerMinute: averageHeartRate,
+            targetBeatsPerMinute: target,
+            targetZoneIndex: nil,
+            speedEvidence: speedEvidence,
+            desiredSpeedKilometresPerHour: nil,
+            legacySummaryDurationSeconds: duration,
+            legacySummaryAverageHeartRateBeatsPerMinute: averageHeartRate,
+            ignoredStepFieldPresent: false,
+            causalAssociation: .notApplicable,
+            warnings: warnings.sorted()
+        )
+        let identityUncertain = workoutIdentifier == nil
+            && healthKitIdentifier == nil
+            && stableSession == nil
+        let summary = LegacyWorkoutCandidateSummary(
+            timestampDerivedDurationMicroseconds: nil,
+            legacySummaryDurationSeconds: duration,
+            targetBeatsPerMinute: target,
+            timestampDerivedAverageHeartRateBeatsPerMinute: nil,
+            legacySummaryAverageHeartRateBeatsPerMinute: averageHeartRate,
+            legacyEstimatedAverageSpeedKilometresPerHour: averageSpeed,
+            timestampDerivedZoneMicroseconds: nil,
+            legacySummaryZoneSeconds: zones,
+            heartRateCoveredMicroseconds: nil,
+            heartRateUncoveredMicroseconds: nil,
+            heartRateSampleCount: 0,
+            missingTimestampCount: endedAt == nil ? 1 : 0,
+            malformedRecordCount: 0,
+            ignoredStepFieldCount: 0,
+            legacySessionEvidenceComplete: nil,
+            warnings: warnings.sorted(),
+            conflicts: []
+        )
+        return (
+            LegacyImportedRecordDraft(
+                importedRecordID: importedRecordID,
+                sourceItemIdentityKey: sourceItemKey,
+                sourceID: sourceID,
+                candidateID: candidateID,
+                sourceRecordIndex: element.recordIndex,
+                sourceByteOffset: element.startOffset,
+                eventKind: "workout_history_summary",
+                occurredAt: endedAt,
+                profileLocalIdentifier: exactProfile,
+                workoutIdentifier: workoutIdentifier,
+                healthKitWorkoutIdentifier: healthKitIdentifier,
+                stableLegacySessionIdentifier: stableSession,
+                provenanceKey: "workout_history_v1",
+                payload: payload,
+                identityUncertain: identityUncertain
+            ),
+            LegacyWorkoutCandidateDraft(
+                candidateID: candidateID,
+                sourceItemIdentityKey: sourceItemKey,
+                sourceID: sourceID,
+                origin: .workoutHistory,
+                profileLocalIdentifier: exactProfile,
+                workoutIdentifier: workoutIdentifier,
+                healthKitWorkoutIdentifier: healthKitIdentifier,
+                stableLegacySessionIdentifier: stableSession,
+                startedAt: nil,
+                endedAt: endedAt,
+                identityUncertain: identityUncertain || exactProfile == nil,
+                possibleDuplicate: identityUncertain,
+                summary: summary
+            )
+        )
+    }
+
+    private static func speedEvidence(
+        _ object: [String: Any],
+        event: String,
+        warnings: inout [String]
+    ) -> LegacyImportedSpeedEvidence? {
+        switch event {
+        case "notify_ftms_treadmill_data":
+            if let value = nonNegativeDouble(object, keys: ["speed_kmh"]) {
+                return .factualDeviceReported(
+                    kilometresPerHour: value,
+                    source: "ftms-treadmill-data"
+                )
+            }
+        case "notify_fitshow_speed", "notify_fitshow_status":
+            if bool(object, keys: ["checksum_ok"]) == true,
+               let value = nonNegativeDouble(object, keys: ["speed_kmh"]) {
+                return .factualDeviceReported(
+                    kilometresPerHour: value,
+                    source: "fitshow-checksum-valid-report"
+                )
+            }
+            if let value = nonNegativeDouble(object, keys: ["speed_kmh"]) {
+                warnings.append("fitshow-speed-not-factual-without-valid-checksum")
+                return .legacyUnknown(
+                    value: value,
+                    field: "speed_kmh",
+                    reason: "checksum-not-proven-valid"
+                )
+            }
+        case "notify_fe01":
+            let unitsMetric = string(object, keys: ["controller_units"]) == "metric"
+            let unitsFresh = bool(object, keys: ["controller_units_fresh"]) == true
+            let checksumValid = bool(object, keys: ["checksum_ok"]) == true
+            if unitsMetric, unitsFresh, checksumValid,
+               let value = nonNegativeDouble(object, keys: ["speed_kmh"]) {
+                return .factualDeviceReported(
+                    kilometresPerHour: value,
+                    source: "walkingpad-explicit-metric-fresh-checksum-valid-report"
+                )
+            }
+            if let value = nonNegativeDouble(object, keys: ["speed_kmh"]) {
+                warnings.append("walkingpad-speed-units-or-quality-unproven")
+                return .legacyUnknown(
+                    value: value,
+                    field: "speed_kmh",
+                    reason: "metric-units-and-quality-not-independently-proven"
+                )
+            }
+        default:
+            break
+        }
+        if event == "workout_saved",
+           let value = nonNegativeDouble(object, keys: ["avg_speed_kmh"]) {
+            warnings.append("legacy-summary-average-speed-kept-estimated")
+            return .legacyEstimated(
+                kilometresPerHour: value,
+                field: "avg_speed_kmh"
+            )
+        }
+        if let value = nonNegativeDouble(object, keys: ["speed_actual_kmh"]) {
+            warnings.append("ambiguous-speed-actual-kept-estimated")
+            return .legacyEstimated(
+                kilometresPerHour: value,
+                field: "speed_actual_kmh"
+            )
+        }
+        return nil
+    }
+
+    private static func jsonlDate(_ value: Any?) -> Date? {
+        if let seconds = double(value), seconds >= 0 {
+            return Date(timeIntervalSince1970: seconds)
+        }
+        guard let raw = value as? String else { return nil }
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractional.date(from: raw) ?? ISO8601DateFormatter().date(from: raw)
+    }
+
+    private static func historyDate(_ value: Any?) -> Date? {
+        if let seconds = double(value), seconds >= 0 {
+            return seconds > 1_200_000_000
+                ? Date(timeIntervalSince1970: seconds)
+                : Date(timeIntervalSinceReferenceDate: seconds)
+        }
+        return jsonlDate(value)
+    }
+
+    private static func stableIdentifier(
+        _ object: [String: Any],
+        keys: [String]
+    ) -> String? {
+        for key in keys {
+            guard let value = object[key] else { continue }
+            let raw: String?
+            if let string = value as? String {
+                raw = string
+            } else if let uuid = value as? UUID {
+                raw = uuid.uuidString
+            } else {
+                raw = nil
+            }
+            if let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !trimmed.isEmpty {
+                return UUID(uuidString: trimmed)?.uuidString.lowercased() ?? trimmed
+            }
+        }
+        return nil
+    }
+
+    private static func uuidIdentifier(
+        _ object: [String: Any],
+        keys: [String]
+    ) -> String? {
+        guard let value = stableIdentifier(object, keys: keys),
+              let uuid = UUID(uuidString: value) else { return nil }
+        return uuid.uuidString.lowercased()
+    }
+
+    private static func string(_ object: [String: Any], keys: [String]) -> String? {
+        keys.lazy.compactMap { object[$0] as? String }.first
+    }
+
+    private static func double(_ value: Any?) -> Double? {
+        if let number = value as? NSNumber {
+            guard CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
+            let result = number.doubleValue
+            return result.isFinite ? result : nil
+        }
+        if let string = value as? String, let result = Double(string), result.isFinite {
+            return result
+        }
+        return nil
+    }
+
+    private static func integer(_ value: Any?) -> Int? {
+        guard let numeric = double(value), numeric.rounded() == numeric,
+              numeric >= Double(Int.min), numeric <= Double(Int.max) else { return nil }
+        return Int(numeric)
+    }
+
+    private static func positiveInteger(
+        _ object: [String: Any],
+        keys: [String],
+        maximum: Int = Int.max
+    ) -> Int? {
+        guard let value = keys.lazy.compactMap({ integer(object[$0]) }).first,
+              value > 0, value <= maximum else { return nil }
+        return value
+    }
+
+    private static func nonNegativeInteger(
+        _ object: [String: Any],
+        keys: [String]
+    ) -> Int? {
+        guard let value = keys.lazy.compactMap({ integer(object[$0]) }).first,
+              value >= 0 else { return nil }
+        return value
+    }
+
+    private static func nonNegativeDouble(
+        _ object: [String: Any],
+        keys: [String]
+    ) -> Double? {
+        guard let value = keys.lazy.compactMap({ double(object[$0]) }).first,
+              value >= 0 else { return nil }
+        return value
+    }
+
+    private static func bool(_ object: [String: Any], keys: [String]) -> Bool? {
+        for key in keys {
+            if let value = object[key] as? Bool { return value }
+            if let value = object[key] as? NSNumber { return value.boolValue }
+            if let value = object[key] as? String {
+                if value == "true" { return true }
+                if value == "false" { return false }
+            }
+        }
+        return nil
+    }
+
+    private static func optionalNonNegativeIntegerArray(
+        _ value: Any?,
+        expectedCount: Int
+    ) -> [Int?]? {
+        guard let raw = value as? [Any] else { return nil }
+        var result = raw.prefix(expectedCount).map { element -> Int? in
+            guard let parsed = integer(element), parsed >= 0 else { return nil }
+            return parsed
+        }
+        while result.count < expectedCount {
+            result.append(nil)
+        }
+        return result
+    }
+}
+
+struct LegacyJSONLAggregateState: Codable, Hashable, Sendable {
+    private static let maximumDistinctValues = 8
+    private static let freshnessMicroseconds: Int64 = 7_000_000
+
+    var sessionIdentifiers: [String] = []
+    var workoutIdentifiers: [String] = []
+    var healthKitIdentifiers: [String] = []
+    var profileIdentifiers: [String] = []
+    var firstTimestamp: Date?
+    var lastTimestamp: Date?
+    var sessionStartedAt: Date?
+    var sessionEndedAt: Date?
+    var targetValues: [Int] = []
+    var averageHeartRateValues: [Int] = []
+    var durationSummaryValues: [Int] = []
+    var averageSpeedValues: [Double] = []
+    var zoneMicroseconds: [Int64] = Array(repeating: 0, count: 5)
+    var heartRateCoveredMicroseconds: Int64 = 0
+    var heartRateUncoveredMicroseconds: Int64 = 0
+    var heartRateWeightedBeatMicroseconds: Int64 = 0
+    var heartRateSampleCount: Int = 0
+    var missingTimestampCount: Int = 0
+    var malformedRecordCount: Int = 0
+    var ignoredStepFieldCount: Int = 0
+    var sawWorkoutSaved = false
+    var warnings: [String] = []
+    var permitsDeterministicPreProfileFallback = true
+    var lastHeartRateTimestamp: Date?
+    var lastHeartRateBeatsPerMinute: Int?
+    var lastHeartRateZoneIndex: Int?
+    var gapBeforeNextHeartRate = false
+
+    mutating func recordMalformed(_ code: String) {
+        malformedRecordCount += 1
+        Self.appendDistinct(code, to: &warnings)
+        gapBeforeNextHeartRate = true
+    }
+
+    mutating func observe(_ record: LegacyImportedRecordDraft) {
+        Self.appendDistinct(record.stableLegacySessionIdentifier, to: &sessionIdentifiers)
+        if record.eventKind == "workout_saved" {
+            Self.appendDistinct(record.workoutIdentifier, to: &workoutIdentifiers)
+        }
+        Self.appendDistinct(record.healthKitWorkoutIdentifier, to: &healthKitIdentifiers)
+        Self.appendDistinct(record.profileLocalIdentifier, to: &profileIdentifiers)
+        for warning in record.payload.warnings {
+            Self.appendDistinct(warning, to: &warnings)
+        }
+        if record.payload.warnings.contains("unknown-explicit-profile") {
+            permitsDeterministicPreProfileFallback = false
+        }
+        if record.payload.ignoredStepFieldPresent {
+            ignoredStepFieldCount += 1
+        }
+        if record.eventKind == "workout_saved" {
+            sawWorkoutSaved = true
+        }
+        guard let occurredAt = record.occurredAt else {
+            missingTimestampCount += 1
+            if record.payload.heartRateBeatsPerMinute != nil {
+                gapBeforeNextHeartRate = true
+            }
+            observeSummaryValues(record)
+            return
+        }
+        firstTimestamp = minDate(firstTimestamp, occurredAt)
+        lastTimestamp = maxDate(lastTimestamp, occurredAt)
+        if record.eventKind == "session_start" {
+            sessionStartedAt = minDate(sessionStartedAt, occurredAt)
+        }
+        if record.eventKind == "session_end" {
+            integrateFinalHeartRate(until: occurredAt)
+            sessionEndedAt = maxDate(sessionEndedAt, occurredAt)
+        }
+        if record.eventKind == "hr_sample",
+           let beatsPerMinute = record.payload.heartRateBeatsPerMinute {
+            observeHeartRate(
+                at: occurredAt,
+                beatsPerMinute: beatsPerMinute,
+                zoneIndex: record.payload.targetZoneIndex
+            )
+        }
+        observeSummaryValues(record)
+    }
+
+    func candidate(
+        sourceID: String,
+        candidateID: String,
+        deterministicFallbackProfile: String?
+    ) -> LegacyWorkoutCandidateDraft {
+        let stableSession = single(sessionIdentifiers)
+        let workout = single(workoutIdentifiers)
+        let healthKit = single(healthKitIdentifiers)
+        let exactProfile = permitsDeterministicPreProfileFallback
+            ? (single(profileIdentifiers) ?? deterministicFallbackProfile)
+            : nil
+        let startedAt = sessionStartedAt ?? firstTimestamp
+        let endedAt = sessionEndedAt ?? lastTimestamp
+        let durationMicroseconds: Int64? = {
+            guard let startedAt, let endedAt, endedAt >= startedAt else { return nil }
+            return Int64((endedAt.timeIntervalSince(startedAt) * 1_000_000).rounded())
+        }()
+        let timestampDerivedAverageHeartRate: Double? = heartRateCoveredMicroseconds > 0
+            ? Double(heartRateWeightedBeatMicroseconds)
+                / Double(heartRateCoveredMicroseconds)
+            : nil
+        var finalWarnings = warnings
+        if sessionStartedAt == nil, startedAt != nil {
+            if !finalWarnings.contains("duration-started-at-first-timestamp") {
+                finalWarnings.append("duration-started-at-first-timestamp")
+            }
+        }
+        if sessionEndedAt == nil, endedAt != nil {
+            if !finalWarnings.contains("duration-ended-at-last-timestamp") {
+                finalWarnings.append("duration-ended-at-last-timestamp")
+            }
+        }
+        if sessionStartedAt == nil {
+            finalWarnings.append("legacy-session-start-missing")
+        }
+        if sessionEndedAt == nil {
+            finalWarnings.append("legacy-session-end-missing")
+        }
+        if !sawWorkoutSaved {
+            finalWarnings.append("legacy-workout-saved-missing")
+        }
+        if malformedRecordCount > 0 {
+            finalWarnings.append("legacy-records-malformed")
+        }
+        if missingTimestampCount > 0 {
+            finalWarnings.append("legacy-timestamps-missing")
+        }
+        if sessionIdentifiers.count > 1 {
+            if !finalWarnings.contains("conflicting-stable-session-identifiers") {
+                finalWarnings.append("conflicting-stable-session-identifiers")
+            }
+        }
+        if workoutIdentifiers.count > 1 {
+            if !finalWarnings.contains("conflicting-workout-identifiers") {
+                finalWarnings.append("conflicting-workout-identifiers")
+            }
+        }
+        if healthKitIdentifiers.count > 1 {
+            if !finalWarnings.contains("conflicting-healthkit-identifiers") {
+                finalWarnings.append("conflicting-healthkit-identifiers")
+            }
+        }
+        if profileIdentifiers.count > 1 {
+            if !finalWarnings.contains("conflicting-profile-identifiers") {
+                finalWarnings.append("conflicting-profile-identifiers")
+            }
+        }
+        let summary = LegacyWorkoutCandidateSummary(
+            timestampDerivedDurationMicroseconds: durationMicroseconds,
+            legacySummaryDurationSeconds: single(durationSummaryValues),
+            targetBeatsPerMinute: single(targetValues),
+            timestampDerivedAverageHeartRateBeatsPerMinute:
+                timestampDerivedAverageHeartRate,
+            legacySummaryAverageHeartRateBeatsPerMinute:
+                single(averageHeartRateValues),
+            legacyEstimatedAverageSpeedKilometresPerHour: single(averageSpeedValues),
+            timestampDerivedZoneMicroseconds: zoneMicroseconds.map(Optional.some),
+            legacySummaryZoneSeconds: nil,
+            heartRateCoveredMicroseconds: heartRateSampleCount > 0
+                ? heartRateCoveredMicroseconds : nil,
+            heartRateUncoveredMicroseconds: heartRateSampleCount > 0
+                ? heartRateUncoveredMicroseconds : nil,
+            heartRateSampleCount: heartRateSampleCount,
+            missingTimestampCount: missingTimestampCount,
+            malformedRecordCount: malformedRecordCount,
+            ignoredStepFieldCount: ignoredStepFieldCount,
+            legacySessionEvidenceComplete: sessionStartedAt != nil
+                && sessionEndedAt != nil
+                && sawWorkoutSaved
+                && malformedRecordCount == 0
+                && missingTimestampCount == 0,
+            warnings: finalWarnings.sorted(),
+            conflicts: summaryConflicts()
+        )
+        let stableIdentityExists = workout != nil || healthKit != nil || stableSession != nil
+        let identityConflict = sessionIdentifiers.count > 1
+            || workoutIdentifiers.count > 1
+            || healthKitIdentifiers.count > 1
+            || profileIdentifiers.count > 1
+        return LegacyWorkoutCandidateDraft(
+            candidateID: candidateID,
+            sourceItemIdentityKey: "jsonl-candidate:\(sourceID)",
+            sourceID: sourceID,
+            origin: .jsonl,
+            profileLocalIdentifier: identityConflict ? nil : exactProfile,
+            workoutIdentifier: identityConflict ? nil : workout,
+            healthKitWorkoutIdentifier: identityConflict ? nil : healthKit,
+            stableLegacySessionIdentifier: identityConflict ? nil : stableSession,
+            startedAt: startedAt,
+            endedAt: endedAt,
+            identityUncertain: identityConflict || !stableIdentityExists || exactProfile == nil,
+            possibleDuplicate: !stableIdentityExists,
+            summary: summary
+        )
+    }
+
+    private mutating func observeHeartRate(
+        at timestamp: Date,
+        beatsPerMinute: Int,
+        zoneIndex: Int?
+    ) {
+        heartRateSampleCount += 1
+        if let previous = lastHeartRateTimestamp {
+            let delta = Int64((timestamp.timeIntervalSince(previous) * 1_000_000).rounded())
+            if delta < 0 {
+                Self.appendDistinct("heart-rate-timestamp-out-of-order", to: &warnings)
+                gapBeforeNextHeartRate = true
+                return
+            } else if gapBeforeNextHeartRate {
+                heartRateUncoveredMicroseconds = saturatedAdd(
+                    heartRateUncoveredMicroseconds,
+                    delta
+                )
+            } else {
+                let covered = min(delta, Self.freshnessMicroseconds)
+                heartRateCoveredMicroseconds = saturatedAdd(
+                    heartRateCoveredMicroseconds,
+                    covered
+                )
+                if let previousBeatsPerMinute = lastHeartRateBeatsPerMinute {
+                    heartRateWeightedBeatMicroseconds = saturatedAdd(
+                        heartRateWeightedBeatMicroseconds,
+                        saturatedMultiply(Int64(previousBeatsPerMinute), covered)
+                    )
+                }
+                if let previousZone = lastHeartRateZoneIndex,
+                   (1...5).contains(previousZone) {
+                    zoneMicroseconds[previousZone - 1] = saturatedAdd(
+                        zoneMicroseconds[previousZone - 1],
+                        covered
+                    )
+                }
+                heartRateUncoveredMicroseconds = saturatedAdd(
+                    heartRateUncoveredMicroseconds,
+                    max(0, delta - covered)
+                )
+            }
+        }
+        lastHeartRateTimestamp = timestamp
+        lastHeartRateBeatsPerMinute = beatsPerMinute
+        lastHeartRateZoneIndex = zoneIndex
+        gapBeforeNextHeartRate = false
+    }
+
+    private mutating func integrateFinalHeartRate(until timestamp: Date) {
+        guard let previous = lastHeartRateTimestamp else { return }
+        let delta = Int64((timestamp.timeIntervalSince(previous) * 1_000_000).rounded())
+        guard delta >= 0 else { return }
+        if gapBeforeNextHeartRate {
+            heartRateUncoveredMicroseconds = saturatedAdd(
+                heartRateUncoveredMicroseconds,
+                delta
+            )
+        } else {
+            let covered = min(delta, Self.freshnessMicroseconds)
+            heartRateCoveredMicroseconds = saturatedAdd(
+                heartRateCoveredMicroseconds,
+                covered
+            )
+            if let beatsPerMinute = lastHeartRateBeatsPerMinute {
+                heartRateWeightedBeatMicroseconds = saturatedAdd(
+                    heartRateWeightedBeatMicroseconds,
+                    saturatedMultiply(Int64(beatsPerMinute), covered)
+                )
+            }
+            if let zone = lastHeartRateZoneIndex, (1...5).contains(zone) {
+                zoneMicroseconds[zone - 1] = saturatedAdd(
+                    zoneMicroseconds[zone - 1],
+                    covered
+                )
+            }
+            heartRateUncoveredMicroseconds = saturatedAdd(
+                heartRateUncoveredMicroseconds,
+                max(0, delta - covered)
+            )
+        }
+        lastHeartRateTimestamp = nil
+        lastHeartRateBeatsPerMinute = nil
+        lastHeartRateZoneIndex = nil
+    }
+
+    private mutating func observeSummaryValues(_ record: LegacyImportedRecordDraft) {
+        guard record.eventKind == "session_start"
+            || record.eventKind == "workout_saved"
+            || record.eventKind == "session_end" else {
+            return
+        }
+        if let target = record.payload.targetBeatsPerMinute {
+            Self.appendDistinct(target, to: &targetValues)
+        }
+        if let duration = record.payload.legacySummaryDurationSeconds {
+            Self.appendDistinct(duration, to: &durationSummaryValues)
+        }
+        if let average = record.payload.legacySummaryAverageHeartRateBeatsPerMinute {
+            Self.appendDistinct(average, to: &averageHeartRateValues)
+        }
+        if case let .legacyEstimated(speed, field)? = record.payload.speedEvidence,
+           field == "speed_actual_kmh" || field == "avg_speed_kmh" {
+            Self.appendDistinct(speed, to: &averageSpeedValues)
+        }
+    }
+
+    private func summaryConflicts() -> [LegacySummaryConflict] {
+        var result: [LegacySummaryConflict] = []
+        if targetValues.count > 1 {
+            result.append(
+                LegacySummaryConflict(
+                    field: "target_bpm",
+                    preferredProvenance: "legacy-jsonl-timestamped-event",
+                    observedProvenances: targetValues.map { "legacy-jsonl:\($0)" }
+                )
+            )
+        }
+        if averageHeartRateValues.count > 1 {
+            result.append(
+                LegacySummaryConflict(
+                    field: "average_hr_bpm",
+                    preferredProvenance: "legacy-jsonl-timestamped-event",
+                    observedProvenances: averageHeartRateValues.map { "legacy-jsonl:\($0)" }
+                )
+            )
+        }
+        return result
+    }
+
+    private func single<T>(_ values: [T]) -> T? {
+        values.count == 1 ? values[0] : nil
+    }
+
+    private func minDate(_ lhs: Date?, _ rhs: Date) -> Date {
+        lhs.map { min($0, rhs) } ?? rhs
+    }
+
+    private func maxDate(_ lhs: Date?, _ rhs: Date) -> Date {
+        lhs.map { max($0, rhs) } ?? rhs
+    }
+
+    private static func appendDistinct<T: Equatable>(_ value: T?, to values: inout [T]) {
+        guard let value else { return }
+        appendDistinct(value, to: &values)
+    }
+
+    private static func appendDistinct<T: Equatable>(_ value: T, to values: inout [T]) {
+        guard !values.contains(value), values.count < Self.maximumDistinctValues else { return }
+        values.append(value)
+    }
+
+    private func saturatedAdd(_ lhs: Int64, _ rhs: Int64) -> Int64 {
+        let result = lhs.addingReportingOverflow(rhs)
+        return result.overflow ? Int64.max : result.partialValue
+    }
+
+    private func saturatedMultiply(_ lhs: Int64, _ rhs: Int64) -> Int64 {
+        let result = lhs.multipliedReportingOverflow(by: rhs)
+        return result.overflow ? Int64.max : result.partialValue
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrationSourceDiscovery.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrationSourceDiscovery.swift
@@ -1,0 +1,80 @@
+import Foundation
+import TelemetryDomain
+
+public enum LegacyTelemetryMigrationSourceDiscovery {
+    public static func makeRequest(
+        userDefaults: UserDefaults,
+        trainingLogsDirectory: URL,
+        knownProfileLocalIdentifiers: [String],
+        deterministicLegacyFallbackProfileLocalIdentifier: String?,
+        maximumRecordsPerBatch: Int = 64
+    ) -> LegacyTelemetryMigrationRequest {
+        let knownProfiles = Set(
+            knownProfileLocalIdentifiers.map(normalizedIdentifier).filter { !$0.isEmpty }
+        )
+        let fallback = deterministicLegacyFallbackProfileLocalIdentifier
+            .map(normalizedIdentifier)
+            .flatMap { knownProfiles.contains($0) ? $0 : nil }
+
+        let jsonlSources: [LegacyJSONLSourceDescriptor] = {
+            guard let urls = try? FileManager.default.contentsOfDirectory(
+                at: trainingLogsDirectory,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles]
+            ) else { return [] }
+            return urls.filter { url in
+                guard url.pathExtension.lowercased() == "jsonl" else { return false }
+                return (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile)
+                    ?? false
+            }.sorted { $0.standardizedFileURL.path < $1.standardizedFileURL.path }
+                .map {
+                    LegacyJSONLSourceDescriptor(
+                        url: $0,
+                        deterministicFallbackProfileLocalIdentifier: fallback
+                    )
+                }
+        }()
+
+        var historySources: [LegacyWorkoutHistorySourceDescriptor] = []
+        for profile in knownProfiles.sorted() {
+            let key = "workout_history_v1_profile_\(profile)"
+            guard let representation = userDefaults.data(forKey: key) else { continue }
+            historySources.append(
+                LegacyWorkoutHistorySourceDescriptor(
+                    storageKey: key,
+                    representation: representation,
+                    exactProfileLocalIdentifier: profile
+                )
+            )
+        }
+        if let representation = userDefaults.data(forKey: "workout_history_v1") {
+            historySources.append(
+                LegacyWorkoutHistorySourceDescriptor(
+                    storageKey: "workout_history_v1",
+                    representation: representation,
+                    exactProfileLocalIdentifier: fallback
+                )
+            )
+        }
+
+        return LegacyTelemetryMigrationRequest(
+            jsonlSources: jsonlSources,
+            workoutHistorySources: historySources.sorted {
+                $0.storageKey < $1.storageKey
+            },
+            knownProfileLocalIdentifiers: knownProfiles,
+            maximumRecordsPerBatch: maximumRecordsPerBatch
+        )
+    }
+
+    public static func defaultTrainingLogsDirectory() -> URL? {
+        FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first?.appendingPathComponent("TrainingLogs", isDirectory: true)
+    }
+
+    private static func normalizedIdentifier(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrationStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrationStore.swift
@@ -293,7 +293,11 @@ extension TelemetryStore {
 
         let canonicalIdentityKey: String
         if !compatible.isEmpty, let kind = match.kind, let value = match.value {
-            canonicalIdentityKey = "\(kind.rawValue):\(value)"
+            canonicalIdentityKey = exactCanonicalIdentityKey(
+                kind: kind,
+                value: value,
+                candidates: [candidate] + compatible
+            )
         } else if !conflicting.isEmpty {
             canonicalIdentityKey = "candidate:\(candidate.candidateID)"
         } else {
@@ -384,17 +388,55 @@ extension TelemetryStore {
         value: String,
         limit: Int
     ) throws -> [TelemetryLegacyWorkoutCandidateV2] {
-        let candidateID = candidate.candidateID
         let oppositeOrigin = candidate.originKindKey == LegacyWorkoutCandidateOrigin.jsonl.rawValue
             ? LegacyWorkoutCandidateOrigin.workoutHistory.rawValue
             : LegacyWorkoutCandidateOrigin.jsonl.rawValue
+        var result = try exactCandidates(
+            excludingCandidateID: candidate.candidateID,
+            kind: kind,
+            value: value,
+            originKindKey: oppositeOrigin,
+            exactProfileLocalIdentifier: nil,
+            limit: limit
+        )
+        if candidate.originKindKey == LegacyWorkoutCandidateOrigin.workoutHistory.rawValue,
+           let profileLocalIdentifier = candidate.profileLocalIdentifier {
+            result.append(contentsOf: try exactCandidates(
+                excludingCandidateID: candidate.candidateID,
+                kind: kind,
+                value: value,
+                originKindKey: LegacyWorkoutCandidateOrigin.workoutHistory.rawValue,
+                exactProfileLocalIdentifier: profileLocalIdentifier,
+                limit: limit
+            ))
+        }
+        result.sort { $0.candidateID < $1.candidateID }
+        guard result.count <= limit else {
+            throw TelemetryStoreError.conflictingStableIdentity(
+                "legacy-reconciliation-match-limit:\(kind.rawValue)"
+            )
+        }
+        return result
+    }
+
+    private func exactCandidates(
+        excludingCandidateID candidateID: String,
+        kind: LegacyReconciliationIdentityKind,
+        value: String,
+        originKindKey: String,
+        exactProfileLocalIdentifier: String?,
+        limit: Int
+    ) throws -> [TelemetryLegacyWorkoutCandidateV2] {
         var descriptor: FetchDescriptor<TelemetryLegacyWorkoutCandidateV2>
+        let requiresExactProfile = exactProfileLocalIdentifier != nil
         switch kind {
         case .workoutIdentifier:
             descriptor = FetchDescriptor(
                 predicate: #Predicate {
                     $0.candidateID != candidateID
-                        && $0.originKindKey == oppositeOrigin
+                        && $0.originKindKey == originKindKey
+                        && (!requiresExactProfile
+                            || $0.profileLocalIdentifier == exactProfileLocalIdentifier)
                         && $0.workoutIdentifier == value
                 },
                 sortBy: [SortDescriptor(\.candidateID)]
@@ -403,7 +445,9 @@ extension TelemetryStore {
             descriptor = FetchDescriptor(
                 predicate: #Predicate {
                     $0.candidateID != candidateID
-                        && $0.originKindKey == oppositeOrigin
+                        && $0.originKindKey == originKindKey
+                        && (!requiresExactProfile
+                            || $0.profileLocalIdentifier == exactProfileLocalIdentifier)
                         && $0.healthKitWorkoutIdentifier == value
                 },
                 sortBy: [SortDescriptor(\.candidateID)]
@@ -412,20 +456,32 @@ extension TelemetryStore {
             descriptor = FetchDescriptor(
                 predicate: #Predicate {
                     $0.candidateID != candidateID
-                        && $0.originKindKey == oppositeOrigin
+                        && $0.originKindKey == originKindKey
+                        && (!requiresExactProfile
+                            || $0.profileLocalIdentifier == exactProfileLocalIdentifier)
                         && $0.stableLegacySessionIdentifier == value
                 },
                 sortBy: [SortDescriptor(\.candidateID)]
             )
         }
         descriptor.fetchLimit = limit + 1
-        let result = try modelContext.fetch(descriptor)
-        guard result.count <= limit else {
-            throw TelemetryStoreError.conflictingStableIdentity(
-                "legacy-reconciliation-match-limit:\(kind.rawValue)"
-            )
+        return try modelContext.fetch(descriptor)
+    }
+
+    private func exactCanonicalIdentityKey(
+        kind: LegacyReconciliationIdentityKind,
+        value: String,
+        candidates: [TelemetryLegacyWorkoutCandidateV2]
+    ) -> String {
+        let historyOrigin = LegacyWorkoutCandidateOrigin.workoutHistory.rawValue
+        if candidates.allSatisfy({ $0.originKindKey == historyOrigin }),
+           let profileLocalIdentifier = candidates.first?.profileLocalIdentifier,
+           candidates.allSatisfy({
+               $0.profileLocalIdentifier == profileLocalIdentifier
+           }) {
+            return "history-profile:\(profileLocalIdentifier):\(kind.rawValue):\(value)"
         }
-        return result
+        return "\(kind.rawValue):\(value)"
     }
 
     private func identityConflicts(

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrationStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrationStore.swift
@@ -1,0 +1,1015 @@
+import Foundation
+import SwiftData
+import TelemetryDomain
+
+struct LegacyMigrationSourceProgress: Sendable {
+    let snapshot: LegacyMigrationSourceSnapshot
+    let aggregateStatePayload: Data
+}
+
+extension TelemetryStore {
+    func beginLegacyMigrationSource(
+        _ definition: LegacyMigrationSourceDefinition,
+        importerVersion: String,
+        emptyAggregateStatePayload: Data,
+        now: Date
+    ) throws -> LegacyMigrationSourceProgress {
+        if let existing = try legacySourceModel(definition.sourceID) {
+            guard existing.sourceKindKey == definition.kind.rawValue,
+                  existing.contentHashDigest == definition.contentHashDigest,
+                  existing.importerVersion == importerVersion else {
+                throw TelemetryStoreError.conflictingStableIdentity(definition.sourceID)
+            }
+            if existing.statusKey != LegacyMigrationSourceStatus.completed.rawValue {
+                try explicitTransaction {
+                    existing.statusKey = LegacyMigrationSourceStatus.inProgress.rawValue
+                    existing.errorCode = nil
+                    existing.errorDetail = nil
+                    existing.updatedAt = now
+                }
+            }
+            return try sourceProgress(existing)
+        }
+
+        let model = TelemetryLegacyMigrationSourceV2(
+            sourceID: definition.sourceID,
+            sourceKindKey: definition.kind.rawValue,
+            contentHashDigest: definition.contentHashDigest,
+            importerVersion: importerVersion,
+            locator: definition.locator,
+            exactProfileLocalIdentifier: definition.exactProfileLocalIdentifier,
+            statusKey: LegacyMigrationSourceStatus.inProgress.rawValue,
+            checkpointByteOffset: 0,
+            checkpointRecordIndex: 0,
+            parsedRecordCount: 0,
+            malformedRecordCount: 0,
+            warningCount: 0,
+            aggregateStatePayload: emptyAggregateStatePayload,
+            errorCode: nil,
+            errorDetail: nil,
+            updatedAt: now,
+            completedAt: nil
+        )
+        try explicitTransaction {
+            modelContext.insert(model)
+        }
+        return try sourceProgress(model)
+    }
+
+    @discardableResult
+    func commitLegacyMigrationBatch(
+        sourceID: String,
+        records: [LegacyImportedRecordDraft],
+        candidates: [LegacyWorkoutCandidateDraft],
+        checkpointByteOffset: Int64,
+        checkpointRecordIndex: Int64,
+        parsedRecordCount: Int64,
+        malformedRecordCount: Int64,
+        warningCount: Int64,
+        aggregateStatePayload: Data,
+        completing: Bool,
+        now: Date
+    ) throws -> Int {
+        guard let source = try legacySourceModel(sourceID) else {
+            throw TelemetryStoreError.corruptStoredRecord("missing migration source \(sourceID)")
+        }
+        guard checkpointByteOffset >= source.checkpointByteOffset,
+              checkpointRecordIndex >= source.checkpointRecordIndex,
+              parsedRecordCount >= source.parsedRecordCount,
+              malformedRecordCount >= source.malformedRecordCount,
+              warningCount >= source.warningCount else {
+            throw TelemetryStoreError.corruptStoredRecord(
+                "regressed migration checkpoint \(sourceID)"
+            )
+        }
+        var insertedRecordCount = 0
+        try explicitTransaction {
+            for record in records {
+                if let existing = try legacyImportedRecordModel(
+                    sourceItemIdentityKey: record.sourceItemIdentityKey
+                ) {
+                    guard try storedRecordMatches(existing, draft: record) else {
+                        throw TelemetryStoreError.conflictingStableIdentity(
+                            record.sourceItemIdentityKey
+                        )
+                    }
+                    continue
+                }
+                modelContext.insert(try makeImportedRecordModel(record))
+                insertedRecordCount += 1
+            }
+            for candidate in candidates {
+                if let existing = try legacyCandidateModel(candidate.candidateID) {
+                    guard try storedCandidateMatches(existing, draft: candidate) else {
+                        throw TelemetryStoreError.conflictingStableIdentity(candidate.candidateID)
+                    }
+                    continue
+                }
+                modelContext.insert(try makeCandidateModel(candidate))
+            }
+            source.checkpointByteOffset = checkpointByteOffset
+            source.checkpointRecordIndex = checkpointRecordIndex
+            source.parsedRecordCount = parsedRecordCount
+            source.malformedRecordCount = malformedRecordCount
+            source.warningCount = warningCount
+            source.aggregateStatePayload = aggregateStatePayload
+            source.statusKey = completing
+                ? LegacyMigrationSourceStatus.completed.rawValue
+                : LegacyMigrationSourceStatus.inProgress.rawValue
+            source.errorCode = nil
+            source.errorDetail = nil
+            source.updatedAt = now
+            source.completedAt = completing ? now : nil
+        }
+        return insertedRecordCount
+    }
+
+    func pauseLegacyMigrationSource(sourceID: String, now: Date) throws {
+        guard let source = try legacySourceModel(sourceID) else { return }
+        try explicitTransaction {
+            source.statusKey = LegacyMigrationSourceStatus.paused.rawValue
+            source.updatedAt = now
+        }
+    }
+
+    func failLegacyMigrationSource(
+        sourceID: String,
+        code: String,
+        detail: String,
+        now: Date
+    ) throws {
+        guard let source = try legacySourceModel(sourceID) else { return }
+        try explicitTransaction {
+            source.statusKey = LegacyMigrationSourceStatus.failed.rawValue
+            source.errorCode = code
+            source.errorDetail = detail
+            source.updatedAt = now
+        }
+    }
+
+    func failLegacyReconciliation(detail: String, now: Date) throws {
+        let completed = LegacyMigrationSourceStatus.completed.rawValue
+        let inProgress = LegacyMigrationSourceStatus.inProgress.rawValue
+        while true {
+            var descriptor = FetchDescriptor<TelemetryLegacyMigrationSourceV2>(
+                predicate: #Predicate {
+                    $0.statusKey == completed || $0.statusKey == inProgress
+                },
+                sortBy: [SortDescriptor(\.sourceID)]
+            )
+            descriptor.fetchLimit = 128
+            let sources = try modelContext.fetch(descriptor)
+            guard !sources.isEmpty else { return }
+            try explicitTransaction {
+                for source in sources {
+                    source.statusKey = LegacyMigrationSourceStatus.failed.rawValue
+                    source.errorCode = "legacy-reconciliation-failed"
+                    source.errorDetail = detail
+                    source.updatedAt = now
+                }
+            }
+        }
+    }
+
+    public func fetchLegacyMigrationSources() throws -> [LegacyMigrationSourceSnapshot] {
+        let descriptor = FetchDescriptor<TelemetryLegacyMigrationSourceV2>(
+            sortBy: [SortDescriptor(\.sourceID)]
+        )
+        return try modelContext.fetch(descriptor).map(sourceSnapshot)
+    }
+
+    public func fetchLegacyImportedRecords(
+        sourceID: String? = nil
+    ) throws -> [LegacyImportedRecordSnapshot] {
+        let models: [TelemetryLegacyImportedRecordV2]
+        if let sourceID {
+            models = try modelContext.fetch(
+                FetchDescriptor(
+                    predicate: #Predicate<TelemetryLegacyImportedRecordV2> {
+                        $0.sourceID == sourceID
+                    },
+                    sortBy: [SortDescriptor(\.sourceRecordIndex)]
+                )
+            )
+        } else {
+            models = try modelContext.fetch(
+                FetchDescriptor(sortBy: [SortDescriptor(\.importedRecordID)])
+            )
+        }
+        return try models.map(importedRecordSnapshot)
+    }
+
+    public func fetchLegacyWorkoutCandidates() throws -> [LegacyWorkoutCandidateSnapshot] {
+        let descriptor = FetchDescriptor<TelemetryLegacyWorkoutCandidateV2>(
+            sortBy: [SortDescriptor(\.candidateID)]
+        )
+        return try modelContext.fetch(descriptor).map(candidateSnapshot)
+    }
+
+    public func fetchLegacyImportedWorkouts(
+        profileLocalIdentifier: String? = nil,
+        includeUnassigned: Bool = true
+    ) throws -> [LegacyImportedWorkoutSnapshot] {
+        let models: [TelemetryLegacyImportedWorkoutV2]
+        if let profileLocalIdentifier {
+            models = try modelContext.fetch(
+                FetchDescriptor(
+                    predicate: #Predicate<TelemetryLegacyImportedWorkoutV2> {
+                        $0.profileLocalIdentifier == profileLocalIdentifier
+                    },
+                    sortBy: [SortDescriptor(\.canonicalIdentityKey)]
+                )
+            )
+        } else if !includeUnassigned {
+            models = try modelContext.fetch(
+                FetchDescriptor(
+                    predicate: #Predicate<TelemetryLegacyImportedWorkoutV2> {
+                        $0.profileLocalIdentifier != nil
+                    },
+                    sortBy: [SortDescriptor(\.canonicalIdentityKey)]
+                )
+            )
+        } else {
+            models = try modelContext.fetch(
+                FetchDescriptor(sortBy: [SortDescriptor(\.canonicalIdentityKey)])
+            )
+        }
+        return try models.map(importedWorkoutSnapshot)
+    }
+
+    public func fetchLegacyReconciliations() throws -> [LegacyReconciliationSnapshot] {
+        let descriptor = FetchDescriptor<TelemetryLegacyReconciliationV2>(
+            sortBy: [SortDescriptor(\.reconciliationID)]
+        )
+        return try modelContext.fetch(descriptor).map(reconciliationSnapshot)
+    }
+
+    @discardableResult
+    func reconcileLegacyWorkoutCandidates(
+        pageSize: Int = 64,
+        maximumMatchesPerIdentity: Int = 64
+    ) throws -> Int {
+        let boundedPageSize = min(256, max(1, pageSize))
+        let boundedMatchLimit = min(256, max(1, maximumMatchesPerIdentity))
+        var offset = 0
+        var insertedWorkoutCount = 0
+        while true {
+            var descriptor = FetchDescriptor<TelemetryLegacyWorkoutCandidateV2>(
+                sortBy: [SortDescriptor(\.candidateID)]
+            )
+            descriptor.fetchLimit = boundedPageSize
+            descriptor.fetchOffset = offset
+            let page = try modelContext.fetch(descriptor)
+            guard !page.isEmpty else { break }
+            for candidate in page {
+                insertedWorkoutCount += try reconcile(
+                    candidate,
+                    maximumMatches: boundedMatchLimit
+                )
+            }
+            offset += page.count
+        }
+        return insertedWorkoutCount
+    }
+
+    private func reconcile(
+        _ candidate: TelemetryLegacyWorkoutCandidateV2,
+        maximumMatches: Int
+    ) throws -> Int {
+        let match = try strongestExactMatch(
+            for: candidate,
+            maximumMatches: maximumMatches
+        )
+        var compatible: [TelemetryLegacyWorkoutCandidateV2] = []
+        var conflicting: [(TelemetryLegacyWorkoutCandidateV2, [String])] = []
+        for other in match.candidates {
+            let conflicts = identityConflicts(candidate, other)
+            if conflicts.isEmpty {
+                compatible.append(other)
+            } else {
+                conflicting.append((other, conflicts))
+            }
+        }
+
+        let canonicalIdentityKey: String
+        if !compatible.isEmpty, let kind = match.kind, let value = match.value {
+            canonicalIdentityKey = "\(kind.rawValue):\(value)"
+        } else if !conflicting.isEmpty {
+            canonicalIdentityKey = "candidate:\(candidate.candidateID)"
+        } else {
+            canonicalIdentityKey = unreconciledIdentityKey(candidate)
+        }
+        let group = [candidate] + compatible
+        let identityStatus: LegacyIdentityStatus = !conflicting.isEmpty
+            ? .conflict
+            : candidate.identityUncertain ? .uncertain : .exact
+        let inserted = try upsertImportedWorkout(
+            canonicalIdentityKey: canonicalIdentityKey,
+            candidates: group,
+            identityStatus: identityStatus,
+            possibleDuplicate: candidate.possibleDuplicate && match.candidates.isEmpty
+        )
+
+        let importedWorkoutID = LegacyMigrationHashing.deterministicIdentifier(
+            "legacy-imported-workout:\(canonicalIdentityKey)"
+        )
+        for other in compatible {
+            try upsertReconciliation(
+                left: candidate,
+                right: other,
+                outcome: .matched,
+                kind: match.kind,
+                value: match.value,
+                importedWorkoutID: nil,
+                detailCodes: []
+            )
+        }
+        for (other, conflicts) in conflicting {
+            try upsertReconciliation(
+                left: candidate,
+                right: other,
+                outcome: .conflict,
+                kind: match.kind,
+                value: match.value,
+                importedWorkoutID: importedWorkoutID,
+                detailCodes: conflicts
+            )
+        }
+        return inserted ? 1 : 0
+    }
+
+    private func strongestExactMatch(
+        for candidate: TelemetryLegacyWorkoutCandidateV2,
+        maximumMatches: Int
+    ) throws -> (
+        kind: LegacyReconciliationIdentityKind?,
+        value: String?,
+        candidates: [TelemetryLegacyWorkoutCandidateV2]
+    ) {
+        if let value = candidate.workoutIdentifier {
+            let matches = try exactCandidates(
+                excluding: candidate,
+                kind: .workoutIdentifier,
+                value: value,
+                limit: maximumMatches
+            )
+            if !matches.isEmpty { return (.workoutIdentifier, value, matches) }
+        }
+        if let value = candidate.healthKitWorkoutIdentifier {
+            let matches = try exactCandidates(
+                excluding: candidate,
+                kind: .healthKitWorkoutIdentifier,
+                value: value,
+                limit: maximumMatches
+            )
+            if !matches.isEmpty { return (.healthKitWorkoutIdentifier, value, matches) }
+        }
+        if let value = candidate.stableLegacySessionIdentifier {
+            let matches = try exactCandidates(
+                excluding: candidate,
+                kind: .stableLegacySessionIdentifier,
+                value: value,
+                limit: maximumMatches
+            )
+            if !matches.isEmpty {
+                return (.stableLegacySessionIdentifier, value, matches)
+            }
+        }
+        return (nil, nil, [])
+    }
+
+    private func exactCandidates(
+        excluding candidate: TelemetryLegacyWorkoutCandidateV2,
+        kind: LegacyReconciliationIdentityKind,
+        value: String,
+        limit: Int
+    ) throws -> [TelemetryLegacyWorkoutCandidateV2] {
+        let candidateID = candidate.candidateID
+        let oppositeOrigin = candidate.originKindKey == LegacyWorkoutCandidateOrigin.jsonl.rawValue
+            ? LegacyWorkoutCandidateOrigin.workoutHistory.rawValue
+            : LegacyWorkoutCandidateOrigin.jsonl.rawValue
+        var descriptor: FetchDescriptor<TelemetryLegacyWorkoutCandidateV2>
+        switch kind {
+        case .workoutIdentifier:
+            descriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    $0.candidateID != candidateID
+                        && $0.originKindKey == oppositeOrigin
+                        && $0.workoutIdentifier == value
+                },
+                sortBy: [SortDescriptor(\.candidateID)]
+            )
+        case .healthKitWorkoutIdentifier:
+            descriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    $0.candidateID != candidateID
+                        && $0.originKindKey == oppositeOrigin
+                        && $0.healthKitWorkoutIdentifier == value
+                },
+                sortBy: [SortDescriptor(\.candidateID)]
+            )
+        case .stableLegacySessionIdentifier:
+            descriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    $0.candidateID != candidateID
+                        && $0.originKindKey == oppositeOrigin
+                        && $0.stableLegacySessionIdentifier == value
+                },
+                sortBy: [SortDescriptor(\.candidateID)]
+            )
+        }
+        descriptor.fetchLimit = limit + 1
+        let result = try modelContext.fetch(descriptor)
+        guard result.count <= limit else {
+            throw TelemetryStoreError.conflictingStableIdentity(
+                "legacy-reconciliation-match-limit:\(kind.rawValue)"
+            )
+        }
+        return result
+    }
+
+    private func identityConflicts(
+        _ lhs: TelemetryLegacyWorkoutCandidateV2,
+        _ rhs: TelemetryLegacyWorkoutCandidateV2
+    ) -> [String] {
+        var conflicts: [String] = []
+        appendConflict(
+            lhs.workoutIdentifier,
+            rhs.workoutIdentifier,
+            code: "conflicting-workout-identifier",
+            into: &conflicts
+        )
+        appendConflict(
+            lhs.healthKitWorkoutIdentifier,
+            rhs.healthKitWorkoutIdentifier,
+            code: "conflicting-healthkit-workout-identifier",
+            into: &conflicts
+        )
+        appendConflict(
+            lhs.stableLegacySessionIdentifier,
+            rhs.stableLegacySessionIdentifier,
+            code: "conflicting-stable-session-identifier",
+            into: &conflicts
+        )
+        appendConflict(
+            lhs.profileLocalIdentifier,
+            rhs.profileLocalIdentifier,
+            code: "conflicting-profile-ownership",
+            into: &conflicts
+        )
+        return conflicts.sorted()
+    }
+
+    private func appendConflict(
+        _ lhs: String?,
+        _ rhs: String?,
+        code: String,
+        into conflicts: inout [String]
+    ) {
+        if let lhs, let rhs, lhs != rhs {
+            conflicts.append(code)
+        }
+    }
+
+    private func unreconciledIdentityKey(
+        _ candidate: TelemetryLegacyWorkoutCandidateV2
+    ) -> String {
+        return "candidate:\(candidate.candidateID)"
+    }
+
+    private func upsertImportedWorkout(
+        canonicalIdentityKey: String,
+        candidates newCandidates: [TelemetryLegacyWorkoutCandidateV2],
+        identityStatus: LegacyIdentityStatus,
+        possibleDuplicate: Bool
+    ) throws -> Bool {
+        let importedWorkoutID = LegacyMigrationHashing.deterministicIdentifier(
+            "legacy-imported-workout:\(canonicalIdentityKey)"
+        )
+        let existing = try importedWorkoutModel(canonicalIdentityKey)
+        var candidateIDs = Set(newCandidates.map(\.candidateID))
+        if let existing {
+            candidateIDs.formUnion(
+                try Self.decode([String].self, from: existing.candidateIDsPayload)
+            )
+        }
+        guard candidateIDs.count <= 256 else {
+            throw TelemetryStoreError.conflictingStableIdentity(
+                "legacy-imported-workout-candidate-limit"
+            )
+        }
+        let candidates = try candidateIDs.sorted().compactMap(legacyCandidateModel)
+        let resolved = try resolveSummary(candidates)
+        let profiles = Set(candidates.compactMap(\.profileLocalIdentifier))
+        let profile = profiles.count == 1 ? profiles.first : nil
+        let hasIdentityConflict = profiles.count > 1
+            || Set(candidates.compactMap(\.workoutIdentifier)).count > 1
+            || Set(candidates.compactMap(\.healthKitWorkoutIdentifier)).count > 1
+            || Set(candidates.compactMap(\.stableLegacySessionIdentifier)).count > 1
+        let finalStatus: LegacyIdentityStatus
+        if hasIdentityConflict || identityStatus == .conflict {
+            finalStatus = .conflict
+        } else if identityStatus == .uncertain || candidates.contains(where: \.identityUncertain) {
+            finalStatus = .uncertain
+        } else {
+            finalStatus = .exact
+        }
+        let startedAt = candidates
+            .filter { $0.originKindKey == LegacyWorkoutCandidateOrigin.jsonl.rawValue }
+            .compactMap(\.startedAt)
+            .min() ?? candidates.compactMap(\.startedAt).min()
+        let endedAt = candidates
+            .filter { $0.originKindKey == LegacyWorkoutCandidateOrigin.jsonl.rawValue }
+            .compactMap(\.endedAt)
+            .max() ?? candidates.compactMap(\.endedAt).max()
+        let candidatePayload = try Self.encode(candidateIDs.sorted())
+        let summaryPayload = try Self.encode(resolved)
+
+        if let existing {
+            try explicitTransaction {
+                existing.profileLocalIdentifier = profile
+                existing.startedAt = startedAt
+                existing.endedAt = endedAt
+                existing.identityStatusKey = finalStatus.rawValue
+                existing.possibleDuplicate = existing.possibleDuplicate || possibleDuplicate
+                existing.adaptationQualityEligible = false
+                existing.candidateIDsPayload = candidatePayload
+                existing.resolvedSummaryPayload = summaryPayload
+            }
+            return false
+        }
+        try explicitTransaction {
+            modelContext.insert(
+                TelemetryLegacyImportedWorkoutV2(
+                    importedWorkoutID: importedWorkoutID,
+                    canonicalIdentityKey: canonicalIdentityKey,
+                    profileLocalIdentifier: profile,
+                    startedAt: startedAt,
+                    endedAt: endedAt,
+                    identityStatusKey: finalStatus.rawValue,
+                    possibleDuplicate: possibleDuplicate,
+                    adaptationQualityEligible: false,
+                    candidateIDsPayload: candidatePayload,
+                    resolvedSummaryPayload: summaryPayload
+                )
+            )
+        }
+        return true
+    }
+
+    private func resolveSummary(
+        _ candidates: [TelemetryLegacyWorkoutCandidateV2]
+    ) throws -> LegacyResolvedWorkoutSummary {
+        let summaries = try candidates.map { model in
+            (
+                origin: try requiredOrigin(model.originKindKey),
+                summary: try Self.decode(
+                    LegacyWorkoutCandidateSummary.self,
+                    from: model.summaryPayload
+                )
+            )
+        }
+        let durationValues = summaries.flatMap { item -> [LegacySourcedValue<Int64>] in
+            var values: [LegacySourcedValue<Int64>] = []
+            if let value = item.summary.timestampDerivedDurationMicroseconds {
+                values.append(.init(value: value, provenance: "legacy-jsonl-timestamp-derived"))
+            }
+            if let value = item.summary.legacySummaryDurationSeconds {
+                values.append(
+                    .init(
+                        value: Int64(value) * 1_000_000,
+                        provenance: item.origin == .jsonl
+                            ? "legacy-jsonl-summary" : "workout_history_v1-summary"
+                    )
+                )
+            }
+            return values
+        }
+        let targetValues = summaries.compactMap { item in
+            item.summary.targetBeatsPerMinute.map {
+                LegacySourcedValue(
+                    value: $0,
+                    provenance: item.origin == .jsonl
+                        ? "legacy-jsonl-timestamped-event"
+                        : "workout_history_v1-summary"
+                )
+            }
+        }
+        let averageHeartRateValues = summaries.flatMap { item
+            -> [LegacySourcedValue<Double>] in
+            var values: [LegacySourcedValue<Double>] = []
+            if let value = item.summary.timestampDerivedAverageHeartRateBeatsPerMinute {
+                values.append(
+                    .init(
+                        value: value,
+                        provenance: "legacy-jsonl-timestamp-derived"
+                    )
+                )
+            }
+            if let value = item.summary.legacySummaryAverageHeartRateBeatsPerMinute {
+                values.append(
+                    .init(
+                        value: Double(value),
+                        provenance: item.origin == .jsonl
+                            ? "legacy-jsonl-summary"
+                            : "workout_history_v1-summary"
+                    )
+                )
+            }
+            return values
+        }
+        let speedValues = summaries.compactMap { item in
+            item.summary.legacyEstimatedAverageSpeedKilometresPerHour.map {
+                LegacySourcedValue(
+                    value: $0,
+                    provenance: item.origin == .jsonl
+                        ? "legacy-jsonl-estimated-summary"
+                        : "workout_history_v1-estimated-summary"
+                )
+            }
+        }
+        let zoneValues = summaries.flatMap { item -> [LegacySourcedValue<[Int64?]>] in
+            var values: [LegacySourcedValue<[Int64?]>] = []
+            if let value = item.summary.timestampDerivedZoneMicroseconds {
+                values.append(
+                    .init(value: value, provenance: "legacy-jsonl-timestamp-derived")
+                )
+            }
+            if let value = item.summary.legacySummaryZoneSeconds {
+                values.append(
+                    .init(
+                        value: value.map { $0.map { Int64($0) * 1_000_000 } },
+                        provenance: item.origin == .jsonl
+                            ? "legacy-jsonl-summary" : "workout_history_v1-summary"
+                    )
+                )
+            }
+            return values
+        }
+        var conflicts = summaries.flatMap(\.summary.conflicts)
+        var warnings = Set(summaries.flatMap(\.summary.warnings))
+        let duration = resolvedValue(durationValues, preferredPrefix: "legacy-jsonl-timestamp-derived")
+        let target = resolvedValue(targetValues, preferredPrefix: "legacy-jsonl")
+        let averageHR = resolvedValue(
+            averageHeartRateValues,
+            preferredPrefix: "legacy-jsonl-timestamp-derived"
+        )
+        let speed = resolvedValue(speedValues, preferredPrefix: "legacy-jsonl")
+        let zones = resolvedValue(zoneValues, preferredPrefix: "legacy-jsonl-timestamp-derived")
+        for (field, isConflict) in [
+            ("duration", duration.conflict),
+            ("target_bpm", target.conflict),
+            ("average_hr_bpm", averageHR.conflict),
+            ("estimated_average_speed_kmh", speed.conflict),
+            ("zone_duration", zones.conflict),
+        ] where isConflict {
+            conflicts.append(
+                LegacySummaryConflict(
+                    field: field,
+                    preferredProvenance: "legacy-jsonl-more-specific-when-present",
+                    observedProvenances: []
+                )
+            )
+            warnings.insert("conflicting-summary-\(field)")
+        }
+        return LegacyResolvedWorkoutSummary(
+            durationMicroseconds: duration,
+            targetBeatsPerMinute: target,
+            averageHeartRateBeatsPerMinute: averageHR,
+            estimatedAverageSpeedKilometresPerHour: speed,
+            zoneMicroseconds: zones,
+            warnings: warnings.sorted(),
+            conflicts: Array(Set(conflicts)).sorted { $0.field < $1.field }
+        )
+    }
+
+    private func resolvedValue<Value: Codable & Hashable & Sendable>(
+        _ values: [LegacySourcedValue<Value>],
+        preferredPrefix: String
+    ) -> LegacyResolvedValue<Value> {
+        var distinct: [LegacySourcedValue<Value>] = []
+        for value in values where !distinct.contains(value) {
+            distinct.append(value)
+        }
+        let selected = distinct.first { $0.provenance.hasPrefix(preferredPrefix) }
+            ?? distinct.first
+        let alternatives = distinct.filter { $0 != selected }
+        let distinctValues = Set(distinct.map(\.value))
+        return LegacyResolvedValue(
+            selected: selected,
+            alternatives: alternatives,
+            conflict: distinctValues.count > 1
+        )
+    }
+
+    private func upsertReconciliation(
+        left: TelemetryLegacyWorkoutCandidateV2,
+        right: TelemetryLegacyWorkoutCandidateV2,
+        outcome: LegacyReconciliationOutcome,
+        kind: LegacyReconciliationIdentityKind?,
+        value: String?,
+        importedWorkoutID: String?,
+        detailCodes: [String]
+    ) throws {
+        let candidateIDs = [left.candidateID, right.candidateID].sorted()
+        let key = candidateIDs.joined(separator: "|")
+        let reconciliationID = LegacyMigrationHashing.deterministicIdentifier(
+            "legacy-reconciliation:\(key)"
+        )
+        let details = try Self.encode(detailCodes.sorted())
+        if let existing = try reconciliationModel(reconciliationID) {
+            try explicitTransaction {
+                existing.outcomeKey = outcome.rawValue
+                existing.identityKindKey = kind?.rawValue
+                existing.identityValue = value
+                existing.importedWorkoutID = importedWorkoutID
+                existing.detailPayload = details
+            }
+            return
+        }
+        try explicitTransaction {
+            modelContext.insert(
+                TelemetryLegacyReconciliationV2(
+                    reconciliationID: reconciliationID,
+                    leftCandidateID: candidateIDs[0],
+                    rightCandidateID: candidateIDs[1],
+                    outcomeKey: outcome.rawValue,
+                    identityKindKey: kind?.rawValue,
+                    identityValue: value,
+                    importedWorkoutID: importedWorkoutID,
+                    detailPayload: details
+                )
+            )
+        }
+    }
+
+    private func legacySourceModel(
+        _ sourceID: String
+    ) throws -> TelemetryLegacyMigrationSourceV2? {
+        var descriptor = FetchDescriptor<TelemetryLegacyMigrationSourceV2>(
+            predicate: #Predicate { $0.sourceID == sourceID }
+        )
+        descriptor.fetchLimit = 1
+        return try modelContext.fetch(descriptor).first
+    }
+
+    private func legacyImportedRecordModel(
+        sourceItemIdentityKey: String
+    ) throws -> TelemetryLegacyImportedRecordV2? {
+        var descriptor = FetchDescriptor<TelemetryLegacyImportedRecordV2>(
+            predicate: #Predicate { $0.sourceItemIdentityKey == sourceItemIdentityKey }
+        )
+        descriptor.fetchLimit = 1
+        return try modelContext.fetch(descriptor).first
+    }
+
+    private func legacyCandidateModel(
+        _ candidateID: String
+    ) throws -> TelemetryLegacyWorkoutCandidateV2? {
+        var descriptor = FetchDescriptor<TelemetryLegacyWorkoutCandidateV2>(
+            predicate: #Predicate { $0.candidateID == candidateID }
+        )
+        descriptor.fetchLimit = 1
+        return try modelContext.fetch(descriptor).first
+    }
+
+    private func importedWorkoutModel(
+        _ canonicalIdentityKey: String
+    ) throws -> TelemetryLegacyImportedWorkoutV2? {
+        var descriptor = FetchDescriptor<TelemetryLegacyImportedWorkoutV2>(
+            predicate: #Predicate { $0.canonicalIdentityKey == canonicalIdentityKey }
+        )
+        descriptor.fetchLimit = 1
+        return try modelContext.fetch(descriptor).first
+    }
+
+    private func reconciliationModel(
+        _ reconciliationID: String
+    ) throws -> TelemetryLegacyReconciliationV2? {
+        var descriptor = FetchDescriptor<TelemetryLegacyReconciliationV2>(
+            predicate: #Predicate { $0.reconciliationID == reconciliationID }
+        )
+        descriptor.fetchLimit = 1
+        return try modelContext.fetch(descriptor).first
+    }
+
+    private func makeImportedRecordModel(
+        _ draft: LegacyImportedRecordDraft
+    ) throws -> TelemetryLegacyImportedRecordV2 {
+        TelemetryLegacyImportedRecordV2(
+            importedRecordID: draft.importedRecordID,
+            sourceItemIdentityKey: draft.sourceItemIdentityKey,
+            sourceID: draft.sourceID,
+            candidateID: draft.candidateID,
+            sourceRecordIndex: draft.sourceRecordIndex,
+            sourceByteOffset: draft.sourceByteOffset,
+            eventKind: draft.eventKind,
+            occurredAt: draft.occurredAt,
+            profileLocalIdentifier: draft.profileLocalIdentifier,
+            workoutIdentifier: draft.workoutIdentifier,
+            healthKitWorkoutIdentifier: draft.healthKitWorkoutIdentifier,
+            stableLegacySessionIdentifier: draft.stableLegacySessionIdentifier,
+            provenanceKey: draft.provenanceKey,
+            normalizedPayload: try Self.encode(draft.payload),
+            identityUncertain: draft.identityUncertain,
+            adaptationQualityEligible: false
+        )
+    }
+
+    private func makeCandidateModel(
+        _ draft: LegacyWorkoutCandidateDraft
+    ) throws -> TelemetryLegacyWorkoutCandidateV2 {
+        TelemetryLegacyWorkoutCandidateV2(
+            candidateID: draft.candidateID,
+            sourceItemIdentityKey: draft.sourceItemIdentityKey,
+            sourceID: draft.sourceID,
+            originKindKey: draft.origin.rawValue,
+            profileLocalIdentifier: draft.profileLocalIdentifier,
+            workoutIdentifier: draft.workoutIdentifier,
+            healthKitWorkoutIdentifier: draft.healthKitWorkoutIdentifier,
+            stableLegacySessionIdentifier: draft.stableLegacySessionIdentifier,
+            startedAt: draft.startedAt,
+            endedAt: draft.endedAt,
+            identityUncertain: draft.identityUncertain,
+            possibleDuplicate: draft.possibleDuplicate,
+            summaryPayload: try Self.encode(draft.summary)
+        )
+    }
+
+    private func storedRecordMatches(
+        _ model: TelemetryLegacyImportedRecordV2,
+        draft: LegacyImportedRecordDraft
+    ) throws -> Bool {
+        let payload = try Self.decode(
+            LegacyImportedRecordPayload.self,
+            from: model.normalizedPayload
+        )
+        return model.importedRecordID == draft.importedRecordID
+            && model.sourceItemIdentityKey == draft.sourceItemIdentityKey
+            && model.sourceID == draft.sourceID
+            && model.candidateID == draft.candidateID
+            && model.sourceRecordIndex == draft.sourceRecordIndex
+            && model.sourceByteOffset == draft.sourceByteOffset
+            && model.eventKind == draft.eventKind
+            && model.occurredAt == draft.occurredAt
+            && model.profileLocalIdentifier == draft.profileLocalIdentifier
+            && model.workoutIdentifier == draft.workoutIdentifier
+            && model.healthKitWorkoutIdentifier == draft.healthKitWorkoutIdentifier
+            && model.stableLegacySessionIdentifier == draft.stableLegacySessionIdentifier
+            && model.provenanceKey == draft.provenanceKey
+            && model.identityUncertain == draft.identityUncertain
+            && !model.adaptationQualityEligible
+            && payload == draft.payload
+    }
+
+    private func storedCandidateMatches(
+        _ model: TelemetryLegacyWorkoutCandidateV2,
+        draft: LegacyWorkoutCandidateDraft
+    ) throws -> Bool {
+        let summary = try Self.decode(
+            LegacyWorkoutCandidateSummary.self,
+            from: model.summaryPayload
+        )
+        return model.sourceItemIdentityKey == draft.sourceItemIdentityKey
+            && model.sourceID == draft.sourceID
+            && model.originKindKey == draft.origin.rawValue
+            && model.profileLocalIdentifier == draft.profileLocalIdentifier
+            && model.workoutIdentifier == draft.workoutIdentifier
+            && model.healthKitWorkoutIdentifier == draft.healthKitWorkoutIdentifier
+            && model.stableLegacySessionIdentifier == draft.stableLegacySessionIdentifier
+            && model.startedAt == draft.startedAt
+            && model.endedAt == draft.endedAt
+            && model.identityUncertain == draft.identityUncertain
+            && model.possibleDuplicate == draft.possibleDuplicate
+            && summary == draft.summary
+    }
+
+    private func sourceProgress(
+        _ model: TelemetryLegacyMigrationSourceV2
+    ) throws -> LegacyMigrationSourceProgress {
+        LegacyMigrationSourceProgress(
+            snapshot: try sourceSnapshot(model),
+            aggregateStatePayload: model.aggregateStatePayload
+        )
+    }
+
+    private func sourceSnapshot(
+        _ model: TelemetryLegacyMigrationSourceV2
+    ) throws -> LegacyMigrationSourceSnapshot {
+        guard let kind = LegacyMigrationSourceKind(rawValue: model.sourceKindKey),
+              let status = LegacyMigrationSourceStatus(rawValue: model.statusKey) else {
+            throw TelemetryStoreError.corruptStoredRecord(model.sourceID)
+        }
+        return LegacyMigrationSourceSnapshot(
+            sourceID: model.sourceID,
+            kind: kind,
+            contentHashDigest: model.contentHashDigest,
+            importerVersion: model.importerVersion,
+            locator: model.locator,
+            exactProfileLocalIdentifier: model.exactProfileLocalIdentifier,
+            status: status,
+            checkpointByteOffset: model.checkpointByteOffset,
+            checkpointRecordIndex: model.checkpointRecordIndex,
+            parsedRecordCount: model.parsedRecordCount,
+            malformedRecordCount: model.malformedRecordCount,
+            warningCount: model.warningCount,
+            errorCode: model.errorCode,
+            errorDetail: model.errorDetail
+        )
+    }
+
+    private func importedRecordSnapshot(
+        _ model: TelemetryLegacyImportedRecordV2
+    ) throws -> LegacyImportedRecordSnapshot {
+        LegacyImportedRecordSnapshot(
+            importedRecordID: model.importedRecordID,
+            sourceID: model.sourceID,
+            candidateID: model.candidateID,
+            sourceRecordIndex: model.sourceRecordIndex,
+            eventKind: model.eventKind,
+            occurredAt: model.occurredAt,
+            profileLocalIdentifier: model.profileLocalIdentifier,
+            workoutIdentifier: model.workoutIdentifier,
+            healthKitWorkoutIdentifier: model.healthKitWorkoutIdentifier,
+            stableLegacySessionIdentifier: model.stableLegacySessionIdentifier,
+            payload: try Self.decode(
+                LegacyImportedRecordPayload.self,
+                from: model.normalizedPayload
+            ),
+            identityUncertain: model.identityUncertain,
+            adaptationQualityEligible: model.adaptationQualityEligible
+        )
+    }
+
+    private func candidateSnapshot(
+        _ model: TelemetryLegacyWorkoutCandidateV2
+    ) throws -> LegacyWorkoutCandidateSnapshot {
+        LegacyWorkoutCandidateSnapshot(
+            candidateID: model.candidateID,
+            sourceID: model.sourceID,
+            origin: try requiredOrigin(model.originKindKey),
+            profileLocalIdentifier: model.profileLocalIdentifier,
+            workoutIdentifier: model.workoutIdentifier,
+            healthKitWorkoutIdentifier: model.healthKitWorkoutIdentifier,
+            stableLegacySessionIdentifier: model.stableLegacySessionIdentifier,
+            startedAt: model.startedAt,
+            endedAt: model.endedAt,
+            identityUncertain: model.identityUncertain,
+            possibleDuplicate: model.possibleDuplicate,
+            summary: try Self.decode(
+                LegacyWorkoutCandidateSummary.self,
+                from: model.summaryPayload
+            )
+        )
+    }
+
+    private func importedWorkoutSnapshot(
+        _ model: TelemetryLegacyImportedWorkoutV2
+    ) throws -> LegacyImportedWorkoutSnapshot {
+        guard let status = LegacyIdentityStatus(rawValue: model.identityStatusKey) else {
+            throw TelemetryStoreError.corruptStoredRecord(model.importedWorkoutID)
+        }
+        return LegacyImportedWorkoutSnapshot(
+            importedWorkoutID: model.importedWorkoutID,
+            canonicalIdentityKey: model.canonicalIdentityKey,
+            profileLocalIdentifier: model.profileLocalIdentifier,
+            startedAt: model.startedAt,
+            endedAt: model.endedAt,
+            identityStatus: status,
+            possibleDuplicate: model.possibleDuplicate,
+            adaptationQualityEligible: model.adaptationQualityEligible,
+            candidateIDs: try Self.decode([String].self, from: model.candidateIDsPayload),
+            resolvedSummary: try Self.decode(
+                LegacyResolvedWorkoutSummary.self,
+                from: model.resolvedSummaryPayload
+            )
+        )
+    }
+
+    private func reconciliationSnapshot(
+        _ model: TelemetryLegacyReconciliationV2
+    ) throws -> LegacyReconciliationSnapshot {
+        guard let outcome = LegacyReconciliationOutcome(rawValue: model.outcomeKey) else {
+            throw TelemetryStoreError.corruptStoredRecord(model.reconciliationID)
+        }
+        return LegacyReconciliationSnapshot(
+            reconciliationID: model.reconciliationID,
+            leftCandidateID: model.leftCandidateID,
+            rightCandidateID: model.rightCandidateID,
+            outcome: outcome,
+            identityKind: model.identityKindKey.flatMap(
+                LegacyReconciliationIdentityKind.init(rawValue:)
+            ),
+            identityValue: model.identityValue,
+            importedWorkoutID: model.importedWorkoutID,
+            detailCodes: try Self.decode([String].self, from: model.detailPayload)
+        )
+    }
+
+    private func requiredOrigin(_ value: String) throws -> LegacyWorkoutCandidateOrigin {
+        guard let origin = LegacyWorkoutCandidateOrigin(rawValue: value) else {
+            throw TelemetryStoreError.corruptStoredRecord(value)
+        }
+        return origin
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrationStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrationStore.swift
@@ -507,12 +507,9 @@ extension TelemetryStore {
             code: "conflicting-stable-session-identifier",
             into: &conflicts
         )
-        appendConflict(
-            lhs.profileLocalIdentifier,
-            rhs.profileLocalIdentifier,
-            code: "conflicting-profile-ownership",
-            into: &conflicts
-        )
+        if lhs.profileLocalIdentifier != rhs.profileLocalIdentifier {
+            conflicts.append("conflicting-profile-ownership")
+        }
         return conflicts.sorted()
     }
 
@@ -549,6 +546,34 @@ extension TelemetryStore {
                 try Self.decode([String].self, from: existing.candidateIDsPayload)
             )
         }
+        var absorbedProvisionalWorkouts: [TelemetryLegacyImportedWorkoutV2] = []
+        var absorbedImportedWorkoutIDs: Set<String> = []
+        var pendingCandidateIDs = candidateIDs.sorted()
+        var pendingIndex = 0
+        while pendingIndex < pendingCandidateIDs.count {
+            let candidateID = pendingCandidateIDs[pendingIndex]
+            pendingIndex += 1
+            let provisionalKey = "candidate:\(candidateID)"
+            guard provisionalKey != canonicalIdentityKey,
+                  let provisional = try importedWorkoutModel(provisionalKey),
+                  absorbedImportedWorkoutIDs.insert(provisional.importedWorkoutID).inserted else {
+                continue
+            }
+            absorbedProvisionalWorkouts.append(provisional)
+            let provisionalCandidateIDs = try Self.decode(
+                [String].self,
+                from: provisional.candidateIDsPayload
+            )
+            for absorbedCandidateID in provisionalCandidateIDs
+            where candidateIDs.insert(absorbedCandidateID).inserted {
+                guard candidateIDs.count <= 256 else {
+                    throw TelemetryStoreError.conflictingStableIdentity(
+                        "legacy-imported-workout-candidate-limit"
+                    )
+                }
+                pendingCandidateIDs.append(absorbedCandidateID)
+            }
+        }
         guard candidateIDs.count <= 256 else {
             throw TelemetryStoreError.conflictingStableIdentity(
                 "legacy-imported-workout-candidate-limit"
@@ -580,6 +605,8 @@ extension TelemetryStore {
             .max() ?? candidates.compactMap(\.endedAt).max()
         let candidatePayload = try Self.encode(candidateIDs.sorted())
         let summaryPayload = try Self.encode(resolved)
+        let retainedPossibleDuplicate = possibleDuplicate
+            || absorbedProvisionalWorkouts.contains(where: \.possibleDuplicate)
 
         if let existing {
             try explicitTransaction {
@@ -587,10 +614,14 @@ extension TelemetryStore {
                 existing.startedAt = startedAt
                 existing.endedAt = endedAt
                 existing.identityStatusKey = finalStatus.rawValue
-                existing.possibleDuplicate = existing.possibleDuplicate || possibleDuplicate
+                existing.possibleDuplicate = existing.possibleDuplicate
+                    || retainedPossibleDuplicate
                 existing.adaptationQualityEligible = false
                 existing.candidateIDsPayload = candidatePayload
                 existing.resolvedSummaryPayload = summaryPayload
+                for provisional in absorbedProvisionalWorkouts {
+                    modelContext.delete(provisional)
+                }
             }
             return false
         }
@@ -603,14 +634,17 @@ extension TelemetryStore {
                     startedAt: startedAt,
                     endedAt: endedAt,
                     identityStatusKey: finalStatus.rawValue,
-                    possibleDuplicate: possibleDuplicate,
+                    possibleDuplicate: retainedPossibleDuplicate,
                     adaptationQualityEligible: false,
                     candidateIDsPayload: candidatePayload,
                     resolvedSummaryPayload: summaryPayload
                 )
             )
+            for provisional in absorbedProvisionalWorkouts {
+                modelContext.delete(provisional)
+            }
         }
-        return true
+        return absorbedProvisionalWorkouts.isEmpty
     }
 
     private func resolveSummary(
@@ -704,11 +738,11 @@ extension TelemetryStore {
         }
         var conflicts = summaries.flatMap(\.summary.conflicts)
         var warnings = Set(summaries.flatMap(\.summary.warnings))
-        let duration = resolvedValue(durationValues, preferredPrefix: "legacy-jsonl-timestamp-derived")
+        let duration = resolvedValue(durationValues, preferredPrefix: "legacy-jsonl")
         let target = resolvedValue(targetValues, preferredPrefix: "legacy-jsonl")
         let averageHR = resolvedValue(
             averageHeartRateValues,
-            preferredPrefix: "legacy-jsonl-timestamp-derived"
+            preferredPrefix: "legacy-jsonl"
         )
         let speed = resolvedValue(speedValues, preferredPrefix: "legacy-jsonl")
         let zones = resolvedValue(zoneValues, preferredPrefix: "legacy-jsonl-timestamp-derived")

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrationStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrationStore.swift
@@ -304,7 +304,7 @@ extension TelemetryStore {
             canonicalIdentityKey = unreconciledIdentityKey(candidate)
         }
         let group = [candidate] + compatible
-        let identityStatus: LegacyIdentityStatus = !conflicting.isEmpty
+        let identityStatus: LegacyIdentityStatus = compatible.isEmpty && !conflicting.isEmpty
             ? .conflict
             : candidate.identityUncertain ? .uncertain : .exact
         let inserted = try upsertImportedWorkout(
@@ -473,9 +473,7 @@ extension TelemetryStore {
         value: String,
         candidates: [TelemetryLegacyWorkoutCandidateV2]
     ) -> String {
-        let historyOrigin = LegacyWorkoutCandidateOrigin.workoutHistory.rawValue
-        if candidates.allSatisfy({ $0.originKindKey == historyOrigin }),
-           let profileLocalIdentifier = candidates.first?.profileLocalIdentifier,
+        if let profileLocalIdentifier = candidates.first?.profileLocalIdentifier,
            candidates.allSatisfy({
                $0.profileLocalIdentifier == profileLocalIdentifier
            }) {
@@ -738,14 +736,26 @@ extension TelemetryStore {
         }
         var conflicts = summaries.flatMap(\.summary.conflicts)
         var warnings = Set(summaries.flatMap(\.summary.warnings))
-        let duration = resolvedValue(durationValues, preferredPrefix: "legacy-jsonl")
-        let target = resolvedValue(targetValues, preferredPrefix: "legacy-jsonl")
+        let duration = resolvedValue(
+            durationValues,
+            preferredPrefixes: [
+                "legacy-jsonl-timestamp-derived",
+                "legacy-jsonl-summary",
+            ]
+        )
+        let target = resolvedValue(targetValues, preferredPrefixes: ["legacy-jsonl"])
         let averageHR = resolvedValue(
             averageHeartRateValues,
-            preferredPrefix: "legacy-jsonl"
+            preferredPrefixes: [
+                "legacy-jsonl-timestamp-derived",
+                "legacy-jsonl-summary",
+            ]
         )
-        let speed = resolvedValue(speedValues, preferredPrefix: "legacy-jsonl")
-        let zones = resolvedValue(zoneValues, preferredPrefix: "legacy-jsonl-timestamp-derived")
+        let speed = resolvedValue(speedValues, preferredPrefixes: ["legacy-jsonl"])
+        let zones = resolvedValue(
+            zoneValues,
+            preferredPrefixes: ["legacy-jsonl-timestamp-derived"]
+        )
         for (field, isConflict) in [
             ("duration", duration.conflict),
             ("target_bpm", target.conflict),
@@ -775,13 +785,15 @@ extension TelemetryStore {
 
     private func resolvedValue<Value: Codable & Hashable & Sendable>(
         _ values: [LegacySourcedValue<Value>],
-        preferredPrefix: String
+        preferredPrefixes: [String]
     ) -> LegacyResolvedValue<Value> {
         var distinct: [LegacySourcedValue<Value>] = []
         for value in values where !distinct.contains(value) {
             distinct.append(value)
         }
-        let selected = distinct.first { $0.provenance.hasPrefix(preferredPrefix) }
+        let selected = preferredPrefixes.compactMap { preferredPrefix in
+            distinct.first { $0.provenance.hasPrefix(preferredPrefix) }
+        }.first
             ?? distinct.first
         let alternatives = distinct.filter { $0 != selected }
         let distinctValues = Set(distinct.map(\.value))

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/LegacyTelemetryMigrator.swift
@@ -1,0 +1,422 @@
+import Foundation
+import TelemetryDomain
+
+private struct LegacyHistoryAggregateState: Codable, Hashable, Sendable {
+    var occurrencesByCanonicalDigest: [String: Int] = [:]
+}
+
+private enum LegacySourceRunOutcome {
+    case completed(importedRecords: Int)
+    case skipped
+    case paused(importedRecords: Int)
+    case failed
+}
+
+public struct LegacyTelemetryMigrator: Sendable {
+    public static let importerVersion = "legacy-to-v2-importer-v1"
+    private static let maximumHistoryRepresentationBytes = 8 * 1_024 * 1_024
+    private static let maximumHistoryEntryCount = 10_000
+
+    private let store: TelemetryStore
+    private let shouldPauseAfterCommittedBatch: @Sendable (Int) -> Bool
+
+    public init(store: TelemetryStore) {
+        self.init(store: store, shouldPauseAfterCommittedBatch: { _ in false })
+    }
+
+    init(
+        store: TelemetryStore,
+        shouldPauseAfterCommittedBatch: @escaping @Sendable (Int) -> Bool
+    ) {
+        self.store = store
+        self.shouldPauseAfterCommittedBatch = shouldPauseAfterCommittedBatch
+    }
+
+    public func run(
+        _ request: LegacyTelemetryMigrationRequest
+    ) async -> LegacyTelemetryMigrationReport {
+        let batchSize = min(512, max(1, request.maximumRecordsPerBatch))
+        var completedSources = 0
+        var skippedSources = 0
+        var failedSources = 0
+        var importedRecords = 0
+        var wasPaused = false
+
+        for source in request.jsonlSources.sorted(by: {
+            $0.url.standardizedFileURL.path < $1.url.standardizedFileURL.path
+        }) {
+            let outcome = await runJSONLSource(
+                source,
+                knownProfiles: request.knownProfileLocalIdentifiers,
+                batchSize: batchSize
+            )
+            switch outcome {
+            case let .completed(count):
+                completedSources += 1
+                importedRecords += count
+            case .skipped:
+                skippedSources += 1
+            case let .paused(count):
+                importedRecords += count
+                wasPaused = true
+            case .failed:
+                failedSources += 1
+            }
+            if wasPaused { break }
+        }
+
+        if !wasPaused {
+            for source in request.workoutHistorySources.sorted(by: {
+                $0.storageKey < $1.storageKey
+            }) {
+                let outcome = await runHistorySource(
+                    source,
+                    knownProfiles: request.knownProfileLocalIdentifiers,
+                    batchSize: batchSize
+                )
+                switch outcome {
+                case let .completed(count):
+                    completedSources += 1
+                    importedRecords += count
+                case .skipped:
+                    skippedSources += 1
+                case let .paused(count):
+                    importedRecords += count
+                    wasPaused = true
+                case .failed:
+                    failedSources += 1
+                }
+                if wasPaused { break }
+            }
+        }
+
+        let importedWorkoutCount: Int
+        if wasPaused {
+            importedWorkoutCount = 0
+        } else {
+            do {
+                importedWorkoutCount = try await store.reconcileLegacyWorkoutCandidates()
+            } catch {
+                importedWorkoutCount = 0
+                failedSources = max(1, failedSources)
+                try? await store.failLegacyReconciliation(
+                    detail: boundedErrorDetail(error),
+                    now: Date()
+                )
+            }
+        }
+        let completion: LegacyTelemetryMigrationCompletion
+        if failedSources > 0, completedSources == 0, skippedSources == 0 {
+            completion = .failed
+        } else if failedSources > 0 || wasPaused {
+            completion = .partial
+        } else {
+            completion = .completed
+        }
+        return LegacyTelemetryMigrationReport(
+            completion: completion,
+            completedSourceCount: completedSources,
+            skippedSourceCount: skippedSources,
+            failedSourceCount: failedSources,
+            importedRecordCount: importedRecords,
+            importedWorkoutCount: importedWorkoutCount
+        )
+    }
+
+    private func runJSONLSource(
+        _ descriptor: LegacyJSONLSourceDescriptor,
+        knownProfiles: Set<String>,
+        batchSize: Int
+    ) async -> LegacySourceRunOutcome {
+        var sourceID: String?
+        var committedBatchCount = 0
+        do {
+            let digest = try LegacyMigrationHashing.fileSHA256(descriptor.url)
+            let definition = LegacyMigrationSourceDefinition(
+                sourceID: LegacyMigrationHashing.deterministicIdentifier(
+                    "legacy-source:jsonl:\(digest)"
+                ),
+                kind: .jsonl,
+                contentHashDigest: digest,
+                locator: descriptor.url.standardizedFileURL.path,
+                exactProfileLocalIdentifier:
+                    descriptor.deterministicFallbackProfileLocalIdentifier
+            )
+            sourceID = definition.sourceID
+            let emptyAggregate = try TelemetryStore.encode(LegacyJSONLAggregateState())
+            let progress = try await store.beginLegacyMigrationSource(
+                definition,
+                importerVersion: Self.importerVersion,
+                emptyAggregateStatePayload: emptyAggregate,
+                now: Date()
+            )
+            if progress.snapshot.status == .completed {
+                return .skipped
+            }
+            var aggregate = try TelemetryStore.decode(
+                LegacyJSONLAggregateState.self,
+                from: progress.aggregateStatePayload
+            )
+            let candidateID = LegacyMigrationHashing.deterministicIdentifier(
+                "jsonl-candidate:\(definition.sourceID)"
+            )
+            let reader = try LegacyJSONLLineReader(
+                url: descriptor.url,
+                startingAt: progress.snapshot.checkpointByteOffset,
+                nextRecordIndex: progress.snapshot.checkpointRecordIndex
+            )
+            var records: [LegacyImportedRecordDraft] = []
+            var batchElementCount = 0
+            var parsedRecordCount = progress.snapshot.parsedRecordCount
+            var malformedRecordCount = progress.snapshot.malformedRecordCount
+            var warningCount = progress.snapshot.warningCount
+            var lastOffset = progress.snapshot.checkpointByteOffset
+            var lastRecordIndex = progress.snapshot.checkpointRecordIndex
+            var insertedRecords = 0
+
+            while let element = try reader.next() {
+                lastOffset = element.endOffset
+                lastRecordIndex = element.recordIndex
+                parsedRecordCount += 1
+                batchElementCount += 1
+                if let structuralWarning = element.structuralWarning {
+                    malformedRecordCount += 1
+                    warningCount += 1
+                    aggregate.recordMalformed(structuralWarning)
+                } else if let data = element.data {
+                    do {
+                        let parsed = try LegacyTelemetryMigrationParser.parseJSONL(
+                            data,
+                            sourceID: definition.sourceID,
+                            candidateID: candidateID,
+                            element: element,
+                            knownProfiles: knownProfiles,
+                            deterministicFallbackProfile:
+                                descriptor.deterministicFallbackProfileLocalIdentifier
+                        )
+                        records.append(parsed.draft)
+                        warningCount += Int64(parsed.draft.payload.warnings.count)
+                        aggregate.observe(parsed.draft)
+                    } catch {
+                        malformedRecordCount += 1
+                        warningCount += 1
+                        aggregate.recordMalformed("malformed-jsonl-record")
+                    }
+                }
+
+                if batchElementCount >= batchSize {
+                    insertedRecords += try await store.commitLegacyMigrationBatch(
+                        sourceID: definition.sourceID,
+                        records: records,
+                        candidates: [],
+                        checkpointByteOffset: lastOffset,
+                        checkpointRecordIndex: lastRecordIndex,
+                        parsedRecordCount: parsedRecordCount,
+                        malformedRecordCount: malformedRecordCount,
+                        warningCount: warningCount,
+                        aggregateStatePayload: try TelemetryStore.encode(aggregate),
+                        completing: false,
+                        now: Date()
+                    )
+                    records.removeAll(keepingCapacity: true)
+                    batchElementCount = 0
+                    committedBatchCount += 1
+                    if shouldPauseAfterCommittedBatch(committedBatchCount) {
+                        try await store.pauseLegacyMigrationSource(
+                            sourceID: definition.sourceID,
+                            now: Date()
+                        )
+                        return .paused(importedRecords: insertedRecords)
+                    }
+                }
+            }
+
+            let candidate = aggregate.candidate(
+                sourceID: definition.sourceID,
+                candidateID: candidateID,
+                deterministicFallbackProfile:
+                    descriptor.deterministicFallbackProfileLocalIdentifier
+            )
+            insertedRecords += try await store.commitLegacyMigrationBatch(
+                sourceID: definition.sourceID,
+                records: records,
+                candidates: [candidate],
+                checkpointByteOffset: lastOffset,
+                checkpointRecordIndex: lastRecordIndex,
+                parsedRecordCount: parsedRecordCount,
+                malformedRecordCount: malformedRecordCount,
+                warningCount: warningCount,
+                aggregateStatePayload: try TelemetryStore.encode(aggregate),
+                completing: true,
+                now: Date()
+            )
+            committedBatchCount += 1
+            return .completed(importedRecords: insertedRecords)
+        } catch {
+            if let sourceID {
+                try? await store.failLegacyMigrationSource(
+                    sourceID: sourceID,
+                    code: "jsonl-source-failed",
+                    detail: boundedErrorDetail(error),
+                    now: Date()
+                )
+            }
+            return .failed
+        }
+    }
+
+    private func runHistorySource(
+        _ descriptor: LegacyWorkoutHistorySourceDescriptor,
+        knownProfiles: Set<String>,
+        batchSize: Int
+    ) async -> LegacySourceRunOutcome {
+        var sourceID: String?
+        var committedBatchCount = 0
+        do {
+            let exactProfile = descriptor.exactProfileLocalIdentifier.flatMap {
+                knownProfiles.contains($0) ? $0 : nil
+            }
+            let digest = LegacyMigrationHashing.dataSHA256(descriptor.representation)
+            let sourceScopeKey = "history:\(exactProfile ?? "unassigned")"
+            let definition = LegacyMigrationSourceDefinition(
+                sourceID: LegacyMigrationHashing.deterministicIdentifier(
+                    "legacy-source:\(sourceScopeKey):\(digest)"
+                ),
+                kind: .workoutHistory,
+                contentHashDigest: digest,
+                locator: descriptor.storageKey,
+                exactProfileLocalIdentifier: exactProfile
+            )
+            sourceID = definition.sourceID
+            let emptyAggregate = try TelemetryStore.encode(LegacyHistoryAggregateState())
+            let progress = try await store.beginLegacyMigrationSource(
+                definition,
+                importerVersion: Self.importerVersion,
+                emptyAggregateStatePayload: emptyAggregate,
+                now: Date()
+            )
+            if progress.snapshot.status == .completed {
+                return .skipped
+            }
+            guard descriptor.representation.count <= Self.maximumHistoryRepresentationBytes else {
+                throw LegacyMigrationParsingError.unreadableSource
+            }
+            var aggregate = try TelemetryStore.decode(
+                LegacyHistoryAggregateState.self,
+                from: progress.aggregateStatePayload
+            )
+            var reader = try LegacyJSONArrayElementReader(
+                data: descriptor.representation,
+                startingAt: progress.snapshot.checkpointByteOffset,
+                nextRecordIndex: progress.snapshot.checkpointRecordIndex
+            )
+            var records: [LegacyImportedRecordDraft] = []
+            var candidates: [LegacyWorkoutCandidateDraft] = []
+            var batchElementCount = 0
+            var parsedRecordCount = progress.snapshot.parsedRecordCount
+            var malformedRecordCount = progress.snapshot.malformedRecordCount
+            var warningCount = progress.snapshot.warningCount
+            var lastOffset = progress.snapshot.checkpointByteOffset
+            var lastRecordIndex = progress.snapshot.checkpointRecordIndex
+            var insertedRecords = 0
+
+            while let element = try reader.next() {
+                guard parsedRecordCount < Self.maximumHistoryEntryCount else {
+                    throw LegacyMigrationParsingError.unreadableSource
+                }
+                lastOffset = element.endOffset
+                lastRecordIndex = element.recordIndex
+                parsedRecordCount += 1
+                batchElementCount += 1
+                if let data = element.data {
+                    do {
+                        let canonicalDigest = try LegacyTelemetryMigrationParser
+                            .canonicalObjectDigest(data)
+                        let occurrence = (aggregate.occurrencesByCanonicalDigest[
+                            canonicalDigest
+                        ] ?? 0) + 1
+                        aggregate.occurrencesByCanonicalDigest[canonicalDigest] = occurrence
+                        let parsed = try LegacyTelemetryMigrationParser.parseWorkoutHistory(
+                            data,
+                            sourceID: definition.sourceID,
+                            element: element,
+                            occurrence: occurrence,
+                            exactProfile: exactProfile
+                        )
+                        records.append(parsed.record)
+                        candidates.append(parsed.candidate)
+                        warningCount += Int64(parsed.record.payload.warnings.count)
+                    } catch {
+                        malformedRecordCount += 1
+                        warningCount += 1
+                    }
+                }
+
+                if batchElementCount >= batchSize {
+                    insertedRecords += try await store.commitLegacyMigrationBatch(
+                        sourceID: definition.sourceID,
+                        records: records,
+                        candidates: candidates,
+                        checkpointByteOffset: lastOffset,
+                        checkpointRecordIndex: lastRecordIndex,
+                        parsedRecordCount: parsedRecordCount,
+                        malformedRecordCount: malformedRecordCount,
+                        warningCount: warningCount,
+                        aggregateStatePayload: try TelemetryStore.encode(aggregate),
+                        completing: false,
+                        now: Date()
+                    )
+                    records.removeAll(keepingCapacity: true)
+                    candidates.removeAll(keepingCapacity: true)
+                    batchElementCount = 0
+                    committedBatchCount += 1
+                    if shouldPauseAfterCommittedBatch(committedBatchCount) {
+                        try await store.pauseLegacyMigrationSource(
+                            sourceID: definition.sourceID,
+                            now: Date()
+                        )
+                        return .paused(importedRecords: insertedRecords)
+                    }
+                }
+            }
+
+            insertedRecords += try await store.commitLegacyMigrationBatch(
+                sourceID: definition.sourceID,
+                records: records,
+                candidates: candidates,
+                checkpointByteOffset: lastOffset,
+                checkpointRecordIndex: lastRecordIndex,
+                parsedRecordCount: parsedRecordCount,
+                malformedRecordCount: malformedRecordCount,
+                warningCount: warningCount,
+                aggregateStatePayload: try TelemetryStore.encode(aggregate),
+                completing: true,
+                now: Date()
+            )
+            committedBatchCount += 1
+            return .completed(importedRecords: insertedRecords)
+        } catch {
+            if let sourceID {
+                try? await store.failLegacyMigrationSource(
+                    sourceID: sourceID,
+                    code: "workout-history-source-failed",
+                    detail: boundedErrorDetail(error),
+                    now: Date()
+                )
+            }
+            return .failed
+        }
+    }
+
+    private func boundedErrorDetail(_ error: Error) -> String {
+        String(describing: error).prefix(512).description
+    }
+}
+
+extension TelemetryStore: LegacyTelemetryMigrationCapability {
+    public func migrateLegacyTelemetry(
+        _ request: LegacyTelemetryMigrationRequest
+    ) async -> LegacyTelemetryMigrationReport {
+        await LegacyTelemetryMigrator(store: self).run(request)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetrySchemaV1.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetrySchemaV1.swift
@@ -20,11 +20,30 @@ enum TelemetrySchemaV1: VersionedSchema {
 
 enum TelemetryMigrationPlan: SchemaMigrationPlan {
     public static var schemas: [any VersionedSchema.Type] {
-        [TelemetrySchemaV1.self]
+        [TelemetrySchemaV1.self, TelemetrySchemaV2.self]
     }
 
     public static var stages: [MigrationStage] {
-        []
+        [
+            .lightweight(
+                fromVersion: TelemetrySchemaV1.self,
+                toVersion: TelemetrySchemaV2.self
+            )
+        ]
+    }
+}
+
+enum TelemetrySchemaV2: VersionedSchema {
+    public static let versionIdentifier = Schema.Version(1, 1, 0)
+
+    public static var models: [any PersistentModel.Type] {
+        TelemetrySchemaV1.models + [
+            TelemetryLegacyMigrationSourceV2.self,
+            TelemetryLegacyImportedRecordV2.self,
+            TelemetryLegacyWorkoutCandidateV2.self,
+            TelemetryLegacyImportedWorkoutV2.self,
+            TelemetryLegacyReconciliationV2.self,
+        ]
     }
 }
 
@@ -507,5 +526,268 @@ final class TelemetryWorkoutAnalysisV1 {
         self.detailSchemaVersion = detailSchemaVersion
         self.detailPayload = detailPayload
         self.session = session
+    }
+}
+
+@Model
+final class TelemetryLegacyMigrationSourceV2 {
+    #Index<TelemetryLegacyMigrationSourceV2>(
+        [\.sourceKindKey, \.contentHashDigest],
+        [\.statusKey, \.updatedAt]
+    )
+
+    @Attribute(.unique) public var sourceID: String
+    public var sourceKindKey: String
+    public var contentHashDigest: String
+    public var importerVersion: String
+    public var locator: String
+    public var exactProfileLocalIdentifier: String?
+    public var statusKey: String
+    public var checkpointByteOffset: Int64
+    public var checkpointRecordIndex: Int64
+    public var parsedRecordCount: Int64
+    public var malformedRecordCount: Int64
+    public var warningCount: Int64
+    public var aggregateStatePayload: Data
+    public var errorCode: String?
+    public var errorDetail: String?
+    public var updatedAt: Date
+    public var completedAt: Date?
+
+    public init(
+        sourceID: String,
+        sourceKindKey: String,
+        contentHashDigest: String,
+        importerVersion: String,
+        locator: String,
+        exactProfileLocalIdentifier: String?,
+        statusKey: String,
+        checkpointByteOffset: Int64,
+        checkpointRecordIndex: Int64,
+        parsedRecordCount: Int64,
+        malformedRecordCount: Int64,
+        warningCount: Int64,
+        aggregateStatePayload: Data,
+        errorCode: String?,
+        errorDetail: String?,
+        updatedAt: Date,
+        completedAt: Date?
+    ) {
+        self.sourceID = sourceID
+        self.sourceKindKey = sourceKindKey
+        self.contentHashDigest = contentHashDigest
+        self.importerVersion = importerVersion
+        self.locator = locator
+        self.exactProfileLocalIdentifier = exactProfileLocalIdentifier
+        self.statusKey = statusKey
+        self.checkpointByteOffset = checkpointByteOffset
+        self.checkpointRecordIndex = checkpointRecordIndex
+        self.parsedRecordCount = parsedRecordCount
+        self.malformedRecordCount = malformedRecordCount
+        self.warningCount = warningCount
+        self.aggregateStatePayload = aggregateStatePayload
+        self.errorCode = errorCode
+        self.errorDetail = errorDetail
+        self.updatedAt = updatedAt
+        self.completedAt = completedAt
+    }
+}
+
+@Model
+final class TelemetryLegacyImportedRecordV2 {
+    #Index<TelemetryLegacyImportedRecordV2>(
+        [\.sourceID, \.sourceRecordIndex],
+        [\.candidateID, \.occurredAt],
+        [\.workoutIdentifier],
+        [\.healthKitWorkoutIdentifier],
+        [\.stableLegacySessionIdentifier]
+    )
+
+    @Attribute(.unique) public var importedRecordID: String
+    @Attribute(.unique) public var sourceItemIdentityKey: String
+    public var sourceID: String
+    public var candidateID: String
+    public var sourceRecordIndex: Int64
+    public var sourceByteOffset: Int64
+    public var eventKind: String
+    public var occurredAt: Date?
+    public var profileLocalIdentifier: String?
+    public var workoutIdentifier: String?
+    public var healthKitWorkoutIdentifier: String?
+    public var stableLegacySessionIdentifier: String?
+    public var provenanceKey: String
+    public var normalizedPayload: Data
+    public var identityUncertain: Bool
+    public var adaptationQualityEligible: Bool
+
+    public init(
+        importedRecordID: String,
+        sourceItemIdentityKey: String,
+        sourceID: String,
+        candidateID: String,
+        sourceRecordIndex: Int64,
+        sourceByteOffset: Int64,
+        eventKind: String,
+        occurredAt: Date?,
+        profileLocalIdentifier: String?,
+        workoutIdentifier: String?,
+        healthKitWorkoutIdentifier: String?,
+        stableLegacySessionIdentifier: String?,
+        provenanceKey: String,
+        normalizedPayload: Data,
+        identityUncertain: Bool,
+        adaptationQualityEligible: Bool
+    ) {
+        self.importedRecordID = importedRecordID
+        self.sourceItemIdentityKey = sourceItemIdentityKey
+        self.sourceID = sourceID
+        self.candidateID = candidateID
+        self.sourceRecordIndex = sourceRecordIndex
+        self.sourceByteOffset = sourceByteOffset
+        self.eventKind = eventKind
+        self.occurredAt = occurredAt
+        self.profileLocalIdentifier = profileLocalIdentifier
+        self.workoutIdentifier = workoutIdentifier
+        self.healthKitWorkoutIdentifier = healthKitWorkoutIdentifier
+        self.stableLegacySessionIdentifier = stableLegacySessionIdentifier
+        self.provenanceKey = provenanceKey
+        self.normalizedPayload = normalizedPayload
+        self.identityUncertain = identityUncertain
+        self.adaptationQualityEligible = adaptationQualityEligible
+    }
+}
+
+@Model
+final class TelemetryLegacyWorkoutCandidateV2 {
+    #Index<TelemetryLegacyWorkoutCandidateV2>(
+        [\.originKindKey, \.workoutIdentifier],
+        [\.originKindKey, \.healthKitWorkoutIdentifier],
+        [\.originKindKey, \.stableLegacySessionIdentifier],
+        [\.profileLocalIdentifier, \.startedAt]
+    )
+
+    @Attribute(.unique) public var candidateID: String
+    @Attribute(.unique) public var sourceItemIdentityKey: String
+    public var sourceID: String
+    public var originKindKey: String
+    public var profileLocalIdentifier: String?
+    public var workoutIdentifier: String?
+    public var healthKitWorkoutIdentifier: String?
+    public var stableLegacySessionIdentifier: String?
+    public var startedAt: Date?
+    public var endedAt: Date?
+    public var identityUncertain: Bool
+    public var possibleDuplicate: Bool
+    public var summaryPayload: Data
+
+    public init(
+        candidateID: String,
+        sourceItemIdentityKey: String,
+        sourceID: String,
+        originKindKey: String,
+        profileLocalIdentifier: String?,
+        workoutIdentifier: String?,
+        healthKitWorkoutIdentifier: String?,
+        stableLegacySessionIdentifier: String?,
+        startedAt: Date?,
+        endedAt: Date?,
+        identityUncertain: Bool,
+        possibleDuplicate: Bool,
+        summaryPayload: Data
+    ) {
+        self.candidateID = candidateID
+        self.sourceItemIdentityKey = sourceItemIdentityKey
+        self.sourceID = sourceID
+        self.originKindKey = originKindKey
+        self.profileLocalIdentifier = profileLocalIdentifier
+        self.workoutIdentifier = workoutIdentifier
+        self.healthKitWorkoutIdentifier = healthKitWorkoutIdentifier
+        self.stableLegacySessionIdentifier = stableLegacySessionIdentifier
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.identityUncertain = identityUncertain
+        self.possibleDuplicate = possibleDuplicate
+        self.summaryPayload = summaryPayload
+    }
+}
+
+@Model
+final class TelemetryLegacyImportedWorkoutV2 {
+    #Index<TelemetryLegacyImportedWorkoutV2>(
+        [\.profileLocalIdentifier, \.startedAt],
+        [\.identityStatusKey]
+    )
+
+    @Attribute(.unique) public var importedWorkoutID: String
+    @Attribute(.unique) public var canonicalIdentityKey: String
+    public var profileLocalIdentifier: String?
+    public var startedAt: Date?
+    public var endedAt: Date?
+    public var identityStatusKey: String
+    public var possibleDuplicate: Bool
+    public var adaptationQualityEligible: Bool
+    public var candidateIDsPayload: Data
+    public var resolvedSummaryPayload: Data
+
+    public init(
+        importedWorkoutID: String,
+        canonicalIdentityKey: String,
+        profileLocalIdentifier: String?,
+        startedAt: Date?,
+        endedAt: Date?,
+        identityStatusKey: String,
+        possibleDuplicate: Bool,
+        adaptationQualityEligible: Bool,
+        candidateIDsPayload: Data,
+        resolvedSummaryPayload: Data
+    ) {
+        self.importedWorkoutID = importedWorkoutID
+        self.canonicalIdentityKey = canonicalIdentityKey
+        self.profileLocalIdentifier = profileLocalIdentifier
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.identityStatusKey = identityStatusKey
+        self.possibleDuplicate = possibleDuplicate
+        self.adaptationQualityEligible = adaptationQualityEligible
+        self.candidateIDsPayload = candidateIDsPayload
+        self.resolvedSummaryPayload = resolvedSummaryPayload
+    }
+}
+
+@Model
+final class TelemetryLegacyReconciliationV2 {
+    #Index<TelemetryLegacyReconciliationV2>(
+        [\.leftCandidateID],
+        [\.rightCandidateID],
+        [\.outcomeKey]
+    )
+
+    @Attribute(.unique) public var reconciliationID: String
+    public var leftCandidateID: String
+    public var rightCandidateID: String
+    public var outcomeKey: String
+    public var identityKindKey: String?
+    public var identityValue: String?
+    public var importedWorkoutID: String?
+    public var detailPayload: Data
+
+    public init(
+        reconciliationID: String,
+        leftCandidateID: String,
+        rightCandidateID: String,
+        outcomeKey: String,
+        identityKindKey: String?,
+        identityValue: String?,
+        importedWorkoutID: String?,
+        detailPayload: Data
+    ) {
+        self.reconciliationID = reconciliationID
+        self.leftCandidateID = leftCandidateID
+        self.rightCandidateID = rightCandidateID
+        self.outcomeKey = outcomeKey
+        self.identityKindKey = identityKindKey
+        self.identityValue = identityValue
+        self.importedWorkoutID = importedWorkoutID
+        self.detailPayload = detailPayload
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryStore.swift
@@ -87,7 +87,7 @@ struct TelemetryGateTraversalCounts: Codable, Hashable, Sendable {
 
 public enum TelemetryStoreFactory {
     public static func make(_ configuration: TelemetryStoreConfiguration) throws -> TelemetryStore {
-        let schema = Schema(versionedSchema: TelemetrySchemaV1.self)
+        let schema = Schema(versionedSchema: TelemetrySchemaV2.self)
         let modelConfiguration: ModelConfiguration
         let onDiskStoreURL: URL?
 
@@ -813,7 +813,7 @@ public actor TelemetryStore {
         Thread.isMainThread
     }
 
-    private func explicitTransaction(_ operation: () throws -> Void) throws {
+    func explicitTransaction(_ operation: () throws -> Void) throws {
         if explicitTransactionDepth > 0 {
             try operation()
             return
@@ -939,7 +939,7 @@ public actor TelemetryStore {
     }
 }
 
-private extension TelemetryStore {
+extension TelemetryStore {
     static let encoder: JSONEncoder = {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
@@ -367,6 +367,8 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
     TreadmillTelemetrySink, @unchecked Sendable
 {
     public typealias PersistenceFactory = @Sendable () throws -> any TelemetryRecorderPersistence
+    public typealias LegacyMigrationRequestFactory =
+        @Sendable () throws -> LegacyTelemetryMigrationRequest
     public typealias StatusHandler = @Sendable (TelemetryV2RuntimeStatus) -> Void
     public typealias WriterHealthHandler = @Sendable (TelemetryV2WriterHealthSnapshot) -> Void
 
@@ -507,6 +509,8 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
     private let runtimeClock: any TelemetryV2RuntimeClock
     private let installationDidPublishForTesting: (@Sendable (SessionID) -> Void)?
     private var persistence: (any TelemetryRecorderPersistence)?
+    private var pendingLegacyMigrationRequestFactory: LegacyMigrationRequestFactory?
+    private var legacyMigrationStarted = false
     private var preparationStarted = false
     private var preparationFailed = false
     private var generation: UInt64 = 0
@@ -589,6 +593,23 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
                 self?.storePreparationFailed(error)
             }
         }
+    }
+
+    /// Schedules optional historical migration after the isolated store is
+    /// available. The request is built and consumed on a utility task; neither
+    /// its result nor its failure changes runtime/control status.
+    public func scheduleLegacyMigrationInBackground(
+        requestFactory: @escaping LegacyMigrationRequestFactory
+    ) {
+        let accepted = withLock {
+            guard !legacyMigrationStarted,
+                  pendingLegacyMigrationRequestFactory == nil else { return false }
+            pendingLegacyMigrationRequestFactory = requestFactory
+            return true
+        }
+        guard accepted else { return }
+        prepareStoreAndRecover()
+        launchLegacyMigrationIfPossible()
     }
 
     public func beginSession(_ descriptor: TelemetryV2SessionDescriptor) {
@@ -774,6 +795,28 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
             }
         }
         launchPendingSessionIfPossible()
+        launchLegacyMigrationIfPossible()
+    }
+
+    private func launchLegacyMigrationIfPossible() {
+        let work: (
+            any LegacyTelemetryMigrationCapability,
+            LegacyMigrationRequestFactory
+        )? = withLock {
+            guard !legacyMigrationStarted,
+                  let factory = pendingLegacyMigrationRequestFactory,
+                  let migration = persistence as? any LegacyTelemetryMigrationCapability else {
+                return nil
+            }
+            legacyMigrationStarted = true
+            pendingLegacyMigrationRequestFactory = nil
+            return (migration, factory)
+        }
+        guard let work else { return }
+        Task.detached(priority: .utility) {
+            guard let request = try? work.1() else { return }
+            _ = await work.0.migrateLegacyTelemetry(request)
+        }
     }
 
     private func storePreparationFailed(_ error: Error) {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/LegacyTelemetryMigrationTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/LegacyTelemetryMigrationTests.swift
@@ -612,6 +612,170 @@ final class LegacyTelemetryMigrationTests: XCTestCase {
         XCTAssertTrue(reconciliations.isEmpty)
     }
 
+    func testOverlappingHistorySnapshotsKeepSameExactIDIsolatedAcrossProfiles() async throws {
+        let shared = ["id": "shared-looking-id", "durationSeconds": 10] as [String: Any]
+        let profileAHistory = try JSONSerialization.data(withJSONObject: [
+            shared,
+            ["id": "profile-a-only", "durationSeconds": 20],
+        ])
+        let profileBHistory = try JSONSerialization.data(withJSONObject: [
+            shared,
+            ["id": "profile-b-only", "durationSeconds": 30],
+        ])
+        let sharedOnly = try JSONSerialization.data(withJSONObject: [shared])
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        _ = await LegacyTelemetryMigrator(store: store).run(
+            LegacyTelemetryMigrationRequest(
+                jsonlSources: [],
+                workoutHistorySources: [
+                    .init(
+                        storageKey: "profile-a-older",
+                        representation: sharedOnly,
+                        exactProfileLocalIdentifier: "profile-a"
+                    ),
+                    .init(
+                        storageKey: "profile-a-newer",
+                        representation: profileAHistory,
+                        exactProfileLocalIdentifier: "profile-a"
+                    ),
+                    .init(
+                        storageKey: "profile-b-older",
+                        representation: sharedOnly,
+                        exactProfileLocalIdentifier: "profile-b"
+                    ),
+                    .init(
+                        storageKey: "profile-b-newer",
+                        representation: profileBHistory,
+                        exactProfileLocalIdentifier: "profile-b"
+                    ),
+                ],
+                knownProfileLocalIdentifiers: ["profile-a", "profile-b"]
+            )
+        )
+
+        let candidates = try await store.fetchLegacyWorkoutCandidates()
+        let workouts = try await store.fetchLegacyImportedWorkouts()
+        let reconciliations = try await store.fetchLegacyReconciliations()
+        let sharedCandidates = candidates.filter {
+            $0.workoutIdentifier == "shared-looking-id"
+        }
+
+        XCTAssertEqual(candidates.count, 6)
+        XCTAssertEqual(workouts.count, 4)
+        XCTAssertEqual(sharedCandidates.count, 4)
+        XCTAssertEqual(
+            Set(workouts.compactMap(\.profileLocalIdentifier)),
+            ["profile-a", "profile-b"]
+        )
+        for profile in ["profile-a", "profile-b"] {
+            let profileSharedCandidateIDs = Set(sharedCandidates.filter {
+                $0.profileLocalIdentifier == profile
+            }.map(\.candidateID))
+            let imported = try XCTUnwrap(workouts.first {
+                Set($0.candidateIDs) == profileSharedCandidateIDs
+            })
+            XCTAssertEqual(imported.identityStatus, .exact)
+            XCTAssertEqual(imported.profileLocalIdentifier, profile)
+        }
+        XCTAssertEqual(reconciliations.count, 2)
+        XCTAssertTrue(reconciliations.allSatisfy {
+            $0.outcome == .matched && $0.identityKind == .workoutIdentifier
+        })
+    }
+
+    func testOverlappingGlobalAndFallbackProfileHistoryReconcileExactWorkoutOnce() async throws {
+        let trainingLogsDirectory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: trainingLogsDirectory) }
+        let suiteName = "LegacyTelemetryMigrationTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let workoutA: [String: Any] = [
+            "id": "overlap-workout-a",
+            "date": 1_800_000_000,
+            "durationSeconds": 600,
+            "avgBpm": 132,
+        ]
+        let workoutB: [String: Any] = [
+            "id": "profile-only-workout-b",
+            "date": 1_800_001_000,
+            "durationSeconds": 900,
+            "avgBpm": 138,
+        ]
+        let globalHistory = try JSONSerialization.data(
+            withJSONObject: [workoutA],
+            options: [.sortedKeys]
+        )
+        let scopedHistory = try JSONSerialization.data(
+            withJSONObject: [workoutA, workoutB],
+            options: [.sortedKeys]
+        )
+        let scopedKey = "workout_history_v1_profile_\(profileID)"
+        defaults.set(globalHistory, forKey: "workout_history_v1")
+        defaults.set(scopedHistory, forKey: scopedKey)
+
+        let request = LegacyTelemetryMigrationSourceDiscovery.makeRequest(
+            userDefaults: defaults,
+            trainingLogsDirectory: trainingLogsDirectory,
+            knownProfileLocalIdentifiers: [profileID],
+            deterministicLegacyFallbackProfileLocalIdentifier: profileID,
+            maximumRecordsPerBatch: 1
+        )
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let migrator = LegacyTelemetryMigrator(store: store)
+
+        let firstReport = await migrator.run(request)
+        let firstSources = try await store.fetchLegacyMigrationSources()
+        let firstCandidates = try await store.fetchLegacyWorkoutCandidates()
+        let firstWorkouts = try await store.fetchLegacyImportedWorkouts()
+        let firstReconciliations = try await store.fetchLegacyReconciliations()
+
+        XCTAssertEqual(firstReport.completion, .completed)
+        XCTAssertEqual(firstReport.completedSourceCount, 2)
+        XCTAssertEqual(firstSources.count, 2)
+        XCTAssertTrue(firstSources.allSatisfy {
+            $0.kind == .workoutHistory && $0.status == .completed
+        })
+        XCTAssertEqual(Set(firstSources.map(\.locator)), ["workout_history_v1", scopedKey])
+        XCTAssertEqual(firstCandidates.count, 3)
+
+        let workoutACandidateIDs = firstCandidates
+            .filter { $0.workoutIdentifier == "overlap-workout-a" }
+            .map(\.candidateID)
+        let workoutBCandidate = try XCTUnwrap(firstCandidates.first {
+            $0.workoutIdentifier == "profile-only-workout-b"
+        })
+        XCTAssertEqual(workoutACandidateIDs.count, 2)
+        XCTAssertEqual(firstWorkouts.count, 2)
+        let importedA = try XCTUnwrap(firstWorkouts.first {
+            Set($0.candidateIDs) == Set(workoutACandidateIDs)
+        })
+        XCTAssertEqual(importedA.identityStatus, .exact)
+        XCTAssertEqual(importedA.profileLocalIdentifier, profileID)
+        XCTAssertNotNil(firstWorkouts.first {
+            $0.candidateIDs == [workoutBCandidate.candidateID]
+        })
+        XCTAssertEqual(firstReconciliations.count, 1)
+        XCTAssertEqual(firstReconciliations.first?.outcome, .matched)
+        XCTAssertEqual(firstReconciliations.first?.identityKind, .workoutIdentifier)
+        XCTAssertEqual(firstReconciliations.first?.identityValue, "overlap-workout-a")
+        XCTAssertEqual(defaults.data(forKey: "workout_history_v1"), globalHistory)
+        XCTAssertEqual(defaults.data(forKey: scopedKey), scopedHistory)
+
+        let secondReport = await migrator.run(request)
+        let secondSources = try await store.fetchLegacyMigrationSources()
+        let secondCandidates = try await store.fetchLegacyWorkoutCandidates()
+        let secondWorkouts = try await store.fetchLegacyImportedWorkouts()
+        let secondReconciliations = try await store.fetchLegacyReconciliations()
+        XCTAssertEqual(secondReport.completion, .completed)
+        XCTAssertEqual(secondReport.skippedSourceCount, 2)
+        XCTAssertEqual(secondSources, firstSources)
+        XCTAssertEqual(secondCandidates, firstCandidates)
+        XCTAssertEqual(secondWorkouts, firstWorkouts)
+        XCTAssertEqual(secondReconciliations, firstReconciliations)
+        XCTAssertEqual(defaults.data(forKey: "workout_history_v1"), globalHistory)
+        XCTAssertEqual(defaults.data(forKey: scopedKey), scopedHistory)
+    }
+
     func testMalformedHistoryFailureIsAuditedAndRepresentationsStayImmutable() async throws {
         let history = Data("{not-an-array}".utf8)
         let original = history

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/LegacyTelemetryMigrationTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/LegacyTelemetryMigrationTests.swift
@@ -166,6 +166,61 @@ final class LegacyTelemetryMigrationTests: XCTestCase {
         XCTAssertEqual(reconciliations.first?.identityKind, .workoutIdentifier)
     }
 
+    func testExplicitJSONLSummaryPrecedesConflictingHistoryWithoutTimestampDerivation() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let jsonlURL = directory.appendingPathComponent("summary-only.jsonl")
+        let jsonl = lines([
+            object([
+                "event": "workout_saved",
+                "workout_id": "summary-only-workout",
+                "profile_id": profileID,
+                "duration_s": 35,
+                "avg_bpm": 141,
+            ]),
+        ])
+        try jsonl.write(to: jsonlURL, options: .atomic)
+        let history = try JSONSerialization.data(withJSONObject: [[
+            "id": "summary-only-workout",
+            "durationSeconds": 40,
+            "avgBpm": 139,
+        ]], options: [.sortedKeys])
+        let originalJSONL = try Data(contentsOf: jsonlURL)
+        let originalHistory = history
+        let store = try TelemetryStoreFactory.make(.inMemory)
+
+        let report = await LegacyTelemetryMigrator(store: store).run(
+            request(jsonlURL: jsonlURL, history: history)
+        )
+
+        XCTAssertEqual(report.completion, .completed)
+        XCTAssertEqual(try Data(contentsOf: jsonlURL), originalJSONL)
+        XCTAssertEqual(history, originalHistory)
+        let workouts = try await store.fetchLegacyImportedWorkouts()
+        let candidates = try await store.fetchLegacyWorkoutCandidates()
+        let workout = try XCTUnwrap(workouts.first)
+        XCTAssertNil(
+            candidates.first { $0.origin == .jsonl }?
+                .summary.timestampDerivedDurationMicroseconds
+        )
+        XCTAssertEqual(
+            workout.resolvedSummary.durationMicroseconds.selected,
+            LegacySourcedValue(
+                value: 35_000_000,
+                provenance: "legacy-jsonl-summary"
+            )
+        )
+        XCTAssertEqual(
+            workout.resolvedSummary.averageHeartRateBeatsPerMinute.selected,
+            LegacySourcedValue(
+                value: 141.0,
+                provenance: "legacy-jsonl-summary"
+            )
+        )
+        XCTAssertTrue(workout.resolvedSummary.durationMicroseconds.conflict)
+        XCTAssertTrue(workout.resolvedSummary.averageHeartRateBeatsPerMinute.conflict)
+    }
+
     func testCopiedJSONLAndCompletedRerunAreDeduplicatedByContent() async throws {
         let directory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -202,6 +257,7 @@ final class LegacyTelemetryMigrationTests: XCTestCase {
 
         XCTAssertEqual(firstReport.completedSourceCount, 1)
         XCTAssertEqual(firstReport.skippedSourceCount, 1)
+        XCTAssertEqual(firstReport.importedWorkoutCount, 1)
         XCTAssertEqual(secondReport.completedSourceCount, 0)
         XCTAssertEqual(secondReport.skippedSourceCount, 2)
         XCTAssertEqual(firstSources.count, 1)
@@ -577,6 +633,85 @@ final class LegacyTelemetryMigrationTests: XCTestCase {
         XCTAssertTrue(activeProfileWorkouts.isEmpty)
     }
 
+    func testUnknownProfileExactIdentityCannotAttachToKnownProfile() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("unknown-profile-collision.jsonl")
+        let bytes = lines([
+            object([
+                "event": "session_start", "ts": 1_800_000_000,
+                "session_id": "unknown-profile-collision",
+                "workout_id": "shared-profile-collision-id",
+                "profile_id": "deleted-profile",
+            ]),
+            object([
+                "event": "workout_saved", "ts": 1_800_000_009,
+                "session_id": "unknown-profile-collision",
+                "workout_id": "shared-profile-collision-id",
+                "profile_id": "deleted-profile",
+            ]),
+            object([
+                "event": "session_end", "ts": 1_800_000_010,
+                "session_id": "unknown-profile-collision",
+                "workout_id": "shared-profile-collision-id",
+                "profile_id": "deleted-profile",
+            ]),
+        ])
+        try bytes.write(to: url)
+        let history = try JSONSerialization.data(withJSONObject: [[
+            "id": "shared-profile-collision-id",
+            "date": 1_800_000_010,
+            "durationSeconds": 10,
+        ]])
+        let originalHistory = history
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        _ = await LegacyTelemetryMigrator(store: store).run(
+            LegacyTelemetryMigrationRequest(
+                jsonlSources: [
+                    .init(
+                        url: url,
+                        deterministicFallbackProfileLocalIdentifier: profileID
+                    ),
+                ],
+                workoutHistorySources: [
+                    .init(
+                        storageKey: "workout_history_v1_profile_\(profileID)",
+                        representation: history,
+                        exactProfileLocalIdentifier: profileID
+                    ),
+                ],
+                knownProfileLocalIdentifiers: [profileID]
+            )
+        )
+
+        let candidates = try await store.fetchLegacyWorkoutCandidates()
+        let workouts = try await store.fetchLegacyImportedWorkouts()
+        let reconciliations = try await store.fetchLegacyReconciliations()
+        let unknownCandidate = try XCTUnwrap(candidates.first { $0.origin == .jsonl })
+        let knownCandidate = try XCTUnwrap(candidates.first { $0.origin == .workoutHistory })
+
+        XCTAssertNil(unknownCandidate.profileLocalIdentifier)
+        XCTAssertEqual(knownCandidate.profileLocalIdentifier, profileID)
+        XCTAssertEqual(workouts.count, 2)
+        XCTAssertNotNil(workouts.first {
+            $0.profileLocalIdentifier == nil
+                && $0.candidateIDs == [unknownCandidate.candidateID]
+        })
+        XCTAssertNotNil(workouts.first {
+            $0.profileLocalIdentifier == profileID
+                && $0.candidateIDs == [knownCandidate.candidateID]
+        })
+        XCTAssertFalse(workouts.contains {
+            Set($0.candidateIDs) == [unknownCandidate.candidateID, knownCandidate.candidateID]
+        })
+        XCTAssertEqual(reconciliations.count, 1)
+        XCTAssertEqual(reconciliations.first?.outcome, .conflict)
+        XCTAssertEqual(reconciliations.first?.identityKind, .workoutIdentifier)
+        XCTAssertEqual(reconciliations.first?.detailCodes, ["conflicting-profile-ownership"])
+        XCTAssertEqual(try Data(contentsOf: url), bytes)
+        XCTAssertEqual(history, originalHistory)
+    }
+
     func testSameOriginIdentityCannotMergeAcrossProfiles() async throws {
         let history = try JSONSerialization.data(withJSONObject: [[
             "id": "shared-looking-id",
@@ -774,6 +909,132 @@ final class LegacyTelemetryMigrationTests: XCTestCase {
         XCTAssertEqual(secondReconciliations, firstReconciliations)
         XCTAssertEqual(defaults.data(forKey: "workout_history_v1"), globalHistory)
         XCTAssertEqual(defaults.data(forKey: scopedKey), scopedHistory)
+    }
+
+    func testSequentialHistoryGrowthConvergesProvisionalWorkoutAcrossRuns() async throws {
+        let trainingLogsDirectory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: trainingLogsDirectory) }
+        let suiteName = "LegacyTelemetryMigrationTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let workoutA: [String: Any] = [
+            "id": "sequential-workout-a",
+            "date": 1_800_000_000,
+            "durationSeconds": 600,
+            "avgBpm": 132,
+        ]
+        let workoutB: [String: Any] = [
+            "id": "sequential-workout-b",
+            "date": 1_800_001_000,
+            "durationSeconds": 900,
+            "avgBpm": 138,
+        ]
+        let historyA = try JSONSerialization.data(
+            withJSONObject: [workoutA],
+            options: [.sortedKeys]
+        )
+        let historyAB = try JSONSerialization.data(
+            withJSONObject: [workoutA, workoutB],
+            options: [.sortedKeys]
+        )
+        let globalKey = "workout_history_v1"
+        let scopedKey = "workout_history_v1_profile_\(profileID)"
+        defaults.set(historyA, forKey: globalKey)
+        defaults.set(historyA, forKey: scopedKey)
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let migrator = LegacyTelemetryMigrator(store: store)
+
+        let firstRequest = LegacyTelemetryMigrationSourceDiscovery.makeRequest(
+            userDefaults: defaults,
+            trainingLogsDirectory: trainingLogsDirectory,
+            knownProfileLocalIdentifiers: [profileID],
+            deterministicLegacyFallbackProfileLocalIdentifier: profileID,
+            maximumRecordsPerBatch: 1
+        )
+        let firstReport = await migrator.run(firstRequest)
+        let firstSources = try await store.fetchLegacyMigrationSources()
+        let firstRecords = try await store.fetchLegacyImportedRecords()
+        let firstCandidates = try await store.fetchLegacyWorkoutCandidates()
+        let firstWorkouts = try await store.fetchLegacyImportedWorkouts()
+
+        XCTAssertEqual(firstReport.completion, .completed)
+        XCTAssertEqual(firstReport.completedSourceCount, 1)
+        XCTAssertEqual(firstReport.skippedSourceCount, 1)
+        XCTAssertEqual(firstSources.count, 1)
+        XCTAssertEqual(firstRecords.count, 1)
+        XCTAssertEqual(firstCandidates.count, 1)
+        XCTAssertEqual(firstWorkouts.count, 1)
+        XCTAssertEqual(firstWorkouts.first?.candidateIDs, [firstCandidates[0].candidateID])
+        XCTAssertTrue(firstWorkouts.first?.canonicalIdentityKey.hasPrefix("candidate:") == true)
+        XCTAssertEqual(defaults.data(forKey: globalKey), historyA)
+        XCTAssertEqual(defaults.data(forKey: scopedKey), historyA)
+
+        defaults.set(historyAB, forKey: scopedKey)
+        let secondRequest = LegacyTelemetryMigrationSourceDiscovery.makeRequest(
+            userDefaults: defaults,
+            trainingLogsDirectory: trainingLogsDirectory,
+            knownProfileLocalIdentifiers: [profileID],
+            deterministicLegacyFallbackProfileLocalIdentifier: profileID,
+            maximumRecordsPerBatch: 1
+        )
+        let secondReport = await migrator.run(secondRequest)
+        let secondSources = try await store.fetchLegacyMigrationSources()
+        let secondRecords = try await store.fetchLegacyImportedRecords()
+        let secondCandidates = try await store.fetchLegacyWorkoutCandidates()
+        let secondWorkouts = try await store.fetchLegacyImportedWorkouts()
+        let secondReconciliations = try await store.fetchLegacyReconciliations()
+        let workoutACandidateIDs = Set(secondCandidates.filter {
+            $0.workoutIdentifier == "sequential-workout-a"
+        }.map(\.candidateID))
+        let workoutBCandidate = try XCTUnwrap(secondCandidates.first {
+            $0.workoutIdentifier == "sequential-workout-b"
+        })
+
+        XCTAssertEqual(secondReport.completion, .completed)
+        XCTAssertEqual(secondReport.completedSourceCount, 1)
+        XCTAssertEqual(secondReport.skippedSourceCount, 1)
+        XCTAssertEqual(secondReport.importedWorkoutCount, 1)
+        XCTAssertEqual(secondSources.count, 2)
+        XCTAssertTrue(secondSources.contains(firstSources[0]))
+        XCTAssertEqual(Set(secondSources.map(\.contentHashDigest)).count, 2)
+        XCTAssertEqual(secondRecords.count, 3)
+        XCTAssertEqual(secondCandidates.count, 3)
+        XCTAssertEqual(workoutACandidateIDs.count, 2)
+        XCTAssertEqual(secondWorkouts.count, 2)
+        let importedAWorkouts = secondWorkouts.filter {
+            !Set($0.candidateIDs).isDisjoint(with: workoutACandidateIDs)
+        }
+        XCTAssertEqual(importedAWorkouts.count, 1)
+        XCTAssertEqual(Set(importedAWorkouts[0].candidateIDs), workoutACandidateIDs)
+        XCTAssertEqual(importedAWorkouts[0].identityStatus, .exact)
+        XCTAssertEqual(importedAWorkouts[0].profileLocalIdentifier, profileID)
+        XCTAssertNotNil(secondWorkouts.first {
+            $0.candidateIDs == [workoutBCandidate.candidateID]
+        })
+        XCTAssertEqual(secondReconciliations.count, 1)
+        XCTAssertEqual(secondReconciliations.first?.outcome, .matched)
+        XCTAssertEqual(secondReconciliations.first?.identityKind, .workoutIdentifier)
+        XCTAssertEqual(secondReconciliations.first?.identityValue, "sequential-workout-a")
+        XCTAssertEqual(defaults.data(forKey: globalKey), historyA)
+        XCTAssertEqual(defaults.data(forKey: scopedKey), historyAB)
+
+        let thirdReport = await migrator.run(secondRequest)
+        let thirdSources = try await store.fetchLegacyMigrationSources()
+        let thirdRecords = try await store.fetchLegacyImportedRecords()
+        let thirdCandidates = try await store.fetchLegacyWorkoutCandidates()
+        let thirdWorkouts = try await store.fetchLegacyImportedWorkouts()
+        let thirdReconciliations = try await store.fetchLegacyReconciliations()
+        XCTAssertEqual(thirdReport.completion, .completed)
+        XCTAssertEqual(thirdReport.completedSourceCount, 0)
+        XCTAssertEqual(thirdReport.skippedSourceCount, 2)
+        XCTAssertEqual(thirdReport.importedWorkoutCount, 0)
+        XCTAssertEqual(thirdSources, secondSources)
+        XCTAssertEqual(thirdRecords, secondRecords)
+        XCTAssertEqual(thirdCandidates, secondCandidates)
+        XCTAssertEqual(thirdWorkouts, secondWorkouts)
+        XCTAssertEqual(thirdReconciliations, secondReconciliations)
+        XCTAssertEqual(defaults.data(forKey: globalKey), historyA)
+        XCTAssertEqual(defaults.data(forKey: scopedKey), historyAB)
     }
 
     func testMalformedHistoryFailureIsAuditedAndRepresentationsStayImmutable() async throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/LegacyTelemetryMigrationTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/LegacyTelemetryMigrationTests.swift
@@ -1,0 +1,863 @@
+import Foundation
+import SwiftData
+import TelemetryDomain
+@testable import TelemetryPersistence
+import XCTest
+
+final class LegacyTelemetryMigrationTests: XCTestCase {
+    private let profileID = "profile-a"
+
+    func testJSONLAndHistoryImportReconcileExactlyAndPreserveEvidenceBoundaries() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let jsonlURL = directory.appendingPathComponent("session.jsonl")
+        let healthKitID = "c9f3bda6-4642-4caf-a6a8-417124ab9c34"
+        let jsonl = lines([
+            object([
+                "event": "session_start", "ts": 1_800_000_000,
+                "session_id": "session-1", "workout_id": "workout-1",
+                "healthkit_workout_uuid": healthKitID, "profile_id": profileID,
+                "target_bpm": 140,
+            ]),
+            object([
+                "event": "hr_sample", "ts": 1_800_000_002,
+                "session_id": "session-1", "workout_id": "workout-1",
+                "profile_id": profileID, "hr_bpm": 135, "zone_index": 2,
+            ]),
+            object([
+                "event": "hr_sample", "ts": 1_800_000_012,
+                "session_id": "session-1", "workout_id": "workout-1",
+                "profile_id": profileID, "hr_bpm": 145, "zone_index": 3,
+            ]),
+            object([
+                "event": "notify_ftms_treadmill_data", "ts": 1_800_000_015,
+                "session_id": "session-1", "workout_id": "workout-1",
+                "profile_id": profileID, "speed_kmh": 6.2,
+            ]),
+            object([
+                "event": "notify_fe01", "ts": 1_800_000_016,
+                "session_id": "session-1", "workout_id": "workout-1",
+                "profile_id": profileID, "speed_kmh": 6.3,
+            ]),
+            object([
+                "event": "command_write", "ts": 1_800_000_017,
+                "session_id": "session-1", "workout_id": "workout-1",
+                "profile_id": profileID, "command_id": "legacy-command",
+                "speed_after_kmh": 6.4,
+            ]),
+            object([
+                "event": "workout_saved", "ts": 1_800_000_030,
+                "session_id": "session-1", "workout_id": "workout-1",
+                "healthkit_workout_uuid": healthKitID, "profile_id": profileID,
+                "duration_s": 35, "avg_bpm": 141, "avg_speed_kmh": 6.0,
+                "steps": 1_234,
+            ]),
+            object([
+                "event": "session_end", "ts": 1_800_000_040,
+                "session_id": "session-1", "workout_id": "workout-1",
+                "profile_id": profileID,
+            ]),
+            "{truncated",
+        ])
+        try jsonl.write(to: jsonlURL, options: .atomic)
+        let history = try JSONSerialization.data(withJSONObject: [[
+            "id": "workout-1",
+            "healthkitWorkoutUUID": healthKitID,
+            "session_id": "session-1",
+            "date": 1_800_000_040,
+            "durationSeconds": 40,
+            "targetBpm": 140,
+            "avgBpm": 139,
+            "avgSpeedKmh": 5.9,
+            "zoneSeconds": [0, 8, 8, 0, 0],
+        ]], options: [.sortedKeys])
+        let originalJSONL = try Data(contentsOf: jsonlURL)
+        let originalHistory = history
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let report = await LegacyTelemetryMigrator(store: store).run(
+            request(jsonlURL: jsonlURL, history: history)
+        )
+
+        XCTAssertEqual(report.completion, .completed)
+        XCTAssertEqual(report.completedSourceCount, 2)
+        XCTAssertEqual(report.failedSourceCount, 0)
+        XCTAssertEqual(try Data(contentsOf: jsonlURL), originalJSONL)
+        XCTAssertEqual(history, originalHistory)
+
+        let sources = try await store.fetchLegacyMigrationSources()
+        XCTAssertEqual(sources.count, 2)
+        let jsonlSource = try XCTUnwrap(sources.first { $0.kind == .jsonl })
+        XCTAssertEqual(jsonlSource.status, .completed)
+        XCTAssertEqual(jsonlSource.parsedRecordCount, 9)
+        XCTAssertEqual(jsonlSource.malformedRecordCount, 1)
+
+        let records = try await store.fetchLegacyImportedRecords(sourceID: jsonlSource.sourceID)
+        XCTAssertEqual(records.count, 8)
+        XCTAssertTrue(records.allSatisfy { !$0.adaptationQualityEligible })
+        XCTAssertEqual(
+            try XCTUnwrap(records.first { $0.eventKind == "notify_ftms_treadmill_data" })
+                .payload.speedEvidence,
+            .factualDeviceReported(kilometresPerHour: 6.2, source: "ftms-treadmill-data")
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(records.first { $0.eventKind == "notify_fe01" })
+                .payload.speedEvidence,
+            .legacyUnknown(
+                value: 6.3,
+                field: "speed_kmh",
+                reason: "metric-units-and-quality-not-independently-proven"
+            )
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(records.first { $0.eventKind == "command_write" })
+                .payload.causalAssociation,
+            .unsupportedSpecificClaim
+        )
+        let saved = try XCTUnwrap(records.first { $0.eventKind == "workout_saved" })
+        XCTAssertTrue(saved.payload.ignoredStepFieldPresent)
+        XCTAssertEqual(
+            saved.payload.speedEvidence,
+            .legacyEstimated(kilometresPerHour: 6.0, field: "avg_speed_kmh")
+        )
+
+        let candidates = try await store.fetchLegacyWorkoutCandidates()
+        XCTAssertEqual(candidates.count, 2)
+        let jsonlCandidate = try XCTUnwrap(candidates.first { $0.origin == .jsonl })
+        XCTAssertEqual(jsonlCandidate.workoutIdentifier, "workout-1")
+        XCTAssertEqual(jsonlCandidate.summary.timestampDerivedDurationMicroseconds, 40_000_000)
+        XCTAssertEqual(jsonlCandidate.summary.legacySummaryDurationSeconds, 35)
+        XCTAssertEqual(jsonlCandidate.summary.heartRateSampleCount, 2)
+        XCTAssertEqual(jsonlCandidate.summary.heartRateCoveredMicroseconds, 14_000_000)
+        XCTAssertEqual(jsonlCandidate.summary.heartRateUncoveredMicroseconds, 24_000_000)
+        XCTAssertEqual(
+            try XCTUnwrap(
+                jsonlCandidate.summary.timestampDerivedAverageHeartRateBeatsPerMinute
+            ),
+            140.0,
+            accuracy: 0.000_001
+        )
+        XCTAssertEqual(jsonlCandidate.summary.timestampDerivedZoneMicroseconds?[1], 7_000_000)
+        XCTAssertEqual(jsonlCandidate.summary.timestampDerivedZoneMicroseconds?[2], 7_000_000)
+        XCTAssertEqual(jsonlCandidate.summary.ignoredStepFieldCount, 1)
+        XCTAssertEqual(jsonlCandidate.summary.legacySessionEvidenceComplete, false)
+        XCTAssertTrue(jsonlCandidate.summary.warnings.contains("legacy-records-malformed"))
+
+        let workouts = try await store.fetchLegacyImportedWorkouts()
+        XCTAssertEqual(workouts.count, 1)
+        let workout = try XCTUnwrap(workouts.first)
+        XCTAssertEqual(workout.identityStatus, .exact)
+        XCTAssertEqual(workout.profileLocalIdentifier, profileID)
+        XCTAssertEqual(workout.candidateIDs.count, 2)
+        XCTAssertFalse(workout.adaptationQualityEligible)
+        XCTAssertEqual(
+            workout.resolvedSummary.durationMicroseconds.selected?.provenance,
+            "legacy-jsonl-timestamp-derived"
+        )
+        XCTAssertTrue(workout.resolvedSummary.durationMicroseconds.conflict)
+        XCTAssertTrue(workout.resolvedSummary.averageHeartRateBeatsPerMinute.conflict)
+        XCTAssertEqual(
+            workout.resolvedSummary.averageHeartRateBeatsPerMinute.selected?.provenance,
+            "legacy-jsonl-timestamp-derived"
+        )
+
+        let reconciliations = try await store.fetchLegacyReconciliations()
+        XCTAssertEqual(reconciliations.count, 1)
+        XCTAssertEqual(reconciliations.first?.outcome, .matched)
+        XCTAssertEqual(reconciliations.first?.identityKind, .workoutIdentifier)
+    }
+
+    func testCopiedJSONLAndCompletedRerunAreDeduplicatedByContent() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let first = directory.appendingPathComponent("first.jsonl")
+        let copy = directory.appendingPathComponent("moved-copy.jsonl")
+        let bytes = lines([
+            object(["event": "session_start", "ts": 1_800_000_000, "session_id": "s1"]),
+            object(["event": "session_end", "ts": 1_800_000_010, "session_id": "s1"]),
+        ])
+        try bytes.write(to: first)
+        try bytes.write(to: copy)
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let migrator = LegacyTelemetryMigrator(store: store)
+        let request = LegacyTelemetryMigrationRequest(
+            jsonlSources: [
+                .init(url: first, deterministicFallbackProfileLocalIdentifier: profileID),
+                .init(url: copy, deterministicFallbackProfileLocalIdentifier: profileID),
+            ],
+            workoutHistorySources: [],
+            knownProfileLocalIdentifiers: [profileID],
+            maximumRecordsPerBatch: 1
+        )
+
+        let firstReport = await migrator.run(request)
+        let firstSources = try await store.fetchLegacyMigrationSources()
+        let firstRecords = try await store.fetchLegacyImportedRecords()
+        let firstCandidates = try await store.fetchLegacyWorkoutCandidates()
+        let firstWorkouts = try await store.fetchLegacyImportedWorkouts()
+        let secondReport = await migrator.run(request)
+        let secondSources = try await store.fetchLegacyMigrationSources()
+        let secondRecords = try await store.fetchLegacyImportedRecords()
+        let secondCandidates = try await store.fetchLegacyWorkoutCandidates()
+        let secondWorkouts = try await store.fetchLegacyImportedWorkouts()
+
+        XCTAssertEqual(firstReport.completedSourceCount, 1)
+        XCTAssertEqual(firstReport.skippedSourceCount, 1)
+        XCTAssertEqual(secondReport.completedSourceCount, 0)
+        XCTAssertEqual(secondReport.skippedSourceCount, 2)
+        XCTAssertEqual(firstSources.count, 1)
+        XCTAssertEqual(firstRecords.count, 2)
+        XCTAssertEqual(firstCandidates.count, 1)
+        XCTAssertEqual(firstWorkouts.count, 1)
+        XCTAssertEqual(secondSources, firstSources)
+        XCTAssertEqual(secondRecords, firstRecords)
+        XCTAssertEqual(secondCandidates, firstCandidates)
+        XCTAssertEqual(secondWorkouts, firstWorkouts)
+        XCTAssertEqual(try Data(contentsOf: first), bytes)
+        XCTAssertEqual(try Data(contentsOf: copy), bytes)
+    }
+
+    func testInterruptedBatchResumesFromCheckpointWithoutDuplicateRows() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("resume.jsonl")
+        var fixtureRows: [Data] = []
+        for index in 0..<7 {
+            let event: String
+            if index == 0 {
+                event = "session_start"
+            } else if index == 6 {
+                event = "session_end"
+            } else {
+                event = "hr_sample"
+            }
+            fixtureRows.append(object([
+                "event": event,
+                "ts": 1_800_000_000 + index,
+                "session_id": "resume-session",
+                "profile_id": profileID,
+                "hr_bpm": 130 + index,
+            ]))
+        }
+        let bytes = lines(fixtureRows)
+        try bytes.write(to: url)
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let request = LegacyTelemetryMigrationRequest(
+            jsonlSources: [.init(url: url, deterministicFallbackProfileLocalIdentifier: nil)],
+            workoutHistorySources: [],
+            knownProfileLocalIdentifiers: [profileID],
+            maximumRecordsPerBatch: 2
+        )
+        let interrupted = LegacyTelemetryMigrator(
+            store: store,
+            shouldPauseAfterCommittedBatch: { $0 == 1 }
+        )
+
+        let partial = await interrupted.run(request)
+        let pausedSources = try await store.fetchLegacyMigrationSources()
+        let pausedSource = try XCTUnwrap(pausedSources.first)
+        let pausedRecords = try await store.fetchLegacyImportedRecords()
+        XCTAssertEqual(partial.completion, .partial)
+        XCTAssertEqual(pausedSource.status, .paused)
+        XCTAssertEqual(pausedSource.checkpointRecordIndex, 2)
+        XCTAssertEqual(pausedRecords.count, 2)
+        XCTAssertEqual(try Data(contentsOf: url), bytes)
+
+        let resumed = await LegacyTelemetryMigrator(store: store).run(request)
+        let completedSources = try await store.fetchLegacyMigrationSources()
+        let completedSource = try XCTUnwrap(completedSources.first)
+        let records = try await store.fetchLegacyImportedRecords()
+        let candidates = try await store.fetchLegacyWorkoutCandidates()
+        let workouts = try await store.fetchLegacyImportedWorkouts()
+        XCTAssertEqual(resumed.completion, .completed)
+        XCTAssertEqual(completedSource.status, .completed)
+        XCTAssertEqual(completedSource.checkpointRecordIndex, 7)
+        XCTAssertEqual(records.count, 7)
+        XCTAssertEqual(
+            Set(records.map(\.sourceRecordIndex)),
+            Set((1...7).map(Int64.init))
+        )
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(workouts.count, 1)
+
+        let rerun = await LegacyTelemetryMigrator(store: store).run(request)
+        let recordsAfterRerun = try await store.fetchLegacyImportedRecords()
+        XCTAssertEqual(rerun.skippedSourceCount, 1)
+        XCTAssertEqual(recordsAfterRerun.count, 7)
+        XCTAssertEqual(try Data(contentsOf: url), bytes)
+    }
+
+    func testExactHealthKitMatchConflictsAreAuditedAndFuzzyCandidatesStaySeparate() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let exactURL = directory.appendingPathComponent("exact.jsonl")
+        let fuzzyURL = directory.appendingPathComponent("fuzzy.jsonl")
+        let healthKitID = "18bd49c3-9ad5-4a1c-b5fa-0cb443756042"
+        try lines([
+            object([
+                "event": "session_start", "ts": 1_800_000_000,
+                "session_id": "jsonl-session", "workout_id": "jsonl-workout",
+                "healthkit_workout_uuid": healthKitID, "profile_id": profileID,
+            ]),
+            object([
+                "event": "workout_saved", "ts": 1_800_000_019,
+                "session_id": "jsonl-session", "workout_id": "jsonl-workout",
+                "healthkit_workout_uuid": healthKitID, "profile_id": profileID,
+            ]),
+            object([
+                "event": "session_end", "ts": 1_800_000_020,
+                "session_id": "jsonl-session", "workout_id": "jsonl-workout",
+                "healthkit_workout_uuid": healthKitID, "profile_id": profileID,
+            ]),
+        ]).write(to: exactURL)
+        try lines([
+            object([
+                "event": "session_start", "ts": 1_800_000_001,
+                "profile_id": profileID,
+            ]),
+            object([
+                "event": "session_end", "ts": 1_800_000_021,
+                "profile_id": profileID,
+            ]),
+        ]).write(to: fuzzyURL)
+        let history = try JSONSerialization.data(withJSONObject: [[
+            "id": "history-workout",
+            "healthkitWorkoutUUID": healthKitID,
+            "session_id": "history-session",
+            "date": 1_800_000_020,
+            "durationSeconds": 20,
+        ]])
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let request = LegacyTelemetryMigrationRequest(
+            jsonlSources: [
+                .init(url: exactURL, deterministicFallbackProfileLocalIdentifier: nil),
+                .init(url: fuzzyURL, deterministicFallbackProfileLocalIdentifier: nil),
+            ],
+            workoutHistorySources: [
+                .init(
+                    storageKey: "workout_history_v1_profile_\(profileID)",
+                    representation: history,
+                    exactProfileLocalIdentifier: profileID
+                ),
+            ],
+            knownProfileLocalIdentifiers: [profileID]
+        )
+        _ = await LegacyTelemetryMigrator(store: store).run(request)
+
+        let reconciliations = try await store.fetchLegacyReconciliations()
+        let candidates = try await store.fetchLegacyWorkoutCandidates()
+        let importedWorkouts = try await store.fetchLegacyImportedWorkouts()
+        XCTAssertEqual(reconciliations.count, 1)
+        XCTAssertEqual(reconciliations.first?.outcome, .conflict)
+        XCTAssertEqual(reconciliations.first?.identityKind, .healthKitWorkoutIdentifier)
+        XCTAssertEqual(
+            Set(reconciliations.first?.detailCodes ?? []),
+            [
+                "conflicting-stable-session-identifier",
+                "conflicting-workout-identifier",
+            ]
+        )
+        let exactCandidateIDs = candidates
+            .filter { $0.healthKitWorkoutIdentifier == healthKitID }
+            .map(\.candidateID)
+        XCTAssertEqual(exactCandidateIDs.count, 2)
+        XCTAssertFalse(importedWorkouts.contains {
+            Set($0.candidateIDs).isSuperset(of: exactCandidateIDs)
+        })
+        XCTAssertEqual(
+            importedWorkouts.filter {
+                !$0.candidateIDs.allSatisfy { !exactCandidateIDs.contains($0) }
+            }.map(\.identityStatus),
+            [.conflict, .conflict]
+        )
+        let fuzzy = try XCTUnwrap(candidates.first {
+            $0.origin == .jsonl && $0.workoutIdentifier == nil
+        })
+        XCTAssertTrue(fuzzy.identityUncertain)
+        XCTAssertTrue(fuzzy.possibleDuplicate)
+        let fuzzyWorkout = try XCTUnwrap(importedWorkouts.first {
+            $0.candidateIDs == [fuzzy.candidateID]
+        })
+        XCTAssertEqual(fuzzyWorkout.identityStatus, .uncertain)
+        XCTAssertTrue(fuzzyWorkout.possibleDuplicate)
+    }
+
+    func testHistoricalJSONLVariantsReconcileByExactStableSessionWithoutWorkoutSaved() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("historical-variant.jsonl")
+        let bytes = lines([
+            object([
+                "event": "session_start",
+                "timestamp": "2027-01-15T08:00:00Z",
+                "legacy_session_id": "stable-session-34",
+                "profileId": profileID,
+                "target_bpm": 132,
+            ]),
+            object([
+                "event": "hr_sample",
+                "legacy_session_id": "stable-session-34",
+                "profileId": profileID,
+                "bpm": 131,
+                "target_zone_index": 2,
+            ]),
+            object([
+                "event": "session_end",
+                "timestamp": "2027-01-15T08:00:15Z",
+                "legacy_session_id": "stable-session-34",
+                "profileId": profileID,
+            ]),
+        ])
+        try bytes.write(to: url)
+        let history = try JSONSerialization.data(withJSONObject: [[
+            "legacy_session_id": "stable-session-34",
+            "date": "2027-01-15T08:00:15Z",
+            "duration_s": 15,
+            "target_bpm": 132,
+        ]])
+        let store = try TelemetryStoreFactory.make(.inMemory)
+
+        let report = await LegacyTelemetryMigrator(store: store).run(
+            request(jsonlURL: url, history: history)
+        )
+        let records = try await store.fetchLegacyImportedRecords()
+        let candidates = try await store.fetchLegacyWorkoutCandidates()
+        let workouts = try await store.fetchLegacyImportedWorkouts()
+        let reconciliations = try await store.fetchLegacyReconciliations()
+
+        XCTAssertEqual(report.completion, .completed)
+        XCTAssertFalse(records.contains { $0.eventKind == "workout_saved" })
+        XCTAssertTrue(records.contains {
+            $0.eventKind == "hr_sample"
+                && $0.occurredAt == nil
+                && $0.payload.warnings.contains("missing-or-invalid-timestamp")
+        })
+        XCTAssertEqual(candidates.first { $0.origin == .jsonl }?
+            .summary.timestampDerivedDurationMicroseconds, 15_000_000)
+        XCTAssertEqual(candidates.first { $0.origin == .jsonl }?
+            .summary.missingTimestampCount, 1)
+        XCTAssertEqual(candidates.first { $0.origin == .jsonl }?
+            .summary.legacySessionEvidenceComplete, false)
+        XCTAssertTrue(candidates.first { $0.origin == .jsonl }?
+            .summary.warnings.contains("legacy-workout-saved-missing") == true)
+        XCTAssertEqual(workouts.count, 1)
+        XCTAssertEqual(workouts.first?.candidateIDs.count, 2)
+        XCTAssertEqual(reconciliations.count, 1)
+        XCTAssertEqual(reconciliations.first?.outcome, .matched)
+        XCTAssertEqual(reconciliations.first?.identityKind, .stableLegacySessionIdentifier)
+        XCTAssertEqual(try Data(contentsOf: url), bytes)
+    }
+
+    func testExactHealthKitUUIDReconcilesWhenStrongerWorkoutIdentityIsUnavailable() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("healthkit-only.jsonl")
+        let healthKitID = "e7140c31-a82f-4a1a-a36b-27a8f0dc4f9b"
+        try lines([
+            object([
+                "event": "session_start", "ts": 1_800_000_000,
+                "healthkit_workout_uuid": healthKitID, "profile_id": profileID,
+            ]),
+            object([
+                "event": "session_end", "ts": 1_800_000_020,
+                "healthkit_workout_uuid": healthKitID, "profile_id": profileID,
+            ]),
+        ]).write(to: url)
+        let history = try JSONSerialization.data(withJSONObject: [[
+            "healthkitWorkoutUUID": healthKitID,
+            "date": 1_800_000_020,
+            "durationSeconds": 20,
+        ]])
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        _ = await LegacyTelemetryMigrator(store: store).run(
+            request(jsonlURL: url, history: history)
+        )
+
+        let workouts = try await store.fetchLegacyImportedWorkouts()
+        let reconciliations = try await store.fetchLegacyReconciliations()
+        XCTAssertEqual(workouts.count, 1)
+        XCTAssertEqual(workouts.first?.candidateIDs.count, 2)
+        XCTAssertEqual(workouts.first?.identityStatus, .exact)
+        XCTAssertEqual(reconciliations.count, 1)
+        XCTAssertEqual(reconciliations.first?.outcome, .matched)
+        XCTAssertEqual(reconciliations.first?.identityKind, .healthKitWorkoutIdentifier)
+        XCTAssertEqual(reconciliations.first?.identityValue, healthKitID)
+    }
+
+    func testTimestampWeightedHeartRateSummaryIsNotSampleCountArithmetic() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("irregular-heart-rate.jsonl")
+        try lines([
+            object([
+                "event": "session_start", "ts": 1_800_000_000,
+                "session_id": "irregular-session", "profile_id": profileID,
+            ]),
+            object([
+                "event": "hr_sample", "ts": 1_800_000_001,
+                "session_id": "irregular-session", "profile_id": profileID,
+                "hr_bpm": 100, "zone_index": 1,
+            ]),
+            object([
+                "event": "hr_sample", "ts": 1_800_000_003,
+                "session_id": "irregular-session", "profile_id": profileID,
+                "hr_bpm": 200, "zone_index": 5,
+            ]),
+            object([
+                "event": "session_end", "ts": 1_800_000_010,
+                "session_id": "irregular-session", "profile_id": profileID,
+            ]),
+        ]).write(to: url)
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        _ = await LegacyTelemetryMigrator(store: store).run(
+            LegacyTelemetryMigrationRequest(
+                jsonlSources: [
+                    .init(url: url, deterministicFallbackProfileLocalIdentifier: nil),
+                ],
+                workoutHistorySources: [],
+                knownProfileLocalIdentifiers: [profileID]
+            )
+        )
+
+        let candidates = try await store.fetchLegacyWorkoutCandidates()
+        let candidate = try XCTUnwrap(candidates.first)
+        let timestampAverage = try XCTUnwrap(
+            candidate.summary.timestampDerivedAverageHeartRateBeatsPerMinute
+        )
+        XCTAssertEqual(candidate.summary.heartRateCoveredMicroseconds, 9_000_000)
+        XCTAssertEqual(timestampAverage, 1_600.0 / 9.0, accuracy: 0.000_001)
+        XCTAssertNotEqual(timestampAverage, 150.0)
+    }
+
+    func testUnknownProfilesAreUnassignedAndNeverMappedToAnActiveProfile() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("unknown-profile.jsonl")
+        try lines([
+            object([
+                "event": "session_start", "ts": 1_800_000_000,
+                "session_id": "unknown-profile-session", "profile_id": "deleted-profile",
+            ]),
+            object([
+                "event": "session_end", "ts": 1_800_000_010,
+                "session_id": "unknown-profile-session", "profile_id": "deleted-profile",
+            ]),
+        ]).write(to: url)
+        let history = try JSONSerialization.data(withJSONObject: [[
+            "id": "unassigned-history", "date": 1_800_000_010,
+        ]])
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let request = LegacyTelemetryMigrationRequest(
+            jsonlSources: [
+                .init(url: url, deterministicFallbackProfileLocalIdentifier: "active-profile"),
+            ],
+            workoutHistorySources: [
+                .init(
+                    storageKey: "workout_history_v1_profile_deleted-profile",
+                    representation: history,
+                    exactProfileLocalIdentifier: "deleted-profile"
+                ),
+            ],
+            knownProfileLocalIdentifiers: [profileID, "active-profile"]
+        )
+        _ = await LegacyTelemetryMigrator(store: store).run(request)
+
+        let records = try await store.fetchLegacyImportedRecords()
+        XCTAssertTrue(records.allSatisfy { $0.profileLocalIdentifier == nil })
+        XCTAssertTrue(records.contains {
+            $0.payload.warnings.contains("unknown-explicit-profile")
+        })
+        XCTAssertTrue(records.contains {
+            $0.payload.warnings.contains("profile-ownership-unknown")
+        })
+        let workouts = try await store.fetchLegacyImportedWorkouts()
+        let activeProfileWorkouts = try await store.fetchLegacyImportedWorkouts(
+            profileLocalIdentifier: "active-profile"
+        )
+        XCTAssertTrue(workouts.allSatisfy { $0.profileLocalIdentifier == nil })
+        XCTAssertTrue(activeProfileWorkouts.isEmpty)
+    }
+
+    func testSameOriginIdentityCannotMergeAcrossProfiles() async throws {
+        let history = try JSONSerialization.data(withJSONObject: [[
+            "id": "shared-looking-id",
+            "date": 1_800_000_000,
+            "durationSeconds": 10,
+        ]])
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        _ = await LegacyTelemetryMigrator(store: store).run(
+            LegacyTelemetryMigrationRequest(
+                jsonlSources: [],
+                workoutHistorySources: [
+                    .init(
+                        storageKey: "workout_history_v1_profile_profile-a",
+                        representation: history,
+                        exactProfileLocalIdentifier: "profile-a"
+                    ),
+                    .init(
+                        storageKey: "workout_history_v1_profile_profile-b",
+                        representation: history,
+                        exactProfileLocalIdentifier: "profile-b"
+                    ),
+                ],
+                knownProfileLocalIdentifiers: ["profile-a", "profile-b"]
+            )
+        )
+
+        let workouts = try await store.fetchLegacyImportedWorkouts()
+        let reconciliations = try await store.fetchLegacyReconciliations()
+        XCTAssertEqual(workouts.count, 2)
+        XCTAssertEqual(Set(workouts.compactMap(\.profileLocalIdentifier)), [
+            "profile-a", "profile-b",
+        ])
+        XCTAssertTrue(reconciliations.isEmpty)
+    }
+
+    func testMalformedHistoryFailureIsAuditedAndRepresentationsStayImmutable() async throws {
+        let history = Data("{not-an-array}".utf8)
+        let original = history
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let request = LegacyTelemetryMigrationRequest(
+            jsonlSources: [],
+            workoutHistorySources: [
+                .init(
+                    storageKey: "workout_history_v1",
+                    representation: history,
+                    exactProfileLocalIdentifier: profileID
+                ),
+            ],
+            knownProfileLocalIdentifiers: [profileID]
+        )
+
+        let report = await LegacyTelemetryMigrator(store: store).run(request)
+        let sources = try await store.fetchLegacyMigrationSources()
+        let records = try await store.fetchLegacyImportedRecords()
+        let candidates = try await store.fetchLegacyWorkoutCandidates()
+        XCTAssertEqual(report.completion, .failed)
+        XCTAssertEqual(report.failedSourceCount, 1)
+        let source = try XCTUnwrap(sources.first)
+        XCTAssertEqual(source.status, .failed)
+        XCTAssertEqual(source.errorCode, "workout-history-source-failed")
+        XCTAssertEqual(history, original)
+        XCTAssertTrue(records.isEmpty)
+        XCTAssertTrue(candidates.isEmpty)
+    }
+
+    func testFailureAfterCommittedHistoryBatchKeepsValidPrefixAndDoesNotReinsertIt() async throws {
+        let history = Data("[{\"id\":\"committed-prefix\",\"durationSeconds\":10},".utf8)
+        let original = history
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let request = LegacyTelemetryMigrationRequest(
+            jsonlSources: [],
+            workoutHistorySources: [
+                .init(
+                    storageKey: "workout_history_v1_profile_\(profileID)",
+                    representation: history,
+                    exactProfileLocalIdentifier: profileID
+                ),
+            ],
+            knownProfileLocalIdentifiers: [profileID],
+            maximumRecordsPerBatch: 1
+        )
+
+        let firstReport = await LegacyTelemetryMigrator(store: store).run(request)
+        let firstSources = try await store.fetchLegacyMigrationSources()
+        let firstRecords = try await store.fetchLegacyImportedRecords()
+        let firstCandidates = try await store.fetchLegacyWorkoutCandidates()
+        XCTAssertEqual(firstReport.completion, .failed)
+        XCTAssertEqual(firstSources.first?.status, .failed)
+        XCTAssertEqual(firstSources.first?.checkpointRecordIndex, 1)
+        XCTAssertEqual(firstRecords.count, 1)
+        XCTAssertEqual(firstCandidates.count, 1)
+        XCTAssertEqual(history, original)
+
+        let secondReport = await LegacyTelemetryMigrator(store: store).run(request)
+        let secondSources = try await store.fetchLegacyMigrationSources()
+        let secondRecords = try await store.fetchLegacyImportedRecords()
+        let secondCandidates = try await store.fetchLegacyWorkoutCandidates()
+        XCTAssertEqual(secondReport.completion, .failed)
+        XCTAssertEqual(secondSources.first?.status, .failed)
+        XCTAssertEqual(secondRecords, firstRecords)
+        XCTAssertEqual(secondCandidates, firstCandidates)
+        XCTAssertEqual(history, original)
+    }
+
+    func testSourceDiscoveryReadsExactStoredRepresentationsWithoutMutation() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let jsonl = directory.appendingPathComponent("a.jsonl")
+        let ignored = directory.appendingPathComponent("ignored.txt")
+        let jsonlBytes = lines([object(["event": "session_start"])])
+        try jsonlBytes.write(to: jsonl)
+        try Data("ignored".utf8).write(to: ignored)
+        let suiteName = "LegacyTelemetryMigrationTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let profileHistory = Data("[]".utf8)
+        let globalHistory = Data("[ { \"id\" : \"legacy\" } ]".utf8)
+        defaults.set(profileHistory, forKey: "workout_history_v1_profile_profile-a")
+        defaults.set(globalHistory, forKey: "workout_history_v1")
+
+        let request = LegacyTelemetryMigrationSourceDiscovery.makeRequest(
+            userDefaults: defaults,
+            trainingLogsDirectory: directory,
+            knownProfileLocalIdentifiers: ["PROFILE-A", "active-profile"],
+            deterministicLegacyFallbackProfileLocalIdentifier: "PROFILE-A"
+        )
+
+        XCTAssertEqual(
+            request.jsonlSources.map { $0.url.standardizedFileURL.path },
+            [jsonl.standardizedFileURL.path]
+        )
+        XCTAssertEqual(request.jsonlSources.first?.deterministicFallbackProfileLocalIdentifier, profileID)
+        XCTAssertEqual(request.workoutHistorySources.count, 2)
+        XCTAssertEqual(
+            request.workoutHistorySources.first {
+                $0.storageKey == "workout_history_v1_profile_profile-a"
+            }?.representation,
+            profileHistory
+        )
+        XCTAssertEqual(
+            request.workoutHistorySources.first { $0.storageKey == "workout_history_v1" }?
+                .exactProfileLocalIdentifier,
+            profileID
+        )
+        XCTAssertEqual(defaults.data(forKey: "workout_history_v1"), globalHistory)
+        XCTAssertEqual(try Data(contentsOf: jsonl), jsonlBytes)
+    }
+
+    func testExistingSchemaV1StoreMigratesLightweightToV2WithoutLosingEvidence() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let storeURL = directory.appendingPathComponent("TelemetryV2.store")
+        let session = TelemetryPersistenceFixtures.session(seed: 34)
+
+        var legacyContainer: ModelContainer? = try ModelContainer(
+            for: Schema(versionedSchema: TelemetrySchemaV1.self),
+            configurations: [
+                ModelConfiguration(
+                    "TelemetryV1MigrationFixture",
+                    schema: Schema(versionedSchema: TelemetrySchemaV1.self),
+                    url: storeURL,
+                    cloudKitDatabase: .none
+                ),
+            ]
+        )
+        var legacyStore: TelemetryStore? = TelemetryStore(
+            modelContainer: try XCTUnwrap(legacyContainer),
+            onDiskStoreURL: storeURL
+        )
+        try await legacyStore?.insertSession(session)
+        legacyStore = nil
+        legacyContainer = nil
+
+        let migrated = try TelemetryStoreFactory.make(.onDisk(storeURL))
+        let migratedSessions = try await migrated.fetchSessions()
+        let migrationSources = try await migrated.fetchLegacyMigrationSources()
+        XCTAssertEqual(migratedSessions, [session])
+        XCTAssertTrue(migrationSources.isEmpty)
+    }
+
+    func testBoundedReadersResumeAtCommittedOffsetsAcrossChunkAndElementBoundaries() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("chunked.jsonl")
+        let firstRow = object(["event": "session_start", "session_id": "chunked"])
+        let secondRow = object(["event": "session_end", "session_id": "chunked"])
+        let bytes = lines([firstRow, secondRow])
+        try bytes.write(to: url)
+
+        let firstReader = try LegacyJSONLLineReader(
+            url: url,
+            startingAt: 0,
+            nextRecordIndex: 0,
+            chunkSize: 3,
+            maximumLineBytes: 1_024
+        )
+        let first = try XCTUnwrap(firstReader.next())
+        XCTAssertEqual(first.data, firstRow)
+        XCTAssertEqual(first.recordIndex, 1)
+
+        let resumedReader = try LegacyJSONLLineReader(
+            url: url,
+            startingAt: first.endOffset,
+            nextRecordIndex: first.recordIndex,
+            chunkSize: 2,
+            maximumLineBytes: 1_024
+        )
+        let resumed = try XCTUnwrap(resumedReader.next())
+        XCTAssertEqual(resumed.data, secondRow)
+        XCTAssertEqual(resumed.recordIndex, 2)
+        XCTAssertNil(try resumedReader.next())
+
+        let history = try JSONSerialization.data(withJSONObject: [
+            ["id": "first"],
+            ["id": "second"],
+        ], options: [.sortedKeys])
+        var historyReader = try LegacyJSONArrayElementReader(
+            data: history,
+            startingAt: 0,
+            nextRecordIndex: 0
+        )
+        let firstHistory = try XCTUnwrap(historyReader.next())
+        var resumedHistoryReader = try LegacyJSONArrayElementReader(
+            data: history,
+            startingAt: firstHistory.endOffset,
+            nextRecordIndex: firstHistory.recordIndex
+        )
+        let secondHistory = try XCTUnwrap(resumedHistoryReader.next())
+        let secondObject = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try XCTUnwrap(secondHistory.data))
+                as? [String: String]
+        )
+        XCTAssertEqual(secondObject["id"], "second")
+        XCTAssertEqual(secondHistory.recordIndex, 2)
+        XCTAssertNil(try resumedHistoryReader.next())
+    }
+
+    private func request(jsonlURL: URL, history: Data) -> LegacyTelemetryMigrationRequest {
+        LegacyTelemetryMigrationRequest(
+            jsonlSources: [
+                .init(url: jsonlURL, deterministicFallbackProfileLocalIdentifier: profileID),
+            ],
+            workoutHistorySources: [
+                .init(
+                    storageKey: "workout_history_v1_profile_\(profileID)",
+                    representation: history,
+                    exactProfileLocalIdentifier: profileID
+                ),
+            ],
+            knownProfileLocalIdentifiers: [profileID],
+            maximumRecordsPerBatch: 3
+        )
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "legacy-migration-tests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func object(_ value: [String: Any]) -> Data {
+        // Test fixtures are deliberately serialized independently of production parsing.
+        try! JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+    }
+
+    private func lines(_ values: [Data]) -> Data {
+        var result = Data()
+        for value in values {
+            result.append(value)
+            result.append(0x0a)
+        }
+        return result
+    }
+
+    private func lines(_ values: [Any]) -> Data {
+        lines(values.map { value in
+            if let data = value as? Data { return data }
+            return Data(String(describing: value).utf8)
+        })
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/LegacyTelemetryMigrationTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/LegacyTelemetryMigrationTests.swift
@@ -221,6 +221,134 @@ final class LegacyTelemetryMigrationTests: XCTestCase {
         XCTAssertTrue(workout.resolvedSummary.averageHeartRateBeatsPerMinute.conflict)
     }
 
+    func testTimestampDerivedJSONLPrecedesEarlierJSONLSummaryAndHistory() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let summaryURL = directory.appendingPathComponent("summary-only.jsonl")
+        let derivedURL = directory.appendingPathComponent("timestamp-derived.jsonl")
+        let summaryJSONL = lines([
+            object([
+                "event": "workout_saved",
+                "workout_id": "ordered-precedence-workout",
+                "profile_id": profileID,
+                "duration_s": 35,
+                "avg_bpm": 141,
+            ]),
+        ])
+        let derivedJSONL = lines([
+            object([
+                "event": "session_start",
+                "ts": 1_800_000_000,
+                "workout_id": "ordered-precedence-workout",
+                "profile_id": profileID,
+            ]),
+            object([
+                "event": "hr_sample",
+                "ts": 1_800_000_001,
+                "workout_id": "ordered-precedence-workout",
+                "profile_id": profileID,
+                "hr_bpm": 150,
+                "zone_index": 3,
+            ]),
+            object([
+                "event": "workout_saved",
+                "ts": 1_800_000_009,
+                "workout_id": "ordered-precedence-workout",
+                "profile_id": profileID,
+            ]),
+            object([
+                "event": "session_end",
+                "ts": 1_800_000_010,
+                "workout_id": "ordered-precedence-workout",
+                "profile_id": profileID,
+            ]),
+        ])
+        try summaryJSONL.write(to: summaryURL)
+        try derivedJSONL.write(to: derivedURL)
+        let history = try JSONSerialization.data(withJSONObject: [[
+            "id": "ordered-precedence-workout",
+            "durationSeconds": 40,
+            "avgBpm": 139,
+        ]], options: [.sortedKeys])
+        let store = try TelemetryStoreFactory.make(.inMemory)
+
+        _ = await LegacyTelemetryMigrator(store: store).run(
+            LegacyTelemetryMigrationRequest(
+                jsonlSources: [
+                    .init(
+                        url: summaryURL,
+                        deterministicFallbackProfileLocalIdentifier: nil
+                    ),
+                    .init(
+                        url: derivedURL,
+                        deterministicFallbackProfileLocalIdentifier: nil
+                    ),
+                ],
+                workoutHistorySources: [
+                    .init(
+                        storageKey: "workout_history_v1_profile_\(profileID)",
+                        representation: history,
+                        exactProfileLocalIdentifier: profileID
+                    ),
+                ],
+                knownProfileLocalIdentifiers: [profileID]
+            )
+        )
+
+        let candidates = try await store.fetchLegacyWorkoutCandidates()
+        let workouts = try await store.fetchLegacyImportedWorkouts()
+        let summaryCandidate = try XCTUnwrap(candidates.first {
+            $0.origin == .jsonl
+                && $0.summary.legacySummaryDurationSeconds == 35
+        })
+        let derivedCandidate = try XCTUnwrap(candidates.first {
+            $0.origin == .jsonl
+                && $0.summary.timestampDerivedDurationMicroseconds == 10_000_000
+        })
+        XCTAssertLessThan(summaryCandidate.candidateID, derivedCandidate.candidateID)
+        XCTAssertEqual(workouts.count, 1)
+        let workout = try XCTUnwrap(workouts.first)
+        XCTAssertEqual(Set(workout.candidateIDs), Set(candidates.map(\.candidateID)))
+        XCTAssertEqual(
+            workout.resolvedSummary.durationMicroseconds.selected,
+            LegacySourcedValue(
+                value: 10_000_000,
+                provenance: "legacy-jsonl-timestamp-derived"
+            )
+        )
+        XCTAssertEqual(
+            workout.resolvedSummary.averageHeartRateBeatsPerMinute.selected,
+            LegacySourcedValue(
+                value: 150.0,
+                provenance: "legacy-jsonl-timestamp-derived"
+            )
+        )
+        XCTAssertEqual(
+            Set(workout.resolvedSummary.durationMicroseconds.alternatives),
+            [
+                LegacySourcedValue(value: 35_000_000, provenance: "legacy-jsonl-summary"),
+                LegacySourcedValue(
+                    value: 40_000_000,
+                    provenance: "workout_history_v1-summary"
+                ),
+            ]
+        )
+        XCTAssertEqual(
+            Set(workout.resolvedSummary.averageHeartRateBeatsPerMinute.alternatives),
+            [
+                LegacySourcedValue(value: 141.0, provenance: "legacy-jsonl-summary"),
+                LegacySourcedValue(
+                    value: 139.0,
+                    provenance: "workout_history_v1-summary"
+                ),
+            ]
+        )
+        XCTAssertTrue(workout.resolvedSummary.durationMicroseconds.conflict)
+        XCTAssertTrue(workout.resolvedSummary.averageHeartRateBeatsPerMinute.conflict)
+        XCTAssertEqual(try Data(contentsOf: summaryURL), summaryJSONL)
+        XCTAssertEqual(try Data(contentsOf: derivedURL), derivedJSONL)
+    }
+
     func testCopiedJSONLAndCompletedRerunAreDeduplicatedByContent() async throws {
         let directory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -747,6 +875,128 @@ final class LegacyTelemetryMigrationTests: XCTestCase {
         XCTAssertTrue(reconciliations.isEmpty)
     }
 
+    func testJSONLAndHistoryExactIdentityRemainIsolatedAcrossProfiles() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let profileA = "profile-a"
+        let profileB = "profile-b"
+        let jsonlAURL = directory.appendingPathComponent("profile-a.jsonl")
+        let jsonlBURL = directory.appendingPathComponent("profile-b.jsonl")
+        let jsonlA = lines([
+            object([
+                "event": "session_start", "ts": 1_800_000_000,
+                "session_id": "shared-session-x", "workout_id": "shared-workout-x",
+                "profile_id": profileA,
+            ]),
+            object([
+                "event": "workout_saved", "ts": 1_800_000_009,
+                "session_id": "shared-session-x", "workout_id": "shared-workout-x",
+                "profile_id": profileA,
+            ]),
+            object([
+                "event": "session_end", "ts": 1_800_000_010,
+                "session_id": "shared-session-x", "workout_id": "shared-workout-x",
+                "profile_id": profileA,
+            ]),
+        ])
+        let jsonlB = lines([
+            object([
+                "event": "session_start", "ts": 1_800_000_000,
+                "session_id": "shared-session-x", "workout_id": "shared-workout-x",
+                "profile_id": profileB,
+            ]),
+            object([
+                "event": "workout_saved", "ts": 1_800_000_009,
+                "session_id": "shared-session-x", "workout_id": "shared-workout-x",
+                "profile_id": profileB,
+            ]),
+            object([
+                "event": "session_end", "ts": 1_800_000_010,
+                "session_id": "shared-session-x", "workout_id": "shared-workout-x",
+                "profile_id": profileB,
+            ]),
+        ])
+        try jsonlA.write(to: jsonlAURL)
+        try jsonlB.write(to: jsonlBURL)
+        let history = try JSONSerialization.data(withJSONObject: [[
+            "id": "shared-workout-x",
+            "session_id": "shared-session-x",
+            "durationSeconds": 10,
+        ]], options: [.sortedKeys])
+        let store = try TelemetryStoreFactory.make(.inMemory)
+
+        _ = await LegacyTelemetryMigrator(store: store).run(
+            LegacyTelemetryMigrationRequest(
+                jsonlSources: [
+                    .init(url: jsonlAURL, deterministicFallbackProfileLocalIdentifier: nil),
+                    .init(url: jsonlBURL, deterministicFallbackProfileLocalIdentifier: nil),
+                ],
+                workoutHistorySources: [
+                    .init(
+                        storageKey: "workout_history_v1_profile_\(profileA)",
+                        representation: history,
+                        exactProfileLocalIdentifier: profileA
+                    ),
+                    .init(
+                        storageKey: "workout_history_v1_profile_\(profileB)",
+                        representation: history,
+                        exactProfileLocalIdentifier: profileB
+                    ),
+                ],
+                knownProfileLocalIdentifiers: [profileA, profileB]
+            )
+        )
+
+        let candidates = try await store.fetchLegacyWorkoutCandidates()
+        let workouts = try await store.fetchLegacyImportedWorkouts()
+        let reconciliations = try await store.fetchLegacyReconciliations()
+        XCTAssertEqual(candidates.count, 4)
+        XCTAssertEqual(workouts.count, 2)
+        XCTAssertEqual(Set(workouts.compactMap(\.profileLocalIdentifier)), [profileA, profileB])
+        for profile in [profileA, profileB] {
+            let profileCandidateIDs = Set(candidates.filter {
+                $0.profileLocalIdentifier == profile
+            }.map(\.candidateID))
+            XCTAssertEqual(profileCandidateIDs.count, 2)
+            let workout = try XCTUnwrap(workouts.first {
+                $0.profileLocalIdentifier == profile
+            })
+            XCTAssertEqual(workout.identityStatus, .exact)
+            XCTAssertEqual(Set(workout.candidateIDs), profileCandidateIDs)
+            XCTAssertTrue(workout.canonicalIdentityKey.hasPrefix("history-profile:\(profile):"))
+            XCTAssertTrue(reconciliations.contains {
+                $0.outcome == .matched
+                    && Set([$0.leftCandidateID, $0.rightCandidateID]) == profileCandidateIDs
+            })
+        }
+        XCTAssertFalse(workouts.contains { workout in
+            Set(workout.candidateIDs.compactMap { candidateID in
+                candidates.first { $0.candidateID == candidateID }?.profileLocalIdentifier
+            }).count > 1
+        })
+        let crossProfileConflicts = reconciliations.filter {
+            $0.outcome == .conflict
+                && $0.identityKind == .workoutIdentifier
+                && $0.identityValue == "shared-workout-x"
+        }
+        XCTAssertEqual(crossProfileConflicts.count, 2)
+        XCTAssertTrue(crossProfileConflicts.allSatisfy {
+            $0.detailCodes == ["conflicting-profile-ownership"]
+        })
+        let candidatesByID = Dictionary(
+            uniqueKeysWithValues: candidates.map { ($0.candidateID, $0) }
+        )
+        for conflict in crossProfileConflicts {
+            let profiles = Set([
+                candidatesByID[conflict.leftCandidateID]?.profileLocalIdentifier,
+                candidatesByID[conflict.rightCandidateID]?.profileLocalIdentifier,
+            ].compactMap { $0 })
+            XCTAssertEqual(profiles, [profileA, profileB])
+        }
+        XCTAssertEqual(try Data(contentsOf: jsonlAURL), jsonlA)
+        XCTAssertEqual(try Data(contentsOf: jsonlBURL), jsonlB)
+    }
+
     func testOverlappingHistorySnapshotsKeepSameExactIDIsolatedAcrossProfiles() async throws {
         let shared = ["id": "shared-looking-id", "durationSeconds": 10] as [String: Any]
         let profileAHistory = try JSONSerialization.data(withJSONObject: [
@@ -909,6 +1159,100 @@ final class LegacyTelemetryMigrationTests: XCTestCase {
         XCTAssertEqual(secondReconciliations, firstReconciliations)
         XCTAssertEqual(defaults.data(forKey: "workout_history_v1"), globalHistory)
         XCTAssertEqual(defaults.data(forKey: scopedKey), scopedHistory)
+    }
+
+    func testHistoryExactWorkoutKeepsCanonicalIdentityWhenJSONLArrivesLater() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let jsonlURL = directory.appendingPathComponent("later-evidence.jsonl")
+        let firstHistory = try JSONSerialization.data(withJSONObject: [[
+            "id": "origin-enrichment-workout",
+            "durationSeconds": 10,
+            "avgBpm": 130,
+        ]], options: [.sortedKeys])
+        let secondHistory = try JSONSerialization.data(withJSONObject: [[
+            "id": "origin-enrichment-workout",
+            "durationSeconds": 11,
+            "avgBpm": 131,
+        ]], options: [.sortedKeys])
+        let jsonl = lines([
+            object([
+                "event": "session_start", "ts": 1_800_000_000,
+                "workout_id": "origin-enrichment-workout", "profile_id": profileID,
+            ]),
+            object([
+                "event": "workout_saved", "ts": 1_800_000_011,
+                "workout_id": "origin-enrichment-workout", "profile_id": profileID,
+            ]),
+            object([
+                "event": "session_end", "ts": 1_800_000_012,
+                "workout_id": "origin-enrichment-workout", "profile_id": profileID,
+            ]),
+        ])
+        try jsonl.write(to: jsonlURL)
+        let historySources: [LegacyWorkoutHistorySourceDescriptor] = [
+            .init(
+                storageKey: "history-origin-enrichment-old",
+                representation: firstHistory,
+                exactProfileLocalIdentifier: profileID
+            ),
+            .init(
+                storageKey: "history-origin-enrichment-new",
+                representation: secondHistory,
+                exactProfileLocalIdentifier: profileID
+            ),
+        ]
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let migrator = LegacyTelemetryMigrator(store: store)
+        let firstRequest = LegacyTelemetryMigrationRequest(
+            jsonlSources: [],
+            workoutHistorySources: historySources,
+            knownProfileLocalIdentifiers: [profileID]
+        )
+
+        let firstReport = await migrator.run(firstRequest)
+        let firstCandidates = try await store.fetchLegacyWorkoutCandidates()
+        let firstWorkouts = try await store.fetchLegacyImportedWorkouts()
+        let firstReconciliations = try await store.fetchLegacyReconciliations()
+        XCTAssertEqual(firstReport.completion, .completed)
+        XCTAssertEqual(firstCandidates.count, 2)
+        XCTAssertEqual(firstWorkouts.count, 1)
+        let firstWorkout = try XCTUnwrap(firstWorkouts.first)
+        XCTAssertEqual(firstWorkout.profileLocalIdentifier, profileID)
+        XCTAssertEqual(firstWorkout.identityStatus, .exact)
+        XCTAssertEqual(Set(firstWorkout.candidateIDs), Set(firstCandidates.map(\.candidateID)))
+        XCTAssertTrue(firstWorkout.canonicalIdentityKey.hasPrefix("history-profile:\(profileID):"))
+        XCTAssertEqual(firstReconciliations.count, 1)
+
+        let secondRequest = LegacyTelemetryMigrationRequest(
+            jsonlSources: [
+                .init(url: jsonlURL, deterministicFallbackProfileLocalIdentifier: nil),
+            ],
+            workoutHistorySources: historySources,
+            knownProfileLocalIdentifiers: [profileID]
+        )
+        let secondReport = await migrator.run(secondRequest)
+        let secondSources = try await store.fetchLegacyMigrationSources()
+        let secondCandidates = try await store.fetchLegacyWorkoutCandidates()
+        let secondWorkouts = try await store.fetchLegacyImportedWorkouts()
+        let secondReconciliations = try await store.fetchLegacyReconciliations()
+        XCTAssertEqual(secondReport.completion, .completed)
+        XCTAssertEqual(secondReport.completedSourceCount, 1)
+        XCTAssertEqual(secondReport.skippedSourceCount, 2)
+        XCTAssertEqual(secondReport.importedWorkoutCount, 0)
+        XCTAssertEqual(secondSources.count, 3)
+        XCTAssertEqual(secondCandidates.count, 3)
+        XCTAssertEqual(secondWorkouts.count, 1)
+        let secondWorkout = try XCTUnwrap(secondWorkouts.first)
+        XCTAssertEqual(secondWorkout.importedWorkoutID, firstWorkout.importedWorkoutID)
+        XCTAssertEqual(secondWorkout.canonicalIdentityKey, firstWorkout.canonicalIdentityKey)
+        XCTAssertEqual(secondWorkout.profileLocalIdentifier, profileID)
+        XCTAssertEqual(secondWorkout.identityStatus, .exact)
+        XCTAssertEqual(Set(secondWorkout.candidateIDs), Set(secondCandidates.map(\.candidateID)))
+        XCTAssertGreaterThan(secondReconciliations.count, firstReconciliations.count)
+        XCTAssertEqual(try Data(contentsOf: jsonlURL), jsonl)
+        XCTAssertEqual(historySources[0].representation, firstHistory)
+        XCTAssertEqual(historySources[1].representation, secondHistory)
     }
 
     func testSequentialHistoryGrowthConvergesProvisionalWorkoutAcrossRuns() async throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetrySchemaAndBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetrySchemaAndBoundaryTests.swift
@@ -7,12 +7,14 @@ import XCTest
 final class TelemetrySchemaAndBoundaryTests: XCTestCase {
     func testVersionedSchemaMigrationPlanIndicesAndUniquenessAreRegistered() throws {
         XCTAssertEqual(TelemetrySchemaV1.versionIdentifier, Schema.Version(1, 0, 0))
-        XCTAssertEqual(TelemetryMigrationPlan.schemas.count, 1)
+        XCTAssertEqual(TelemetrySchemaV2.versionIdentifier, Schema.Version(1, 1, 0))
+        XCTAssertEqual(TelemetryMigrationPlan.schemas.count, 2)
         XCTAssertTrue(TelemetryMigrationPlan.schemas[0] == TelemetrySchemaV1.self)
-        XCTAssertTrue(TelemetryMigrationPlan.stages.isEmpty)
+        XCTAssertTrue(TelemetryMigrationPlan.schemas[1] == TelemetrySchemaV2.self)
+        XCTAssertEqual(TelemetryMigrationPlan.stages.count, 1)
 
-        let schema = Schema(versionedSchema: TelemetrySchemaV1.self)
-        XCTAssertEqual(schema.entities.count, 8)
+        let schema = Schema(versionedSchema: TelemetrySchemaV2.self)
+        XCTAssertEqual(schema.entities.count, 13)
 
         let sessions = try XCTUnwrap(schema.entitiesByName["TelemetryWorkoutSessionV1"])
         XCTAssertTrue(sessions.attributesByName["sessionID"]?.isUnique == true)
@@ -40,6 +42,40 @@ final class TelemetrySchemaAndBoundaryTests: XCTestCase {
 
         let treadmill = try XCTUnwrap(schema.entitiesByName["TelemetryTreadmillSampleV1"])
         XCTAssertNotNil(treadmill.attributesByName["factualSpeedNormalizationRuleKey"])
+
+        let migrationSources = try XCTUnwrap(
+            schema.entitiesByName["TelemetryLegacyMigrationSourceV2"]
+        )
+        XCTAssertTrue(migrationSources.attributesByName["sourceID"]?.isUnique == true)
+        XCTAssertTrue(
+            migrationSources.indices.contains(["binary", "sourceKindKey", "contentHashDigest"])
+        )
+
+        let importedRecords = try XCTUnwrap(
+            schema.entitiesByName["TelemetryLegacyImportedRecordV2"]
+        )
+        XCTAssertTrue(importedRecords.attributesByName["sourceItemIdentityKey"]?.isUnique == true)
+        XCTAssertTrue(
+            importedRecords.indices.contains(["binary", "sourceID", "sourceRecordIndex"])
+        )
+
+        let candidates = try XCTUnwrap(
+            schema.entitiesByName["TelemetryLegacyWorkoutCandidateV2"]
+        )
+        XCTAssertTrue(candidates.attributesByName["sourceItemIdentityKey"]?.isUnique == true)
+        XCTAssertTrue(
+            candidates.indices.contains(["binary", "originKindKey", "workoutIdentifier"])
+        )
+
+        let importedWorkouts = try XCTUnwrap(
+            schema.entitiesByName["TelemetryLegacyImportedWorkoutV2"]
+        )
+        XCTAssertTrue(importedWorkouts.attributesByName["canonicalIdentityKey"]?.isUnique == true)
+
+        let reconciliations = try XCTUnwrap(
+            schema.entitiesByName["TelemetryLegacyReconciliationV2"]
+        )
+        XCTAssertTrue(reconciliations.attributesByName["reconciliationID"]?.isUnique == true)
     }
 
     func testInsertDuplicatePreflightsAreBoundedPredicates() throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
@@ -7,6 +7,55 @@ import TelemetryRecorder
 import XCTest
 
 final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
+    func testLegacyMigrationRunsOnceInBackgroundAndCannotOwnRuntimeLifecycle() async throws {
+        let persistence = RuntimePersistence(
+            suspendMigration: true,
+            migrationReport: LegacyTelemetryMigrationReport(
+                completion: .failed,
+                completedSourceCount: 0,
+                skippedSourceCount: 0,
+                failedSourceCount: 1,
+                importedRecordCount: 0,
+                importedWorkoutCount: 0
+            )
+        )
+        let coordinator = TelemetryV2RuntimeCoordinator { persistence }
+        coordinator.prepareStoreAndRecover()
+        try await eventually { coordinator.status == .idle }
+
+        let request = LegacyTelemetryMigrationRequest(
+            jsonlSources: [],
+            workoutHistorySources: [],
+            knownProfileLocalIdentifiers: ["profile-a"]
+        )
+        coordinator.scheduleLegacyMigrationInBackground { request }
+        coordinator.scheduleLegacyMigrationInBackground { request }
+        try await eventually { await persistence.migrationCallCount == 1 }
+        XCTAssertEqual(coordinator.status, .idle)
+
+        let session = Self.descriptor()
+        coordinator.beginSession(session)
+        try await eventually { coordinator.activeSessionIDForTesting == session.sessionID }
+        if case .active = coordinator.status {
+            // Migration is still suspended and has no authority over runtime state.
+        } else {
+            XCTFail("A background migration must not block session activation")
+        }
+        coordinator.endSession(reason: "migration-isolation-test")
+        try await eventually { await persistence.finalizations.count == 1 }
+        try await eventually { coordinator.status == .idle }
+
+        await persistence.resumeMigration()
+        try await eventually { await persistence.migrationCompletionCount == 1 }
+        let migrationRequests = await persistence.migrationRequests
+        XCTAssertEqual(coordinator.status, .idle)
+        XCTAssertEqual(migrationRequests.count, 1)
+        XCTAssertEqual(
+            migrationRequests.first?.knownProfileLocalIdentifiers,
+            ["profile-a"]
+        )
+    }
+
     func testWriterHealthSnapshotMapsOnlyTypedOperationalDiagnostics() {
         let snapshot = TelemetryV2WriterHealthSnapshot(
             runtimeStatus: .active(.incomplete),
@@ -1108,7 +1157,8 @@ private final class ManualRuntimeClock: TelemetryV2RuntimeClock, @unchecked Send
 
 private actor RuntimePersistence:
     TelemetryRecorderPersistence,
-    TelemetryPostWorkoutAnalysisCapability
+    TelemetryPostWorkoutAnalysisCapability,
+    LegacyTelemetryMigrationCapability
 {
     struct Snapshot: Sendable {
         let headers: [WorkoutSessionRecord]
@@ -1129,22 +1179,39 @@ private actor RuntimePersistence:
     private let suspendBegin: Bool
     private let suspendFinalize: Bool
     private let suspendAnalysis: Bool
+    private let suspendMigration: Bool
     private let finalizeFailure: Bool
+    private let migrationReport: LegacyTelemetryMigrationReport
     private var beginContinuation: CheckedContinuation<Void, Never>?
     private var finalizeContinuation: CheckedContinuation<Void, Never>?
     private var analysisContinuation: CheckedContinuation<Void, Never>?
+    private var migrationContinuation: CheckedContinuation<Void, Never>?
     private(set) var analysisSessionIDs: [SessionID] = []
+    private(set) var migrationRequests: [LegacyTelemetryMigrationRequest] = []
+    private(set) var migrationCallCount = 0
+    private(set) var migrationCompletionCount = 0
 
     init(
         suspendBegin: Bool = false,
         suspendFinalize: Bool = false,
         suspendAnalysis: Bool = false,
-        finalizeFailure: Bool = false
+        suspendMigration: Bool = false,
+        finalizeFailure: Bool = false,
+        migrationReport: LegacyTelemetryMigrationReport = LegacyTelemetryMigrationReport(
+            completion: .completed,
+            completedSourceCount: 0,
+            skippedSourceCount: 0,
+            failedSourceCount: 0,
+            importedRecordCount: 0,
+            importedWorkoutCount: 0
+        )
     ) {
         self.suspendBegin = suspendBegin
         self.suspendFinalize = suspendFinalize
         self.suspendAnalysis = suspendAnalysis
+        self.suspendMigration = suspendMigration
         self.finalizeFailure = finalizeFailure
+        self.migrationReport = migrationReport
     }
 
     func beginSession(_ header: WorkoutSessionRecord) async throws {
@@ -1190,6 +1257,18 @@ private actor RuntimePersistence:
         []
     }
 
+    func migrateLegacyTelemetry(
+        _ request: LegacyTelemetryMigrationRequest
+    ) async -> LegacyTelemetryMigrationReport {
+        migrationCallCount += 1
+        migrationRequests.append(request)
+        if suspendMigration {
+            await withCheckedContinuation { migrationContinuation = $0 }
+        }
+        migrationCompletionCount += 1
+        return migrationReport
+    }
+
     func resumeBegin() {
         beginContinuation?.resume()
         beginContinuation = nil
@@ -1203,6 +1282,11 @@ private actor RuntimePersistence:
     func resumeAnalysis() {
         analysisContinuation?.resume()
         analysisContinuation = nil
+    }
+
+    func resumeMigration() {
+        migrationContinuation?.resume()
+        migrationContinuation = nil
     }
 
     func snapshot() -> Snapshot {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateMigrationTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateMigrationTests.swift
@@ -5,7 +5,7 @@ import TelemetryDomain
 import XCTest
 
 @Model
-private final class TelemetrySyntheticMigrationMarkerV2 {
+private final class TelemetrySyntheticMigrationMarkerV3 {
     @Attribute(.unique) var key: String
     var createdAt: Date
 
@@ -15,24 +15,28 @@ private final class TelemetrySyntheticMigrationMarkerV2 {
     }
 }
 
-private enum TelemetrySyntheticSchemaV2: VersionedSchema {
+private enum TelemetrySyntheticSchemaV3: VersionedSchema {
     static let versionIdentifier = Schema.Version(2, 0, 0)
 
     static var models: [any PersistentModel.Type] {
-        TelemetrySchemaV1.models + [TelemetrySyntheticMigrationMarkerV2.self]
+        TelemetrySchemaV2.models + [TelemetrySyntheticMigrationMarkerV3.self]
     }
 }
 
 private enum TelemetrySyntheticMigrationPlan: SchemaMigrationPlan {
     static var schemas: [any VersionedSchema.Type] {
-        [TelemetrySchemaV1.self, TelemetrySyntheticSchemaV2.self]
+        [TelemetrySchemaV1.self, TelemetrySchemaV2.self, TelemetrySyntheticSchemaV3.self]
     }
 
     static var stages: [MigrationStage] {
         [
             .lightweight(
                 fromVersion: TelemetrySchemaV1.self,
-                toVersion: TelemetrySyntheticSchemaV2.self
+                toVersion: TelemetrySchemaV2.self
+            ),
+            .lightweight(
+                fromVersion: TelemetrySchemaV2.self,
+                toVersion: TelemetrySyntheticSchemaV3.self
             ),
         ]
     }
@@ -45,7 +49,7 @@ private struct TelemetrySyntheticMigrationEvidence: Equatable {
 }
 
 final class TelemetryGateMigrationTests: XCTestCase {
-    func testV1ToSyntheticV2MigrationRetainsEvidenceAcrossRepeatedReopen() async throws {
+    func testCurrentSchemaToSyntheticSuccessorRetainsEvidenceAcrossRepeatedReopen() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(
             "telemetry-gate-migration-\(UUID().uuidString)",
             isDirectory: true
@@ -139,7 +143,7 @@ final class TelemetryGateMigrationTests: XCTestCase {
             primaryStoreURL: storeURL,
             phase: "before migration open"
         )
-        let schema = Schema(versionedSchema: TelemetrySyntheticSchemaV2.self)
+        let schema = Schema(versionedSchema: TelemetrySyntheticSchemaV3.self)
         let configuration = ModelConfiguration(
             "TelemetryV2SyntheticMigration",
             schema: schema,
@@ -156,7 +160,7 @@ final class TelemetryGateMigrationTests: XCTestCase {
         if addMarker {
             try context.transaction {
                 context.insert(
-                    TelemetrySyntheticMigrationMarkerV2(
+                    TelemetrySyntheticMigrationMarkerV3(
                         key: "synthetic-successor-v2",
                         createdAt: TelemetryGateFixtureGenerator.baseDate
                     )
@@ -195,7 +199,7 @@ final class TelemetryGateMigrationTests: XCTestCase {
             ),
             heartRateIdentityHash: hasher.lowercaseHexDigest,
             markerCount: try context.fetchCount(
-                FetchDescriptor<TelemetrySyntheticMigrationMarkerV2>()
+                FetchDescriptor<TelemetrySyntheticMigrationMarkerV3>()
             )
         )
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -1886,6 +1886,30 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @Published var workoutHistory: [WorkoutEntry] = []
 
     // Lifecycle
+    private func scheduleLegacyTelemetryMigration() {
+        let knownProfiles = sortedProfiles(userProfiles).map {
+            $0.id.uuidString.lowercased()
+        }
+        let deterministicFallbackProfile = knownProfiles.first
+        telemetryV2Coordinator.scheduleLegacyMigrationInBackground {
+            guard let logsDirectory = LegacyTelemetryMigrationSourceDiscovery
+                .defaultTrainingLogsDirectory() else {
+                return LegacyTelemetryMigrationRequest(
+                    jsonlSources: [],
+                    workoutHistorySources: [],
+                    knownProfileLocalIdentifiers: Set(knownProfiles)
+                )
+            }
+            return LegacyTelemetryMigrationSourceDiscovery.makeRequest(
+                userDefaults: .standard,
+                trainingLogsDirectory: logsDirectory,
+                knownProfileLocalIdentifiers: knownProfiles,
+                deterministicLegacyFallbackProfileLocalIdentifier:
+                    deterministicFallbackProfile
+            )
+        }
+    }
+
     func start() {
         ensureCentral()
         autoConnectSuppressed = false
@@ -1899,6 +1923,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         setHeartRateTelemetrySink(telemetryV2Coordinator)
         setTreadmillTelemetrySink(telemetryV2Coordinator)
         telemetryV2Coordinator.prepareStoreAndRecover()
+        scheduleLegacyTelemetryMigration()
 #if canImport(WatchConnectivity)
         startWatchConnectivity()
 #endif

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -231,6 +231,47 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         )
     }
 
+    func testLegacyMigrationIsStartupOnlyAndCannotEnterControlOrSafetyPaths() throws {
+        let schedule = try functionBody(
+            "private func scheduleLegacyTelemetryMigration()",
+            in: managerSource
+        )
+        let startLifecycle = try functionBody("func start()", in: managerSource)
+        let controlStart = try functionBody("func startHrControl()", in: managerSource)
+        let recompute = try functionBody(
+            "private func recomputeHrStartAllowed()",
+            in: managerSource
+        )
+        let controlTick = try functionBody("private func tickTelemetry()", in: managerSource)
+
+        XCTAssertTrue(schedule.contains("scheduleLegacyMigrationInBackground"))
+        XCTAssertTrue(schedule.contains("LegacyTelemetryMigrationSourceDiscovery.makeRequest"))
+        XCTAssertTrue(schedule.contains("sortedProfiles(userProfiles)"))
+        XCTAssertFalse(schedule.contains("activeUserProfileID"))
+        for forbidden in [
+            "sendTreadmill", "startHrControl", "stopHrControl", "recomputeHrStartAllowed",
+            "hrStartAllowed", "controllerUnits", "speedTargetKmh", "tickTelemetry",
+        ] {
+            XCTAssertFalse(schedule.contains(forbidden), "Migration scheduling contains \(forbidden)")
+        }
+
+        assertOrdered(
+            [
+                "loadProfilesState()",
+                "telemetryV2Coordinator.prepareStoreAndRecover()",
+                "scheduleLegacyTelemetryMigration()",
+                "recomputeHrStartAllowed()",
+            ],
+            in: startLifecycle
+        )
+        for controlPath in [controlStart, recompute, controlTick] {
+            XCTAssertFalse(controlPath.contains("LegacyTelemetryMigration"))
+            XCTAssertFalse(controlPath.contains("scheduleLegacyMigration"))
+            XCTAssertFalse(controlPath.contains("workout_history_v1"))
+            XCTAssertFalse(controlPath.contains("TrainingLogs"))
+        }
+    }
+
     func testInstrumentationCannotAuthorizeControlStopCooldownOrWatchBehavior() throws {
         let start = try functionBody("func startHrControl()", in: managerSource)
         let stop = try functionBody("func stopHrControl()", in: managerSource)


### PR DESCRIPTION
## Summary

- Add an additive SwiftData V2 schema for legacy migration sources, imported evidence, candidate workouts, reconciled workouts, and audit records.
- Import legacy JSONL and workout_history_v1 evidence with streaming readers, bounded transactional batches, durable checkpoints, deterministic content identity, exact-only reconciliation, and explicit quarantine/conflict outcomes.
- Launch migration as a background telemetry-only capability that cannot affect Start, control decisions, Stop, safety state, or native Telemetry V2 provenance.
- Cover deduplication, interruption/resume, malformed and partial inputs, exact identity precedence/conflicts, profile ownership, timestamp gaps, speed/steps provenance, causal uncertainty, schema upgrade, and runtime isolation.

## Verification

- swift test
- swift test --filter TelemetryRuntimeTests
- xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination platform=iOS\ Simulator,id=37F68E06-41D3-4749-8712-1B8DC865F923 -derivedDataPath /tmp/walkingpad-issue34-derived-exact-head CODE_SIGNING_ALLOWED=NO build
- git diff HEAD^ --check
- Independent Terra/high review: clean; no actionable P0/P1/P2 findings.

## Risks / Notes

- Legacy JSONL files and workout_history_v1 remain immutable; only additive Telemetry V2 migration and reconciliation state is written.
- Imported evidence remains adaptation-ineligible, and ambiguous or conflicting identities stay explicit instead of being heuristically joined.
- Issue #35, #36, and #37 work is excluded.
- No device, BLE, hardware, deploy, Ready-for-review transition, or merge action is included.
- One full Swift test run overlapped with the simulator build and reported a transient TelemetryRuntimeTests failure; the isolated 16-test suite and the subsequent sequential full run both passed.

Closes #34