### PR TITLE
Telemetry V2: cut workout reads over

### DIFF
--- a/docs/telemetry-v2/rollout-and-migration.md
+++ b/docs/telemetry-v2/rollout-and-migration.md
@@ -135,6 +135,31 @@ import gates. At its completion:
 The shadow writer MUST NOT gain product fields or features, drive UI/analysis,
 delete V2 evidence, or become a permanent fallback.
 
+The accepted #35 implementation exposes history through a stable, bounded
+profile/date keyset cursor. History pages project persisted session and latest
+usable analysis rows only; list loading MUST NOT hydrate HR, treadmill, event,
+or frame time series. Statistics use the same profile/date scope and preserve
+missing values as unavailable rather than synthesizing zero. Imported,
+incomplete, uncertain, duplicate-candidate, and low-quality records remain
+queryable with explicit provenance and quality. Statistics consume only
+available fields from identity-safe, non-duplicate records; adaptation
+eligibility remains a separate, stricter decision and imported evidence remains
+adaptation-ineligible.
+
+The V2 developer export is a read-only bundle containing versioned raw JSONL,
+normalized CSV, session-summary JSONL/CSV, and a manifest describing schema,
+algorithm/analyzer versions, quality, omitted identifiers, and the health-data
+privacy warning. Export reads are streamed in bounded batches. Cancellation or
+failure may remove only the temporary export bundle and MUST preserve V2 and
+legacy source evidence. HealthKit workout UUID/version association remains an
+explicit, conflict-checked V2 session link and is visible in history/export
+projections.
+
+This cutover does not change the deployed SwiftData schema version. It remains
+compatible with the accepted #34 store and importer. Legacy JSONL and
+`workout_history_v1` evidence, the isolated shadow writer, and importer/parity
+support remain until #37 evidence and #36 retirement authorize removal.
+
 ## Physical real-evidence gate (#37)
 
 Gate #37 consumes ordinary real workout evidence supplied by the user/PM for

--- a/docs/telemetry-v2/rollout-and-migration.md
+++ b/docs/telemetry-v2/rollout-and-migration.md
@@ -144,7 +144,9 @@ incomplete, uncertain, duplicate-candidate, and low-quality records remain
 queryable with explicit provenance and quality. Statistics consume only
 available fields from identity-safe, non-duplicate records; adaptation
 eligibility remains a separate, stricter decision and imported evidence remains
-adaptation-ineligible.
+adaptation-ineligible. Excluded queryable workouts make aggregate completeness
+partial and expose a reason-class count without changing valid totals or
+substituting zero.
 
 The V2 developer export is a read-only bundle containing versioned raw JSONL,
 normalized CSV, session-summary JSONL/CSV, and a manifest describing schema,

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/WorkoutReadProjection.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/WorkoutReadProjection.swift
@@ -195,6 +195,7 @@ public struct WorkoutStatisticsProjection: Codable, Hashable, Sendable {
     public let queryableWorkoutCount: Int
     public let includedWorkoutCount: Int
     public let excludedWorkoutCount: Int
+    public let exclusionReasonCounts: [WorkoutStatisticsExclusionReason: Int]
     public let workoutsWithUnavailableDuration: Int
     public let workoutsWithUnavailableZones: Int
     public let isPartial: Bool
@@ -207,6 +208,7 @@ public struct WorkoutStatisticsProjection: Codable, Hashable, Sendable {
         queryableWorkoutCount: Int,
         includedWorkoutCount: Int,
         excludedWorkoutCount: Int,
+        exclusionReasonCounts: [WorkoutStatisticsExclusionReason: Int],
         workoutsWithUnavailableDuration: Int,
         workoutsWithUnavailableZones: Int,
         isPartial: Bool,
@@ -218,11 +220,18 @@ public struct WorkoutStatisticsProjection: Codable, Hashable, Sendable {
         self.queryableWorkoutCount = queryableWorkoutCount
         self.includedWorkoutCount = includedWorkoutCount
         self.excludedWorkoutCount = excludedWorkoutCount
+        self.exclusionReasonCounts = exclusionReasonCounts
         self.workoutsWithUnavailableDuration = workoutsWithUnavailableDuration
         self.workoutsWithUnavailableZones = workoutsWithUnavailableZones
         self.isPartial = isPartial
         self.diagnostics = diagnostics
     }
+}
+
+public enum WorkoutStatisticsExclusionReason: String, Codable, Hashable, Sendable {
+    case identity
+    case possibleDuplicate
+    case lifecycleOrQuality
 }
 
 public enum WorkoutExportSelection: Codable, Hashable, Sendable {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/WorkoutReadProjection.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/WorkoutReadProjection.swift
@@ -1,0 +1,394 @@
+import Foundation
+
+public enum WorkoutReadProfileScope: Codable, Hashable, Sendable {
+    case exact(String)
+    case unassigned
+    case all
+}
+
+public struct WorkoutReadFilter: Codable, Hashable, Sendable {
+    public let profileScope: WorkoutReadProfileScope
+    public let startedAtOrAfter: Date?
+    public let startedBefore: Date?
+
+    public init(
+        profileScope: WorkoutReadProfileScope,
+        startedAtOrAfter: Date? = nil,
+        startedBefore: Date? = nil
+    ) {
+        self.profileScope = profileScope
+        self.startedAtOrAfter = startedAtOrAfter
+        self.startedBefore = startedBefore
+    }
+}
+
+public struct WorkoutHistoryCursor: Codable, Hashable, Sendable {
+    public let startedAt: Date?
+    public let stableTieBreaker: String
+
+    public init(startedAt: Date?, stableTieBreaker: String) {
+        self.startedAt = startedAt
+        self.stableTieBreaker = stableTieBreaker
+    }
+}
+
+public enum WorkoutProjectionOrigin: String, Codable, Hashable, Sendable {
+    case nativeV2
+    case importedLegacy
+}
+
+public enum WorkoutSpeedEvidenceKind: String, Codable, Hashable, Sendable {
+    case factual
+    case legacyEstimated
+}
+
+public struct WorkoutSpeedProjection: Codable, Hashable, Sendable {
+    public let kilometresPerHour: Double
+    public let evidenceKind: WorkoutSpeedEvidenceKind
+    public let provenance: String
+
+    public init(
+        kilometresPerHour: Double,
+        evidenceKind: WorkoutSpeedEvidenceKind,
+        provenance: String
+    ) {
+        self.kilometresPerHour = kilometresPerHour
+        self.evidenceKind = evidenceKind
+        self.provenance = provenance
+    }
+}
+
+public struct WorkoutProjectionQuality: Codable, Hashable, Sendable {
+    public let lifecycleState: String
+    public let recorderComplete: Bool?
+    public let analysisGrade: String?
+    public let identityStatus: String?
+    public let possibleDuplicate: Bool
+    public let adaptationEligible: Bool
+    public let includedInStatistics: Bool
+    public let provenance: [String]
+    public let unavailableMetrics: [String]
+    public let warnings: [String]
+
+    public init(
+        lifecycleState: String,
+        recorderComplete: Bool?,
+        analysisGrade: String?,
+        identityStatus: String?,
+        possibleDuplicate: Bool,
+        adaptationEligible: Bool,
+        includedInStatistics: Bool,
+        provenance: [String],
+        unavailableMetrics: [String],
+        warnings: [String]
+    ) {
+        self.lifecycleState = lifecycleState
+        self.recorderComplete = recorderComplete
+        self.analysisGrade = analysisGrade
+        self.identityStatus = identityStatus
+        self.possibleDuplicate = possibleDuplicate
+        self.adaptationEligible = adaptationEligible
+        self.includedInStatistics = includedInStatistics
+        self.provenance = provenance.sorted()
+        self.unavailableMetrics = unavailableMetrics.sorted()
+        self.warnings = warnings.sorted()
+    }
+}
+
+public struct WorkoutHistoryProjection: Codable, Hashable, Identifiable, Sendable {
+    public let id: String
+    public let origin: WorkoutProjectionOrigin
+    public let startedAt: Date?
+    public let endedAt: Date?
+    public let durationSeconds: Double?
+    public let targetHeartRate: Int?
+    public let averageHeartRate: Double?
+    public let averageSpeed: WorkoutSpeedProjection?
+    public let beatsPerMetre: Double?
+    public let zoneSeconds: [Double?]?
+    public let healthKitWorkoutIdentifier: UUID?
+    public let telemetrySchemaVersion: String?
+    public let appVersion: String?
+    public let buildNumber: String?
+    public let algorithmVersion: String?
+    public let analyzerVersion: String?
+    public let quality: WorkoutProjectionQuality
+
+    public init(
+        id: String,
+        origin: WorkoutProjectionOrigin,
+        startedAt: Date?,
+        endedAt: Date?,
+        durationSeconds: Double?,
+        targetHeartRate: Int?,
+        averageHeartRate: Double?,
+        averageSpeed: WorkoutSpeedProjection?,
+        beatsPerMetre: Double?,
+        zoneSeconds: [Double?]?,
+        healthKitWorkoutIdentifier: UUID?,
+        telemetrySchemaVersion: String?,
+        appVersion: String?,
+        buildNumber: String?,
+        algorithmVersion: String?,
+        analyzerVersion: String?,
+        quality: WorkoutProjectionQuality
+    ) {
+        self.id = id
+        self.origin = origin
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.durationSeconds = durationSeconds
+        self.targetHeartRate = targetHeartRate
+        self.averageHeartRate = averageHeartRate
+        self.averageSpeed = averageSpeed
+        self.beatsPerMetre = beatsPerMetre
+        self.zoneSeconds = zoneSeconds
+        self.healthKitWorkoutIdentifier = healthKitWorkoutIdentifier
+        self.telemetrySchemaVersion = telemetrySchemaVersion
+        self.appVersion = appVersion
+        self.buildNumber = buildNumber
+        self.algorithmVersion = algorithmVersion
+        self.analyzerVersion = analyzerVersion
+        self.quality = quality
+    }
+}
+
+public struct WorkoutReadDiagnostics: Codable, Hashable, Sendable {
+    public let storeFetchCount: Int
+    public let maximumStoreFetchLimit: Int
+    public let hydratedTimeSeriesRecordCount: Int
+    public let exactNativeDuplicateCount: Int
+
+    public init(
+        storeFetchCount: Int,
+        maximumStoreFetchLimit: Int,
+        hydratedTimeSeriesRecordCount: Int,
+        exactNativeDuplicateCount: Int
+    ) {
+        self.storeFetchCount = storeFetchCount
+        self.maximumStoreFetchLimit = maximumStoreFetchLimit
+        self.hydratedTimeSeriesRecordCount = hydratedTimeSeriesRecordCount
+        self.exactNativeDuplicateCount = exactNativeDuplicateCount
+    }
+}
+
+public struct WorkoutHistoryPage: Codable, Hashable, Sendable {
+    public let items: [WorkoutHistoryProjection]
+    public let nextCursor: WorkoutHistoryCursor?
+    public let diagnostics: WorkoutReadDiagnostics
+
+    public init(
+        items: [WorkoutHistoryProjection],
+        nextCursor: WorkoutHistoryCursor?,
+        diagnostics: WorkoutReadDiagnostics
+    ) {
+        self.items = items
+        self.nextCursor = nextCursor
+        self.diagnostics = diagnostics
+    }
+}
+
+public struct WorkoutStatisticsProjection: Codable, Hashable, Sendable {
+    public let totalDurationSeconds: Double?
+    public let averageBeatsPerMetre: Double?
+    public let zoneSeconds: [Double?]
+    public let queryableWorkoutCount: Int
+    public let includedWorkoutCount: Int
+    public let excludedWorkoutCount: Int
+    public let workoutsWithUnavailableDuration: Int
+    public let workoutsWithUnavailableZones: Int
+    public let isPartial: Bool
+    public let diagnostics: WorkoutReadDiagnostics
+
+    public init(
+        totalDurationSeconds: Double?,
+        averageBeatsPerMetre: Double?,
+        zoneSeconds: [Double?],
+        queryableWorkoutCount: Int,
+        includedWorkoutCount: Int,
+        excludedWorkoutCount: Int,
+        workoutsWithUnavailableDuration: Int,
+        workoutsWithUnavailableZones: Int,
+        isPartial: Bool,
+        diagnostics: WorkoutReadDiagnostics
+    ) {
+        self.totalDurationSeconds = totalDurationSeconds
+        self.averageBeatsPerMetre = averageBeatsPerMetre
+        self.zoneSeconds = zoneSeconds
+        self.queryableWorkoutCount = queryableWorkoutCount
+        self.includedWorkoutCount = includedWorkoutCount
+        self.excludedWorkoutCount = excludedWorkoutCount
+        self.workoutsWithUnavailableDuration = workoutsWithUnavailableDuration
+        self.workoutsWithUnavailableZones = workoutsWithUnavailableZones
+        self.isPartial = isPartial
+        self.diagnostics = diagnostics
+    }
+}
+
+public enum WorkoutExportSelection: Codable, Hashable, Sendable {
+    case all
+    case latestCompleted(Int)
+}
+
+public struct WorkoutExportRequest: Codable, Hashable, Sendable {
+    public let filter: WorkoutReadFilter
+    public let selection: WorkoutExportSelection
+    public let batchSize: Int
+
+    public init(
+        filter: WorkoutReadFilter,
+        selection: WorkoutExportSelection,
+        batchSize: Int = 128
+    ) {
+        self.filter = filter
+        self.selection = selection
+        self.batchSize = batchSize
+    }
+}
+
+public struct WorkoutExportArtifact: Codable, Hashable, Sendable {
+    public let directoryURL: URL
+    public let fileURLs: [URL]
+    public let exportedWorkoutCount: Int
+    public let exportedRecordCount: Int
+    public let containsHealthData: Bool
+
+    public init(
+        directoryURL: URL,
+        fileURLs: [URL],
+        exportedWorkoutCount: Int,
+        exportedRecordCount: Int,
+        containsHealthData: Bool
+    ) {
+        self.directoryURL = directoryURL
+        self.fileURLs = fileURLs
+        self.exportedWorkoutCount = exportedWorkoutCount
+        self.exportedRecordCount = exportedRecordCount
+        self.containsHealthData = containsHealthData
+    }
+}
+
+public struct WorkoutExportManifestQuality: Codable, Hashable, Sendable {
+    public let lifecycleCounts: [String: Int]
+    public let analysisGradeCounts: [String: Int]
+    public let identityStatusCounts: [String: Int]
+    public let workoutCountWithUnavailableMetrics: Int
+    public let possibleDuplicateCount: Int
+
+    public init(
+        lifecycleCounts: [String: Int],
+        analysisGradeCounts: [String: Int],
+        identityStatusCounts: [String: Int],
+        workoutCountWithUnavailableMetrics: Int,
+        possibleDuplicateCount: Int
+    ) {
+        self.lifecycleCounts = lifecycleCounts
+        self.analysisGradeCounts = analysisGradeCounts
+        self.identityStatusCounts = identityStatusCounts
+        self.workoutCountWithUnavailableMetrics = workoutCountWithUnavailableMetrics
+        self.possibleDuplicateCount = possibleDuplicateCount
+    }
+}
+
+public struct WorkoutExportManifest: Codable, Hashable, Sendable {
+    public static let formatVersion = "workout-export-manifest-v1"
+    public static let sessionSummaryVersion = "workout-session-summary-v1"
+
+    public let manifestVersion: String
+    public let sessionSummaryVersion: String
+    public let generatedAt: Date
+    public let storageSchemaVersion: String
+    public let telemetrySchemaVersions: [String]
+    public let appVersions: [String]
+    public let buildNumbers: [String]
+    public let algorithmVersions: [String]
+    public let analyzerVersions: [String]
+    public let exportedWorkoutCount: Int
+    public let exportedRecordCount: Int
+    public let batchSize: Int
+    public let containsHealthData: Bool
+    public let healthDataNotice: String
+    public let omittedIdentifierKinds: [String]
+    public let files: [String]
+    public let quality: WorkoutExportManifestQuality
+
+    public init(
+        generatedAt: Date,
+        storageSchemaVersion: String,
+        telemetrySchemaVersions: [String],
+        appVersions: [String],
+        buildNumbers: [String],
+        algorithmVersions: [String],
+        analyzerVersions: [String],
+        exportedWorkoutCount: Int,
+        exportedRecordCount: Int,
+        batchSize: Int,
+        containsHealthData: Bool,
+        healthDataNotice: String,
+        omittedIdentifierKinds: [String],
+        files: [String],
+        quality: WorkoutExportManifestQuality
+    ) {
+        manifestVersion = Self.formatVersion
+        sessionSummaryVersion = Self.sessionSummaryVersion
+        self.generatedAt = generatedAt
+        self.storageSchemaVersion = storageSchemaVersion
+        self.telemetrySchemaVersions = telemetrySchemaVersions.sorted()
+        self.appVersions = appVersions.sorted()
+        self.buildNumbers = buildNumbers.sorted()
+        self.algorithmVersions = algorithmVersions.sorted()
+        self.analyzerVersions = analyzerVersions.sorted()
+        self.exportedWorkoutCount = exportedWorkoutCount
+        self.exportedRecordCount = exportedRecordCount
+        self.batchSize = batchSize
+        self.containsHealthData = containsHealthData
+        self.healthDataNotice = healthDataNotice
+        self.omittedIdentifierKinds = omittedIdentifierKinds.sorted()
+        self.files = files.sorted()
+        self.quality = quality
+    }
+}
+
+public enum TelemetryWorkoutReadError: Error, Codable, Equatable, Sendable {
+    case unavailable(String)
+    case invalidPageSize
+    case corruptProjection(String)
+    case exportFailed(String)
+}
+
+extension TelemetryWorkoutReadError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .unavailable(reason):
+            return "Telemetry V2 is unavailable (\(reason))."
+        case .invalidPageSize:
+            return "Telemetry V2 rejected the requested page size."
+        case let .corruptProjection(reason):
+            return "Telemetry V2 projection is corrupt (\(reason))."
+        case let .exportFailed(reason):
+            return "Telemetry V2 export failed (\(reason))."
+        }
+    }
+}
+
+public protocol TelemetryWorkoutReadCapability: Sendable {
+    func fetchWorkoutHistoryPage(
+        filter: WorkoutReadFilter,
+        after cursor: WorkoutHistoryCursor?,
+        limit: Int
+    ) async throws -> WorkoutHistoryPage
+
+    func fetchWorkoutStatistics(
+        filter: WorkoutReadFilter,
+        batchSize: Int
+    ) async throws -> WorkoutStatisticsProjection
+
+    func exportWorkouts(_ request: WorkoutExportRequest) async throws -> WorkoutExportArtifact
+}
+
+public protocol TelemetryHealthKitWorkoutLinkageCapability: Sendable {
+    func associateHealthKitWorkout(
+        sessionID: SessionID,
+        workoutIdentifier: UUID
+    ) async throws
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutExportStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutExportStore.swift
@@ -1,0 +1,1088 @@
+import Foundation
+import SwiftData
+import TelemetryDomain
+
+private struct WorkoutExportEnvelope<Payload: Encodable>: Encodable {
+    let schemaVersion: String
+    let recordType: String
+    let payload: Payload
+}
+
+private struct NativeSessionExportRecord: Encodable {
+    let recordID: String
+    let sessionID: String
+    let lifecycleState: String
+    let workoutMode: WorkoutMode
+    let startedAt: Date
+    let endedAt: Date?
+    let endedElapsedMicroseconds: Int64?
+    let incompleteReason: String?
+    let appVersion: String
+    let buildNumber: String
+    let operatingSystemVersion: String
+    let telemetrySchemaVersion: String
+    let algorithmVersion: String
+    let safetyPolicyVersion: String
+    let workoutProtocolVersion: String
+    let healthKitWorkoutIdentifier: String?
+    let recorderIsComplete: Bool
+    let lostCriticalRecordCount: Int64
+    let lostNativeRecordCount: Int64
+    let lastPersistedElapsedMicroseconds: Int64?
+    let configuration: PrivacySafeConfigurationExportRecord
+    let configurationHashAlgorithm: String?
+    let configurationHashDigest: String?
+}
+
+private struct PrivacySafeConfigurationExportRecord: Codable {
+    let workoutMode: WorkoutMode?
+    let targetHeartRate: Int?
+    let durationMinutes: Int?
+    let decisionIntervalSeconds: Int?
+    let adaptiveStepEnabled: Bool?
+    let maximumStepKilometresPerHour: Double?
+    let heartRateZones: [Int]?
+    let cooldownTargetHeartRate: Int?
+    let cooldownMinimumSpeedKilometresPerHour: Double?
+    let cooldownMaximumMinutes: Int?
+    let heartRateProviderKind: String?
+    let treadmill: PrivacySafeTreadmillConfigurationExportRecord?
+}
+
+private struct PrivacySafeTreadmillConfigurationExportRecord: Codable {
+    let protocolName: String?
+    let protocolVersion: String?
+    let minimumSpeedKilometresPerHour: Double?
+    let maximumSpeedKilometresPerHour: Double?
+    let speedIncrementKilometresPerHour: Double?
+}
+
+private struct HeartRateExportRecord: Encodable {
+    let recordID: String
+    let observationID: String
+    let sessionID: String
+    let sourceID: String
+    let beatsPerMinute: UInt16
+    let arrivalOrder: UInt64
+    let providerSequence: Int64?
+    let timestamp: ObservationTimestamp
+    let provenance: EvidenceProvenance
+    let freshness: EvidenceFreshness
+    let quality: QualityFlags
+    let controlUse: ControlUseState
+}
+
+private struct TreadmillExportRecord: Encodable {
+    let recordID: String
+    let observationID: String
+    let sessionID: String
+    let sourceID: String
+    let nativeSpeed: NativeTreadmillSpeed
+    let factualSpeed: FactualSpeedKilometresPerHour?
+    let deviceState: TreadmillDeviceState
+    let arrivalOrder: UInt64
+    let timestamp: ObservationTimestamp
+    let provenance: EvidenceProvenance
+    let freshness: EvidenceFreshness
+    let quality: QualityFlags
+}
+
+private struct ImportedWorkoutExportRecord: Encodable {
+    let importedWorkoutID: String
+    let startedAt: Date?
+    let endedAt: Date?
+    let identityStatus: String
+    let possibleDuplicate: Bool
+    let adaptationQualityEligible: Bool
+    let candidateIDs: [String]
+    let resolvedSummary: LegacyResolvedWorkoutSummary
+}
+
+private struct ImportedCandidateExportRecord: Encodable {
+    let candidateID: String
+    let sourceID: String
+    let origin: String
+    let workoutIdentifier: String?
+    let healthKitWorkoutIdentifier: String?
+    let stableLegacySessionIdentifier: String?
+    let startedAt: Date?
+    let endedAt: Date?
+    let identityUncertain: Bool
+    let possibleDuplicate: Bool
+    let summary: LegacyWorkoutCandidateSummary
+}
+
+private struct ImportedEvidenceExportRecord: Encodable {
+    let importedRecordID: String
+    let sourceID: String
+    let candidateID: String
+    let sourceRecordIndex: Int64
+    let eventKind: String
+    let occurredAt: Date?
+    let workoutIdentifier: String?
+    let healthKitWorkoutIdentifier: String?
+    let stableLegacySessionIdentifier: String?
+    let provenance: String
+    let payload: LegacyImportedRecordPayload
+    let identityUncertain: Bool
+    let adaptationQualityEligible: Bool
+}
+
+private final class WorkoutExportStream {
+    let directoryURL: URL
+    let rawURL: URL
+    let normalizedURL: URL
+    let summaryJSONLURL: URL
+    let summaryCSVURL: URL
+    let manifestURL: URL
+
+    private let rawHandle: FileHandle
+    private let normalizedHandle: FileHandle
+    private let summaryJSONLHandle: FileHandle
+    private let summaryCSVHandle: FileHandle
+    private let encoder: JSONEncoder
+    private var closed = false
+
+    init(root: URL) throws {
+        directoryURL = root
+        rawURL = root.appendingPathComponent("raw_evidence_v1.jsonl")
+        normalizedURL = root.appendingPathComponent("normalized_evidence_v1.csv")
+        summaryJSONLURL = root.appendingPathComponent("session_summary_v1.jsonl")
+        summaryCSVURL = root.appendingPathComponent("session_summary_v1.csv")
+        manifestURL = root.appendingPathComponent("manifest.json")
+
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        for url in [rawURL, normalizedURL, summaryJSONLURL, summaryCSVURL] {
+            FileManager.default.createFile(atPath: url.path, contents: nil)
+        }
+        rawHandle = try FileHandle(forWritingTo: rawURL)
+        normalizedHandle = try FileHandle(forWritingTo: normalizedURL)
+        summaryJSONLHandle = try FileHandle(forWritingTo: summaryJSONLURL)
+        summaryCSVHandle = try FileHandle(forWritingTo: summaryCSVURL)
+        encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+
+        try writeCSV(
+            [
+                "record_type", "session_id", "record_id", "occurred_at",
+                "elapsed_us", "heart_rate_bpm", "native_speed_value",
+                "native_speed_unit", "factual_speed_kmh", "event_kind",
+                "lifecycle_state", "quality", "provenance",
+            ],
+            to: normalizedHandle
+        )
+        try writeCSV(
+            [
+                "summary_version", "id", "origin", "started_at", "ended_at",
+                "duration_s", "target_bpm", "average_hr_bpm", "average_speed_kmh",
+                "average_speed_evidence", "beats_per_metre", "zone_1_s", "zone_2_s",
+                "zone_3_s", "zone_4_s", "zone_5_s", "healthkit_workout_uuid",
+                "lifecycle_state", "recorder_complete", "analysis_grade",
+                "identity_status", "possible_duplicate", "adaptation_eligible",
+                "included_in_statistics", "provenance", "unavailable_metrics",
+                "warnings",
+            ],
+            to: summaryCSVHandle
+        )
+    }
+
+    deinit {
+        close()
+    }
+
+    var fileURLs: [URL] {
+        [rawURL, normalizedURL, summaryJSONLURL, summaryCSVURL, manifestURL]
+    }
+
+    func writeRaw<Payload: Encodable>(recordType: String, payload: Payload) throws {
+        let envelope = WorkoutExportEnvelope(
+            schemaVersion: "telemetry-v2-portable-raw-v1",
+            recordType: recordType,
+            payload: payload
+        )
+        try writeJSONLine(envelope, to: rawHandle)
+    }
+
+    func writeNormalized(_ fields: [String]) throws {
+        try writeCSV(fields, to: normalizedHandle)
+    }
+
+    func writeSummary(_ projection: WorkoutHistoryProjection) throws {
+        let envelope = WorkoutExportEnvelope(
+            schemaVersion: WorkoutExportManifest.sessionSummaryVersion,
+            recordType: "workout_summary",
+            payload: projection
+        )
+        try writeJSONLine(envelope, to: summaryJSONLHandle)
+        let zones = projection.zoneSeconds ?? []
+        try writeCSV(
+            [
+                WorkoutExportManifest.sessionSummaryVersion,
+                projection.id,
+                projection.origin.rawValue,
+                Self.dateString(projection.startedAt),
+                Self.dateString(projection.endedAt),
+                Self.numberString(projection.durationSeconds),
+                projection.targetHeartRate.map(String.init) ?? "",
+                Self.numberString(projection.averageHeartRate),
+                Self.numberString(projection.averageSpeed?.kilometresPerHour),
+                projection.averageSpeed?.evidenceKind.rawValue ?? "",
+                Self.numberString(projection.beatsPerMetre),
+                Self.numberString(zones[safe: 0] ?? nil),
+                Self.numberString(zones[safe: 1] ?? nil),
+                Self.numberString(zones[safe: 2] ?? nil),
+                Self.numberString(zones[safe: 3] ?? nil),
+                Self.numberString(zones[safe: 4] ?? nil),
+                projection.healthKitWorkoutIdentifier?.uuidString.lowercased() ?? "",
+                projection.quality.lifecycleState,
+                projection.quality.recorderComplete.map(String.init) ?? "",
+                projection.quality.analysisGrade ?? "",
+                projection.quality.identityStatus ?? "",
+                String(projection.quality.possibleDuplicate),
+                String(projection.quality.adaptationEligible),
+                String(projection.quality.includedInStatistics),
+                projection.quality.provenance.joined(separator: ";"),
+                projection.quality.unavailableMetrics.joined(separator: ";"),
+                projection.quality.warnings.joined(separator: ";"),
+            ],
+            to: summaryCSVHandle
+        )
+    }
+
+    func writeManifest(_ manifest: WorkoutExportManifest) throws {
+        let data = try encoder.encode(manifest)
+        try data.write(to: manifestURL, options: .atomic)
+    }
+
+    func close() {
+        guard !closed else { return }
+        closed = true
+        try? rawHandle.close()
+        try? normalizedHandle.close()
+        try? summaryJSONLHandle.close()
+        try? summaryCSVHandle.close()
+    }
+
+    private func writeJSONLine<Value: Encodable>(
+        _ value: Value,
+        to handle: FileHandle
+    ) throws {
+        var data = try encoder.encode(value)
+        data.append(0x0a)
+        try handle.write(contentsOf: data)
+    }
+
+    private func writeCSV(_ fields: [String], to handle: FileHandle) throws {
+        let line = fields.map(Self.csvEscape).joined(separator: ",") + "\n"
+        try handle.write(contentsOf: Data(line.utf8))
+    }
+
+    private static func csvEscape(_ value: String) -> String {
+        guard value.contains(",") || value.contains("\"")
+                || value.contains("\n") || value.contains("\r") else {
+            return value
+        }
+        return "\"\(value.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+
+    private static func dateString(_ date: Date?) -> String {
+        date.map { ISO8601DateFormatter().string(from: $0) } ?? ""
+    }
+
+    private static func numberString(_ value: Double?) -> String {
+        value.map { String(format: "%.6f", locale: Locale(identifier: "en_US_POSIX"), $0) }
+            ?? ""
+    }
+}
+
+private extension Collection {
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}
+
+private struct WorkoutExportManifestAccumulator {
+    var telemetrySchemaVersions: Set<String> = []
+    var appVersions: Set<String> = []
+    var buildNumbers: Set<String> = []
+    var algorithmVersions: Set<String> = []
+    var analyzerVersions: Set<String> = []
+    var lifecycleCounts: [String: Int] = [:]
+    var analysisGradeCounts: [String: Int] = [:]
+    var identityStatusCounts: [String: Int] = [:]
+    var unavailableMetricWorkoutCount = 0
+    var possibleDuplicateCount = 0
+    var workoutCount = 0
+    var recordCount = 0
+
+    mutating func record(_ projection: WorkoutHistoryProjection) {
+        workoutCount += 1
+        telemetrySchemaVersions.insertIfPresent(projection.telemetrySchemaVersion)
+        appVersions.insertIfPresent(projection.appVersion)
+        buildNumbers.insertIfPresent(projection.buildNumber)
+        algorithmVersions.insertIfPresent(projection.algorithmVersion)
+        analyzerVersions.insertIfPresent(projection.analyzerVersion)
+        lifecycleCounts[projection.quality.lifecycleState, default: 0] += 1
+        if let grade = projection.quality.analysisGrade {
+            analysisGradeCounts[grade, default: 0] += 1
+        }
+        if let identity = projection.quality.identityStatus {
+            identityStatusCounts[identity, default: 0] += 1
+        }
+        if !projection.quality.unavailableMetrics.isEmpty {
+            unavailableMetricWorkoutCount += 1
+        }
+        if projection.quality.possibleDuplicate {
+            possibleDuplicateCount += 1
+        }
+    }
+}
+
+private extension Set where Element == String {
+    mutating func insertIfPresent(_ value: String?) {
+        if let value, !value.isEmpty { insert(value) }
+    }
+}
+
+public extension TelemetryStore {
+    func exportWorkouts(
+        _ request: WorkoutExportRequest
+    ) async throws -> WorkoutExportArtifact {
+        let batchSize = min(256, max(1, request.batchSize))
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TelemetryV2Export_\(UUID().uuidString)", isDirectory: true)
+        let stream: WorkoutExportStream
+        do {
+            stream = try WorkoutExportStream(root: directoryURL)
+        } catch {
+            try? FileManager.default.removeItem(at: directoryURL)
+            throw TelemetryWorkoutReadError.exportFailed("create-export: \(error)")
+        }
+
+        do {
+            var manifest = WorkoutExportManifestAccumulator()
+            var cursor: WorkoutHistoryCursor?
+            var completedSelectionCount = 0
+            var shouldContinue = true
+
+            while shouldContinue {
+                try Task.checkCancellation()
+                let page = try await fetchWorkoutHistoryPage(
+                    filter: request.filter,
+                    after: cursor,
+                    limit: min(100, batchSize)
+                )
+                cursor = page.nextCursor
+
+                for projection in page.items {
+                    try Task.checkCancellation()
+                    switch request.selection {
+                    case .all:
+                        break
+                    case let .latestCompleted(limit):
+                        guard limit > 0 else {
+                            throw TelemetryWorkoutReadError.invalidPageSize
+                        }
+                        guard projection.quality.lifecycleState == SessionLifecycleState.completed.rawValue
+                                || projection.quality.lifecycleState == "imported" else {
+                            continue
+                        }
+                        guard completedSelectionCount < limit else {
+                            shouldContinue = false
+                            break
+                        }
+                        completedSelectionCount += 1
+                    }
+
+                    try stream.writeSummary(projection)
+                    let evidenceCount: Int
+                    switch projection.origin {
+                    case .nativeV2:
+                        evidenceCount = try exportNativeEvidence(
+                            projection: projection,
+                            batchSize: batchSize,
+                            stream: stream
+                        )
+                    case .importedLegacy:
+                        evidenceCount = try exportImportedEvidence(
+                            projection: projection,
+                            batchSize: batchSize,
+                            stream: stream
+                        )
+                    }
+                    manifest.record(projection)
+                    manifest.recordCount += evidenceCount
+
+                    if case let .latestCompleted(limit) = request.selection,
+                       completedSelectionCount == limit {
+                        shouldContinue = false
+                        break
+                    }
+                }
+
+                if cursor == nil { shouldContinue = false }
+            }
+
+            let files = stream.fileURLs.map(\.lastPathComponent)
+            let containsHealthData = manifest.workoutCount > 0
+            let outputManifest = WorkoutExportManifest(
+                generatedAt: Date(),
+                storageSchemaVersion: "1.1.0",
+                telemetrySchemaVersions: Array(manifest.telemetrySchemaVersions),
+                appVersions: Array(manifest.appVersions),
+                buildNumbers: Array(manifest.buildNumbers),
+                algorithmVersions: Array(manifest.algorithmVersions),
+                analyzerVersions: Array(manifest.analyzerVersions),
+                exportedWorkoutCount: manifest.workoutCount,
+                exportedRecordCount: manifest.recordCount,
+                batchSize: batchSize,
+                containsHealthData: containsHealthData,
+                healthDataNotice: "This export contains health and workout data. Share and store it carefully.",
+                omittedIdentifierKinds: [
+                    "installation-id",
+                    "profile-id",
+                    "profile-label",
+                    "device-model",
+                    "treadmill-stable-identifier",
+                    "provider-stable-local-key",
+                    "provider-native-sample-identifier",
+                ],
+                files: files,
+                quality: WorkoutExportManifestQuality(
+                    lifecycleCounts: manifest.lifecycleCounts,
+                    analysisGradeCounts: manifest.analysisGradeCounts,
+                    identityStatusCounts: manifest.identityStatusCounts,
+                    workoutCountWithUnavailableMetrics: manifest.unavailableMetricWorkoutCount,
+                    possibleDuplicateCount: manifest.possibleDuplicateCount
+                )
+            )
+            stream.close()
+            try stream.writeManifest(outputManifest)
+            return WorkoutExportArtifact(
+                directoryURL: directoryURL,
+                fileURLs: stream.fileURLs,
+                exportedWorkoutCount: manifest.workoutCount,
+                exportedRecordCount: manifest.recordCount,
+                containsHealthData: containsHealthData
+            )
+        } catch is CancellationError {
+            stream.close()
+            try? FileManager.default.removeItem(at: directoryURL)
+            throw CancellationError()
+        } catch {
+            stream.close()
+            try? FileManager.default.removeItem(at: directoryURL)
+            if let readError = error as? TelemetryWorkoutReadError {
+                throw readError
+            }
+            throw TelemetryWorkoutReadError.exportFailed(String(describing: error))
+        }
+    }
+
+    func associateHealthKitWorkout(
+        sessionID: SessionID,
+        workoutIdentifier: UUID
+    ) async throws {
+        let sessionKey = sessionID.description
+        var descriptor = FetchDescriptor<TelemetryWorkoutSessionV1>(
+            predicate: #Predicate { $0.sessionID == sessionKey }
+        )
+        descriptor.fetchLimit = 1
+        guard let session = try modelContext.fetch(descriptor).first else {
+            throw TelemetryStoreError.missingSession(sessionID)
+        }
+        let value = workoutIdentifier.uuidString.lowercased()
+        var conflictingDescriptor = FetchDescriptor<TelemetryWorkoutSessionV1>(
+            predicate: #Predicate {
+                $0.healthKitWorkoutIdentifier == value && $0.sessionID != sessionKey
+            }
+        )
+        conflictingDescriptor.fetchLimit = 1
+        guard try modelContext.fetch(conflictingDescriptor).isEmpty else {
+            throw TelemetryStoreError.conflictingStableIdentity(
+                "healthkit-workout:\(value)"
+            )
+        }
+        if let existing = session.healthKitWorkoutIdentifier {
+            guard existing == value else {
+                throw TelemetryStoreError.conflictingStableIdentity(
+                    "healthkit-workout:\(sessionID.description)"
+                )
+            }
+            return
+        }
+        try explicitTransaction {
+            session.healthKitWorkoutIdentifier = value
+        }
+    }
+}
+
+extension TelemetryStore: TelemetryWorkoutReadCapability {}
+extension TelemetryStore: TelemetryHealthKitWorkoutLinkageCapability {}
+
+private extension TelemetryStore {
+    func exportNativeEvidence(
+        projection: WorkoutHistoryProjection,
+        batchSize: Int,
+        stream: WorkoutExportStream
+    ) throws -> Int {
+        let sessionID = String(projection.id.dropFirst("native:".count))
+        var sessionDescriptor = FetchDescriptor<TelemetryWorkoutSessionV1>(
+            predicate: #Predicate { $0.sessionID == sessionID }
+        )
+        sessionDescriptor.fetchLimit = 1
+        guard let sessionModel = try modelContext.fetch(sessionDescriptor).first else {
+            throw TelemetryWorkoutReadError.corruptProjection("missing native session \(sessionID)")
+        }
+        let session = try Self.domainSession(sessionModel)
+        let privacySafeConfiguration = try Self.decode(
+            PrivacySafeConfigurationExportRecord.self,
+            from: session.configuration.canonicalPayload
+        )
+        try stream.writeRaw(
+            recordType: "workout_session",
+            payload: NativeSessionExportRecord(
+                recordID: session.recordID.description,
+                sessionID: session.sessionID.description,
+                lifecycleState: session.lifecycleState.rawValue,
+                workoutMode: session.workoutMode,
+                startedAt: session.startedAt,
+                endedAt: session.endedAt,
+                endedElapsedMicroseconds: session.endedElapsed?.microseconds,
+                incompleteReason: session.incompleteReason,
+                appVersion: session.appContext.appVersion,
+                buildNumber: session.appContext.buildNumber,
+                operatingSystemVersion: session.appContext.operatingSystemVersion,
+                telemetrySchemaVersion: session.versions.telemetrySchema.rawValue,
+                algorithmVersion: session.versions.algorithm.rawValue,
+                safetyPolicyVersion: session.versions.safetyPolicy.rawValue,
+                workoutProtocolVersion: session.versions.workoutProtocol.rawValue,
+                healthKitWorkoutIdentifier: session.healthKitWorkoutIdentifier?.uuidString.lowercased(),
+                recorderIsComplete: session.recorderHealth.isComplete,
+                lostCriticalRecordCount: sessionModel.lostCriticalRecordCount,
+                lostNativeRecordCount: sessionModel.lostNativeRecordCount,
+                lastPersistedElapsedMicroseconds: session.recorderHealth.lastPersistedElapsed?.microseconds,
+                configuration: privacySafeConfiguration,
+                configurationHashAlgorithm: session.configuration.contentHash.algorithm.rawValue,
+                configurationHashDigest: session.configuration.contentHash.lowercaseHexDigest
+            )
+        )
+        try stream.writeNormalized([
+            "workout_session", sessionID, session.recordID.description,
+            WorkoutExportStreamDate.string(session.startedAt), "", "", "", "", "", "",
+            session.lifecycleState.rawValue,
+            session.recorderHealth.isComplete ? "complete" : "incomplete",
+            "telemetry-v2-native",
+        ])
+        var count = 1
+        count += try exportHeartRate(sessionID: sessionID, batchSize: batchSize, stream: stream)
+        count += try exportTreadmill(sessionID: sessionID, batchSize: batchSize, stream: stream)
+        count += try exportEvents(sessionID: sessionID, batchSize: batchSize, stream: stream)
+        count += try exportFrames(sessionID: sessionID, batchSize: batchSize, stream: stream)
+        count += try exportAnalyses(sessionID: sessionID, batchSize: batchSize, stream: stream)
+        return count
+    }
+
+    func exportHeartRate(
+        sessionID: String,
+        batchSize: Int,
+        stream: WorkoutExportStream
+    ) throws -> Int {
+        var lastReceivedElapsed: Int64?
+        var lastID = ""
+        var count = 0
+        while true {
+            try Task.checkCancellation()
+            var descriptor: FetchDescriptor<TelemetryHeartRateSampleV1>
+            if let lastReceivedElapsed {
+                descriptor = FetchDescriptor(
+                    predicate: #Predicate {
+                        $0.sessionID == sessionID
+                            && ($0.receivedElapsedMicroseconds > lastReceivedElapsed
+                                || ($0.receivedElapsedMicroseconds == lastReceivedElapsed
+                                    && $0.observationID > lastID))
+                    },
+                    sortBy: [
+                        SortDescriptor(\.receivedElapsedMicroseconds),
+                        SortDescriptor(\.observationID),
+                    ]
+                )
+            } else {
+                descriptor = FetchDescriptor(
+                    predicate: #Predicate { $0.sessionID == sessionID },
+                    sortBy: [
+                        SortDescriptor(\.receivedElapsedMicroseconds),
+                        SortDescriptor(\.observationID),
+                    ]
+                )
+            }
+            descriptor.fetchLimit = batchSize
+            let models = try modelContext.fetch(descriptor)
+            guard !models.isEmpty else { break }
+            for model in models {
+                let observation = try Self.domainHeartRate(model)
+                try stream.writeRaw(
+                    recordType: "heart_rate_observation",
+                    payload: HeartRateExportRecord(
+                        recordID: observation.recordID.description,
+                        observationID: observation.observationID.description,
+                        sessionID: observation.sessionID.description,
+                        sourceID: observation.source.id.description,
+                        beatsPerMinute: observation.beatsPerMinute,
+                        arrivalOrder: observation.arrivalOrder,
+                        providerSequence: observation.providerSequence,
+                        timestamp: observation.timestamp,
+                        provenance: observation.provenance,
+                        freshness: observation.freshness,
+                        quality: observation.quality,
+                        controlUse: observation.controlUse
+                    )
+                )
+                try stream.writeNormalized([
+                    "heart_rate_observation", sessionID, observation.recordID.description,
+                    WorkoutExportStreamDate.string(observation.timestamp.recordedAt),
+                    String(observation.timestamp.recordedElapsed.microseconds),
+                    String(observation.beatsPerMinute), "", "", "", "", "",
+                    observation.quality.values.map(\.rawValue).sorted().joined(separator: ";"),
+                    observation.provenance.rawValue,
+                ])
+                count += 1
+                lastReceivedElapsed = model.receivedElapsedMicroseconds
+                lastID = model.observationID
+            }
+            if models.count < batchSize { break }
+        }
+        return count
+    }
+
+    func exportTreadmill(
+        sessionID: String,
+        batchSize: Int,
+        stream: WorkoutExportStream
+    ) throws -> Int {
+        var lastReceivedElapsed: Int64?
+        var lastID = ""
+        var count = 0
+        while true {
+            try Task.checkCancellation()
+            var descriptor: FetchDescriptor<TelemetryTreadmillSampleV1>
+            if let lastReceivedElapsed {
+                descriptor = FetchDescriptor(
+                    predicate: #Predicate {
+                        $0.sessionID == sessionID
+                            && ($0.receivedElapsedMicroseconds > lastReceivedElapsed
+                                || ($0.receivedElapsedMicroseconds == lastReceivedElapsed
+                                    && $0.observationID > lastID))
+                    },
+                    sortBy: [
+                        SortDescriptor(\.receivedElapsedMicroseconds),
+                        SortDescriptor(\.observationID),
+                    ]
+                )
+            } else {
+                descriptor = FetchDescriptor(
+                    predicate: #Predicate { $0.sessionID == sessionID },
+                    sortBy: [
+                        SortDescriptor(\.receivedElapsedMicroseconds),
+                        SortDescriptor(\.observationID),
+                    ]
+                )
+            }
+            descriptor.fetchLimit = batchSize
+            let models = try modelContext.fetch(descriptor)
+            guard !models.isEmpty else { break }
+            for model in models {
+                let observation = try Self.domainTreadmill(model)
+                try stream.writeRaw(
+                    recordType: "treadmill_observation",
+                    payload: TreadmillExportRecord(
+                        recordID: observation.recordID.description,
+                        observationID: observation.observationID.description,
+                        sessionID: observation.sessionID.description,
+                        sourceID: observation.source.id.description,
+                        nativeSpeed: observation.nativeSpeed,
+                        factualSpeed: observation.factualSpeed,
+                        deviceState: observation.deviceState,
+                        arrivalOrder: observation.arrivalOrder,
+                        timestamp: observation.timestamp,
+                        provenance: observation.provenance,
+                        freshness: observation.freshness,
+                        quality: observation.quality
+                    )
+                )
+                try stream.writeNormalized([
+                    "treadmill_observation", sessionID, observation.recordID.description,
+                    WorkoutExportStreamDate.string(observation.timestamp.recordedAt),
+                    String(observation.timestamp.recordedElapsed.microseconds), "",
+                    String(observation.nativeSpeed.value),
+                    treadmillUnitString(observation.nativeSpeed.unit),
+                    observation.factualSpeed.map { String($0.value) } ?? "", "", "",
+                    observation.quality.values.map(\.rawValue).sorted().joined(separator: ";"),
+                    observation.provenance.rawValue,
+                ])
+                count += 1
+                lastReceivedElapsed = model.receivedElapsedMicroseconds
+                lastID = model.observationID
+            }
+            if models.count < batchSize { break }
+        }
+        return count
+    }
+
+    func exportEvents(
+        sessionID: String,
+        batchSize: Int,
+        stream: WorkoutExportStream
+    ) throws -> Int {
+        var lastElapsed: Int64?
+        var lastID = ""
+        var count = 0
+        while true {
+            try Task.checkCancellation()
+            var descriptor: FetchDescriptor<TelemetryWorkoutEventV1>
+            if let lastElapsed {
+                descriptor = FetchDescriptor(
+                    predicate: #Predicate {
+                        $0.sessionID == sessionID
+                            && ($0.occurredElapsedMicroseconds > lastElapsed
+                                || ($0.occurredElapsedMicroseconds == lastElapsed
+                                    && $0.recordID > lastID))
+                    },
+                    sortBy: [
+                        SortDescriptor(\.occurredElapsedMicroseconds),
+                        SortDescriptor(\.recordID),
+                    ]
+                )
+            } else {
+                descriptor = FetchDescriptor(
+                    predicate: #Predicate { $0.sessionID == sessionID },
+                    sortBy: [
+                        SortDescriptor(\.occurredElapsedMicroseconds),
+                        SortDescriptor(\.recordID),
+                    ]
+                )
+            }
+            descriptor.fetchLimit = batchSize
+            let models = try modelContext.fetch(descriptor)
+            guard !models.isEmpty else { break }
+            for model in models {
+                let event = try Self.domainEvent(model)
+                try stream.writeRaw(recordType: "workout_event", payload: event)
+                try stream.writeNormalized([
+                    "workout_event", sessionID, event.recordID.description,
+                    WorkoutExportStreamDate.string(event.timestamp.occurredAt),
+                    String(event.timestamp.occurredElapsed.microseconds), "", "", "", "",
+                    event.kind.rawValue, "", "", "typed-v2-event",
+                ])
+                count += 1
+                lastElapsed = model.occurredElapsedMicroseconds
+                lastID = model.recordID
+            }
+            if models.count < batchSize { break }
+        }
+        return count
+    }
+
+    func exportFrames(
+        sessionID: String,
+        batchSize: Int,
+        stream: WorkoutExportStream
+    ) throws -> Int {
+        var lastSecond: Int64?
+        var lastID = ""
+        var count = 0
+        while true {
+            try Task.checkCancellation()
+            var descriptor: FetchDescriptor<TelemetryWorkoutFrameV1>
+            if let lastSecond {
+                descriptor = FetchDescriptor(
+                    predicate: #Predicate {
+                        $0.sessionID == sessionID
+                            && ($0.canonicalElapsedSecond > lastSecond
+                                || ($0.canonicalElapsedSecond == lastSecond && $0.frameID > lastID))
+                    },
+                    sortBy: [
+                        SortDescriptor(\.canonicalElapsedSecond),
+                        SortDescriptor(\.frameID),
+                    ]
+                )
+            } else {
+                descriptor = FetchDescriptor(
+                    predicate: #Predicate { $0.sessionID == sessionID },
+                    sortBy: [
+                        SortDescriptor(\.canonicalElapsedSecond),
+                        SortDescriptor(\.frameID),
+                    ]
+                )
+            }
+            descriptor.fetchLimit = batchSize
+            let models = try modelContext.fetch(descriptor)
+            guard !models.isEmpty else { break }
+            for model in models {
+                let frame = try Self.domainFrame(model)
+                try stream.writeRaw(recordType: "canonical_frame", payload: frame)
+                try stream.writeNormalized([
+                    "canonical_frame", sessionID, frame.recordID.description,
+                    WorkoutExportStreamDate.string(frame.materializedAt.recordedAt),
+                    String(frame.materializedAt.elapsed.microseconds),
+                    frame.heartRateEvidence.map { String($0.beatsPerMinute) } ?? "",
+                    frame.treadmillEvidence.map { String($0.nativeSpeed.value) } ?? "",
+                    frame.treadmillEvidence.map {
+                        treadmillUnitString($0.nativeSpeed.unit)
+                    } ?? "",
+                    frame.treadmillEvidence?.factualSpeed.map { String($0.value) } ?? "",
+                    "", "", "", "canonical-frame-projection",
+                ])
+                count += 1
+                lastSecond = model.canonicalElapsedSecond
+                lastID = model.frameID
+            }
+            if models.count < batchSize { break }
+        }
+        return count
+    }
+
+    func exportAnalyses(
+        sessionID: String,
+        batchSize: Int,
+        stream: WorkoutExportStream
+    ) throws -> Int {
+        var lastGeneratedAt: Date?
+        var lastID = ""
+        var count = 0
+        while true {
+            try Task.checkCancellation()
+            var descriptor: FetchDescriptor<TelemetryWorkoutAnalysisV1>
+            if let lastGeneratedAt {
+                descriptor = FetchDescriptor(
+                    predicate: #Predicate {
+                        $0.sessionID == sessionID
+                            && ($0.generatedAt > lastGeneratedAt
+                                || ($0.generatedAt == lastGeneratedAt && $0.analysisID > lastID))
+                    },
+                    sortBy: [SortDescriptor(\.generatedAt), SortDescriptor(\.analysisID)]
+                )
+            } else {
+                descriptor = FetchDescriptor(
+                    predicate: #Predicate { $0.sessionID == sessionID },
+                    sortBy: [SortDescriptor(\.generatedAt), SortDescriptor(\.analysisID)]
+                )
+            }
+            descriptor.fetchLimit = batchSize
+            let models = try modelContext.fetch(descriptor)
+            guard !models.isEmpty else { break }
+            for model in models {
+                let analysis = try Self.domainAnalysis(model)
+                try stream.writeRaw(recordType: "workout_analysis", payload: analysis)
+                try stream.writeNormalized([
+                    "workout_analysis", sessionID, analysis.recordID.description,
+                    WorkoutExportStreamDate.string(analysis.generatedAt), "", "", "", "",
+                    analysis.keyMetrics.averageFactualSpeedKilometresPerHour.map { String($0) } ?? "",
+                    "", "", analysis.qualityGrade.rawValue, "derived-analysis",
+                ])
+                count += 1
+                lastGeneratedAt = model.generatedAt
+                lastID = model.analysisID
+            }
+            if models.count < batchSize { break }
+        }
+        return count
+    }
+
+    func exportImportedEvidence(
+        projection: WorkoutHistoryProjection,
+        batchSize: Int,
+        stream: WorkoutExportStream
+    ) throws -> Int {
+        let workoutID = String(projection.id.dropFirst("imported:".count))
+        var descriptor = FetchDescriptor<TelemetryLegacyImportedWorkoutV2>(
+            predicate: #Predicate { $0.importedWorkoutID == workoutID }
+        )
+        descriptor.fetchLimit = 1
+        guard let model = try modelContext.fetch(descriptor).first else {
+            throw TelemetryWorkoutReadError.corruptProjection("missing imported workout \(workoutID)")
+        }
+        let candidates = try exportImportedCandidateModels(model)
+        let resolvedSummary = try Self.decode(
+            LegacyResolvedWorkoutSummary.self,
+            from: model.resolvedSummaryPayload
+        )
+        try stream.writeRaw(
+            recordType: "imported_workout",
+            payload: ImportedWorkoutExportRecord(
+                importedWorkoutID: model.importedWorkoutID,
+                startedAt: model.startedAt,
+                endedAt: model.endedAt,
+                identityStatus: model.identityStatusKey,
+                possibleDuplicate: model.possibleDuplicate,
+                adaptationQualityEligible: model.adaptationQualityEligible,
+                candidateIDs: try exportModelCandidateIDs(model),
+                resolvedSummary: resolvedSummary
+            )
+        )
+        try stream.writeNormalized([
+            "imported_workout", workoutID, workoutID,
+            WorkoutExportStreamDate.string(model.startedAt), "", "", "", "", "", "",
+            projection.quality.lifecycleState, model.identityStatusKey,
+            "telemetry-v2-imported-legacy",
+        ])
+        var count = 1
+        for candidate in candidates {
+            try Task.checkCancellation()
+            let summary = try Self.decode(
+                LegacyWorkoutCandidateSummary.self,
+                from: candidate.summaryPayload
+            )
+            try stream.writeRaw(
+                recordType: "imported_workout_candidate",
+                payload: ImportedCandidateExportRecord(
+                    candidateID: candidate.candidateID,
+                    sourceID: candidate.sourceID,
+                    origin: candidate.originKindKey,
+                    workoutIdentifier: candidate.workoutIdentifier,
+                    healthKitWorkoutIdentifier: candidate.healthKitWorkoutIdentifier,
+                    stableLegacySessionIdentifier: candidate.stableLegacySessionIdentifier,
+                    startedAt: candidate.startedAt,
+                    endedAt: candidate.endedAt,
+                    identityUncertain: candidate.identityUncertain,
+                    possibleDuplicate: candidate.possibleDuplicate,
+                    summary: summary
+                )
+            )
+            count += 1
+            count += try exportImportedRecords(
+                candidateID: candidate.candidateID,
+                batchSize: batchSize,
+                stream: stream
+            )
+        }
+        return count
+    }
+
+    func exportImportedRecords(
+        candidateID: String,
+        batchSize: Int,
+        stream: WorkoutExportStream
+    ) throws -> Int {
+        var lastIndex: Int64?
+        var lastID = ""
+        var count = 0
+        while true {
+            try Task.checkCancellation()
+            var descriptor: FetchDescriptor<TelemetryLegacyImportedRecordV2>
+            if let lastIndex {
+                descriptor = FetchDescriptor(
+                    predicate: #Predicate {
+                        $0.candidateID == candidateID
+                            && ($0.sourceRecordIndex > lastIndex
+                                || ($0.sourceRecordIndex == lastIndex
+                                    && $0.importedRecordID > lastID))
+                    },
+                    sortBy: [SortDescriptor(\.sourceRecordIndex), SortDescriptor(\.importedRecordID)]
+                )
+            } else {
+                descriptor = FetchDescriptor(
+                    predicate: #Predicate { $0.candidateID == candidateID },
+                    sortBy: [SortDescriptor(\.sourceRecordIndex), SortDescriptor(\.importedRecordID)]
+                )
+            }
+            descriptor.fetchLimit = batchSize
+            let models = try modelContext.fetch(descriptor)
+            guard !models.isEmpty else { break }
+            for model in models {
+                let payload = try Self.decode(
+                    LegacyImportedRecordPayload.self,
+                    from: model.normalizedPayload
+                )
+                try stream.writeRaw(
+                    recordType: "imported_evidence_record",
+                    payload: ImportedEvidenceExportRecord(
+                        importedRecordID: model.importedRecordID,
+                        sourceID: model.sourceID,
+                        candidateID: model.candidateID,
+                        sourceRecordIndex: model.sourceRecordIndex,
+                        eventKind: model.eventKind,
+                        occurredAt: model.occurredAt,
+                        workoutIdentifier: model.workoutIdentifier,
+                        healthKitWorkoutIdentifier: model.healthKitWorkoutIdentifier,
+                        stableLegacySessionIdentifier: model.stableLegacySessionIdentifier,
+                        provenance: model.provenanceKey,
+                        payload: payload,
+                        identityUncertain: model.identityUncertain,
+                        adaptationQualityEligible: model.adaptationQualityEligible
+                    )
+                )
+                try stream.writeNormalized([
+                    "imported_evidence_record", candidateID, model.importedRecordID,
+                    WorkoutExportStreamDate.string(model.occurredAt), "",
+                    payload.heartRateBeatsPerMinute.map(String.init) ?? "",
+                    "", "", "", model.eventKind, "",
+                    model.identityUncertain ? "identity-uncertain" : "",
+                    model.provenanceKey,
+                ])
+                count += 1
+                lastIndex = model.sourceRecordIndex
+                lastID = model.importedRecordID
+            }
+            if models.count < batchSize { break }
+        }
+        return count
+    }
+
+    func exportImportedCandidateModels(
+        _ model: TelemetryLegacyImportedWorkoutV2
+    ) throws -> [TelemetryLegacyWorkoutCandidateV2] {
+        var candidates: [TelemetryLegacyWorkoutCandidateV2] = []
+        for candidateID in try exportModelCandidateIDs(model) {
+            var descriptor = FetchDescriptor<TelemetryLegacyWorkoutCandidateV2>(
+                predicate: #Predicate { $0.candidateID == candidateID }
+            )
+            descriptor.fetchLimit = 1
+            guard let candidate = try modelContext.fetch(descriptor).first else {
+                throw TelemetryWorkoutReadError.corruptProjection(
+                    "missing imported candidate \(candidateID)"
+                )
+            }
+            candidates.append(candidate)
+        }
+        return candidates.sorted { $0.candidateID < $1.candidateID }
+    }
+
+    func exportModelCandidateIDs(
+        _ model: TelemetryLegacyImportedWorkoutV2
+    ) throws -> [String] {
+        do {
+            return try Self.decode([String].self, from: model.candidateIDsPayload)
+        } catch {
+            throw TelemetryWorkoutReadError.corruptProjection(
+                "invalid imported candidate linkage for \(model.importedWorkoutID)"
+            )
+        }
+    }
+
+    func treadmillUnitString(_ unit: TreadmillNativeSpeedUnit) -> String {
+        switch unit {
+        case .kilometresPerHour: return "kilometresPerHour"
+        case .milesPerHour: return "milesPerHour"
+        case let .controllerNative(code):
+            return code.map { "controllerNative:\($0)" } ?? "controllerNative"
+        case .unknown: return "unknown"
+        }
+    }
+}
+
+private enum WorkoutExportStreamDate {
+    static let formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    static func string(_ date: Date?) -> String {
+        date.map(formatter.string) ?? ""
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutReadStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutReadStore.swift
@@ -1,0 +1,879 @@
+import Foundation
+import SwiftData
+import TelemetryAnalysis
+import TelemetryDomain
+
+private struct TelemetrySessionConfigurationProjection: Decodable {
+    let targetHeartRate: Int?
+}
+
+private enum StoredWorkoutProjectionCandidate {
+    case native(TelemetryWorkoutSessionV1)
+    case imported(TelemetryLegacyImportedWorkoutV2)
+
+    var cursor: WorkoutHistoryCursor {
+        switch self {
+        case let .native(model):
+            WorkoutHistoryCursor(
+                startedAt: model.startedAt,
+                stableTieBreaker: "native:\(model.sessionID)"
+            )
+        case let .imported(model):
+            WorkoutHistoryCursor(
+                startedAt: model.startedAt,
+                stableTieBreaker: "imported:\(model.importedWorkoutID)"
+            )
+        }
+    }
+}
+
+private struct WorkoutReadDiagnosticsAccumulator {
+    var storeFetchCount = 0
+    var maximumStoreFetchLimit = 0
+    var exactNativeDuplicateCount = 0
+
+    mutating func recordFetch(limit: Int) {
+        storeFetchCount += 1
+        maximumStoreFetchLimit = max(maximumStoreFetchLimit, limit)
+    }
+
+    mutating func merge(_ diagnostics: WorkoutReadDiagnostics) {
+        storeFetchCount += diagnostics.storeFetchCount
+        maximumStoreFetchLimit = max(
+            maximumStoreFetchLimit,
+            diagnostics.maximumStoreFetchLimit
+        )
+        exactNativeDuplicateCount += diagnostics.exactNativeDuplicateCount
+    }
+
+    var snapshot: WorkoutReadDiagnostics {
+        WorkoutReadDiagnostics(
+            storeFetchCount: storeFetchCount,
+            maximumStoreFetchLimit: maximumStoreFetchLimit,
+            hydratedTimeSeriesRecordCount: 0,
+            exactNativeDuplicateCount: exactNativeDuplicateCount
+        )
+    }
+}
+
+public extension TelemetryStore {
+    func fetchWorkoutHistoryPage(
+        filter: WorkoutReadFilter,
+        after cursor: WorkoutHistoryCursor?,
+        limit: Int
+    ) async throws -> WorkoutHistoryPage {
+        guard limit > 0, limit <= 100 else {
+            throw TelemetryWorkoutReadError.invalidPageSize
+        }
+
+        let batchLimit = min(256, max(32, limit * 2))
+        var scanCursor = cursor ?? filter.startedBefore.map {
+            WorkoutHistoryCursor(
+                startedAt: $0,
+                stableTieBreaker: "range-upper-bound"
+            )
+        }
+        var projections: [WorkoutHistoryProjection] = []
+        var diagnostics = WorkoutReadDiagnosticsAccumulator()
+
+        while projections.count < limit {
+            let nativeBatch = try fetchNativeProjectionCandidates(
+                scope: filter.profileScope,
+                after: scanCursor,
+                limit: batchLimit + 1
+            )
+            diagnostics.recordFetch(limit: batchLimit + 1)
+            let importedBatch = try fetchImportedProjectionCandidates(
+                scope: filter.profileScope,
+                after: scanCursor,
+                limit: batchLimit + 1
+            )
+            diagnostics.recordFetch(limit: batchLimit + 1)
+
+            let nativeHasMore = nativeBatch.count > batchLimit
+            let importedHasMore = importedBatch.count > batchLimit
+            let merged = mergeProjectionCandidates(
+                native: Array(nativeBatch.prefix(batchLimit)),
+                imported: Array(importedBatch.prefix(batchLimit))
+            )
+            guard !merged.isEmpty else {
+                return WorkoutHistoryPage(
+                    items: projections,
+                    nextCursor: nil,
+                    diagnostics: diagnostics.snapshot
+                )
+            }
+
+            for (index, candidate) in merged.enumerated() {
+                try Task.checkCancellation()
+                scanCursor = candidate.cursor
+                if let lowerBound = filter.startedAtOrAfter {
+                    guard let startedAt = candidate.cursor.startedAt,
+                          startedAt >= lowerBound else {
+                        return WorkoutHistoryPage(
+                            items: projections,
+                            nextCursor: nil,
+                            diagnostics: diagnostics.snapshot
+                        )
+                    }
+                }
+                guard matchesDateFilter(candidate.cursor.startedAt, filter: filter) else {
+                    continue
+                }
+
+                switch candidate {
+                case let .native(model):
+                    projections.append(try nativeProjection(model))
+                case let .imported(model):
+                    let candidateModels = try importedCandidateModels(model)
+                    diagnostics.recordFetch(limit: max(1, try modelCandidateIDs(model).count))
+                    if try hasExactNativeSession(
+                        for: candidateModels,
+                        profileScope: filter.profileScope
+                    ) {
+                        diagnostics.exactNativeDuplicateCount += 1
+                        continue
+                    }
+                    projections.append(try importedProjection(model, candidates: candidateModels))
+                }
+
+                if projections.count == limit {
+                    let hasUnprocessed = index + 1 < merged.count
+                        || nativeHasMore
+                        || importedHasMore
+                    return WorkoutHistoryPage(
+                        items: projections,
+                        nextCursor: hasUnprocessed ? scanCursor : nil,
+                        diagnostics: diagnostics.snapshot
+                    )
+                }
+            }
+
+            guard nativeHasMore || importedHasMore else {
+                return WorkoutHistoryPage(
+                    items: projections,
+                    nextCursor: nil,
+                    diagnostics: diagnostics.snapshot
+                )
+            }
+        }
+
+        return WorkoutHistoryPage(
+            items: projections,
+            nextCursor: scanCursor,
+            diagnostics: diagnostics.snapshot
+        )
+    }
+
+    func fetchWorkoutStatistics(
+        filter: WorkoutReadFilter,
+        batchSize: Int = 100
+    ) async throws -> WorkoutStatisticsProjection {
+        let boundedBatchSize = min(100, max(1, batchSize))
+        var cursor: WorkoutHistoryCursor?
+        var queryableWorkoutCount = 0
+        var includedWorkoutCount = 0
+        var excludedWorkoutCount = 0
+        var unavailableDurationCount = 0
+        var unavailableZoneCount = 0
+        var durationTotal = 0.0
+        var durationValueCount = 0
+        var beatsPerMetreWeightedTotal = 0.0
+        var beatsPerMetreWeight = 0.0
+        var zoneTotals = Array(repeating: 0.0, count: 5)
+        var zoneValueCounts = Array(repeating: 0, count: 5)
+        var diagnostics = WorkoutReadDiagnosticsAccumulator()
+
+        repeat {
+            try Task.checkCancellation()
+            let page = try await fetchWorkoutHistoryPage(
+                filter: filter,
+                after: cursor,
+                limit: boundedBatchSize
+            )
+            diagnostics.merge(page.diagnostics)
+            cursor = page.nextCursor
+
+            for item in page.items {
+                queryableWorkoutCount += 1
+                guard item.quality.includedInStatistics else {
+                    excludedWorkoutCount += 1
+                    continue
+                }
+                includedWorkoutCount += 1
+                if let duration = item.durationSeconds {
+                    durationTotal += duration
+                    durationValueCount += 1
+                    if let beatsPerMetre = item.beatsPerMetre {
+                        beatsPerMetreWeightedTotal += beatsPerMetre * duration
+                        beatsPerMetreWeight += duration
+                    }
+                } else {
+                    unavailableDurationCount += 1
+                }
+
+                guard let zones = item.zoneSeconds, zones.count == 5 else {
+                    unavailableZoneCount += 1
+                    continue
+                }
+                var hasUnavailableZone = false
+                for index in 0..<5 {
+                    if let value = zones[index] {
+                        zoneTotals[index] += value
+                        zoneValueCounts[index] += 1
+                    } else {
+                        hasUnavailableZone = true
+                    }
+                }
+                if hasUnavailableZone {
+                    unavailableZoneCount += 1
+                }
+            }
+        } while cursor != nil
+
+        return WorkoutStatisticsProjection(
+            totalDurationSeconds: durationValueCount > 0 ? durationTotal : nil,
+            averageBeatsPerMetre: beatsPerMetreWeight > 0
+                ? beatsPerMetreWeightedTotal / beatsPerMetreWeight
+                : nil,
+            zoneSeconds: zip(zoneTotals, zoneValueCounts).map { total, count in
+                count > 0 ? total : nil
+            },
+            queryableWorkoutCount: queryableWorkoutCount,
+            includedWorkoutCount: includedWorkoutCount,
+            excludedWorkoutCount: excludedWorkoutCount,
+            workoutsWithUnavailableDuration: unavailableDurationCount,
+            workoutsWithUnavailableZones: unavailableZoneCount,
+            isPartial: unavailableDurationCount > 0 || unavailableZoneCount > 0,
+            diagnostics: diagnostics.snapshot
+        )
+    }
+}
+
+private extension TelemetryStore {
+    func fetchNativeProjectionCandidates(
+        scope: WorkoutReadProfileScope,
+        after cursor: WorkoutHistoryCursor?,
+        limit: Int
+    ) throws -> [TelemetryWorkoutSessionV1] {
+        guard cursor?.startedAt != nil || cursor == nil else {
+            return []
+        }
+        let descriptor: FetchDescriptor<TelemetryWorkoutSessionV1>
+        let cursorDate = cursor?.startedAt
+        let cursorSource = cursor?.stableTieBreaker.split(separator: ":", maxSplits: 1).first
+        let cursorID = cursor?.stableTieBreaker.split(separator: ":", maxSplits: 1).last
+        switch (scope, cursorDate, cursorSource, cursorID) {
+        case let (.exact(profile), .some(date), .some("native"), .some(id)):
+            let id = String(id)
+            let alternateProfile = Self.alternateUUIDSpelling(for: profile)
+            descriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    ($0.profileLocalIdentifier == profile
+                        || $0.profileLocalIdentifier == alternateProfile)
+                        && ($0.startedAt < date || ($0.startedAt == date && $0.sessionID > id))
+                },
+                sortBy: nativeSortDescriptors
+            )
+        case let (.exact(profile), .some(date), _, _):
+            let alternateProfile = Self.alternateUUIDSpelling(for: profile)
+            descriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    ($0.profileLocalIdentifier == profile
+                        || $0.profileLocalIdentifier == alternateProfile)
+                        && $0.startedAt <= date
+                },
+                sortBy: nativeSortDescriptors
+            )
+        case let (.exact(profile), nil, _, _):
+            let alternateProfile = Self.alternateUUIDSpelling(for: profile)
+            descriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    $0.profileLocalIdentifier == profile
+                        || $0.profileLocalIdentifier == alternateProfile
+                },
+                sortBy: nativeSortDescriptors
+            )
+        case (.unassigned, _, _, _):
+            return []
+        case let (.all, .some(date), .some("native"), .some(id)):
+            let id = String(id)
+            descriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    $0.startedAt < date || ($0.startedAt == date && $0.sessionID > id)
+                },
+                sortBy: nativeSortDescriptors
+            )
+        case let (.all, .some(date), _, _):
+            descriptor = FetchDescriptor(
+                predicate: #Predicate { $0.startedAt <= date },
+                sortBy: nativeSortDescriptors
+            )
+        case (.all, nil, _, _):
+            descriptor = FetchDescriptor(sortBy: nativeSortDescriptors)
+        }
+
+        var bounded = descriptor
+        bounded.fetchLimit = limit
+        return try modelContext.fetch(bounded)
+    }
+
+    func fetchImportedProjectionCandidates(
+        scope: WorkoutReadProfileScope,
+        after cursor: WorkoutHistoryCursor?,
+        limit: Int
+    ) throws -> [TelemetryLegacyImportedWorkoutV2] {
+        let descriptor: FetchDescriptor<TelemetryLegacyImportedWorkoutV2>
+        let cursorDate = cursor?.startedAt
+        let cursorSource = cursor?.stableTieBreaker.split(separator: ":", maxSplits: 1).first
+        let cursorID = cursor?.stableTieBreaker.split(separator: ":", maxSplits: 1).last
+        let nilAsNewestDate = Date.distantFuture
+
+        switch (scope, cursorDate, cursorSource, cursorID) {
+        case let (.exact(profile), .some(date), .some("imported"), .some(id)):
+            let id = String(id)
+            let alternateProfile = Self.alternateUUIDSpelling(for: profile)
+            return try fetchImportedSegments(
+                [
+                    FetchDescriptor(
+                        predicate: #Predicate {
+                            ($0.profileLocalIdentifier == profile
+                                || $0.profileLocalIdentifier == alternateProfile)
+                                && $0.startedAt == date
+                                && $0.importedWorkoutID > id
+                        },
+                        sortBy: importedSortDescriptors
+                    ),
+                    FetchDescriptor(
+                        predicate: #Predicate {
+                            ($0.profileLocalIdentifier == profile
+                                || $0.profileLocalIdentifier == alternateProfile)
+                                && $0.startedAt != nil
+                                && ($0.startedAt ?? nilAsNewestDate) < date
+                        },
+                        sortBy: importedSortDescriptors
+                    ),
+                    FetchDescriptor(
+                        predicate: #Predicate {
+                            ($0.profileLocalIdentifier == profile
+                                || $0.profileLocalIdentifier == alternateProfile)
+                                && $0.startedAt == nil
+                        },
+                        sortBy: importedSortDescriptors
+                    ),
+                ],
+                limit: limit
+            )
+        case let (.exact(profile), .some(date), _, _):
+            let alternateProfile = Self.alternateUUIDSpelling(for: profile)
+            return try fetchImportedSegments(
+                [
+                    FetchDescriptor(
+                        predicate: #Predicate {
+                            ($0.profileLocalIdentifier == profile
+                                || $0.profileLocalIdentifier == alternateProfile)
+                                && $0.startedAt != nil
+                                && ($0.startedAt ?? nilAsNewestDate) < date
+                        },
+                        sortBy: importedSortDescriptors
+                    ),
+                    FetchDescriptor(
+                        predicate: #Predicate {
+                            ($0.profileLocalIdentifier == profile
+                                || $0.profileLocalIdentifier == alternateProfile)
+                                && $0.startedAt == nil
+                        },
+                        sortBy: importedSortDescriptors
+                    ),
+                ],
+                limit: limit
+            )
+        case let (.exact(profile), nil, .some("imported"), .some(id)):
+            let id = String(id)
+            let alternateProfile = Self.alternateUUIDSpelling(for: profile)
+            descriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    ($0.profileLocalIdentifier == profile
+                        || $0.profileLocalIdentifier == alternateProfile)
+                        && $0.startedAt == nil
+                        && $0.importedWorkoutID > id
+                },
+                sortBy: importedSortDescriptors
+            )
+        case let (.exact(profile), nil, _, _):
+            let alternateProfile = Self.alternateUUIDSpelling(for: profile)
+            descriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    $0.profileLocalIdentifier == profile
+                        || $0.profileLocalIdentifier == alternateProfile
+                },
+                sortBy: importedSortDescriptors
+            )
+        case let (.unassigned, .some(date), .some("imported"), .some(id)):
+            let id = String(id)
+            var equalDateDescriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    $0.profileLocalIdentifier == nil
+                        && $0.startedAt == date
+                        && $0.importedWorkoutID > id
+                },
+                sortBy: importedSortDescriptors
+            )
+            equalDateDescriptor.fetchLimit = limit
+            var result = try modelContext.fetch(equalDateDescriptor)
+            guard result.count < limit else { return result }
+
+            var olderDatedDescriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    $0.profileLocalIdentifier == nil
+                        && $0.startedAt != nil
+                        && ($0.startedAt ?? nilAsNewestDate) < date
+                },
+                sortBy: importedSortDescriptors
+            )
+            olderDatedDescriptor.fetchLimit = limit - result.count
+            result.append(contentsOf: try modelContext.fetch(olderDatedDescriptor))
+            guard result.count < limit else { return result }
+
+            var nilDateDescriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    $0.profileLocalIdentifier == nil && $0.startedAt == nil
+                },
+                sortBy: importedSortDescriptors
+            )
+            nilDateDescriptor.fetchLimit = limit - result.count
+            result.append(contentsOf: try modelContext.fetch(nilDateDescriptor))
+            return result
+        case let (.unassigned, .some(date), _, _):
+            return try fetchImportedSegments(
+                [
+                    FetchDescriptor(
+                        predicate: #Predicate {
+                            $0.profileLocalIdentifier == nil
+                                && $0.startedAt != nil
+                                && ($0.startedAt ?? nilAsNewestDate) < date
+                        },
+                        sortBy: importedSortDescriptors
+                    ),
+                    FetchDescriptor(
+                        predicate: #Predicate {
+                            $0.profileLocalIdentifier == nil && $0.startedAt == nil
+                        },
+                        sortBy: importedSortDescriptors
+                    ),
+                ],
+                limit: limit
+            )
+        case let (.unassigned, nil, .some("imported"), .some(id)):
+            let id = String(id)
+            descriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    $0.profileLocalIdentifier == nil
+                        && $0.startedAt == nil
+                        && $0.importedWorkoutID > id
+                },
+                sortBy: importedSortDescriptors
+            )
+        case (.unassigned, nil, _, _):
+            descriptor = FetchDescriptor(
+                predicate: #Predicate { $0.profileLocalIdentifier == nil },
+                sortBy: importedSortDescriptors
+            )
+        case let (.all, .some(date), .some("imported"), .some(id)):
+            let id = String(id)
+            return try fetchImportedSegments(
+                [
+                    FetchDescriptor(
+                        predicate: #Predicate {
+                            $0.startedAt == date && $0.importedWorkoutID > id
+                        },
+                        sortBy: importedSortDescriptors
+                    ),
+                    FetchDescriptor(
+                        predicate: #Predicate {
+                            $0.startedAt != nil
+                                && ($0.startedAt ?? nilAsNewestDate) < date
+                        },
+                        sortBy: importedSortDescriptors
+                    ),
+                    FetchDescriptor(
+                        predicate: #Predicate { $0.startedAt == nil },
+                        sortBy: importedSortDescriptors
+                    ),
+                ],
+                limit: limit
+            )
+        case let (.all, .some(date), _, _):
+            return try fetchImportedSegments(
+                [
+                    FetchDescriptor(
+                        predicate: #Predicate {
+                            $0.startedAt != nil
+                                && ($0.startedAt ?? nilAsNewestDate) < date
+                        },
+                        sortBy: importedSortDescriptors
+                    ),
+                    FetchDescriptor(
+                        predicate: #Predicate { $0.startedAt == nil },
+                        sortBy: importedSortDescriptors
+                    ),
+                ],
+                limit: limit
+            )
+        case let (.all, nil, .some("imported"), .some(id)):
+            let id = String(id)
+            descriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    $0.startedAt == nil && $0.importedWorkoutID > id
+                },
+                sortBy: importedSortDescriptors
+            )
+        case (.all, nil, _, _):
+            descriptor = FetchDescriptor(sortBy: importedSortDescriptors)
+        }
+
+        var bounded = descriptor
+        bounded.fetchLimit = limit
+        return try modelContext.fetch(bounded)
+    }
+
+    func fetchImportedSegments(
+        _ descriptors: [FetchDescriptor<TelemetryLegacyImportedWorkoutV2>],
+        limit: Int
+    ) throws -> [TelemetryLegacyImportedWorkoutV2] {
+        var result: [TelemetryLegacyImportedWorkoutV2] = []
+        result.reserveCapacity(limit)
+        for descriptor in descriptors where result.count < limit {
+            var bounded = descriptor
+            bounded.fetchLimit = limit - result.count
+            result.append(contentsOf: try modelContext.fetch(bounded))
+        }
+        return result
+    }
+
+    var nativeSortDescriptors: [SortDescriptor<TelemetryWorkoutSessionV1>] {
+        [
+            SortDescriptor(\.startedAt, order: .reverse),
+            SortDescriptor(\.sessionID),
+        ]
+    }
+
+    var importedSortDescriptors: [SortDescriptor<TelemetryLegacyImportedWorkoutV2>] {
+        [
+            SortDescriptor(\.startedAt, order: .reverse),
+            SortDescriptor(\.importedWorkoutID),
+        ]
+    }
+
+    func mergeProjectionCandidates(
+        native: [TelemetryWorkoutSessionV1],
+        imported: [TelemetryLegacyImportedWorkoutV2]
+    ) -> [StoredWorkoutProjectionCandidate] {
+        var left = 0
+        var right = 0
+        var merged: [StoredWorkoutProjectionCandidate] = []
+        merged.reserveCapacity(native.count + imported.count)
+        while left < native.count || right < imported.count {
+            if left == native.count {
+                merged.append(.imported(imported[right]))
+                right += 1
+            } else if right == imported.count {
+                merged.append(.native(native[left]))
+                left += 1
+            } else {
+                let nativeCandidate = StoredWorkoutProjectionCandidate.native(native[left])
+                let importedCandidate = StoredWorkoutProjectionCandidate.imported(imported[right])
+                if projectionCursorPrecedes(nativeCandidate.cursor, importedCandidate.cursor) {
+                    merged.append(nativeCandidate)
+                    left += 1
+                } else {
+                    merged.append(importedCandidate)
+                    right += 1
+                }
+            }
+        }
+        return merged
+    }
+
+    func projectionCursorPrecedes(
+        _ lhs: WorkoutHistoryCursor,
+        _ rhs: WorkoutHistoryCursor
+    ) -> Bool {
+        switch (lhs.startedAt, rhs.startedAt) {
+        case let (.some(left), .some(right)) where left != right:
+            return left > right
+        case (.some, nil):
+            return true
+        case (nil, .some):
+            return false
+        default:
+            return lhs.stableTieBreaker < rhs.stableTieBreaker
+        }
+    }
+
+    func matchesDateFilter(_ date: Date?, filter: WorkoutReadFilter) -> Bool {
+        guard let date else {
+            return filter.startedAtOrAfter == nil && filter.startedBefore == nil
+        }
+        if let lower = filter.startedAtOrAfter, date < lower {
+            return false
+        }
+        if let upper = filter.startedBefore, date >= upper {
+            return false
+        }
+        return true
+    }
+
+    func nativeProjection(
+        _ model: TelemetryWorkoutSessionV1
+    ) throws -> WorkoutHistoryProjection {
+        let configuration: TelemetrySessionConfigurationProjection? = try model.configuration.map {
+            try Self.decode(
+                TelemetrySessionConfigurationProjection.self,
+                from: $0.canonicalPayload
+            )
+        }
+        let analysis = try latestAnalysisModel(sessionID: model.sessionID)
+        let analysisMetricsUsable = analysis.map {
+            $0.qualityGradeKey != AnalysisQualityGrade.unusable.rawValue
+        } ?? false
+        let metricAnalysis = analysisMetricsUsable ? analysis : nil
+        let detail: WorkoutAnalysisDetailV1? = try metricAnalysis.flatMap {
+            guard $0.detailSchemaVersion == Int(WorkoutAnalysisDetailV1.schemaVersion) else {
+                return nil
+            }
+            return try Self.decode(WorkoutAnalysisDetailV1.self, from: $0.detailPayload)
+        }
+        let durationSeconds = detail?.quality.sessionDurationSeconds
+            ?? model.endedElapsedMicroseconds.map { Double($0) / 1_000_000 }
+        let zoneSeconds = detail?.control.zoneDurations.isEmpty == false
+            ? (1...5).map { zone in
+                detail?.control.zoneDurations.first(where: { $0.zone == zone })?.seconds
+            }
+            : nil
+        let averageSpeed = metricAnalysis?.averageFactualSpeedKilometresPerHour.map {
+            WorkoutSpeedProjection(
+                kilometresPerHour: $0,
+                evidenceKind: .factual,
+                provenance: "telemetry-v2-analysis-factual"
+            )
+        }
+        var unavailable: [String] = []
+        if durationSeconds == nil { unavailable.append("duration") }
+        if configuration?.targetHeartRate == nil { unavailable.append("targetHeartRate") }
+        if metricAnalysis?.averageHeartRate == nil { unavailable.append("averageHeartRate") }
+        if averageSpeed == nil { unavailable.append("averageFactualSpeed") }
+        unavailable.append("beatsPerMetre")
+        if zoneSeconds == nil { unavailable.append("zoneSeconds") }
+
+        let completed = model.lifecycleStateKey == SessionLifecycleState.completed.rawValue
+        let adaptationEligible = completed
+            && analysis?.qualityGradeKey == AnalysisQualityGrade.high.rawValue
+        return WorkoutHistoryProjection(
+            id: "native:\(model.sessionID)",
+            origin: .nativeV2,
+            startedAt: model.startedAt,
+            endedAt: model.endedAt,
+            durationSeconds: durationSeconds,
+            targetHeartRate: configuration?.targetHeartRate,
+            averageHeartRate: metricAnalysis?.averageHeartRate,
+            averageSpeed: averageSpeed,
+            beatsPerMetre: nil,
+            zoneSeconds: zoneSeconds,
+            healthKitWorkoutIdentifier: model.healthKitWorkoutIdentifier.flatMap(UUID.init),
+            telemetrySchemaVersion: model.telemetrySchemaVersion,
+            appVersion: model.appVersion,
+            buildNumber: model.buildNumber,
+            algorithmVersion: model.algorithmVersion,
+            analyzerVersion: analysis?.analyzerVersion,
+            quality: WorkoutProjectionQuality(
+                lifecycleState: model.lifecycleStateKey,
+                recorderComplete: model.recorderIsComplete,
+                analysisGrade: analysis?.qualityGradeKey,
+                identityStatus: "exact",
+                possibleDuplicate: false,
+                adaptationEligible: adaptationEligible,
+                includedInStatistics: completed,
+                provenance: ["telemetry-v2-native"],
+                unavailableMetrics: unavailable,
+                warnings: model.incompleteReason.map { [$0] } ?? []
+            )
+        )
+    }
+
+    func importedProjection(
+        _ model: TelemetryLegacyImportedWorkoutV2,
+        candidates: [TelemetryLegacyWorkoutCandidateV2]
+    ) throws -> WorkoutHistoryProjection {
+        let summary = try Self.decode(
+            LegacyResolvedWorkoutSummary.self,
+            from: model.resolvedSummaryPayload
+        )
+        let candidateSummaries = try candidates.map {
+            try Self.decode(LegacyWorkoutCandidateSummary.self, from: $0.summaryPayload)
+        }
+        let healthKitIdentifiers = Set(
+            candidates.compactMap(\.healthKitWorkoutIdentifier).compactMap(UUID.init)
+        )
+        let healthKitIdentifier = healthKitIdentifiers.count == 1
+            ? healthKitIdentifiers.first
+            : nil
+        let durationSeconds = summary.durationMicroseconds.selected.map {
+            Double($0.value) / 1_000_000
+        }
+        let averageSpeed = summary.estimatedAverageSpeedKilometresPerHour.selected.map {
+            WorkoutSpeedProjection(
+                kilometresPerHour: $0.value,
+                evidenceKind: .legacyEstimated,
+                provenance: $0.provenance
+            )
+        }
+        let zoneSeconds = summary.zoneMicroseconds.selected.map { sourced in
+            sourced.value.map { value in value.map { Double($0) / 1_000_000 } }
+        }
+        let isIncomplete = candidateSummaries.contains {
+            $0.legacySessionEvidenceComplete == false || $0.malformedRecordCount > 0
+        }
+        let identityStatus = model.identityStatusKey
+        let includedInStatistics = identityStatus == LegacyIdentityStatus.exact.rawValue
+            && !model.possibleDuplicate
+        var unavailable: [String] = []
+        if durationSeconds == nil { unavailable.append("duration") }
+        if summary.targetBeatsPerMinute.selected == nil { unavailable.append("targetHeartRate") }
+        if summary.averageHeartRateBeatsPerMinute.selected == nil {
+            unavailable.append("averageHeartRate")
+        }
+        if averageSpeed == nil { unavailable.append("averageSpeed") }
+        unavailable.append("beatsPerMetre")
+        if zoneSeconds == nil { unavailable.append("zoneSeconds") }
+
+        let warnings = (
+            summary.warnings
+                + summary.conflicts.map { "conflict:\($0.field)" }
+                + candidateSummaries.flatMap(\.warnings)
+                + (healthKitIdentifiers.count > 1 ? ["conflicting-healthkit-workout-identifier"] : [])
+        )
+
+        return WorkoutHistoryProjection(
+            id: "imported:\(model.importedWorkoutID)",
+            origin: .importedLegacy,
+            startedAt: model.startedAt,
+            endedAt: model.endedAt,
+            durationSeconds: durationSeconds,
+            targetHeartRate: summary.targetBeatsPerMinute.selected?.value,
+            averageHeartRate: summary.averageHeartRateBeatsPerMinute.selected?.value,
+            averageSpeed: averageSpeed,
+            beatsPerMetre: nil,
+            zoneSeconds: zoneSeconds,
+            healthKitWorkoutIdentifier: healthKitIdentifier,
+            telemetrySchemaVersion: nil,
+            appVersion: nil,
+            buildNumber: nil,
+            algorithmVersion: nil,
+            analyzerVersion: nil,
+            quality: WorkoutProjectionQuality(
+                lifecycleState: isIncomplete ? "imported-incomplete" : "imported",
+                recorderComplete: isIncomplete ? false : nil,
+                analysisGrade: nil,
+                identityStatus: identityStatus,
+                possibleDuplicate: model.possibleDuplicate,
+                adaptationEligible: model.adaptationQualityEligible,
+                includedInStatistics: includedInStatistics,
+                provenance: ["telemetry-v2-imported-legacy"],
+                unavailableMetrics: unavailable,
+                warnings: warnings
+            )
+        )
+    }
+
+    func latestAnalysisModel(
+        sessionID: String
+    ) throws -> TelemetryWorkoutAnalysisV1? {
+        var descriptor = FetchDescriptor<TelemetryWorkoutAnalysisV1>(
+            predicate: #Predicate { $0.sessionID == sessionID },
+            sortBy: [
+                SortDescriptor(\.generatedAt, order: .reverse),
+                SortDescriptor(\.analysisID),
+            ]
+        )
+        descriptor.fetchLimit = 1
+        return try modelContext.fetch(descriptor).first
+    }
+
+    func importedCandidateModels(
+        _ model: TelemetryLegacyImportedWorkoutV2
+    ) throws -> [TelemetryLegacyWorkoutCandidateV2] {
+        var candidates: [TelemetryLegacyWorkoutCandidateV2] = []
+        for candidateID in try modelCandidateIDs(model) {
+            var descriptor = FetchDescriptor<TelemetryLegacyWorkoutCandidateV2>(
+                predicate: #Predicate { $0.candidateID == candidateID }
+            )
+            descriptor.fetchLimit = 1
+            guard let candidate = try modelContext.fetch(descriptor).first else {
+                throw TelemetryWorkoutReadError.corruptProjection(
+                    "missing imported candidate \(candidateID)"
+                )
+            }
+            candidates.append(candidate)
+        }
+        return candidates.sorted { $0.candidateID < $1.candidateID }
+    }
+
+    func modelCandidateIDs(
+        _ model: TelemetryLegacyImportedWorkoutV2
+    ) throws -> [String] {
+        do {
+            return try Self.decode([String].self, from: model.candidateIDsPayload)
+        } catch {
+            throw TelemetryWorkoutReadError.corruptProjection(
+                "invalid imported candidate linkage for \(model.importedWorkoutID)"
+            )
+        }
+    }
+
+    func hasExactNativeSession(
+        for candidates: [TelemetryLegacyWorkoutCandidateV2],
+        profileScope: WorkoutReadProfileScope
+    ) throws -> Bool {
+        guard case let .exact(profile) = profileScope else {
+            return false
+        }
+        let alternateProfile = Self.alternateUUIDSpelling(for: profile)
+        for candidate in candidates where candidate.profileLocalIdentifier == profile
+            || candidate.profileLocalIdentifier == alternateProfile {
+            if let stableSessionID = candidate.stableLegacySessionIdentifier {
+                var descriptor = FetchDescriptor<TelemetryWorkoutSessionV1>(
+                    predicate: #Predicate {
+                        ($0.profileLocalIdentifier == profile
+                            || $0.profileLocalIdentifier == alternateProfile)
+                            && $0.sessionID == stableSessionID
+                    }
+                )
+                descriptor.fetchLimit = 1
+                if try !modelContext.fetch(descriptor).isEmpty {
+                    return true
+                }
+            }
+            if let healthKitID = candidate.healthKitWorkoutIdentifier {
+                var descriptor = FetchDescriptor<TelemetryWorkoutSessionV1>(
+                    predicate: #Predicate {
+                        ($0.profileLocalIdentifier == profile
+                            || $0.profileLocalIdentifier == alternateProfile)
+                            && $0.healthKitWorkoutIdentifier == healthKitID
+                    }
+                )
+                descriptor.fetchLimit = 1
+                if try !modelContext.fetch(descriptor).isEmpty {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    static func alternateUUIDSpelling(for value: String) -> String {
+        guard let uuid = UUID(uuidString: value) else { return value }
+        let canonical = uuid.uuidString
+        return value == canonical ? canonical.lowercased() : canonical
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutReadStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutReadStore.swift
@@ -56,6 +56,22 @@ private struct WorkoutReadDiagnosticsAccumulator {
     }
 }
 
+private struct ExactImportedHealthKitEvidence {
+    let identifier: UUID?
+    let hasLinkageEvidence: Bool
+    let warnings: [String]
+    let storeFetchCount: Int
+    let maximumStoreFetchLimit: Int
+
+    static let none = ExactImportedHealthKitEvidence(
+        identifier: nil,
+        hasLinkageEvidence: false,
+        warnings: [],
+        storeFetchCount: 0,
+        maximumStoreFetchLimit: 0
+    )
+}
+
 public extension TelemetryStore {
     func fetchWorkoutHistoryPage(
         filter: WorkoutReadFilter,
@@ -123,7 +139,19 @@ public extension TelemetryStore {
 
                 switch candidate {
                 case let .native(model):
-                    projections.append(try nativeProjection(model))
+                    let healthKitEvidence = try exactImportedHealthKitEvidence(
+                        for: model,
+                        profileScope: filter.profileScope
+                    )
+                    for _ in 0..<healthKitEvidence.storeFetchCount {
+                        diagnostics.recordFetch(limit: healthKitEvidence.maximumStoreFetchLimit)
+                    }
+                    projections.append(
+                        try nativeProjection(
+                            model,
+                            exactImportedHealthKitEvidence: healthKitEvidence
+                        )
+                    )
                 case let .imported(model):
                     let candidateModels = try importedCandidateModels(model)
                     diagnostics.recordFetch(limit: max(1, try modelCandidateIDs(model).count))
@@ -174,6 +202,7 @@ public extension TelemetryStore {
         var queryableWorkoutCount = 0
         var includedWorkoutCount = 0
         var excludedWorkoutCount = 0
+        var exclusionReasonCounts: [WorkoutStatisticsExclusionReason: Int] = [:]
         var unavailableDurationCount = 0
         var unavailableZoneCount = 0
         var durationTotal = 0.0
@@ -198,6 +227,7 @@ public extension TelemetryStore {
                 queryableWorkoutCount += 1
                 guard item.quality.includedInStatistics else {
                     excludedWorkoutCount += 1
+                    exclusionReasonCounts[statisticsExclusionReason(for: item), default: 0] += 1
                     continue
                 }
                 includedWorkoutCount += 1
@@ -242,9 +272,12 @@ public extension TelemetryStore {
             queryableWorkoutCount: queryableWorkoutCount,
             includedWorkoutCount: includedWorkoutCount,
             excludedWorkoutCount: excludedWorkoutCount,
+            exclusionReasonCounts: exclusionReasonCounts,
             workoutsWithUnavailableDuration: unavailableDurationCount,
             workoutsWithUnavailableZones: unavailableZoneCount,
-            isPartial: unavailableDurationCount > 0 || unavailableZoneCount > 0,
+            isPartial: excludedWorkoutCount > 0
+                || unavailableDurationCount > 0
+                || unavailableZoneCount > 0,
             diagnostics: diagnostics.snapshot
         )
     }
@@ -625,7 +658,8 @@ private extension TelemetryStore {
     }
 
     func nativeProjection(
-        _ model: TelemetryWorkoutSessionV1
+        _ model: TelemetryWorkoutSessionV1,
+        exactImportedHealthKitEvidence: ExactImportedHealthKitEvidence
     ) throws -> WorkoutHistoryProjection {
         let configuration: TelemetrySessionConfigurationProjection? = try model.configuration.map {
             try Self.decode(
@@ -669,6 +703,12 @@ private extension TelemetryStore {
         let completed = model.lifecycleStateKey == SessionLifecycleState.completed.rawValue
         let adaptationEligible = completed
             && analysis?.qualityGradeKey == AnalysisQualityGrade.high.rawValue
+        let nativeHealthKitIdentifier = model.healthKitWorkoutIdentifier.flatMap(UUID.init)
+        let resolvedHealthKitIdentifier = nativeHealthKitIdentifier
+            ?? exactImportedHealthKitEvidence.identifier
+        let linkageProvenance = exactImportedHealthKitEvidence.hasLinkageEvidence
+            ? ["telemetry-v2-imported-exact-healthkit-linkage"]
+            : []
         return WorkoutHistoryProjection(
             id: "native:\(model.sessionID)",
             origin: .nativeV2,
@@ -680,7 +720,7 @@ private extension TelemetryStore {
             averageSpeed: averageSpeed,
             beatsPerMetre: nil,
             zoneSeconds: zoneSeconds,
-            healthKitWorkoutIdentifier: model.healthKitWorkoutIdentifier.flatMap(UUID.init),
+            healthKitWorkoutIdentifier: resolvedHealthKitIdentifier,
             telemetrySchemaVersion: model.telemetrySchemaVersion,
             appVersion: model.appVersion,
             buildNumber: model.buildNumber,
@@ -694,11 +734,118 @@ private extension TelemetryStore {
                 possibleDuplicate: false,
                 adaptationEligible: adaptationEligible,
                 includedInStatistics: completed,
-                provenance: ["telemetry-v2-native"],
+                provenance: ["telemetry-v2-native"] + linkageProvenance,
                 unavailableMetrics: unavailable,
-                warnings: model.incompleteReason.map { [$0] } ?? []
+                warnings: (model.incompleteReason.map { [$0] } ?? [])
+                    + exactImportedHealthKitEvidence.warnings
             )
         )
+    }
+
+    func exactImportedHealthKitEvidence(
+        for model: TelemetryWorkoutSessionV1,
+        profileScope: WorkoutReadProfileScope
+    ) throws -> ExactImportedHealthKitEvidence {
+        guard model.healthKitWorkoutIdentifier == nil,
+              case let .exact(profile) = profileScope else {
+            return .none
+        }
+        let alternateProfile = Self.alternateUUIDSpelling(for: profile)
+        guard model.profileLocalIdentifier == profile
+                || model.profileLocalIdentifier == alternateProfile else {
+            return .none
+        }
+
+        let candidateBatchSize = 64
+        let stableSessionID = model.sessionID
+        var candidates: [TelemetryLegacyWorkoutCandidateV2] = []
+        var storeFetchCount = 0
+        for origin in [
+            LegacyWorkoutCandidateOrigin.jsonl.rawValue,
+            LegacyWorkoutCandidateOrigin.workoutHistory.rawValue,
+        ] {
+            var candidateCursor: String?
+            repeat {
+                let descriptor: FetchDescriptor<TelemetryLegacyWorkoutCandidateV2>
+                if let cursor = candidateCursor {
+                    descriptor = FetchDescriptor(
+                        predicate: #Predicate {
+                            $0.originKindKey == origin
+                                && ($0.profileLocalIdentifier == profile
+                                    || $0.profileLocalIdentifier == alternateProfile)
+                                && $0.stableLegacySessionIdentifier == stableSessionID
+                                && $0.candidateID > cursor
+                        },
+                        sortBy: [SortDescriptor(\.candidateID)]
+                    )
+                } else {
+                    descriptor = FetchDescriptor(
+                        predicate: #Predicate {
+                            $0.originKindKey == origin
+                                && ($0.profileLocalIdentifier == profile
+                                    || $0.profileLocalIdentifier == alternateProfile)
+                                && $0.stableLegacySessionIdentifier == stableSessionID
+                        },
+                        sortBy: [SortDescriptor(\.candidateID)]
+                    )
+                }
+                var bounded = descriptor
+                bounded.fetchLimit = candidateBatchSize + 1
+                let page = try modelContext.fetch(bounded)
+                storeFetchCount += 1
+                candidates.append(contentsOf: page.prefix(candidateBatchSize))
+                guard candidates.count <= 256 else {
+                    throw TelemetryWorkoutReadError.corruptProjection(
+                        "too many exact imported linkage candidates for \(stableSessionID)"
+                    )
+                }
+                candidateCursor = page.count > candidateBatchSize
+                    ? page[candidateBatchSize - 1].candidateID
+                    : nil
+            } while candidateCursor != nil
+        }
+
+        let rawIdentifiers = candidates
+            .filter { !$0.identityUncertain }
+            .compactMap(\.healthKitWorkoutIdentifier)
+        guard !rawIdentifiers.isEmpty else {
+            return ExactImportedHealthKitEvidence(
+                identifier: nil,
+                hasLinkageEvidence: false,
+                warnings: [],
+                storeFetchCount: storeFetchCount,
+                maximumStoreFetchLimit: candidateBatchSize + 1
+            )
+        }
+        let parsedIdentifiers = rawIdentifiers.compactMap(UUID.init)
+        let identifiers = Set(parsedIdentifiers)
+        var warnings: [String] = []
+        if identifiers.count > 1 {
+            warnings.append("conflicting-healthkit-workout-identifier")
+        }
+        if parsedIdentifiers.count != rawIdentifiers.count {
+            warnings.append("invalid-healthkit-workout-identifier")
+        }
+        return ExactImportedHealthKitEvidence(
+            identifier: identifiers.count == 1 ? identifiers.first : nil,
+            hasLinkageEvidence: true,
+            warnings: warnings,
+            storeFetchCount: storeFetchCount,
+            maximumStoreFetchLimit: candidateBatchSize + 1
+        )
+    }
+
+    func statisticsExclusionReason(
+        for item: WorkoutHistoryProjection
+    ) -> WorkoutStatisticsExclusionReason {
+        if let identityStatus = item.quality.identityStatus,
+           identityStatus != LegacyIdentityStatus.exact.rawValue {
+            return .identity
+        }
+        if item.quality.possibleDuplicate {
+            return .possibleDuplicate
+        }
+        return .lifecycleOrQuality
     }
 
     func importedProjection(

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
@@ -371,6 +371,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         @Sendable () throws -> LegacyTelemetryMigrationRequest
     public typealias StatusHandler = @Sendable (TelemetryV2RuntimeStatus) -> Void
     public typealias WriterHealthHandler = @Sendable (TelemetryV2WriterHealthSnapshot) -> Void
+    public typealias ProjectionChangeHandler = @Sendable () -> Void
 
     fileprivate struct PendingHeartRateControlDecision: Sendable {
         let decisionID: DecisionID
@@ -506,6 +507,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
     private let persistenceFactory: PersistenceFactory
     private let statusHandler: StatusHandler?
     private let writerHealthHandler: WriterHealthHandler?
+    private let projectionChangeHandler: ProjectionChangeHandler?
     private let runtimeClock: any TelemetryV2RuntimeClock
     private let installationDidPublishForTesting: (@Sendable (SessionID) -> Void)?
     private var persistence: (any TelemetryRecorderPersistence)?
@@ -524,13 +526,15 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         persistenceFactory: @escaping PersistenceFactory,
         runtimeClock: any TelemetryV2RuntimeClock = ContinuousTelemetryV2RuntimeClock(),
         statusHandler: StatusHandler? = nil,
-        writerHealthHandler: WriterHealthHandler? = nil
+        writerHealthHandler: WriterHealthHandler? = nil,
+        projectionChangeHandler: ProjectionChangeHandler? = nil
     ) {
         self.init(
             persistenceFactory: persistenceFactory,
             runtimeClock: runtimeClock,
             statusHandler: statusHandler,
             writerHealthHandler: writerHealthHandler,
+            projectionChangeHandler: projectionChangeHandler,
             installationDidPublishForTesting: nil
         )
     }
@@ -540,12 +544,14 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         runtimeClock: any TelemetryV2RuntimeClock = ContinuousTelemetryV2RuntimeClock(),
         statusHandler: StatusHandler? = nil,
         writerHealthHandler: WriterHealthHandler? = nil,
+        projectionChangeHandler: ProjectionChangeHandler? = nil,
         installationDidPublishForTesting: @escaping @Sendable (SessionID) -> Void
     ) {
         self.persistenceFactory = persistenceFactory
         self.runtimeClock = runtimeClock
         self.statusHandler = statusHandler
         self.writerHealthHandler = writerHealthHandler
+        self.projectionChangeHandler = projectionChangeHandler
         self.installationDidPublishForTesting = installationDidPublishForTesting
     }
 
@@ -554,12 +560,14 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         runtimeClock: any TelemetryV2RuntimeClock,
         statusHandler: StatusHandler?,
         writerHealthHandler: WriterHealthHandler?,
+        projectionChangeHandler: ProjectionChangeHandler?,
         installationDidPublishForTesting: (@Sendable (SessionID) -> Void)?
     ) {
         self.persistenceFactory = persistenceFactory
         self.runtimeClock = runtimeClock
         self.statusHandler = statusHandler
         self.writerHealthHandler = writerHealthHandler
+        self.projectionChangeHandler = projectionChangeHandler
         self.installationDidPublishForTesting = installationDidPublishForTesting
     }
 
@@ -569,6 +577,79 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
 
     public var writerHealthSnapshot: TelemetryV2WriterHealthSnapshot {
         withLock { storedWriterHealthSnapshot }
+    }
+
+    public func fetchWorkoutHistoryPage(
+        filter: WorkoutReadFilter,
+        after cursor: WorkoutHistoryCursor?,
+        limit: Int
+    ) async throws -> WorkoutHistoryPage {
+        let reader = try await requireWorkoutReadCapability()
+        return try await reader.fetchWorkoutHistoryPage(
+            filter: filter,
+            after: cursor,
+            limit: limit
+        )
+    }
+
+    public func fetchWorkoutStatistics(
+        filter: WorkoutReadFilter,
+        batchSize: Int = 100
+    ) async throws -> WorkoutStatisticsProjection {
+        let reader = try await requireWorkoutReadCapability()
+        return try await reader.fetchWorkoutStatistics(
+            filter: filter,
+            batchSize: batchSize
+        )
+    }
+
+    public func exportWorkouts(
+        _ request: WorkoutExportRequest
+    ) async throws -> WorkoutExportArtifact {
+        let reader = try await requireWorkoutReadCapability()
+        return try await reader.exportWorkouts(request)
+    }
+
+    public func associateHealthKitWorkout(
+        sessionID: SessionID,
+        workoutIdentifier: UUID
+    ) async throws {
+        let linkage = try await requireHealthKitWorkoutLinkageCapability()
+        try await linkage.associateHealthKitWorkout(
+            sessionID: sessionID,
+            workoutIdentifier: workoutIdentifier
+        )
+        projectionChangeHandler?()
+    }
+
+    private func requireWorkoutReadCapability() async throws
+        -> any TelemetryWorkoutReadCapability
+    {
+        prepareStoreAndRecover()
+        for _ in 0..<250 {
+            try Task.checkCancellation()
+            if let reader = workoutReadCapability() { return reader }
+            if case let .unavailable(reason) = status {
+                throw TelemetryWorkoutReadError.unavailable(reason)
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        throw TelemetryWorkoutReadError.unavailable("telemetry-v2-store-prepare-timeout")
+    }
+
+    private func requireHealthKitWorkoutLinkageCapability() async throws
+        -> any TelemetryHealthKitWorkoutLinkageCapability
+    {
+        prepareStoreAndRecover()
+        for _ in 0..<250 {
+            try Task.checkCancellation()
+            if let linkage = healthKitWorkoutLinkageCapability() { return linkage }
+            if case let .unavailable(reason) = status {
+                throw TelemetryWorkoutReadError.unavailable(reason)
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        throw TelemetryWorkoutReadError.unavailable("telemetry-v2-store-prepare-timeout")
     }
 
     public func prepareStoreAndRecover() {
@@ -589,6 +670,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
                 if let analyzer = persistence as? any TelemetryPostWorkoutAnalysisCapability {
                     _ = await analyzer.resumePendingWorkoutAnalyses()
                 }
+                self?.projectionChangeHandler?()
             } catch {
                 self?.storePreparationFailed(error)
             }
@@ -667,6 +749,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
             if let analyzer = self?.postWorkoutAnalysisCapability() {
                 _ = await analyzer.analyzeTerminalWorkout(sessionID: session.sessionID)
             }
+            self?.projectionChangeHandler?()
         }
     }
 
@@ -816,6 +899,7 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         Task.detached(priority: .utility) {
             guard let request = try? work.1() else { return }
             _ = await work.0.migrateLegacyTelemetry(request)
+            self.projectionChangeHandler?()
         }
     }
 
@@ -928,6 +1012,16 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
             guard activeSession?.generation == generation else { return nil }
             return activeSession?.session
         }
+    }
+
+    private func workoutReadCapability() -> (any TelemetryWorkoutReadCapability)? {
+        withLock { persistence as? any TelemetryWorkoutReadCapability }
+    }
+
+    private func healthKitWorkoutLinkageCapability()
+        -> (any TelemetryHealthKitWorkoutLinkageCapability)?
+    {
+        withLock { persistence as? any TelemetryHealthKitWorkoutLinkageCapability }
     }
 
     private func postWorkoutAnalysisCapability()

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryWorkoutReadAndExportTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryWorkoutReadAndExportTests.swift
@@ -1,0 +1,602 @@
+import Foundation
+import TelemetryAnalysis
+import TelemetryDomain
+@testable import TelemetryPersistence
+import XCTest
+
+final class TelemetryWorkoutReadAndExportTests: XCTestCase {
+    func testFailedLegacyShadowSourceDoesNotBlockOrCorruptNativeV2Read() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let native = session(
+            index: 99,
+            profile: "profile-a",
+            startedAt: Date(timeIntervalSince1970: 1_900_000_999)
+        )
+        try await store.insertSession(native)
+
+        let report = await LegacyTelemetryMigrator(store: store).run(
+            LegacyTelemetryMigrationRequest(
+                jsonlSources: [],
+                workoutHistorySources: [
+                    LegacyWorkoutHistorySourceDescriptor(
+                        storageKey: "workout_history_v1_profile_profile-a",
+                        representation: Data("not-json".utf8),
+                        exactProfileLocalIdentifier: "profile-a"
+                    ),
+                ],
+                knownProfileLocalIdentifiers: ["profile-a"]
+            )
+        )
+        XCTAssertEqual(report.completion, .failed)
+
+        let page = try await store.fetchWorkoutHistoryPage(
+            filter: WorkoutReadFilter(profileScope: .exact("profile-a")),
+            after: nil,
+            limit: 50
+        )
+        XCTAssertEqual(page.items.map(\.id), ["native:\(native.sessionID.description)"])
+        XCTAssertEqual(page.items.first?.origin, .nativeV2)
+    }
+
+    func testProfileScopedKeysetPaginationIsStableForEqualTimestampsAndNewerInsert() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let sharedDate = Date(timeIntervalSince1970: 1_900_000_000)
+        let sessions = [
+            session(index: 2, profile: "profile-a", startedAt: sharedDate),
+            session(index: 1, profile: "profile-a", startedAt: sharedDate),
+            session(index: 3, profile: "profile-a", startedAt: sharedDate.addingTimeInterval(-60)),
+            session(index: 4, profile: "profile-b", startedAt: sharedDate.addingTimeInterval(120)),
+        ]
+        for session in sessions {
+            try await store.insertSession(session)
+        }
+
+        let filter = WorkoutReadFilter(profileScope: .exact("profile-a"))
+        let first = try await store.fetchWorkoutHistoryPage(
+            filter: filter,
+            after: nil,
+            limit: 1
+        )
+        XCTAssertEqual(first.items.count, 1)
+        XCTAssertNotNil(first.nextCursor)
+
+        let newer = session(
+            index: 5,
+            profile: "profile-a",
+            startedAt: sharedDate.addingTimeInterval(300)
+        )
+        try await store.insertSession(newer)
+
+        var observed = first.items
+        var cursor = first.nextCursor
+        while let current = cursor {
+            let page = try await store.fetchWorkoutHistoryPage(
+                filter: filter,
+                after: current,
+                limit: 1
+            )
+            observed.append(contentsOf: page.items)
+            cursor = page.nextCursor
+        }
+
+        XCTAssertEqual(observed.count, 3)
+        XCTAssertEqual(Set(observed.map(\.id)).count, 3)
+        XCTAssertFalse(observed.contains { $0.id == "native:\(newer.sessionID.description)" })
+        XCTAssertTrue(observed.allSatisfy { $0.id != "native:\(sessions[3].sessionID.description)" })
+        XCTAssertEqual(
+            Array(observed.prefix(2).map(\.id)),
+            [sessions[1], sessions[0]].map { "native:\($0.sessionID.description)" }
+        )
+    }
+
+    func testExactUUIDProfileScopeIncludesHistoricalCaseSpellingsOnly() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let profile = "A1000000-0000-0000-0000-000000000001"
+        try await store.insertSession(
+            session(index: 40, profile: profile, startedAt: Date(timeIntervalSince1970: 40))
+        )
+        try await store.insertSession(
+            session(
+                index: 41,
+                profile: profile.lowercased(),
+                startedAt: Date(timeIntervalSince1970: 41)
+            )
+        )
+        try await store.insertSession(
+            session(
+                index: 42,
+                profile: "B2000000-0000-0000-0000-000000000002",
+                startedAt: Date(timeIntervalSince1970: 42)
+            )
+        )
+
+        let page = try await store.fetchWorkoutHistoryPage(
+            filter: WorkoutReadFilter(profileScope: .exact(profile)),
+            after: nil,
+            limit: 50
+        )
+        XCTAssertEqual(page.items.count, 2)
+        XCTAssertEqual(Set(page.items.map(\.id)).count, 2)
+    }
+
+
+    func testThousandsOfSessionsUseBoundedFetchesWithoutTimeSeriesHydration() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let configuration = self.configuration(targetHeartRate: 135)
+        let total = 1_200
+        for batchStart in stride(from: 0, to: total, by: 100) {
+            let upper = min(total, batchStart + 100)
+            let records: [TelemetryGateRecord] = (batchStart..<upper).map { index in
+                .session(
+                    session(
+                        index: 10_000 + index,
+                        profile: "scale-profile",
+                        startedAt: Date(timeIntervalSince1970: 1_900_000_000 + Double(index)),
+                        configuration: configuration
+                    )
+                )
+            }
+            try await store.insertGateBatch(records)
+        }
+
+        let filter = WorkoutReadFilter(profileScope: .exact("scale-profile"))
+        var cursor: WorkoutHistoryCursor?
+        var count = 0
+        repeat {
+            let page = try await store.fetchWorkoutHistoryPage(
+                filter: filter,
+                after: cursor,
+                limit: 37
+            )
+            XCTAssertLessThanOrEqual(page.diagnostics.maximumStoreFetchLimit, 75)
+            XCTAssertEqual(page.diagnostics.hydratedTimeSeriesRecordCount, 0)
+            count += page.items.count
+            cursor = page.nextCursor
+        } while cursor != nil
+
+        XCTAssertEqual(count, total)
+    }
+
+    func testStatisticsDateRangeStopsAtLowerBoundWithoutScanningWholeHistory() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let base = Date(timeIntervalSince1970: 1_900_000_000)
+        for batchStart in stride(from: 0, to: 1_000, by: 100) {
+            let records: [TelemetryGateRecord] = (batchStart..<(batchStart + 100)).map { index in
+                .session(
+                    session(
+                        index: 20_000 + index,
+                        profile: "range-profile",
+                        startedAt: base.addingTimeInterval(Double(index))
+                    )
+                )
+            }
+            try await store.insertGateBatch(records)
+        }
+
+        let statistics = try await store.fetchWorkoutStatistics(
+            filter: WorkoutReadFilter(
+                profileScope: .exact("range-profile"),
+                startedAtOrAfter: base.addingTimeInterval(990),
+                startedBefore: base.addingTimeInterval(1_000)
+            ),
+            batchSize: 50
+        )
+        XCTAssertEqual(statistics.queryableWorkoutCount, 10)
+        XCTAssertLessThanOrEqual(statistics.diagnostics.storeFetchCount, 4)
+        XCTAssertEqual(statistics.diagnostics.hydratedTimeSeriesRecordCount, 0)
+    }
+
+    func testImportedIncompleteIdentityUncertainAndUnavailableMetricsRemainQueryable() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let now = Date(timeIntervalSince1970: 1_900_100_000)
+        let definition = LegacyMigrationSourceDefinition(
+            sourceID: "source-imported-uncertain",
+            kind: .jsonl,
+            contentHashDigest: String(repeating: "a", count: 64),
+            locator: "immutable-source.jsonl",
+            exactProfileLocalIdentifier: "profile-a"
+        )
+        _ = try await store.beginLegacyMigrationSource(
+            definition,
+            importerVersion: LegacyTelemetryMigrator.importerVersion,
+            emptyAggregateStatePayload: Data("{}".utf8),
+            now: now
+        )
+        let candidate = LegacyWorkoutCandidateDraft(
+            candidateID: "candidate-uncertain",
+            sourceItemIdentityKey: "source-item-uncertain",
+            sourceID: definition.sourceID,
+            origin: .jsonl,
+            profileLocalIdentifier: "profile-a",
+            workoutIdentifier: nil,
+            healthKitWorkoutIdentifier: nil,
+            stableLegacySessionIdentifier: nil,
+            startedAt: now,
+            endedAt: nil,
+            identityUncertain: true,
+            possibleDuplicate: true,
+            summary: importedSummary(
+                malformedRecordCount: 1,
+                complete: false,
+                warnings: ["truncated-tail", "missing-factual-speed"]
+            )
+        )
+        _ = try await store.commitLegacyMigrationBatch(
+            sourceID: definition.sourceID,
+            records: [],
+            candidates: [candidate],
+            checkpointByteOffset: 100,
+            checkpointRecordIndex: 1,
+            parsedRecordCount: 1,
+            malformedRecordCount: 1,
+            warningCount: 2,
+            aggregateStatePayload: Data("{}".utf8),
+            completing: true,
+            now: now
+        )
+        let reconciledCount = try await store.reconcileLegacyWorkoutCandidates()
+        XCTAssertEqual(reconciledCount, 1)
+
+        let page = try await store.fetchWorkoutHistoryPage(
+            filter: WorkoutReadFilter(profileScope: .exact("profile-a")),
+            after: nil,
+            limit: 10
+        )
+        let item = try XCTUnwrap(page.items.first)
+        XCTAssertEqual(item.origin, .importedLegacy)
+        XCTAssertNil(item.durationSeconds)
+        XCTAssertNil(item.averageHeartRate)
+        XCTAssertNil(item.averageSpeed)
+        XCTAssertEqual(item.quality.identityStatus, LegacyIdentityStatus.uncertain.rawValue)
+        XCTAssertEqual(item.quality.lifecycleState, "imported-incomplete")
+        XCTAssertTrue(item.quality.possibleDuplicate)
+        XCTAssertFalse(item.quality.adaptationEligible)
+        XCTAssertFalse(item.quality.includedInStatistics)
+        XCTAssertTrue(item.quality.unavailableMetrics.contains("averageFactualSpeed") == false)
+        XCTAssertTrue(item.quality.unavailableMetrics.contains("averageSpeed"))
+        XCTAssertTrue(item.quality.warnings.contains("truncated-tail"))
+    }
+
+    func testUnusableNativeAnalysisDoesNotUpgradeMetricsOrAdaptationEligibility() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let storedSession = session(
+            index: 70,
+            profile: "profile-low-quality",
+            startedAt: Date(timeIntervalSince1970: 1_900_100_070)
+        )
+        try await store.insertSession(storedSession)
+        try await store.insertAnalysis(
+            WorkoutAnalysisResult(
+                analysisID: AnalysisID(rawValue: uuid(810_001)),
+                recordID: RecordID(rawValue: uuid(810_002)),
+                sessionID: storedSession.sessionID,
+                analyzerVersion: AnalyzerVersion(rawValue: "low-quality-fixture"),
+                evidenceHash: ContentHash(
+                    algorithm: .sha256,
+                    lowercaseHexDigest: String(repeating: "d", count: 64)
+                ),
+                generatedAt: Date(timeIntervalSince1970: 1_900_100_071),
+                qualityGrade: .unusable,
+                exclusions: [],
+                keyMetrics: AnalysisKeyMetrics(
+                    coveredDuration: ElapsedDuration(microseconds: 10_000_000),
+                    averageHeartRate: 199,
+                    maximumHeartRate: 220,
+                    averageFactualSpeedKilometresPerHour: 19
+                ),
+                detailSchemaVersion: WorkoutAnalysisDetailV1.schemaVersion,
+                versionedDetailPayload: Data("unusable-detail".utf8)
+            )
+        )
+
+        let page = try await store.fetchWorkoutHistoryPage(
+            filter: WorkoutReadFilter(profileScope: .exact("profile-low-quality")),
+            after: nil,
+            limit: 10
+        )
+        let item = try XCTUnwrap(page.items.first)
+        XCTAssertEqual(item.quality.analysisGrade, AnalysisQualityGrade.unusable.rawValue)
+        XCTAssertNil(item.averageHeartRate)
+        XCTAssertNil(item.averageSpeed)
+        XCTAssertNil(item.zoneSeconds)
+        XCTAssertFalse(item.quality.adaptationEligible)
+        XCTAssertTrue(item.quality.includedInStatistics)
+    }
+
+    func testExportStreamsBatchesOmitsUnnecessaryIdentifiersAndManifestRoundTrips() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = session(
+            index: 50,
+            profile: "private-profile-id",
+            startedAt: Date(timeIntervalSince1970: 1_900_200_000)
+        )
+        let source = TelemetryPersistenceFixtures.source(seed: 31, kind: .healthKitSelected)
+        try await store.insertSession(session)
+        try await store.insertSource(
+            source,
+            firstSeen: session.startedAt,
+            lastSeen: session.startedAt.addingTimeInterval(120)
+        )
+        for index in 0..<101 {
+            try await store.insertHeartRate(
+                TelemetryPersistenceFixtures.heartRate(
+                    seed: UInt8(index + 1),
+                    session: session,
+                    source: source,
+                    arrivalOrder: UInt64(index),
+                    bpm: UInt16(110 + (index % 20))
+                )
+            )
+        }
+        let healthKitID = UUID()
+        try await store.associateHealthKitWorkout(
+            sessionID: session.sessionID,
+            workoutIdentifier: healthKitID
+        )
+
+        let artifact = try await store.exportWorkouts(
+            WorkoutExportRequest(
+                filter: WorkoutReadFilter(profileScope: .exact("private-profile-id")),
+                selection: .all,
+                batchSize: 17
+            )
+        )
+        defer { try? FileManager.default.removeItem(at: artifact.directoryURL) }
+
+        XCTAssertEqual(artifact.exportedWorkoutCount, 1)
+        XCTAssertEqual(artifact.exportedRecordCount, 102)
+        XCTAssertTrue(artifact.containsHealthData)
+        XCTAssertEqual(Set(artifact.fileURLs.map(\.lastPathComponent)), Set([
+            "raw_evidence_v1.jsonl",
+            "normalized_evidence_v1.csv",
+            "session_summary_v1.jsonl",
+            "session_summary_v1.csv",
+            "manifest.json",
+        ]))
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let manifest = try decoder.decode(
+            WorkoutExportManifest.self,
+            from: Data(contentsOf: artifact.directoryURL.appendingPathComponent("manifest.json"))
+        )
+        XCTAssertEqual(manifest.manifestVersion, WorkoutExportManifest.formatVersion)
+        XCTAssertEqual(manifest.exportedRecordCount, 102)
+        XCTAssertEqual(manifest.batchSize, 17)
+        XCTAssertTrue(manifest.containsHealthData)
+        XCTAssertTrue(manifest.omittedIdentifierKinds.contains("profile-id"))
+
+        let raw = try String(
+            contentsOf: artifact.directoryURL.appendingPathComponent("raw_evidence_v1.jsonl"),
+            encoding: .utf8
+        )
+        XCTAssertEqual(raw.split(separator: "\n").count, 102)
+        XCTAssertFalse(raw.contains("private-profile-id"))
+        XCTAssertFalse(raw.contains("source-31"))
+        XCTAssertFalse(raw.contains("test.source.31"))
+        XCTAssertTrue(raw.contains("\"targetHeartRate\":135"))
+        XCTAssertTrue(raw.contains(healthKitID.uuidString.lowercased()))
+    }
+
+    func testHealthKitWorkoutCannotBeAssociatedWithTwoV2Sessions() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let first = session(
+            index: 60,
+            profile: "profile-healthkit",
+            startedAt: Date(timeIntervalSince1970: 1_900_250_000)
+        )
+        let second = session(
+            index: 61,
+            profile: "profile-healthkit",
+            startedAt: Date(timeIntervalSince1970: 1_900_251_000)
+        )
+        try await store.insertSession(first)
+        try await store.insertSession(second)
+        let workoutIdentifier = UUID()
+        try await store.associateHealthKitWorkout(
+            sessionID: first.sessionID,
+            workoutIdentifier: workoutIdentifier
+        )
+
+        do {
+            try await store.associateHealthKitWorkout(
+                sessionID: second.sessionID,
+                workoutIdentifier: workoutIdentifier
+            )
+            XCTFail("One HealthKit workout UUID must not link to two V2 sessions")
+        } catch let error as TelemetryStoreError {
+            XCTAssertEqual(
+                error,
+                .conflictingStableIdentity(
+                    "healthkit-workout:\(workoutIdentifier.uuidString.lowercased())"
+                )
+            )
+        }
+    }
+
+    func testCancelledExportRemovesOnlyTemporaryArtifactAndPreservesStore() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        for index in 0..<100 {
+            try await store.insertSession(
+                session(
+                    index: 20_000 + index,
+                    profile: "profile-cancel",
+                    startedAt: Date(timeIntervalSince1970: 1_900_300_000 + Double(index))
+                )
+            )
+        }
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+        let before = try exportDirectories(in: temporaryDirectory)
+        let task = Task {
+            try await store.exportWorkouts(
+                WorkoutExportRequest(
+                    filter: WorkoutReadFilter(profileScope: .exact("profile-cancel")),
+                    selection: .all,
+                    batchSize: 1
+                )
+            )
+        }
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("Cancelled export unexpectedly completed")
+        } catch is CancellationError {
+            // Expected.
+        }
+        let after = try exportDirectories(in: temporaryDirectory)
+        XCTAssertEqual(after, before)
+        let counts = try await store.counts()
+        XCTAssertEqual(counts.sessions, 100)
+    }
+
+    func testExportProjectionErrorRemovesTemporaryArtifactAndPreservesEvidence() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let storedSession = session(
+            index: 30_000,
+            profile: "profile-export-error",
+            startedAt: Date(timeIntervalSince1970: 1_900_400_000)
+        )
+        try await store.insertSession(storedSession)
+        try await store.insertAnalysis(
+            WorkoutAnalysisResult(
+                analysisID: AnalysisID(rawValue: uuid(800_001)),
+                recordID: RecordID(rawValue: uuid(800_002)),
+                sessionID: storedSession.sessionID,
+                analyzerVersion: AnalyzerVersion(rawValue: "malformed-fixture"),
+                evidenceHash: ContentHash(
+                    algorithm: .sha256,
+                    lowercaseHexDigest: String(repeating: "c", count: 64)
+                ),
+                generatedAt: Date(timeIntervalSince1970: 1_900_400_001),
+                qualityGrade: .high,
+                exclusions: [],
+                keyMetrics: AnalysisKeyMetrics(
+                    coveredDuration: ElapsedDuration(microseconds: 600_000_000),
+                    averageHeartRate: 130,
+                    maximumHeartRate: 145,
+                    averageFactualSpeedKilometresPerHour: 5.5
+                ),
+                detailSchemaVersion: WorkoutAnalysisDetailV1.schemaVersion,
+                versionedDetailPayload: Data("not-json".utf8)
+            )
+        )
+
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+        let before = try exportDirectories(in: temporaryDirectory)
+        do {
+            _ = try await store.exportWorkouts(
+                WorkoutExportRequest(
+                    filter: WorkoutReadFilter(
+                        profileScope: .exact("profile-export-error")
+                    ),
+                    selection: .all,
+                    batchSize: 10
+                )
+            )
+            XCTFail("Malformed persisted analysis must fail explicitly")
+        } catch {
+            // Expected: the projection cannot decode persisted analysis detail.
+        }
+        let after = try exportDirectories(in: temporaryDirectory)
+        XCTAssertEqual(after, before)
+        let counts = try await store.counts()
+        XCTAssertEqual(counts.sessions, 1)
+        XCTAssertEqual(counts.analyses, 1)
+    }
+
+    private func session(
+        index: Int,
+        profile: String,
+        startedAt: Date,
+        configuration: ImmutableConfigurationSnapshot? = nil
+    ) -> WorkoutSessionRecord {
+        WorkoutSessionRecord(
+            recordID: RecordID(rawValue: uuid(index * 2 + 1)),
+            sessionID: SessionID(rawValue: uuid(index * 2 + 2)),
+            profileLocalIdentifier: profile,
+            lifecycleState: .completed,
+            workoutMode: .heartRateControlled,
+            startedAt: startedAt,
+            endedAt: startedAt.addingTimeInterval(600),
+            endedElapsed: ElapsedDuration(microseconds: 600_000_000),
+            incompleteReason: nil,
+            appContext: AppRuntimeContext(
+                appVersion: "1.2.3",
+                buildNumber: "456",
+                operatingSystemVersion: "iOS 26",
+                deviceModel: "private-device-model"
+            ),
+            versions: RuntimeVersionContext(
+                telemetrySchema: TelemetrySchemaVersion(rawValue: "1.0.0"),
+                algorithm: AlgorithmVersion(rawValue: "algorithm-v1"),
+                safetyPolicy: SafetyPolicyVersion(rawValue: "safety-v1"),
+                workoutProtocol: WorkoutProtocolVersion(rawValue: "workout-v1")
+            ),
+            configuration: configuration ?? self.configuration(targetHeartRate: 135),
+            healthKitWorkoutIdentifier: nil,
+            treadmill: KnownTreadmillMetadata(
+                stableLocalIdentifier: "private-treadmill-id",
+                model: "private-treadmill-model",
+                protocolName: "test"
+            ),
+            recorderHealth: RecorderHealthSummary(
+                isComplete: true,
+                lostCriticalRecordCount: 0,
+                lostNativeRecordCount: 0,
+                lastPersistedElapsed: ElapsedDuration(microseconds: 600_000_000)
+            )
+        )
+    }
+
+    private func configuration(targetHeartRate: Int) -> ImmutableConfigurationSnapshot {
+        let payload = Data("{\"targetHeartRate\":\(targetHeartRate)}".utf8)
+        return ImmutableConfigurationSnapshot(
+            id: ConfigurationSnapshotID(rawValue: uuid(900_000 + targetHeartRate)),
+            formatVersion: 1,
+            format: .canonicalJSON,
+            canonicalPayload: payload,
+            contentHash: ContentHash(
+                algorithm: .sha256,
+                lowercaseHexDigest: String(repeating: "b", count: 64)
+            )
+        )
+    }
+
+    private func importedSummary(
+        malformedRecordCount: Int,
+        complete: Bool,
+        warnings: [String]
+    ) -> LegacyWorkoutCandidateSummary {
+        LegacyWorkoutCandidateSummary(
+            timestampDerivedDurationMicroseconds: nil,
+            legacySummaryDurationSeconds: nil,
+            targetBeatsPerMinute: nil,
+            timestampDerivedAverageHeartRateBeatsPerMinute: nil,
+            legacySummaryAverageHeartRateBeatsPerMinute: nil,
+            legacyEstimatedAverageSpeedKilometresPerHour: nil,
+            timestampDerivedZoneMicroseconds: nil,
+            legacySummaryZoneSeconds: nil,
+            heartRateCoveredMicroseconds: nil,
+            heartRateUncoveredMicroseconds: nil,
+            heartRateSampleCount: 0,
+            missingTimestampCount: 1,
+            malformedRecordCount: malformedRecordCount,
+            ignoredStepFieldCount: 0,
+            legacySessionEvidenceComplete: complete,
+            warnings: warnings,
+            conflicts: []
+        )
+    }
+
+    private func uuid(_ value: Int) -> UUID {
+        UUID(uuidString: String(format: "00000000-0000-4000-8000-%012llx", value))!
+    }
+
+    private func exportDirectories(in directory: URL) throws -> Set<String> {
+        Set(
+            try FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: nil
+            ).map(\.lastPathComponent).filter { $0.hasPrefix("TelemetryV2Export_") }
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryWorkoutReadAndExportTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryWorkoutReadAndExportTests.swift
@@ -182,7 +182,8 @@ final class TelemetryWorkoutReadAndExportTests: XCTestCase {
             batchSize: 50
         )
         XCTAssertEqual(statistics.queryableWorkoutCount, 10)
-        XCTAssertLessThanOrEqual(statistics.diagnostics.storeFetchCount, 4)
+        XCTAssertLessThanOrEqual(statistics.diagnostics.storeFetchCount, 24)
+        XCTAssertLessThanOrEqual(statistics.diagnostics.maximumStoreFetchLimit, 101)
         XCTAssertEqual(statistics.diagnostics.hydratedTimeSeriesRecordCount, 0)
     }
 
@@ -301,6 +302,219 @@ final class TelemetryWorkoutReadAndExportTests: XCTestCase {
         XCTAssertNil(item.zoneSeconds)
         XCTAssertFalse(item.quality.adaptationEligible)
         XCTAssertTrue(item.quality.includedInStatistics)
+    }
+
+    func testExactImportedDuplicateEnrichesNativeHealthKitLinkageInHistoryAndExport() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let startedAt = Date(timeIntervalSince1970: 1_900_150_000)
+        let native = session(index: 80, profile: "profile-historical", startedAt: startedAt)
+        let healthKitIdentifier = uuid(880_001)
+        try await store.insertSession(native)
+
+        let sourceID = "source-historical-healthkit"
+        try await importCandidates(
+            [
+                LegacyWorkoutCandidateDraft(
+                    candidateID: "candidate-historical-healthkit",
+                    sourceItemIdentityKey: "source-item-historical-healthkit",
+                    sourceID: sourceID,
+                    origin: .jsonl,
+                    profileLocalIdentifier: "profile-historical",
+                    workoutIdentifier: nil,
+                    healthKitWorkoutIdentifier: healthKitIdentifier.uuidString.lowercased(),
+                    stableLegacySessionIdentifier: native.sessionID.description,
+                    startedAt: startedAt,
+                    endedAt: startedAt.addingTimeInterval(600),
+                    identityUncertain: false,
+                    possibleDuplicate: false,
+                    summary: importedSummary(
+                        malformedRecordCount: 0,
+                        complete: true,
+                        warnings: []
+                    )
+                ),
+            ],
+            sourceID: sourceID,
+            store: store,
+            now: startedAt
+        )
+
+        let page = try await store.fetchWorkoutHistoryPage(
+            filter: WorkoutReadFilter(profileScope: .exact("profile-historical")),
+            after: nil,
+            limit: 10
+        )
+        let item = try XCTUnwrap(page.items.first)
+        XCTAssertEqual(page.items.count, 1)
+        XCTAssertEqual(item.origin, .nativeV2)
+        XCTAssertEqual(item.healthKitWorkoutIdentifier, healthKitIdentifier)
+        XCTAssertTrue(
+            item.quality.provenance.contains("telemetry-v2-imported-exact-healthkit-linkage")
+        )
+
+        let artifact = try await store.exportWorkouts(
+            WorkoutExportRequest(
+                filter: WorkoutReadFilter(profileScope: .exact("profile-historical")),
+                selection: .all,
+                batchSize: 10
+            )
+        )
+        defer { try? FileManager.default.removeItem(at: artifact.directoryURL) }
+        let summary = try String(
+            contentsOf: artifact.directoryURL.appendingPathComponent("session_summary_v1.jsonl"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(summary.lowercased().contains(healthKitIdentifier.uuidString.lowercased()))
+        XCTAssertTrue(summary.contains("telemetry-v2-imported-exact-healthkit-linkage"))
+    }
+
+    func testConflictingExactImportedHealthKitEvidenceDoesNotEnrichNativeLinkage() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let startedAt = Date(timeIntervalSince1970: 1_900_160_000)
+        let native = session(index: 81, profile: "profile-conflict", startedAt: startedAt)
+        try await store.insertSession(native)
+
+        let sourceID = "source-conflicting-healthkit"
+        let candidates: [LegacyWorkoutCandidateDraft] = [
+            LegacyWorkoutCandidateDraft(
+                candidateID: "candidate-conflicting-healthkit-a",
+                sourceItemIdentityKey: "source-item-conflicting-healthkit-a",
+                sourceID: sourceID,
+                origin: .jsonl,
+                profileLocalIdentifier: "profile-conflict",
+                workoutIdentifier: nil,
+                healthKitWorkoutIdentifier: uuid(881_001).uuidString.lowercased(),
+                stableLegacySessionIdentifier: native.sessionID.description,
+                startedAt: startedAt,
+                endedAt: startedAt.addingTimeInterval(600),
+                identityUncertain: false,
+                possibleDuplicate: false,
+                summary: importedSummary(
+                    malformedRecordCount: 0,
+                    complete: true,
+                    warnings: []
+                )
+            ),
+            LegacyWorkoutCandidateDraft(
+                candidateID: "candidate-conflicting-healthkit-b",
+                sourceItemIdentityKey: "source-item-conflicting-healthkit-b",
+                sourceID: sourceID,
+                origin: .workoutHistory,
+                profileLocalIdentifier: "profile-conflict",
+                workoutIdentifier: nil,
+                healthKitWorkoutIdentifier: uuid(881_002).uuidString.lowercased(),
+                stableLegacySessionIdentifier: native.sessionID.description,
+                startedAt: startedAt,
+                endedAt: startedAt.addingTimeInterval(600),
+                identityUncertain: false,
+                possibleDuplicate: false,
+                summary: importedSummary(
+                    malformedRecordCount: 0,
+                    complete: true,
+                    warnings: []
+                )
+            ),
+        ]
+        try await importCandidates(
+            candidates,
+            sourceID: sourceID,
+            store: store,
+            now: startedAt
+        )
+
+        let page = try await store.fetchWorkoutHistoryPage(
+            filter: WorkoutReadFilter(profileScope: .exact("profile-conflict")),
+            after: nil,
+            limit: 10
+        )
+        let item = try XCTUnwrap(page.items.first { $0.origin == .nativeV2 })
+        XCTAssertNil(item.healthKitWorkoutIdentifier)
+        XCTAssertTrue(item.quality.warnings.contains("conflicting-healthkit-workout-identifier"))
+        XCTAssertTrue(
+            item.quality.provenance.contains("telemetry-v2-imported-exact-healthkit-linkage")
+        )
+    }
+
+    func testStatisticsExclusionAloneMarksPartialWithoutChangingSafeTotals() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let startedAt = Date(timeIntervalSince1970: 1_900_170_000)
+        let sourceID = "source-statistics-exclusion"
+        let safeSummary = LegacyWorkoutCandidateSummary(
+            timestampDerivedDurationMicroseconds: 600_000_000,
+            legacySummaryDurationSeconds: nil,
+            targetBeatsPerMinute: 135,
+            timestampDerivedAverageHeartRateBeatsPerMinute: 130,
+            legacySummaryAverageHeartRateBeatsPerMinute: nil,
+            legacyEstimatedAverageSpeedKilometresPerHour: 5.0,
+            timestampDerivedZoneMicroseconds: [
+                60_000_000, 120_000_000, 180_000_000, 120_000_000, 120_000_000,
+            ],
+            legacySummaryZoneSeconds: nil,
+            heartRateCoveredMicroseconds: 600_000_000,
+            heartRateUncoveredMicroseconds: 0,
+            heartRateSampleCount: 600,
+            missingTimestampCount: 0,
+            malformedRecordCount: 0,
+            ignoredStepFieldCount: 0,
+            legacySessionEvidenceComplete: true,
+            warnings: [],
+            conflicts: []
+        )
+        try await importCandidates(
+            [
+                LegacyWorkoutCandidateDraft(
+                    candidateID: "candidate-statistics-safe",
+                    sourceItemIdentityKey: "source-item-statistics-safe",
+                    sourceID: sourceID,
+                    origin: .jsonl,
+                    profileLocalIdentifier: "profile-statistics",
+                    workoutIdentifier: "workout-statistics-safe",
+                    healthKitWorkoutIdentifier: nil,
+                    stableLegacySessionIdentifier: nil,
+                    startedAt: startedAt,
+                    endedAt: startedAt.addingTimeInterval(600),
+                    identityUncertain: false,
+                    possibleDuplicate: false,
+                    summary: safeSummary
+                ),
+                LegacyWorkoutCandidateDraft(
+                    candidateID: "candidate-statistics-uncertain",
+                    sourceItemIdentityKey: "source-item-statistics-uncertain",
+                    sourceID: sourceID,
+                    origin: .jsonl,
+                    profileLocalIdentifier: "profile-statistics",
+                    workoutIdentifier: nil,
+                    healthKitWorkoutIdentifier: nil,
+                    stableLegacySessionIdentifier: nil,
+                    startedAt: startedAt.addingTimeInterval(-900),
+                    endedAt: nil,
+                    identityUncertain: true,
+                    possibleDuplicate: false,
+                    summary: importedSummary(
+                        malformedRecordCount: 0,
+                        complete: true,
+                        warnings: []
+                    )
+                ),
+            ],
+            sourceID: sourceID,
+            store: store,
+            now: startedAt
+        )
+
+        let statistics = try await store.fetchWorkoutStatistics(
+            filter: WorkoutReadFilter(profileScope: .exact("profile-statistics")),
+            batchSize: 10
+        )
+        XCTAssertEqual(statistics.queryableWorkoutCount, 2)
+        XCTAssertEqual(statistics.includedWorkoutCount, 1)
+        XCTAssertEqual(statistics.excludedWorkoutCount, 1)
+        XCTAssertEqual(statistics.totalDurationSeconds, 600)
+        XCTAssertEqual(statistics.zoneSeconds, [60, 120, 180, 120, 120])
+        XCTAssertEqual(statistics.workoutsWithUnavailableDuration, 0)
+        XCTAssertEqual(statistics.workoutsWithUnavailableZones, 0)
+        XCTAssertEqual(statistics.exclusionReasonCounts, [.identity: 1])
+        XCTAssertTrue(statistics.isPartial)
     }
 
     func testExportStreamsBatchesOmitsUnnecessaryIdentifiersAndManifestRoundTrips() async throws {
@@ -585,6 +799,41 @@ final class TelemetryWorkoutReadAndExportTests: XCTestCase {
             warnings: warnings,
             conflicts: []
         )
+    }
+
+    private func importCandidates(
+        _ candidates: [LegacyWorkoutCandidateDraft],
+        sourceID: String,
+        store: TelemetryStore,
+        now: Date
+    ) async throws {
+        let definition = LegacyMigrationSourceDefinition(
+            sourceID: sourceID,
+            kind: .jsonl,
+            contentHashDigest: String(repeating: "e", count: 64),
+            locator: "\(sourceID).jsonl",
+            exactProfileLocalIdentifier: candidates.first?.profileLocalIdentifier
+        )
+        _ = try await store.beginLegacyMigrationSource(
+            definition,
+            importerVersion: LegacyTelemetryMigrator.importerVersion,
+            emptyAggregateStatePayload: Data("{}".utf8),
+            now: now
+        )
+        _ = try await store.commitLegacyMigrationBatch(
+            sourceID: sourceID,
+            records: [],
+            candidates: candidates,
+            checkpointByteOffset: 100,
+            checkpointRecordIndex: Int64(candidates.count),
+            parsedRecordCount: Int64(candidates.count),
+            malformedRecordCount: 0,
+            warningCount: 0,
+            aggregateStatePayload: Data("{}".utf8),
+            completing: true,
+            now: now
+        )
+        _ = try await store.reconcileLegacyWorkoutCandidates()
     }
 
     private func uuid(_ value: Int) -> UUID {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
@@ -7,6 +7,80 @@ import TelemetryRecorder
 import XCTest
 
 final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
+    func testReadProjectionFailureCannotChangeRuntimeLifecycleOrSelectedControlOutput() async throws {
+        let persistence = RuntimePersistence()
+        let coordinator = TelemetryV2RuntimeCoordinator { persistence }
+        coordinator.prepareStoreAndRecover()
+        try await eventually { coordinator.status == .idle }
+
+        do {
+            _ = try await coordinator.fetchWorkoutHistoryPage(
+                filter: WorkoutReadFilter(profileScope: .exact("profile-30")),
+                after: nil,
+                limit: 50
+            )
+            XCTFail("The injected read failure must be surfaced")
+        } catch let error as TelemetryWorkoutReadError {
+            XCTAssertEqual(error, .unavailable("injected-read-failure"))
+        }
+        XCTAssertEqual(coordinator.status, .idle)
+
+        coordinator.beginSession(Self.descriptor())
+        try await eventually {
+            if case .active = coordinator.status { return true }
+            return false
+        }
+        let selected = Issue50ProductionDecisionFixture.ControlOutput(
+            desiredSpeedKilometresPerHour: 4.1,
+            deviceTargetSpeedKilometresPerHour: 4.1,
+            commandLabel: "SPEED 4.1 km/h (HR)"
+        )
+        do {
+            _ = try await coordinator.fetchWorkoutStatistics(
+                filter: WorkoutReadFilter(profileScope: .exact("profile-30")),
+                batchSize: 50
+            )
+            XCTFail("The injected statistics failure must be surfaced")
+        } catch let error as TelemetryWorkoutReadError {
+            XCTAssertEqual(error, .unavailable("injected-read-failure"))
+        }
+        let output = Self.alreadySelectedControlOutput(selected) { nil }
+        XCTAssertEqual(output, selected)
+        if case .active = coordinator.status {
+            // Read failure is diagnostic-only and cannot stop or degrade the recorder lifecycle.
+        } else {
+            XCTFail("Read projection failure must not change active runtime lifecycle")
+        }
+
+        coordinator.endSession(reason: "read-failure-isolation")
+        try await eventually { await persistence.finalizations.count == 1 }
+    }
+
+    func testReadBeforeFailedStorePreparationSurfacesExplicitUnavailableError() async throws {
+        enum FactoryFailure: Error { case unavailable }
+        let coordinator = TelemetryV2RuntimeCoordinator {
+            throw FactoryFailure.unavailable
+        }
+
+        do {
+            _ = try await coordinator.fetchWorkoutHistoryPage(
+                filter: WorkoutReadFilter(profileScope: .exact("profile-30")),
+                after: nil,
+                limit: 50
+            )
+            XCTFail("Store preparation failure must be explicit")
+        } catch let error as TelemetryWorkoutReadError {
+            guard case let .unavailable(reason) = error else {
+                return XCTFail("Unexpected read error: \(error)")
+            }
+            XCTAssertTrue(reason.hasPrefix("store-or-recovery-failed:"))
+        }
+        guard case .unavailable = coordinator.status else {
+            return XCTFail("Read failure must preserve the explicit runtime diagnostic")
+        }
+    }
+
+
     func testLegacyMigrationRunsOnceInBackgroundAndCannotOwnRuntimeLifecycle() async throws {
         let persistence = RuntimePersistence(
             suspendMigration: true,
@@ -1158,7 +1232,8 @@ private final class ManualRuntimeClock: TelemetryV2RuntimeClock, @unchecked Send
 private actor RuntimePersistence:
     TelemetryRecorderPersistence,
     TelemetryPostWorkoutAnalysisCapability,
-    LegacyTelemetryMigrationCapability
+    LegacyTelemetryMigrationCapability,
+    TelemetryWorkoutReadCapability
 {
     struct Snapshot: Sendable {
         let headers: [WorkoutSessionRecord]
@@ -1236,6 +1311,25 @@ private actor RuntimePersistence:
             throw TelemetryPersistenceOperationError.terminal(code: "test-finalize")
         }
         finalizations.append(finalization)
+    }
+
+    func fetchWorkoutHistoryPage(
+        filter: WorkoutReadFilter,
+        after cursor: WorkoutHistoryCursor?,
+        limit: Int
+    ) async throws -> WorkoutHistoryPage {
+        throw TelemetryWorkoutReadError.unavailable("injected-read-failure")
+    }
+
+    func fetchWorkoutStatistics(
+        filter: WorkoutReadFilter,
+        batchSize: Int
+    ) async throws -> WorkoutStatisticsProjection {
+        throw TelemetryWorkoutReadError.unavailable("injected-read-failure")
+    }
+
+    func exportWorkouts(_ request: WorkoutExportRequest) async throws -> WorkoutExportArtifact {
+        throw TelemetryWorkoutReadError.unavailable("injected-read-failure")
     }
 
     func unfinishedSessions() async throws -> [WorkoutSessionRecord] {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateRecoveryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/TelemetryGateRecoveryTests.swift
@@ -113,6 +113,14 @@ final class TelemetryGateRecoveryTests: XCTestCase {
     }
 
     private func crashWorkerExecutableURL() throws -> URL {
+        let testProductsDirectory = Bundle(for: Self.self).bundleURL
+            .deletingLastPathComponent()
+        let colocatedWorker = testProductsDirectory
+            .appendingPathComponent("TelemetryGateCrashWorker", isDirectory: false)
+        if FileManager.default.isExecutableFile(atPath: colocatedWorker.path) {
+            return colocatedWorker
+        }
+
         let buildRoot = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent(".build", isDirectory: true)
         guard let enumerator = FileManager.default.enumerator(

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -189,6 +189,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var nextCommandAllowedAt: Date = .distantPast
     private var pendingHealthkitWorkoutUUID: String? = nil
     private var pendingHealthkitWorkoutProfileID: UUID? = nil
+    private var activeTelemetryV2SessionID: SessionID? = nil
+    private var pendingHealthkitTelemetryV2SessionID: SessionID? = nil
     private var hrControlFailed: Bool = false
     private let legacyWatchHeartRateSource = HeartRateProviderIdentity(
         kind: .legacyWatchWorkoutStream,
@@ -203,6 +205,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var treadmillTelemetrySink: (any TreadmillTelemetrySink)?
     @Published private(set) var telemetryV2StatusText: String = "idle"
     @Published private(set) var telemetryV2WriterHealthSnapshot: TelemetryV2WriterHealthSnapshot = .idle
+    @Published private(set) var legacyShadowWriterStatusText: String = "idle"
     private lazy var telemetryV2Coordinator = TelemetryV2RuntimeCoordinator(
         persistenceFactory: {
             let appIdentifier = Bundle.main.bundleIdentifier ?? "sw.WalkingPadRemote"
@@ -219,6 +222,11 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         writerHealthHandler: { [weak self] snapshot in
             Task { @MainActor [weak self] in
                 self?.telemetryV2WriterHealthSnapshot = snapshot
+            }
+        },
+        projectionChangeHandler: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.telemetryV2ProjectionDidChange()
             }
         }
     )
@@ -507,8 +515,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         UserDefaults.standard.set(data, forKey: profileScopedStoreKey(zonePlanStoreKey, profileID: profileID))
     }
 
-    private func workoutEntry(from dto: WorkoutEntryDTO) -> WorkoutEntry {
-        WorkoutEntry(
+    private func legacyShadowWorkoutEntry(from dto: WorkoutEntryDTO) -> LegacyShadowWorkoutEntry {
+        LegacyShadowWorkoutEntry(
             id: dto.id,
             date: dto.date,
             beatsPerMeter: dto.beatsPerMeter,
@@ -521,7 +529,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         )
     }
 
-    private func workoutEntryDTO(from entry: WorkoutEntry) -> WorkoutEntryDTO {
+    private func workoutEntryDTO(from entry: LegacyShadowWorkoutEntry) -> WorkoutEntryDTO {
         WorkoutEntryDTO(
             id: entry.id,
             date: entry.date,
@@ -535,33 +543,48 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         )
     }
 
-    private func loadWorkoutHistory(profileID: UUID) -> [WorkoutEntry] {
+    private func loadLegacyShadowWorkoutHistory(profileID: UUID) -> [LegacyShadowWorkoutEntry] {
         let key = profileScopedStoreKey(workoutHistoryStoreKey, profileID: profileID)
         guard let data = UserDefaults.standard.data(forKey: key),
               let list = try? JSONDecoder().decode([WorkoutEntryDTO].self, from: data) else {
             return []
         }
 
-        return list.map { workoutEntry(from: $0) }
+        return list.map { legacyShadowWorkoutEntry(from: $0) }
     }
 
-    private func saveWorkoutHistory(_ entries: [WorkoutEntry], profileID: UUID) {
+    private func saveLegacyShadowWorkoutHistory(
+        _ entries: [LegacyShadowWorkoutEntry],
+        profileID: UUID
+    ) {
+        // Compatibility-only parity evidence through #37; #36 owns mandatory removal.
         let list = entries.prefix(50).map { workoutEntryDTO(from: $0) }
-        guard let data = try? JSONEncoder().encode(list) else { return }
-        UserDefaults.standard.set(data, forKey: profileScopedStoreKey(workoutHistoryStoreKey, profileID: profileID))
+        guard let data = try? JSONEncoder().encode(list) else {
+            legacyShadowWriterStatusText = "failed: encode"
+            appendLog("Legacy shadow writer failed: encode")
+            return
+        }
+        let key = profileScopedStoreKey(workoutHistoryStoreKey, profileID: profileID)
+        UserDefaults.standard.set(data, forKey: key)
+        if UserDefaults.standard.data(forKey: key) == data {
+            legacyShadowWriterStatusText = "ok"
+        } else {
+            legacyShadowWriterStatusText = "failed: persistence"
+            appendLog("Legacy shadow writer failed: persistence")
+        }
     }
 
     private func removeStoredData(for profileID: UUID) {
         let defaults = UserDefaults.standard
         defaults.removeObject(forKey: profileScopedStoreKey(hrSettingsStoreKey, profileID: profileID))
         defaults.removeObject(forKey: profileScopedStoreKey(zonePlanStoreKey, profileID: profileID))
-        defaults.removeObject(forKey: profileScopedStoreKey(workoutHistoryStoreKey, profileID: profileID))
+        // Preserve legacy workout shadow evidence until the explicit #36 retirement.
     }
 
     private func loadActiveProfileScopedData() {
         loadHrSettings()
         loadZonePlan()
-        loadWorkoutHistory()
+        loadLegacyShadowWorkoutHistory()
     }
 
     func selectUserProfile(id: UUID) {
@@ -574,11 +597,12 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
         saveHrSettingsIfNeeded()
         saveZonePlan()
-        saveWorkoutHistory()
+        saveLegacyShadowWorkoutHistory()
 
         activeUserProfileID = id
         saveProfilesState()
         loadActiveProfileScopedData()
+        refreshWorkoutHistoryFromV2(reset: true)
         refreshTrainingLogsInventory()
         appendLog("Active profile switched: \(activeUserProfileLabel)")
         infoToastMessage = "Активный профиль: \(activeUserProfileLabel)"
@@ -598,16 +622,17 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
         saveHrSettingsIfNeeded()
         saveZonePlan()
-        saveWorkoutHistory()
+        saveLegacyShadowWorkoutHistory()
 
         saveHrSettings(profileID: profile.id)
         saveZonePlan(profileID: profile.id)
-        saveWorkoutHistory([], profileID: profile.id)
+        saveLegacyShadowWorkoutHistory([], profileID: profile.id)
 
         userProfiles = sortedProfiles(userProfiles + [profile])
         activeUserProfileID = profile.id
         saveProfilesState()
         loadActiveProfileScopedData()
+        refreshWorkoutHistoryFromV2(reset: true)
         refreshTrainingLogsInventory()
         appendLog("Profile created: \(profile.label)")
         infoToastMessage = "Создан профиль: \(profile.label)"
@@ -651,52 +676,28 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         self.activeUserProfileID = userProfiles.first?.id
         saveProfilesState()
         loadActiveProfileScopedData()
+        refreshWorkoutHistoryFromV2(reset: true)
         refreshTrainingLogsInventory()
         appendLog("Profile deleted: \(deletedLabel)")
         infoToastMessage = "Профиль удалён: \(deletedLabel)"
     }
 
-    private func loadWorkoutHistory() {
+    private func loadLegacyShadowWorkoutHistory() {
         guard let activeUserProfileID else {
-            workoutHistory = []
+            legacyShadowWorkoutHistory = []
             return
         }
-        workoutHistory = loadWorkoutHistory(profileID: activeUserProfileID)
+        legacyShadowWorkoutHistory = loadLegacyShadowWorkoutHistory(
+            profileID: activeUserProfileID
+        )
     }
 
-    private func saveWorkoutHistory() {
+    private func saveLegacyShadowWorkoutHistory() {
         guard let activeUserProfileID else { return }
-        saveWorkoutHistory(workoutHistory, profileID: activeUserProfileID)
-    }
-
-    func deleteWorkoutEntry(id: UUID) {
-        guard let idx = workoutHistory.firstIndex(where: { $0.id == id }) else { return }
-        let entry = workoutHistory.remove(at: idx)
-        saveWorkoutHistory()
-        guard let uuidString = entry.healthkitWorkoutUUID, let uuid = UUID(uuidString: uuidString) else { return }
-        guard HKHealthStore.isHealthDataAvailable() else { return }
-        let workoutType = HKObjectType.workoutType()
-        healthStore.requestAuthorization(toShare: [workoutType], read: [workoutType]) { [weak self] success, error in
-            guard success, error == nil else {
-                self?.appendLog("HealthKit delete auth failed")
-                return
-            }
-            let predicate = HKQuery.predicateForObject(with: uuid)
-            let query = HKSampleQuery(sampleType: workoutType, predicate: predicate, limit: 1, sortDescriptors: nil) { _, samples, _ in
-                guard let workout = samples?.first as? HKWorkout else {
-                    self?.appendLog("HealthKit workout not found for UUID \(uuidString)")
-                    return
-                }
-                self?.healthStore.delete(workout) { ok, _ in
-                    if ok {
-                        self?.appendLog("HealthKit workout deleted \(uuidString)")
-                    } else {
-                        self?.appendLog("HealthKit delete failed \(uuidString)")
-                    }
-                }
-            }
-            self?.healthStore.execute(query)
-        }
+        saveLegacyShadowWorkoutHistory(
+            legacyShadowWorkoutHistory,
+            profileID: activeUserProfileID
+        )
     }
 
     private struct HrSettingsDTO: Codable {
@@ -1513,7 +1514,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private func startTrainingStructuredLog(trigger: String) -> UUID? {
         stopTrainingStructuredLog(reason: "restart_before_new_session")
         guard let dir = trainingLogsDirectoryURL() else { return nil }
-        pruneTrainingLogs(in: dir)
 
         let sessionId = UUID().uuidString
         let fileName = "hr_session_\(trainingLogTimestampFormatter.string(from: Date()))_\(sessionId).jsonl"
@@ -1688,50 +1688,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     func finalizeTrainingLogsCsvExport(_ export: TrainingLogsCsvExport, completed: Bool) {
-        defer {
-            try? FileManager.default.removeItem(at: export.csvURL)
-        }
-
-        guard completed else {
-            appendLog("Training CSV share cancelled: \(export.csvURL.lastPathComponent)")
-            return
-        }
-
-        let activeLogFile: URL? = trainingLogQueue.sync { trainingLogFileURL?.standardizedFileURL }
-        let protectedFiles = Set(activeLogFile.map { [$0] } ?? [])
-        let cleanup = TrainingTelemetryWriter.cleanupExportedJsonlFiles(
-            export.sourceFiles,
-            keeping: protectedFiles
+        try? FileManager.default.removeItem(at: export.csvURL)
+        appendLog(
+            "Legacy CSV share \(completed ? "completed" : "cancelled"); source evidence preserved"
         )
-
-        if let dir = trainingLogsDirectoryURL() {
-            pruneTrainingLogs(in: dir)
-        }
-
-        refreshTrainingLogsInventory()
-
-        let reclaimedText = ByteCountFormatter.string(
-            fromByteCount: cleanup.reclaimedBytes,
-            countStyle: .file
-        )
-
-        let message: String
-        if cleanup.removedCount > 0 {
-            if cleanup.skippedCount > 0 {
-                message = "CSV выгружен. Очищено \(cleanup.removedCount) raw логов, освобождено \(reclaimedText), пропущено \(cleanup.skippedCount)."
-            } else {
-                message = "CSV выгружен. Очищено \(cleanup.removedCount) raw логов, освобождено \(reclaimedText)."
-            }
-        } else if cleanup.skippedCount > 0 {
-            message = "CSV выгружен. Raw логи не удалены: активная сессия ещё открыта или файлы уже были очищены."
-        } else {
-            message = "CSV выгружен. Дополнительная очистка raw логов не потребовалась."
-        }
-
-        appendLog("Training raw logs cleanup: scope=\(export.scope.logDescription) removed=\(cleanup.removedCount) skipped=\(cleanup.skippedCount) freed=\(cleanup.reclaimedBytes) rows=\(export.rowCount)")
-        DispatchQueue.main.async {
-            self.infoToastMessage = message
-        }
     }
 
     private func hex(_ data: Data) -> String {
@@ -1798,57 +1758,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     func clearTrainingLogsForActiveProfile() {
-        synchronizeTrainingLogFileIfNeeded()
-        guard let allJsonlFiles = allTrainingJsonlFiles(),
-              !allJsonlFiles.isEmpty else {
-            trainingLogsInventory = .empty
-            infoToastMessage = "Raw training logs не найдены."
-            return
-        }
-
-        let protectedFiles = currentProtectedTrainingLogFiles()
-        let selectedFiles = TrainingTelemetryWriter.selectJsonlFilesForClear(
-            allJsonlFiles,
-            matchingProfileID: activeUserProfileID?.uuidString,
-            legacyFallbackProfileID: legacyFallbackProfileID,
-            keeping: protectedFiles
-        )
-
-        guard !selectedFiles.isEmpty else {
-            refreshTrainingLogsInventory()
-            infoToastMessage = "Для активного профиля нечего очищать. Активная сессия не удаляется."
-            return
-        }
-
-        let cleanup = TrainingTelemetryWriter.cleanupExportedJsonlFiles(
-            selectedFiles,
-            keeping: protectedFiles
-        )
-
-        if let dir = trainingLogsDirectoryURL() {
-            pruneTrainingLogs(in: dir)
-        }
-
-        refreshTrainingLogsInventory()
-
-        let reclaimedText = ByteCountFormatter.string(
-            fromByteCount: cleanup.reclaimedBytes,
-            countStyle: .file
-        )
-
-        let message: String
-        if cleanup.removedCount > 0 {
-            if cleanup.skippedCount > 0 {
-                message = "Raw training logs очищены: удалено \(cleanup.removedCount) файлов, освобождено \(reclaimedText), пропущено \(cleanup.skippedCount). История тренировок в статистике сохранена."
-            } else {
-                message = "Raw training logs очищены: удалено \(cleanup.removedCount) файлов, освобождено \(reclaimedText). История тренировок в статистике сохранена."
-            }
-        } else {
-            message = "Raw training logs не очищены: активная сессия ещё открыта или файлы уже отсутствуют."
-        }
-
-        appendLog("Training raw logs cleared manually: removed=\(cleanup.removedCount) skipped=\(cleanup.skippedCount) freed=\(cleanup.reclaimedBytes)")
-        infoToastMessage = message
+        appendLog("Legacy training log clear ignored; source evidence preserved through #37")
+        infoToastMessage = "Legacy source evidence is preserved until the explicit retirement gate."
     }
 
     private func availableTrainingJsonlFiles(scope: TrainingLogCsvExportScope) -> [URL]? {
@@ -1872,7 +1783,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @Published var infoToastMessage: String? = nil
 
     // History
-    struct WorkoutEntry: Identifiable {
+    private struct LegacyShadowWorkoutEntry: Identifiable {
         let id: UUID
         let date: Date
         let beatsPerMeter: Double?
@@ -1883,7 +1794,171 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let healthkitWorkoutUUID: String?
         let zoneSeconds: [Int]?
     }
-    @Published var workoutHistory: [WorkoutEntry] = []
+    private var legacyShadowWorkoutHistory: [LegacyShadowWorkoutEntry] = []
+
+    enum WorkoutReadState: Equatable {
+        case idle
+        case loading
+        case loaded
+        case failed(String)
+    }
+
+    @Published private(set) var telemetryV2WorkoutHistory: [WorkoutHistoryProjection] = []
+    @Published private(set) var telemetryV2WorkoutHistoryState: WorkoutReadState = .idle
+    @Published private(set) var telemetryV2WorkoutHistoryHasMore: Bool = false
+    @Published private(set) var telemetryV2Statistics: [String: WorkoutStatisticsProjection] = [:]
+    @Published private(set) var telemetryV2StatisticsState: [String: WorkoutReadState] = [:]
+    @Published private(set) var telemetryV2ProjectionGeneration: UInt = 0
+    private var telemetryV2WorkoutHistoryCursor: WorkoutHistoryCursor? = nil
+    private var telemetryV2WorkoutReadRequestID: UUID? = nil
+    private let telemetryV2WorkoutPageSize = 50
+
+    private func telemetryV2ProjectionDidChange() {
+        telemetryV2ProjectionGeneration &+= 1
+        telemetryV2Statistics.removeAll()
+        telemetryV2StatisticsState.removeAll()
+        refreshWorkoutHistoryFromV2(reset: true)
+    }
+
+    private func activeWorkoutReadFilter(
+        startedAtOrAfter: Date? = nil,
+        startedBefore: Date? = nil
+    ) -> WorkoutReadFilter? {
+        guard let profileID = activeUserProfileID else { return nil }
+        return WorkoutReadFilter(
+            profileScope: .exact(profileID.uuidString),
+            startedAtOrAfter: startedAtOrAfter,
+            startedBefore: startedBefore
+        )
+    }
+
+    func refreshWorkoutHistoryFromV2(reset: Bool = true) {
+        guard let filter = activeWorkoutReadFilter(),
+              let requestedProfileID = activeUserProfileID else {
+            telemetryV2WorkoutHistory = []
+            telemetryV2WorkoutHistoryState = .failed("active-profile-unavailable")
+            telemetryV2WorkoutHistoryHasMore = false
+            telemetryV2WorkoutHistoryCursor = nil
+            return
+        }
+
+        if reset {
+            telemetryV2WorkoutHistory = []
+            telemetryV2WorkoutHistoryCursor = nil
+        }
+        telemetryV2WorkoutHistoryState = .loading
+        let cursor = telemetryV2WorkoutHistoryCursor
+        let requestID = UUID()
+        telemetryV2WorkoutReadRequestID = requestID
+
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let page = try await self.telemetryV2Coordinator.fetchWorkoutHistoryPage(
+                    filter: filter,
+                    after: cursor,
+                    limit: self.telemetryV2WorkoutPageSize
+                )
+                await MainActor.run {
+                    guard self.activeUserProfileID == requestedProfileID,
+                          self.telemetryV2WorkoutReadRequestID == requestID else { return }
+                    if reset {
+                        self.telemetryV2WorkoutHistory = page.items
+                    } else {
+                        let existingIDs = Set(self.telemetryV2WorkoutHistory.map(\.id))
+                        self.telemetryV2WorkoutHistory.append(
+                            contentsOf: page.items.filter { !existingIDs.contains($0.id) }
+                        )
+                    }
+                    self.telemetryV2WorkoutHistoryCursor = page.nextCursor
+                    self.telemetryV2WorkoutHistoryHasMore = page.nextCursor != nil
+                    self.telemetryV2WorkoutHistoryState = .loaded
+                }
+            } catch {
+                await MainActor.run {
+                    guard self.activeUserProfileID == requestedProfileID,
+                          self.telemetryV2WorkoutReadRequestID == requestID else { return }
+                    self.telemetryV2WorkoutHistoryState = .failed(error.localizedDescription)
+                    self.appendLog("Telemetry V2 workout read failed: \(error)")
+                }
+            }
+        }
+    }
+
+    func loadNextWorkoutHistoryPageFromV2() {
+        guard telemetryV2WorkoutHistoryHasMore,
+              telemetryV2WorkoutHistoryState != .loading else { return }
+        refreshWorkoutHistoryFromV2(reset: false)
+    }
+
+    func workoutStatisticsKey(for interval: DateInterval) -> String {
+        let profile = activeUserProfileID?.uuidString ?? "unassigned"
+        return "\(profile)|\(interval.start.timeIntervalSince1970)|\(interval.end.timeIntervalSince1970)"
+    }
+
+    func refreshWorkoutStatisticsFromV2(for interval: DateInterval) {
+        guard let filter = activeWorkoutReadFilter(
+            startedAtOrAfter: interval.start,
+            startedBefore: interval.end
+        ), let requestedProfileID = activeUserProfileID else { return }
+        let key = workoutStatisticsKey(for: interval)
+        let requestedProjectionGeneration = telemetryV2ProjectionGeneration
+        telemetryV2StatisticsState[key] = .loading
+
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let statistics = try await self.telemetryV2Coordinator.fetchWorkoutStatistics(
+                    filter: filter,
+                    batchSize: 100
+                )
+                await MainActor.run {
+                    guard self.activeUserProfileID == requestedProfileID,
+                          self.telemetryV2ProjectionGeneration
+                            == requestedProjectionGeneration else { return }
+                    self.telemetryV2Statistics[key] = statistics
+                    self.telemetryV2StatisticsState[key] = .loaded
+                }
+            } catch {
+                await MainActor.run {
+                    guard self.activeUserProfileID == requestedProfileID,
+                          self.telemetryV2ProjectionGeneration
+                            == requestedProjectionGeneration else { return }
+                    self.telemetryV2StatisticsState[key] = .failed(error.localizedDescription)
+                    self.appendLog("Telemetry V2 statistics read failed: \(error)")
+                }
+            }
+        }
+    }
+
+    func prepareTelemetryV2Export(
+        scope: TrainingLogCsvExportScope
+    ) async throws -> WorkoutExportArtifact {
+        guard let filter = activeWorkoutReadFilter() else {
+            throw TelemetryWorkoutReadError.unavailable("active-profile-unavailable")
+        }
+        let selection: WorkoutExportSelection
+        switch scope {
+        case .all:
+            selection = .all
+        case .lastCompletedWorkouts(let count):
+            selection = .latestCompleted(count)
+        }
+        return try await telemetryV2Coordinator.exportWorkouts(
+            WorkoutExportRequest(filter: filter, selection: selection)
+        )
+    }
+
+    func finalizeTelemetryV2Export(_ artifact: WorkoutExportArtifact, completed: Bool) {
+        do {
+            try FileManager.default.removeItem(at: artifact.directoryURL)
+        } catch {
+            appendLog("Telemetry V2 export temporary cleanup failed: \(error.localizedDescription)")
+        }
+        infoToastMessage = completed
+            ? "Telemetry V2 export shared. Source evidence was preserved."
+            : "Telemetry V2 export cancelled. Source evidence was preserved."
+    }
 
     // Lifecycle
     private func scheduleLegacyTelemetryMigration() {
@@ -1918,7 +1993,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         loadProfilesState()
         loadHrSettings()
         loadZonePlan()
-        loadWorkoutHistory()
+        loadLegacyShadowWorkoutHistory()
+        refreshWorkoutHistoryFromV2(reset: true)
         refreshTrainingLogsInventory()
         setHeartRateTelemetrySink(telemetryV2Coordinator)
         setTreadmillTelemetrySink(telemetryV2Coordinator)
@@ -5443,6 +5519,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let sessionID = TelemetryV2SessionDescriptor.sessionID(
             deterministicallyLinkedTo: legacySessionID
         )
+        activeTelemetryV2SessionID = sessionID
 #if canImport(UIKit)
         let deviceModel: String? = UIDevice.current.model
 #else
@@ -5821,7 +5898,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let averageSpeed = (avgSpeedActive && avgSpeedKmh > 0.05) ? avgSpeedKmh : nil
         let workoutProfileID = activeUserProfileID
         let attachedHealthkitWorkoutUUID = pendingHealthkitWorkoutUUID
-        let entry = WorkoutEntry(
+        let telemetryV2SessionID = activeTelemetryV2SessionID
+        let entry = LegacyShadowWorkoutEntry(
             id: UUID(),
             date: Date(),
             beatsPerMeter: beatsPerMeter,
@@ -5832,11 +5910,22 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             healthkitWorkoutUUID: attachedHealthkitWorkoutUUID,
             zoneSeconds: hrZoneSeconds
         )
-        workoutHistory.insert(entry, at: 0)
+        legacyShadowWorkoutHistory.insert(entry, at: 0)
         pendingHealthkitWorkoutUUID = nil
         pendingHealthkitWorkoutProfileID = attachedHealthkitWorkoutUUID == nil ? workoutProfileID : nil
+        pendingHealthkitTelemetryV2SessionID = attachedHealthkitWorkoutUUID == nil
+            ? telemetryV2SessionID
+            : nil
         hrWorkoutRecorded = true
-        saveWorkoutHistory()
+        saveLegacyShadowWorkoutHistory()
+        if let attachedHealthkitWorkoutUUID,
+           let workoutIdentifier = UUID(uuidString: attachedHealthkitWorkoutUUID),
+           let telemetryV2SessionID {
+            associateHealthKitWorkoutWithTelemetryV2(
+                sessionID: telemetryV2SessionID,
+                workoutIdentifier: workoutIdentifier
+            )
+        }
         logTrainingEvent("workout_saved", fields: [
             "workout_id": entry.id.uuidString,
             "duration_s": actualDuration,
@@ -5850,6 +5939,15 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     private func attachHealthkitWorkoutUUID(_ uuid: String, endedAt: Date?) {
+        if let workoutIdentifier = UUID(uuidString: uuid),
+           let telemetryV2SessionID = pendingHealthkitTelemetryV2SessionID
+                ?? activeTelemetryV2SessionID {
+            pendingHealthkitTelemetryV2SessionID = nil
+            associateHealthKitWorkoutWithTelemetryV2(
+                sessionID: telemetryV2SessionID,
+                workoutIdentifier: workoutIdentifier
+            )
+        }
         let matchWindow: TimeInterval = 15 * 60
         let targetProfileID = pendingHealthkitWorkoutProfileID ?? activeUserProfileID
         guard let targetProfileID else {
@@ -5857,11 +5955,11 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             return
         }
 
-        var entries = loadWorkoutHistory(profileID: targetProfileID)
+        var entries = loadLegacyShadowWorkoutHistory(profileID: targetProfileID)
 
         let attachUUID: (Int) -> Void = { index in
             let entry = entries[index]
-            entries[index] = WorkoutEntry(
+            entries[index] = LegacyShadowWorkoutEntry(
                 id: entry.id,
                 date: entry.date,
                 beatsPerMeter: entry.beatsPerMeter,
@@ -5872,9 +5970,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 healthkitWorkoutUUID: uuid,
                 zoneSeconds: entry.zoneSeconds
             )
-            self.saveWorkoutHistory(entries, profileID: targetProfileID)
+            self.saveLegacyShadowWorkoutHistory(entries, profileID: targetProfileID)
             if self.activeUserProfileID == targetProfileID {
-                self.workoutHistory = entries
+                self.legacyShadowWorkoutHistory = entries
             }
             self.pendingHealthkitWorkoutProfileID = nil
         }
@@ -5891,6 +5989,28 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
         pendingHealthkitWorkoutUUID = uuid
         pendingHealthkitWorkoutProfileID = targetProfileID
+    }
+
+    private func associateHealthKitWorkoutWithTelemetryV2(
+        sessionID: SessionID,
+        workoutIdentifier: UUID
+    ) {
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.telemetryV2Coordinator.associateHealthKitWorkout(
+                    sessionID: sessionID,
+                    workoutIdentifier: workoutIdentifier
+                )
+            } catch {
+                await MainActor.run {
+                    self.appendLog("Telemetry V2 HealthKit linkage failed: \(error)")
+                    self.telemetryV2WorkoutHistoryState = .failed(
+                        "HealthKit linkage failed: \(error.localizedDescription)"
+                    )
+                }
+            }
+        }
     }
 
     // KS-F0 protocol: F7 A2 <cmd> <val> <crc> FD, crc = sum(bytes[1..3]) % 256

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -2353,13 +2353,42 @@ private struct WorkoutStatsView: View {
 
                 zoneSummaryList(scope: scope, zoneSeconds: stats?.zoneSeconds)
 
-                if stats?.isPartial == true {
+                if let stats, stats.excludedWorkoutCount > 0 {
+                    Text(
+                        "Исключено из агрегатов: \(stats.excludedWorkoutCount) · "
+                            + statisticsExclusionReasonText(stats.exclusionReasonCounts)
+                            + ". Валидные суммы сохранены; исключённые тренировки не считаются нулями."
+                    )
+                    .font(.caption2)
+                    .foregroundColor(.orange)
+                }
+
+                if let stats,
+                   stats.workoutsWithUnavailableDuration > 0
+                    || stats.workoutsWithUnavailableZones > 0 {
                     Text("Часть метрик недоступна; пропуски показаны как «—» и не заменены нулями.")
                         .font(.caption2)
                         .foregroundColor(.secondary)
                 }
             }
         }
+    }
+
+    private func statisticsExclusionReasonText(
+        _ counts: [WorkoutStatisticsExclusionReason: Int]
+    ) -> String {
+        counts.keys.sorted { $0.rawValue < $1.rawValue }.map { reason in
+            let title: String
+            switch reason {
+            case .identity:
+                title = "identity"
+            case .possibleDuplicate:
+                title = "duplicate"
+            case .lifecycleOrQuality:
+                title = "lifecycle/quality"
+            }
+            return "\(title): \(counts[reason, default: 0])"
+        }.joined(separator: ", ")
     }
 
     private var zoneRanges: [String] {
@@ -2667,7 +2696,7 @@ private struct WorkoutHistoryCard: View {
                                         .foregroundColor(.orange)
                                 }
                                 if let healthKitID = entry.healthKitWorkoutIdentifier {
-                                    Text("HealthKit: \(healthKitID.uuidString.lowercased())")
+                                    Text(healthKitLinkageText(for: entry, identifier: healthKitID))
                                         .font(.caption2.monospaced())
                                         .foregroundColor(.secondary)
                                         .textSelection(.enabled)
@@ -2734,6 +2763,16 @@ private struct WorkoutHistoryCard: View {
         let lifecycle = entry.quality.lifecycleState
         let grade = entry.quality.analysisGrade.map { " · \($0)" } ?? ""
         return "\(origin) · \(lifecycle)\(grade)"
+    }
+
+    private func healthKitLinkageText(
+        for entry: WorkoutHistoryProjection,
+        identifier: UUID
+    ) -> String {
+        let provenance = entry.quality.provenance.contains(
+            "telemetry-v2-imported-exact-healthkit-linkage"
+        ) ? " · exact import linkage" : " · native linkage"
+        return "HealthKit: \(identifier.uuidString.lowercased())\(provenance)"
     }
 }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 #if canImport(TelemetryRuntime)
 import TelemetryRuntime
 #endif
+#if canImport(TelemetryDomain)
+import TelemetryDomain
+#endif
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -14,21 +17,6 @@ struct HrFailureReport: Identifiable {
     let start: Date
     let end: Date
     let lines: [String]
-}
-#endif
-
-// Fallback definition for WorkoutEntry used by WorkoutHistoryCard if not provided by the app.
-#if !canImport(WorkoutHistoryModule)
-struct WorkoutEntry: Identifiable {
-    let id: UUID
-    let date: Date
-    let beatsPerMeter: Double?
-    let targetBpm: Int
-    let durationSeconds: Int
-    let avgBpm: Int
-    let avgSpeedKmh: Double?
-    let healthkitWorkoutUUID: String?
-    let zoneSeconds: [Int]?
 }
 #endif
 
@@ -2171,12 +2159,6 @@ private struct WorkoutStatsView: View {
         }
     }
 
-    private struct StatsResult {
-        let totalSeconds: Int
-        let avgBeatsPerMeter: Double?
-        let zoneSeconds: [Int]
-    }
-
     private struct StatsPageHeightPreferenceKey: PreferenceKey {
         static var defaultValue: [StatsScope: CGFloat] = [:]
 
@@ -2222,9 +2204,13 @@ private struct WorkoutStatsView: View {
                         pageHeights.merge(values, uniquingKeysWith: { _, new in new })
                     }
 
-                    WorkoutHistoryCard(entries: manager.workoutHistory, onDelete: { id in
-                        manager.deleteWorkoutEntry(id: id)
-                    })
+                    WorkoutHistoryCard(
+                        entries: manager.telemetryV2WorkoutHistory,
+                        readState: manager.telemetryV2WorkoutHistoryState,
+                        hasMore: manager.telemetryV2WorkoutHistoryHasMore,
+                        onRetry: { manager.refreshWorkoutHistoryFromV2(reset: true) },
+                        onLoadMore: { manager.loadNextWorkoutHistoryPageFromV2() }
+                    )
                     .padding(.horizontal)
                     .padding(.bottom)
                 }
@@ -2276,9 +2262,10 @@ private struct WorkoutStatsView: View {
 
     @ViewBuilder
     private func statsSummaryPage(for scope: StatsScope) -> some View {
+        let interval = currentInterval(for: scope)
         VStack(spacing: 16) {
             periodHeader(for: scope)
-            statsCard(scope: scope, title: scope.title, interval: currentInterval(for: scope))
+            statsCard(scope: scope, title: scope.title, interval: interval)
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -2290,6 +2277,9 @@ private struct WorkoutStatsView: View {
                 )
             }
         )
+        .task(id: "\(manager.workoutStatisticsKey(for: interval))|\(manager.telemetryV2ProjectionGeneration)") {
+            manager.refreshWorkoutStatisticsFromV2(for: interval)
+        }
     }
 
     private func periodHeader(for scope: StatsScope) -> some View {
@@ -2323,9 +2313,11 @@ private struct WorkoutStatsView: View {
 
     @ViewBuilder
     private func statsCard(scope: StatsScope, title: String, interval: DateInterval) -> some View {
-        let stats = computeStats(interval: interval)
-        let totalTime = formatTotalTime(stats.totalSeconds)
-        let beatsValue = stats.avgBeatsPerMeter.map { String(format: "%.2f", $0) } ?? "—"
+        let key = manager.workoutStatisticsKey(for: interval)
+        let stats = manager.telemetryV2Statistics[key]
+        let state = manager.telemetryV2StatisticsState[key] ?? .idle
+        let totalTime = formatTotalTime(stats?.totalDurationSeconds)
+        let beatsValue = stats?.averageBeatsPerMetre.map { String(format: "%.2f", $0) } ?? "—"
 
         Card {
             VStack(alignment: .leading, spacing: 12) {
@@ -2338,7 +2330,34 @@ private struct WorkoutStatsView: View {
                     StatTile(title: "Удары/м", value: beatsValue, unit: "")
                 }
 
-                zoneSummaryList(scope: scope, totalSeconds: stats.totalSeconds, zoneSeconds: stats.zoneSeconds)
+                if case .loading = state, stats == nil {
+                    ProgressView("Чтение Telemetry V2…")
+                        .font(.caption)
+                }
+                if case let .failed(message) = state {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Telemetry V2 недоступна: \(message)")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                        if stats != nil {
+                            Text("Ниже показан последний успешный V2 snapshot; обновление не выполнено.")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        }
+                        Button("Повторить") {
+                            manager.refreshWorkoutStatisticsFromV2(for: interval)
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+
+                zoneSummaryList(scope: scope, zoneSeconds: stats?.zoneSeconds)
+
+                if stats?.isPartial == true {
+                    Text("Часть метрик недоступна; пропуски показаны как «—» и не заменены нулями.")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
             }
         }
     }
@@ -2348,14 +2367,16 @@ private struct WorkoutStatsView: View {
     }
 
     @ViewBuilder
-    private func zoneSummaryList(scope: StatsScope, totalSeconds: Int, zoneSeconds: [Int]) -> some View {
+    private func zoneSummaryList(scope: StatsScope, zoneSeconds: [Double?]?) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             ForEach(0..<5, id: \.self) { idx in
-                let seconds = idx < zoneSeconds.count ? zoneSeconds[idx] : 0
-                let actualMinutes = seconds / 60
+                let seconds = zoneSeconds.flatMap { idx < $0.count ? $0[idx] : nil }
+                let actualMinutes = seconds.map { Int($0 / 60.0) }
                 let monthPlan = idx < manager.zonePlanMinutes.count ? manager.zonePlanMinutes[idx] : 0
                 let planMinutes = scope == .week ? Int(round(Double(monthPlan) / 4.0)) : monthPlan
-                let progress = planMinutes > 0 ? min(1.0, Double(actualMinutes) / Double(planMinutes)) : 0
+                let progress = actualMinutes.map {
+                    planMinutes > 0 ? min(1.0, Double($0) / Double(planMinutes)) : 0
+                }
                 ZoneSummaryRow(
                     title: "Зона \(idx + 1)",
                     rangeText: zoneRangeText(index: idx),
@@ -2369,33 +2390,9 @@ private struct WorkoutStatsView: View {
         .padding(.top, 2)
     }
 
-    private func computeStats(interval: DateInterval) -> StatsResult {
-        var totalSeconds = 0
-        var weightedSum = 0.0
-        var weightedSeconds = 0.0
-        var zoneTotals = Array(repeating: 0, count: 5)
-
-        for entry in manager.workoutHistory where interval.contains(entry.date) {
-            totalSeconds += entry.durationSeconds
-            if let bpm = entry.beatsPerMeter {
-                let weight = Double(max(1, entry.durationSeconds))
-                weightedSum += bpm * weight
-                weightedSeconds += weight
-            }
-            if let zones = entry.zoneSeconds, zones.count == 5 {
-                for idx in 0..<5 { zoneTotals[idx] += zones[idx] }
-            } else if entry.avgBpm > 0 {
-                let idx = zoneIndex(for: entry.avgBpm)
-                zoneTotals[idx] += entry.durationSeconds
-            }
-        }
-
-        let avg = weightedSeconds > 0 ? (weightedSum / weightedSeconds) : nil
-        return StatsResult(totalSeconds: totalSeconds, avgBeatsPerMeter: avg, zoneSeconds: zoneTotals)
-    }
-
-    private func formatTotalTime(_ seconds: Int) -> String {
-        let total = max(0, seconds)
+    private func formatTotalTime(_ seconds: Double?) -> String {
+        guard let seconds else { return "—" }
+        let total = max(0, Int(seconds))
         let hours = total / 3600
         let minutes = (total % 3600) / 60
         if hours > 0 {
@@ -2487,25 +2484,18 @@ private struct WorkoutStatsView: View {
         }
     }
 
-    private func zoneIndex(for bpm: Int) -> Int {
-        if bpm <= manager.hrZone1Max { return 0 }
-        if bpm <= manager.hrZone2Max { return 1 }
-        if bpm <= manager.hrZone3Max { return 2 }
-        if bpm <= manager.hrZone4Max { return 3 }
-        return 4
-    }
 }
 
 private struct ZoneSummaryRow: View {
     let title: String
     let rangeText: String
-    let actualMinutes: Int
+    let actualMinutes: Int?
     let planMinutes: Int
-    let progress: Double
+    let progress: Double?
     let color: Color
 
     var body: some View {
-        let achieved = planMinutes > 0 && actualMinutes >= planMinutes
+        let achieved = planMinutes > 0 && (actualMinutes ?? -1) >= planMinutes
         VStack(alignment: .leading, spacing: 6) {
             HStack {
                 Text(title)
@@ -2522,7 +2512,7 @@ private struct ZoneSummaryRow: View {
                 }
             }
             HStack(spacing: 6) {
-                Text("Факт \(actualMinutes) мин")
+                Text(actualMinutes.map { "Факт \($0) мин" } ?? "Факт —")
                     .font(.caption2)
                     .foregroundColor(.secondary)
                 Text("·")
@@ -2538,7 +2528,7 @@ private struct ZoneSummaryRow: View {
                         .foregroundColor(.secondary)
                 }
             }
-            if planMinutes > 0 {
+            if planMinutes > 0, let progress {
                 ProgressView(value: min(1.0, max(0.0, progress)))
                     .progressViewStyle(.linear)
                     .tint(color)
@@ -2623,26 +2613,11 @@ private struct ZonePlanRow: View {
 }
 
 private struct WorkoutHistoryCard: View {
-    let entries: [WorkoutEntry]
-    let onDelete: (UUID) -> Void
-
-    // Convenience initializer to accept manager's nested WorkoutEntry type
-    init(entries: [BluetoothManager.WorkoutEntry], onDelete: @escaping (UUID) -> Void) {
-        self.entries = entries.map { src in
-            WorkoutEntry(
-                id: src.id,
-                date: src.date,
-                beatsPerMeter: src.beatsPerMeter,
-                targetBpm: src.targetBpm,
-                durationSeconds: src.durationSeconds,
-                avgBpm: src.avgBpm,
-                avgSpeedKmh: src.avgSpeedKmh,
-                healthkitWorkoutUUID: src.healthkitWorkoutUUID,
-                zoneSeconds: src.zoneSeconds
-            )
-        }
-        self.onDelete = onDelete
-    }
+    let entries: [WorkoutHistoryProjection]
+    let readState: BluetoothManager.WorkoutReadState
+    let hasMore: Bool
+    let onRetry: () -> Void
+    let onLoadMore: () -> Void
 
     private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -2658,27 +2633,52 @@ private struct WorkoutHistoryCard: View {
                     .font(.subheadline)
                     .foregroundColor(.secondary)
 
-                if entries.isEmpty {
+                if case .loading = readState, entries.isEmpty {
+                    ProgressView("Чтение Telemetry V2…")
+                        .font(.caption)
+                } else if case let .failed(message) = readState, entries.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("История Telemetry V2 недоступна: \(message)")
+                            .font(.caption2)
+                            .foregroundColor(.red)
+                        Button("Повторить", action: onRetry)
+                            .buttonStyle(.bordered)
+                    }
+                } else if entries.isEmpty {
                     Text("Пока нет данных")
                         .font(.caption2)
                         .foregroundColor(.secondary)
                 } else {
-                    ForEach(entries.prefix(20)) { entry in
+                    ForEach(entries) { entry in
                         HStack(alignment: .top, spacing: 12) {
                             VStack(alignment: .leading, spacing: 4) {
-                                Text(Self.dateFormatter.string(from: entry.date))
+                                Text(entry.startedAt.map(Self.dateFormatter.string(from:)) ?? "Дата неизвестна")
                                     .font(.footnote.weight(.semibold))
                                     .foregroundColor(.primary)
                                 Text("Время: \(formatDuration(entry.durationSeconds))")
                                     .font(.caption2)
                                     .foregroundColor(.secondary)
+                                Text(provenanceText(for: entry))
+                                    .font(.caption2.weight(.medium))
+                                    .foregroundColor(entry.origin == .nativeV2 ? .blue : .orange)
+                                if !entry.quality.warnings.isEmpty {
+                                    Text(entry.quality.warnings.joined(separator: "; "))
+                                        .font(.caption2)
+                                        .foregroundColor(.orange)
+                                }
+                                if let healthKitID = entry.healthKitWorkoutIdentifier {
+                                    Text("HealthKit: \(healthKitID.uuidString.lowercased())")
+                                        .font(.caption2.monospaced())
+                                        .foregroundColor(.secondary)
+                                        .textSelection(.enabled)
+                                }
                             }
                             Spacer()
                             VStack(alignment: .trailing, spacing: 4) {
-                                Text("Удары/м: \(entry.beatsPerMeter.map { String(format: "%.2f", $0) } ?? "—")")
+                                Text("Удары/м: \(entry.beatsPerMetre.map { String(format: "%.2f", $0) } ?? "—")")
                                     .font(.caption2)
                                     .foregroundColor(.secondary)
-                                Text("Цель: \(entry.targetBpm)")
+                                Text("Цель: \(entry.targetHeartRate.map(String.init) ?? "—")")
                                     .font(.caption2)
                                     .foregroundColor(.secondary)
                                 Text("Ср. скорость: \(averageSpeedText(for: entry))")
@@ -2686,39 +2686,54 @@ private struct WorkoutHistoryCard: View {
                                     .foregroundColor(.secondary)
                                 Text("Ср. пульс: \(averageBpmText(for: entry))")
                                     .font(.caption2.weight(.semibold))
-                                    .foregroundColor(entry.avgBpm > 0 ? .red : .secondary)
+                                    .foregroundColor(entry.averageHeartRate == nil ? .secondary : .red)
                             }
-                            Button {
-                                onDelete(entry.id)
-                            } label: {
-                                Image(systemName: "trash")
-                                    .foregroundColor(.red)
-                            }
-                            .buttonStyle(.plain)
                         }
-                        if entry.id != entries.prefix(20).last?.id {
+                        if entry.id != entries.last?.id {
                             Divider()
                         }
+                    }
+
+                    if hasMore {
+                        Button("Показать ещё", action: onLoadMore)
+                            .buttonStyle(.bordered)
+                            .frame(maxWidth: .infinity)
+                    }
+
+                    if case let .failed(message) = readState {
+                        Text("Следующая страница недоступна: \(message)")
+                            .font(.caption2)
+                            .foregroundColor(.red)
                     }
                 }
             }
         }
     }
 
-    private func formatDuration(_ seconds: Int) -> String {
-        let minutes = max(0, seconds) / 60
-        let secs = max(0, seconds) % 60
+    private func formatDuration(_ seconds: Double?) -> String {
+        guard let seconds else { return "—" }
+        let value = max(0, Int(seconds))
+        let minutes = value / 60
+        let secs = value % 60
         return String(format: "%d:%02d", minutes, secs)
     }
 
-    private func averageBpmText(for entry: WorkoutEntry) -> String {
-        guard entry.avgBpm > 0 else { return "—" }
-        return "\(entry.avgBpm) bpm"
+    private func averageBpmText(for entry: WorkoutHistoryProjection) -> String {
+        guard let average = entry.averageHeartRate else { return "—" }
+        return "\(Int(average.rounded())) bpm"
     }
 
-    private func averageSpeedText(for entry: WorkoutEntry) -> String {
-        guard let avgSpeed = entry.avgSpeedKmh, avgSpeed > 0.05 else { return "—" }
-        return String(format: "%.1f км/ч", avgSpeed)
+    private func averageSpeedText(for entry: WorkoutHistoryProjection) -> String {
+        guard let speed = entry.averageSpeed else { return "—" }
+        let prefix = speed.evidenceKind == .legacyEstimated ? "≈" : ""
+        return prefix + String(format: "%.1f км/ч", speed.kilometresPerHour)
+    }
+
+    private func provenanceText(for entry: WorkoutHistoryProjection) -> String {
+        let origin = entry.origin == .nativeV2 ? "V2 native" : "Legacy import"
+        let lifecycle = entry.quality.lifecycleState
+        let grade = entry.quality.analysisGrade.map { " · \($0)" } ?? ""
+        return "\(origin) · \(lifecycle)\(grade)"
     }
 }
 
@@ -2762,16 +2777,11 @@ private struct DebugView: View {
         scope: TrainingLogCsvExportScope,
         sessionSummaryOnly: Bool
     ) -> String {
-        let count = manager.trainingLogsExportCount(for: scope, sessionSummaryOnly: sessionSummaryOnly)
-
         switch scope {
         case .all:
-            if sessionSummaryOnly {
-                return "Все тренировки (\(count))"
-            }
-            return "Все raw логи (\(count))"
+            return sessionSummaryOnly ? "Все V2 summary" : "Все V2 evidence"
         case .lastCompletedWorkouts(let limit):
-            return "Последние \(limit) тренировки (будет \(count))"
+            return "Последние \(limit) завершённых"
         }
     }
 
@@ -2795,25 +2805,43 @@ private struct DebugView: View {
 
     private var telemetryV2WriterHealthDetailLines: [String] {
         let duration = manager.telemetryV2WriterHealthSnapshot.mostRecentFlushDuration
-        guard let duration else { return ["Latest flush: —"] }
+        guard let duration else {
+            return [
+                "Latest flush: —",
+                "Legacy shadow parity writer: \(manager.legacyShadowWriterStatusText)",
+            ]
+        }
         let components = duration.components
         let milliseconds = (Double(components.seconds) * 1_000)
             + (Double(components.attoseconds) / 1_000_000_000_000_000)
-        return ["Latest flush: \(String(format: "%.1f", milliseconds)) ms"]
+        return [
+            "Latest flush: \(String(format: "%.1f", milliseconds)) ms",
+            "Legacy shadow parity writer: \(manager.legacyShadowWriterStatusText)",
+        ]
     }
 
     private var trainingLogsCardPresentation: DebugTrainingLogsCard.Presentation {
-        let inventory = manager.trainingLogsInventory
-        let lastLogName = manager.lastTrainingLogPath.isEmpty
-            ? nil
-            : URL(fileURLWithPath: manager.lastTrainingLogPath).lastPathComponent
+        let entries = manager.telemetryV2WorkoutHistory
+        let readReady = manager.telemetryV2WorkoutHistoryState == .loaded
+        let readStatusText: String = {
+            switch manager.telemetryV2WorkoutHistoryState {
+            case .idle: return "V2 read: idle"
+            case .loading: return "V2 read: loading"
+            case .loaded: return "V2 read: ready"
+            case let .failed(message): return "V2 read failed: \(message)"
+            }
+        }()
+        let completedCount = entries.filter {
+            $0.quality.lifecycleState == "completed" || $0.quality.lifecycleState == "imported"
+        }.count
+        let unavailableCount = entries.filter { !$0.quality.unavailableMetrics.isEmpty }.count
+        let possibleDuplicateCount = entries.filter(\.quality.possibleDuplicate).count
         let detailLines = [
-            "Session Summary включает только завершённые тренировки (`workout_saved`).",
-            inventory.clearableSessionFiles > 0
-                ? "Ручная очистка удаляет только raw JSONL-логи активного профиля; статистика тренировок сохраняется."
-                : "Активная сессия защищена от удаления и не участвует в ручной очистке.",
-            lastLogName.map { "Последний JSONL: \($0)" }
-        ].compactMap { $0 }
+            "Export формируется потоково из Telemetry V2 и включает manifest, raw JSONL, normalized CSV и session summary.",
+            "Legacy JSONL и UserDefaults shadow history не читаются, не очищаются и не удаляются.",
+            "Поля HealthKit linkage и version context сохраняются; device/profile identifiers исключены.",
+            readStatusText,
+        ]
 
         let rawExportOptions = trainingLogScopeOptions.map { scope in
             DebugTrainingLogsCard.Presentation.ExportOption(
@@ -2834,36 +2862,28 @@ private struct DebugView: View {
             testRunActive: manager.treadmillTestRunIsActive,
             testRunStatusText: manager.treadmillTestRunDisplayText,
             canStartTestRun: manager.canStartTreadmillTestRun,
-            subtitle: "Активный профиль: \(manager.activeUserProfileLabel)",
+            subtitle: "Telemetry V2 · активный профиль: \(manager.activeUserProfileLabel)",
             profileMetrics: [
-                .init(id: "profile_raw", title: "Raw", value: "\(inventory.matchingProfileSessionFiles)", tint: .accentColor),
-                .init(id: "profile_completed", title: "Трен.", value: "\(inventory.matchingProfileCompletedWorkoutFiles)", tint: .blue),
-                .init(id: "profile_size", title: "Размер", value: formattedByteCount(inventory.matchingProfileBytes), tint: .green)
+                .init(id: "profile_loaded", title: "Загружено", value: "\(entries.count)", tint: .accentColor),
+                .init(id: "profile_completed", title: "Заверш.", value: "\(completedCount)", tint: .blue),
+                .init(id: "profile_quality", title: "Missing / dup", value: "\(unavailableCount) / \(possibleDuplicateCount)", tint: .orange)
             ],
-            deviceMetrics: [
-                .init(id: "device_raw", title: "Все raw", value: "\(inventory.totalSessionFiles)", tint: .secondary),
-                .init(id: "device_completed", title: "Все тр.", value: "\(inventory.completedWorkoutFiles)", tint: .secondary),
-                .init(id: "device_size", title: "Память", value: formattedByteCount(inventory.totalBytes), tint: .secondary)
-            ],
+            deviceMetrics: [],
             writerHealthMetrics: telemetryV2WriterHealthMetrics,
             writerHealthDetailLines: telemetryV2WriterHealthDetailLines,
             rawExportOptions: rawExportOptions,
-            rawExportSubtitle: inventory.matchingProfileSessionFiles > 0
-                ? "\(inventory.matchingProfileSessionFiles) raw сессий доступно"
-                : "Нет raw логов",
-            canExportRaw: inventory.matchingProfileSessionFiles > 0,
+            rawExportSubtitle: readReady ? "Raw + normalized + manifest" : "V2 read unavailable",
+            canExportRaw: readReady,
             sessionSummaryOptions: summaryExportOptions,
-            sessionSummarySubtitle: inventory.matchingProfileCompletedWorkoutFiles > 0
-                ? "\(inventory.matchingProfileCompletedWorkoutFiles) тренировок готово"
-                : "Нет завершённых тренировок",
-            canExportSessionSummary: inventory.matchingProfileCompletedWorkoutFiles > 0,
-            clearSubtitle: inventory.clearableSessionFiles > 0
-                ? "\(inventory.clearableSessionFiles) файлов · \(formattedByteCount(inventory.clearableBytes))"
-                : "Сейчас очищать нечего",
-            canClear: inventory.clearableSessionFiles > 0,
-            clearConfirmationMessage: "Будут удалены только raw JSONL training logs активного профиля: \(inventory.clearableSessionFiles) файлов, \(formattedByteCount(inventory.clearableBytes)). История тренировок в статистике останется.",
+            sessionSummarySubtitle: readReady
+                ? "V2 summary + quality fields"
+                : "V2 read unavailable",
+            canExportSessionSummary: readReady,
+            clearSubtitle: "Source evidence is immutable in this cutover.",
+            canClear: false,
+            clearConfirmationMessage: "",
             detailLines: detailLines,
-            footer: inventory.matchingProfileCompletedWorkoutFiles < 3
+            footer: completedCount < 3
                 ? "Для анализа лучше накопить хотя бы 3 завершённые тренировки."
                 : nil
         )
@@ -3106,9 +3126,6 @@ private struct DebugView: View {
                         },
                         onExportSessionSummary: { scope in
                             exportTrainingSessionSummaryCsv(manager: manager, scope: scope)
-                        },
-                        onClear: {
-                            manager.clearTrainingLogsForActiveProfile()
                         }
                     )
 
@@ -3127,7 +3144,7 @@ private struct DebugView: View {
             }
             .navigationTitle("Отладка")
             .onAppear {
-                manager.refreshTrainingLogsInventory()
+                manager.refreshWorkoutHistoryFromV2(reset: true)
             }
         }
     }
@@ -3150,50 +3167,65 @@ private func exportTrainingHistoryCsv(
     manager: BluetoothManager,
     scope: TrainingLogCsvExportScope
 ) {
-    let present: (UIActivityViewController) -> Void = { vc in
-        if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let root = scene.windows.first?.rootViewController {
-            root.present(vc, animated: true)
-        }
-    }
-
-    guard let export = manager.prepareTrainingLogsCsvExport(scope: scope) else {
-        let message = scope.missingLogsMessage
-        let vc = UIActivityViewController(activityItems: [message], applicationActivities: nil)
-        present(vc)
-        return
-    }
-
-    let vc = UIActivityViewController(activityItems: [export.csvURL], applicationActivities: nil)
-    vc.completionWithItemsHandler = { _, completed, _, _ in
-        manager.finalizeTrainingLogsCsvExport(export, completed: completed)
-    }
-    present(vc)
+    presentTelemetryV2ExportWarning(manager: manager, scope: scope)
 }
 
 private func exportTrainingSessionSummaryCsv(
     manager: BluetoothManager,
     scope: TrainingLogCsvExportScope
 ) {
-    let present: (UIActivityViewController) -> Void = { vc in
-        if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let root = scene.windows.first?.rootViewController {
-            root.present(vc, animated: true)
+    presentTelemetryV2ExportWarning(manager: manager, scope: scope)
+}
+
+private func presentTelemetryV2ExportWarning(
+    manager: BluetoothManager,
+    scope: TrainingLogCsvExportScope
+) {
+    guard let root = activeRootViewController() else { return }
+    let alert = UIAlertController(
+        title: "Health Data Export",
+        message: "The export contains heart-rate and workout health data. Share it only with a trusted recipient. Source evidence will not be deleted.",
+        preferredStyle: .alert
+    )
+    alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+    alert.addAction(UIAlertAction(title: "Continue", style: .default) { _ in
+        Task { @MainActor in
+            do {
+                let artifact = try await manager.prepareTelemetryV2Export(scope: scope)
+                let activity = UIActivityViewController(
+                    activityItems: artifact.fileURLs,
+                    applicationActivities: nil
+                )
+                activity.completionWithItemsHandler = { _, completed, _, _ in
+                    Task { @MainActor in
+                        manager.finalizeTelemetryV2Export(artifact, completed: completed)
+                    }
+                }
+                activeRootViewController()?.present(activity, animated: true)
+            } catch {
+                let failure = UIAlertController(
+                    title: "Telemetry V2 Export Failed",
+                    message: error.localizedDescription,
+                    preferredStyle: .alert
+                )
+                failure.addAction(UIAlertAction(title: "OK", style: .default))
+                activeRootViewController()?.present(failure, animated: true)
+            }
         }
-    }
+    })
+    root.present(alert, animated: true)
+}
 
-    guard let export = manager.prepareTrainingSessionSummaryCsvExport(scope: scope) else {
-        let message = "Completed training logs not found yet. Start and save an HR workout first."
-        let vc = UIActivityViewController(activityItems: [message], applicationActivities: nil)
-        present(vc)
-        return
+private func activeRootViewController() -> UIViewController? {
+    guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+        return nil
     }
-
-    let vc = UIActivityViewController(activityItems: [export.csvURL], applicationActivities: nil)
-    vc.completionWithItemsHandler = { _, completed, _, _ in
-        manager.finalizeTrainingLogsCsvExport(export, completed: completed)
+    var controller = scene.windows.first(where: \.isKeyWindow)?.rootViewController
+        ?? scene.windows.first?.rootViewController
+    while let presented = controller?.presentedViewController {
+        controller = presented
     }
-    present(vc)
+    return controller
 }
 
 // Overload to accept manager's nested type and forward to the existing exporter

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DebugTrainingLogsCard.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DebugTrainingLogsCard.swift
@@ -40,9 +40,6 @@ struct DebugTrainingLogsCard: View {
     let onToggleTestRun: () -> Void
     let onExportRaw: (TrainingLogCsvExportScope) -> Void
     let onExportSessionSummary: (TrainingLogCsvExportScope) -> Void
-    let onClear: () -> Void
-
-    @State private var showClearConfirmation = false
 
     private let metricColumns = [
         GridItem(.flexible(), spacing: 10),
@@ -81,7 +78,9 @@ struct DebugTrainingLogsCard: View {
                 }
 
                 metricsSection(title: "Активный профиль", items: presentation.profileMetrics)
-                metricsSection(title: "Всё устройство", items: presentation.deviceMetrics)
+                if !presentation.deviceMetrics.isEmpty {
+                    metricsSection(title: "Всё устройство", items: presentation.deviceMetrics)
+                }
                 metricsSection(
                     title: "Telemetry V2 Writer",
                     items: presentation.writerHealthMetrics
@@ -132,18 +131,9 @@ struct DebugTrainingLogsCard: View {
                     .disabled(!presentation.canExportSessionSummary)
                 }
 
-                Button {
-                    showClearConfirmation = true
-                } label: {
-                    DebugActionTileLabel(
-                        title: "Clear Training Logs",
-                        subtitle: presentation.clearSubtitle,
-                        tint: .red,
-                        enabled: presentation.canClear
-                    )
-                }
-                .buttonStyle(.plain)
-                .disabled(!presentation.canClear)
+                Text(presentation.clearSubtitle)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
 
                 VStack(alignment: .leading, spacing: 6) {
                     ForEach(Array(presentation.detailLines.enumerated()), id: \.offset) { _, line in
@@ -159,14 +149,6 @@ struct DebugTrainingLogsCard: View {
                         .foregroundColor(.secondary)
                 }
             }
-        }
-        .alert("Clear Training Logs?", isPresented: $showClearConfirmation) {
-            Button("Cancel", role: .cancel) {}
-            Button("Clear", role: .destructive) {
-                onClear()
-            }
-        } message: {
-            Text(presentation.clearConfirmationMessage)
         }
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WorkoutReadCutoverContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WorkoutReadCutoverContractTests.swift
@@ -78,6 +78,19 @@ final class WorkoutReadCutoverContractTests: XCTestCase {
         XCTAssertFalse(legacyClear.contains("pruneTrainingLogs"))
     }
 
+    func testStatisticsUIExposesExcludedWorkoutCompleteness() {
+        XCTAssertTrue(contentSource.contains("stats.excludedWorkoutCount"))
+        XCTAssertTrue(contentSource.contains("exclusionReasonCounts"))
+        XCTAssertTrue(contentSource.contains("Исключено из агрегатов"))
+    }
+
+    func testHistoryUIExposesExactImportedHealthKitLinkageProvenance() {
+        XCTAssertTrue(
+            contentSource.contains("telemetry-v2-imported-exact-healthkit-linkage")
+        )
+        XCTAssertTrue(contentSource.contains("exact import linkage"))
+    }
+
     private func source(_ fileName: String) -> String {
         let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
         let appDirectory = testsDirectory.deletingLastPathComponent()

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WorkoutReadCutoverContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WorkoutReadCutoverContractTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import XCTest
+
+final class WorkoutReadCutoverContractTests: XCTestCase {
+    private lazy var managerSource = source("BluetoothManager.swift")
+    private lazy var contentSource = source("ContentView.swift")
+
+    func testNormalHistoryStatisticsAndExportUIUseOnlyTelemetryV2() {
+        XCTAssertTrue(contentSource.contains("manager.telemetryV2WorkoutHistory"))
+        XCTAssertTrue(contentSource.contains("manager.telemetryV2Statistics"))
+        XCTAssertTrue(contentSource.contains("manager.prepareTelemetryV2Export"))
+        XCTAssertFalse(contentSource.contains("manager.workoutHistory"))
+        XCTAssertFalse(contentSource.contains("manager.prepareTrainingLogsCsvExport"))
+        XCTAssertFalse(contentSource.contains("manager.prepareTrainingSessionSummaryCsvExport"))
+        XCTAssertFalse(contentSource.contains("manager.clearTrainingLogsForActiveProfile"))
+    }
+
+    func testLegacyHistoryIsPrivateShadowEvidenceAndCannotGateStart() throws {
+        XCTAssertTrue(
+            managerSource.contains(
+                "private var legacyShadowWorkoutHistory: [LegacyShadowWorkoutEntry] = []"
+            )
+        )
+        XCTAssertTrue(managerSource.contains("Compatibility-only parity evidence through #37"))
+        XCTAssertFalse(managerSource.contains("@Published var workoutHistory"))
+
+        let startGate = try sourceSlice(
+            from: "private func recomputeHrStartAllowed()",
+            to: "private func startTelemetry()",
+            in: managerSource
+        )
+        XCTAssertFalse(startGate.contains("telemetryV2WorkoutHistory"))
+        XCTAssertFalse(startGate.contains("telemetryV2Statistics"))
+        XCTAssertFalse(startGate.contains("legacyShadowWorkoutHistory"))
+        XCTAssertFalse(startGate.contains("legacyShadowWriterStatusText"))
+    }
+
+    func testShadowWriteFailureIsDiagnosticOnlyAndDoesNotOwnV2SessionSuccess() throws {
+        let shadowWrite = try sourceSlice(
+            from: "private func saveLegacyShadowWorkoutHistory(",
+            to: "private func removeStoredData(",
+            in: managerSource
+        )
+        XCTAssertTrue(shadowWrite.contains("legacyShadowWriterStatusText"))
+        XCTAssertTrue(shadowWrite.contains("appendLog("))
+        XCTAssertFalse(shadowWrite.contains("throw"))
+        XCTAssertFalse(shadowWrite.contains("telemetryV2Coordinator"))
+
+        let workoutSave = try sourceSlice(
+            from: "private func recordHrWorkoutIfNeeded(",
+            to: "private func attachHealthkitWorkoutUUID(",
+            in: managerSource
+        )
+        XCTAssertTrue(workoutSave.contains("saveLegacyShadowWorkoutHistory()"))
+        XCTAssertFalse(workoutSave.contains("guard saveLegacyShadowWorkoutHistory"))
+        XCTAssertFalse(workoutSave.contains("if saveLegacyShadowWorkoutHistory"))
+    }
+
+    func testLegacySourceEvidenceHasNoAutomaticOrExportCleanupCaller() throws {
+        XCTAssertFalse(managerSource.contains("pruneTrainingLogs(in: "))
+
+        let legacyFinalize = try sourceSlice(
+            from: "func finalizeTrainingLogsCsvExport(",
+            to: "private func hex(",
+            in: managerSource
+        )
+        XCTAssertTrue(legacyFinalize.contains("source evidence preserved"))
+        XCTAssertFalse(legacyFinalize.contains("cleanupExportedJsonlFiles"))
+        XCTAssertFalse(legacyFinalize.contains("pruneTrainingLogs"))
+
+        let legacyClear = try sourceSlice(
+            from: "func clearTrainingLogsForActiveProfile()",
+            to: "private func availableTrainingJsonlFiles(",
+            in: managerSource
+        )
+        XCTAssertTrue(legacyClear.contains("source evidence preserved"))
+        XCTAssertFalse(legacyClear.contains("cleanupExportedJsonlFiles"))
+        XCTAssertFalse(legacyClear.contains("pruneTrainingLogs"))
+    }
+
+    private func source(_ fileName: String) -> String {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let appDirectory = testsDirectory.deletingLastPathComponent()
+            .appendingPathComponent("WalkingPadRemote", isDirectory: true)
+        return try! String(
+            contentsOf: appDirectory.appendingPathComponent(fileName),
+            encoding: .utf8
+        )
+    }
+
+    private func sourceSlice(
+        from start: String,
+        to end: String,
+        in source: String
+    ) throws -> String {
+        guard let startRange = source.range(of: start),
+              let endRange = source.range(of: end, range: startRange.upperBound..<source.endIndex)
+        else {
+            throw NSError(domain: "WorkoutReadCutoverContractTests", code: 1)
+        }
+        return String(source[startRange.lowerBound..<endRange.lowerBound])
+    }
+}


### PR DESCRIPTION
## Outcome

- cuts user-visible workout history and weekly/monthly statistics over to profile-scoped Telemetry V2 projections
- adds stable keyset pagination with bounded fetches and no time-series hydration for list/history reads
- keeps incomplete, imported, uncertain, duplicate-candidate, and low-quality evidence queryable with explicit provenance, unavailable metrics, and estimated-speed markers
- adds streamed, read-only V2 export bundles: portable raw JSONL, normalized CSV, versioned summary JSONL/CSV, and a quality/version/privacy manifest
- preserves and conflict-checks HealthKit workout UUID linkage in V2 history and exports

## Safety and compatibility

- no Start HR Control, HR/speed decisions, commands, cooldown, Stop, Watch, units, BLE, or safety authority changes
- V2 read/export failures are explicit and never fall back to legacy data or gate workout control
- the existing legacy UserDefaults shadow writer remains isolated parity/rollback evidence through #37, with failure reported as diagnostic-only state
- legacy JSONL/UserDefaults source evidence and the #34 importer are preserved; automatic pruning, export cleanup, and manual cleanup are disabled until #36 retirement authorization
- the accepted #34 SwiftData schema remains unchanged

## Verification

- `swift test --scratch-path /private/tmp/walkingpad_issue35_swift_build`
- `xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' -derivedDataPath /private/tmp/walkingpad_issue35_derived_ios_final CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project WalkingPadRemote.xcodeproj -scheme 'WalkingPadRemoteWatch Watch App' -destination 'generic/platform=watchOS' -derivedDataPath /private/tmp/walkingpad_issue35_derived_watch_final CODE_SIGNING_ALLOWED=NO build`
- independent safety challenge: no remaining findings
- fresh Terra/high final review: no remaining concrete findings

## Documentation consulted

- Apple `FetchDescriptor`: `fetchLimit`, predicates, and sort descriptors informed bounded read/export queries
  - https://developer.apple.com/documentation/swiftdata/fetchdescriptor
- Apple `Index`: existing profile/date and session/time indexes are reused without mutating the deployed schema
  - https://developer.apple.com/documentation/swiftdata/index(_:) 

No app/device launch, deploy, physical-device validation, BLE/treadmill activity, Ready-for-review transition, or merge was performed.

Closes #35
