### PR TITLE
Redesign the training preflight hub

### DIFF
--- a/docs/design/qa-ledger.md
+++ b/docs/design/qa-ledger.md
@@ -1,8 +1,24 @@
 # Redesign QA ledger
 
-Status: no redesign QA run.
+Status: passed for the frozen Issue #56 presentation scope.
 
 | Pass | State / form factor | Severity | Finding | Evidence | Owner path | Status |
 | --- | --- | --- | --- | --- | --- | --- |
+| Baseline | Ready, unknown HR source / iPhone 17 / light | P0 | Frozen hierarchy, generic HR readiness, mode menu, zone range, metrics, and pinned Start are present. | `/private/tmp/issue56-ready-unknown-source.png` | `ContentView.swift` | Pass |
+| Baseline | Ready, known HR source / iPhone 17 / light | P0 | A factual source label is optional presentation data; no Apple-Watch-specific readiness is required. | `/private/tmp/issue56-ready-known-source.png` | `ContentView.swift` | Pass |
+| Baseline | Treadmill unavailable / iPhone 17 / light | P0 | Treadmill readiness reports unavailable and Start stays disabled. | `/private/tmp/issue56-treadmill-unavailable.png` | `ContentView.swift` | Pass |
+| Baseline | HR unavailable / iPhone 17 / light | P0 | Heart Rate readiness reports unavailable and Start stays disabled without naming a provider. | `/private/tmp/issue56-hr-unavailable.png` | `ContentView.swift` | Pass |
+| Baseline | Preparing / iPhone 17 / light | P1 | Preparing treatment is testable through a DEBUG-only fixture and cannot issue a production start. | `/private/tmp/issue56-preparing.png` | `ContentView.swift` | Pass |
+| Baseline | Intervals and Weekly Zones preview modes / iPhone 17 / light | P0 | Both future modes reuse the same small presentation shape; Start is disabled and no runtime mode exists. | `/private/tmp/issue56-intervals.png`, `/private/tmp/issue56-weekly-zones.png` | `ContentView.swift` | Pass |
+| Baseline | Actual production unavailable state / iPhone 17 / light | P0 | Production mapping reflects current manager facts and does not fabricate readiness or a source. | `/private/tmp/issue56-production-unavailable.png` | `ContentView.swift` | Pass |
+| Correction 1 | Selected Z3 / iPhone 17 / light | P2 | Yellow selected-segment label had insufficient contrast. | `/private/tmp/issue56-ready-unknown-source.png` | `ContentView.swift` | Fixed: selected label now uses `Color.primary`. |
+| Correction 1 | Ready / iPhone 17 / dark | P1 | Hierarchy, semantic colors, and materials remain legible in dark appearance. | `/private/tmp/issue56-ready-dark.png` | `ContentView.swift` | Pass |
+| Correction 2 | Ready / iPhone 17 / Accessibility XL | P2 | The mode name wrapped and the CTA consumed excessive height. | `/private/tmp/issue56-ready-accessibility-xl-pass2.png` | `ContentView.swift` | Fixed: resilient one-line labels with scaling; Start remains pinned and target remains visible. |
+| Correction 2 | Ready / iPad / regular width | P1 | The compact hierarchy remains coherent at regular width and uses native iPad tab placement. | `/private/tmp/issue56-ready-ipad.png` | `ContentView.swift` | Pass |
+| Independent review | DEBUG fixture launch | P1 | Fixture presentation originally still allowed root manager lifecycle startup. | Source review and contract test | `ContentView.swift` | Fixed: DEBUG fixture launches now skip manager startup and scene lifecycle actions; fresh re-review found no P0–P2. |
+| Final review | Code accessibility and localization resilience | P1 | Interactive controls use native `Button`, `Menu`, segmented buttons, and labels; concise unavailable copy and line limits tolerate Russian and large type. VoiceOver reading order follows source order. | Source inspection plus Accessibility XL fixture | `ContentView.swift` | Pass |
+| Final review | Compact-height attempt | P3 | The headless Simulator host exposes no orientation command, and its active screen mode rejected a landscape geometry. Portrait small-screen scrolling and pinned Start were verified instead. | `simctl io screenConfig geometry 2622x1206@3` rejected as unsupported | QA environment | Accepted limitation; no P0-P2 finding. |
+
+DEBUG fixture safety is covered by `HeartRateLegacyBehaviorContractTests`: preview-only modes report `canStart == false`, the fixture source contains no production control or telemetry entry points, and fixture launches skip root manager startup/scene lifecycle actions.
 
 Normal visual QA is limited to two correction passes. If a P0–P2 finding remains, or a correction would cross the approved presentation-only write set, return to PM.

--- a/docs/design/redesign-brief.md
+++ b/docs/design/redesign-brief.md
@@ -1,16 +1,122 @@
-# Redesign brief
+# Issue #56 redesign brief
 
-Status: no redesign is selected by Issue #2.
+Status: refined Concept B approved and frozen for Issue #56 implementation.
 
-Complete this artifact only for a PM-scoped screen or flow using the project redesign skill.
+## Scope and contract
 
-- Screen/flow:
-- User problem and evidence:
-- Exact base and writable files:
-- Required states/form factors:
-- Existing patterns to preserve:
-- Audit findings (maximum 8):
-- Concept A — benefit/tradeoff:
-- Concept B — benefit/tradeoff:
-- Acceptance evidence:
-- Non-goals and safety boundary:
+- Screen/flow: primary `Training` tab, idle Training Hub, and the compact preparing/preflight presentation immediately after the existing Start request.
+- Primary user: a person preparing to begin the current HR Control workout, often reading the phone at arm's length near the treadmill.
+- Single problem: the current idle screen behaves like an HR-Control telemetry/configuration dashboard, so workout readiness, the selected goal, and Start are not glanceable.
+- Exact base: `22bd8bdbccf1be82e3b66c3b17e4fb0b22099caa` (`origin/main`, fetched 2026-08-22).
+- Frozen writable paths: `ContentView.swift`, the existing `HeartRateLegacyBehaviorContractTests.swift`, and `docs/design/{redesign-brief,selected-direction,qa-ledger}.md`.
+- Read-only evidence paths: `ContentView.swift`, `CommonInfoCard.swift`, `ContentSharedUIComponents.swift`, and existing runtime readiness facts in `BluetoothManager.swift` / `HRDomainService.swift`.
+- Acceptance evidence for this pass: current-code audit, simulator screenshot from the exact base on iPhone 17 / iOS 27.0, exactly two recorded concepts, and redesign scope check.
+- Mock inputs for later preview/test work: idle ready; treadmill unavailable; HR unavailable/stale; known and unknown HR source identity; simple preparing; preview-only `Work 2/4` and `Zone 5` future-mode values.
+
+## Required states and form factors
+
+- Normal: HR Control selected, treadmill ready, fresh accepted HR available, concise goal visible, Start enabled.
+- Loading/preparing: compact indeterminate progress and truthful prerequisite/status copy derived from existing runtime facts; no new countdown or authorization state.
+- Empty: no separate production no-mode state is needed because HR Control exists today; unavailable factual values use `—` or an explicit unavailable status rather than fabricated zeroes.
+- Error/degraded: treadmill unavailable and HR unavailable/stale remain separate, actionable statuses; exact HR source is omitted when unknown.
+- Disabled: Start availability stays at parity with the accepted current affordance inputs; Telemetry/history readiness never becomes a gate.
+- Accessibility: useful VoiceOver grouping/order, status conveyed by text and symbol rather than color alone, Dynamic Type without three-column compression, sufficient contrast, and Reduce Motion-safe progress.
+- Form factors: compact-width iPhone portrait is primary; compact-height/landscape and regular-width iPad should keep the same hierarchy without adding content. watchOS UI is out of scope.
+
+## Existing patterns to preserve
+
+- Native SwiftUI, SF Symbols, semantic system colors/materials, grouped backgrounds, `NavigationStack`, `Button`, `ProgressView`, and existing sheets/navigation for device selection and HR parameters.
+- Reuse the existing `Card` / `PrimaryActionButton` only where they support the selected hierarchy; do not create a token or design-system layer for this Goal.
+- Presentation observes existing accepted runtime facts and calls the existing Start action; it does not own lifecycle or authorization.
+
+## Prioritized audit findings
+
+1. The root tab and first card are named `HR-control`, making the entry point a single-feature console rather than the universal `Training` destination required by #56.
+2. Before Start, `CommonInfoCard` presents nine live/accumulated metrics, including distance, steps, averages, beats-per-meter, and speed delta. Most are empty or zero and do not help choose or start a workout.
+3. On the exact-base iPhone 17 simulator, the metric dashboard plus configuration cards push the primary Start action below the initial viewport; the most important action is not glanceable.
+4. Readiness is modeled as `Treadmill` plus `Watch`; `Watch offline` and the Watch-specific issue affordance conflate HR availability/freshness with one transport/device identity.
+5. Readiness and failure guidance are scattered across the top tiles, Watch alert, disabled Start subtitle, and trailing status strip, so the user must reconcile several surfaces before acting.
+6. The idle hierarchy exposes implementation detail (`Adaptive` step, cooldown limits) alongside goal choice, while the selected mode, target, and duration are not summarized as one clear workout intent.
+7. Nested cards, repeated gradients/strokes, three-column metrics, and small captions create competing emphasis and fragile Dynamic Type behavior; decorative weight is highest where decision value is lowest.
+8. The idle-to-running transition has no concise preparing/preflight presentation. Any new preparing state should only reflect existing prerequisites and must not become a parallel workout state machine.
+
+## Frozen problem statement
+
+Replace the dense HR-Control-specific idle dashboard with a sparse Training entry point that answers, in order: what workout is selected, what is its current goal, whether the treadmill and fresh HR are ready, and whether Start is available. Preserve every runtime/control decision and keep future-mode readiness limited to a small generic presentation shape proven by deterministic preview/test values.
+
+## Concepts
+
+Both concepts use the same deliberately small foundation: one immutable presentation value carrying mode/title, an optional phase label, one primary target/status, a small secondary metric collection, generic HR availability/freshness plus an optional truthful source label, and an unavailable/warning message only when needed. Current HR Control gets the only production mapping. `Intervals · Скоро` is a disabled production selector placeholder; richer Intervals and Weekly Zones Auto examples remain deterministic preview/test values and cannot start runtime behavior.
+
+### Concept A — Readiness-first compact stack
+
+- Screen hierarchy/layout: large `Training` navigation title; one compact workout-summary card; two full-width readiness rows; one dominant Start action at the bottom of the content. `Goal` / `Settings` is a secondary disclosure from the summary instead of an always-expanded configuration grid.
+- Before Start: `HR Control`, selected zone/target, duration, and a concise cooldown note only if it materially affects the choice. No steps, distance, averages, speed delta, or pre-session zeroes.
+- Treadmill and HR readiness: separate text-led rows with symbol + status. The treadmill row can retain access to the existing device picker. The HR row leads with `Pulse available • 128 bpm` or `Pulse unavailable/stale`; a reliably known source is secondary (`Apple Watch`, for example), otherwise it says `HealthKit` / `Pulse available` and never guesses a device.
+- Primary action: full-width native `Button` / existing `PrimaryActionButton`, visually isolated after readiness. Disabled state is obvious; the first actionable blocker is placed directly above the button rather than packed into its label. Preparing replaces the action area with a compact `ProgressView` and existing prerequisite/status copy.
+- Glanceability/future modes: the reading path is one vertical answer sequence: workout → goal → two prerequisites → Start. The summary's generic primary/secondary fields can show `Work 2/4` or `Zone 5` preview values without altering the shell.
+- Approximate implementation complexity/code footprint: low; likely one small presentation value plus pure HR-Control mapping co-located at the current presentation boundary unless focused tests justify one new file, two small reusable rows/metrics, and about 180–280 production lines changed/added while removing a comparable obsolete idle path.
+- Main trade-offs: strongest YAGNI and Dynamic Type fit, but intentionally restrained visually; changing the full goal configuration is one secondary navigation step rather than an always-visible zone grid.
+
+### Concept B — Refined mode-and-target hero
+
+#### Screen representation
+
+```text
+┌─ Training ───────────────────────────────┐
+│  [treadmill ✓]   [heart 128 ✓]          │  compact, secondary readiness
+│                                          │
+│  ┌─ WORKOUT MODE ────────────────────┐   │
+│  │ HR Control                     ▾  │   │  native Menu/select button
+│  │                                      │
+│  │              Zone 3                  │  dominant configured target
+│  │             135–142 bpm              │
+│  │                                      │
+│  │  Z1 ━━━━━│ Z2 ━━│ Z3 ━━│ Z4 ━│ Z5  │  tappable segmented HR scale
+│  │           ▲ selected target          │  future current-HR marker fits here
+│  │                                      │
+│  │  10 min        Cooldown to 115 bpm   │  mode-specific information
+│  │  Speed adapts to hold the target.    │
+│  │                           Settings › │
+│  └──────────────────────────────────────┘
+│                                          │
+│  First actionable blocker, only if any   │
+│  [              Start workout          ]│  always visible without scrolling
+└──────────────────────────────────────────┘
+```
+
+- Top-to-bottom hierarchy: `Training` title; one quiet readiness row; a single visually dominant hero containing the mode selector, current mode configuration, and mode-specific information; optional actionable blocker; full-width Start. Freed space stays empty rather than becoming more cards.
+- Workout-mode selector: the hero starts with a labelled native `Menu` / selection button (`HR Control` + chevron). Production also shows `Intervals · Скоро` as a disabled, non-startable placeholder implemented directly in the Menu; it has no mode registry, router, provider, persistence, or runtime type. Deterministic previews may instantiate richer Intervals and Weekly Zones Auto presentation values directly.
+- HR Control target selection: a horizontal segmented zone scale is built from native `Button`, `Capsule`, and `Shape` primitives. The selected zone/range has a strong outline/fill and target marker; the dominant target reads as a zone plus configured range (for example `Zone 3` and `135–142 bpm`), never as one target bpm. Each segment has a 44-point hit target and explicit VoiceOver label. Tapping another zone preserves the existing target-setting behavior. During a later active-workout Goal, the same scale can add a separate current-HR marker moving relative to the selected range without changing control authority.
+- Compact readiness: directly below the title, two low-emphasis chips show `treadmill ✓` and `heart 128 ✓`. Unavailable/stale states replace the checkmark with an explicit symbol and short label. The HR chip represents availability/freshness, never Watch reachability; exact source appears only as a small secondary label when reliably known, otherwise the truthful generic identity is `HealthKit` / `Pulse available` or is omitted.
+- Mode-specific information area: it is the lower portion of the same hero, not another generic card. HR Control shows duration, cooldown target, and at most one concise explanation of adaptive target holding. `Settings` leads to existing workout parameters. There is no standalone `Heart Rate Zones` menu on the Training screen; global zone definitions stay in Settings.
+- Primary action/preparing: Start remains full-width and visible without required scrolling, using semantic accent styling rather than a prescribed orange/neon treatment. A disabled state has one short blocker immediately above it. After the existing Start request, the same action area becomes a compact native `ProgressView` plus truthful existing-state copy; no countdown or presentation lifecycle is added.
+- Native visual language: system typography, materials/grouped background, semantic colors, SF Symbols, native controls, and a small SwiftUI zone scale. No photography, bitmap chrome, mandated dark theme, glow language, or new token layer.
+- Glanceability/future active reuse: mode name and configured target own most visual weight; readiness remains visible but peripheral. The HR scale establishes a visual grammar that can later add factual current HR during Goal #58 while remaining observational and downstream from runtime truth.
+
+#### Preview-only mode examples
+
+- Weekly Zones Auto: mode title `Weekly Zones Auto`; hero primary value `15 min remaining this week`; the mode-specific area shows `Zone 5 • 3 min remaining` and `Zone 4 • 12 min remaining`. Start is non-operative in the fixture; no weekly engine, persistence, or algorithm exists.
+- Intervals: mode title `Intervals`; hero primary value `4 × 3 min`; the mode-specific area shows `Work 3:00 • Recovery 2:00` and the planned round count. Start is non-operative in the fixture; no interval runtime or state machine exists.
+- Both fixtures populate the same generic mode/title, primary target/status, and small secondary metric slots directly. They do not require production mode enums, option registries, specialized mappers, or navigation routes.
+
+#### Complexity and trade-offs
+
+- Approximate production impact: medium, about 260–390 changed/added production LOC while removing the obsolete idle metric/configuration composition. Expected ownership is primarily existing `ContentView.swift` / shared UI components, plus one small immutable presentation value and pure HR-Control mapping; keep them co-located unless focused tests establish a concrete reason for one new file. The zone scale can start as a focused local component and move only when Goal #58 creates real reuse.
+- Expected preview/test impact: deterministic ready/unavailable/source/preparing fixtures plus direct Weekly Zones Auto and Intervals values; no production behavior or future-mode code.
+- Main trade-offs: more custom accessibility and layout QA than Concept A, and a one-option production Menu is temporarily modest in utility. In return, the selected mode and target become unmistakable, Start stays visible, and the HR visual can be reused later without making readiness or settings dominate the screen.
+
+## Recommendation
+
+Implement frozen **Concept B**. It keeps the selected expressive goal-first hierarchy, reduces readiness to secondary chips, exposes the committed Intervals direction only as a disabled placeholder, and keeps all richer future-mode proof in deterministic preview/test data.
+
+## PM selection
+
+PM approved refined Concept B for Freeze → Implement → Verify in [Issue #56 comment 5380900151](https://github.com/tourvald/walkingpad-remote/issues/56#issuecomment-5380900151). Concept A is rejected because its status/settings stack makes the workout goal less visually dominant.
+
+## Non-goals and safety boundary
+
+- No production SwiftUI changes in this pass.
+- No providers, registries, factories, coordinators, DI, mode routers, future-mode production types, or second workout state machine.
+- No changes to HR-control behavior or authorization, HR freshness/source selection, BLE, treadmill commands, speed/control safety, controller units, cooldown/stop semantics, HealthKit truth, Watch workout lifecycle, Telemetry V2, persistence, project settings, signing, install, device launch, or physical hardware activity.
+- No speculative Intervals or Weekly Zones Auto runtime; no countdown unless a later selected design proves it valuable without new machinery.

--- a/docs/design/selected-direction.md
+++ b/docs/design/selected-direction.md
@@ -1,12 +1,20 @@
 # Selected redesign direction
 
-Status: not selected.
+Status: frozen for implementation.
 
-- Related issue:
-- PM decision reference:
-- Selected concept:
-- Why it was selected:
+- Related issue: GitHub Issue #56, parent Epic #55.
+- PM decision reference: [PM approval — freeze refined Concept B and implement Goal 1](https://github.com/tourvald/walkingpad-remote/issues/56#issuecomment-5380900151), including the preceding [mode/range refinement](https://github.com/tourvald/walkingpad-remote/issues/56#issuecomment-5380829689).
+- Selected concept: refined Concept B — compact readiness plus a dominant mode-and-target hero.
+- Why it was selected: the workout mode and configured target own the hierarchy; readiness and settings remain available without recreating the idle telemetry dashboard; the small presentation shape can serve later active-workout UI without speculative runtime architecture.
 - Exact writable paths:
-- Frozen behavior and non-goals:
-- Mock/simulator inputs:
-- Acceptance criteria:
+  - `ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift`
+  - `ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift`
+  - `docs/design/redesign-brief.md`
+  - `docs/design/selected-direction.md`
+  - `docs/design/qa-ledger.md`
+- Frozen hierarchy: `Training` title; low-emphasis treadmill and source-agnostic fresh-HR readiness; native mode Menu; one dominant hero; selected HR zone and configured range; segmented Z1–Z5 target control; compact duration/cooldown facts; visible full-width Start.
+- Frozen mode selector: working `HR Control` plus a disabled, non-startable `Intervals · Скоро` production placeholder. Weekly Zones Auto and richer Intervals states exist only as deterministic preview/test values.
+- Frozen target semantics: show the selected zone and its configured range, not a single target bpm. Zone taps reuse the existing target assignment; a future live-HR marker is a separate observational value and is not implemented in #56.
+- Mock/simulator inputs: ready with unknown source; ready with known source; treadmill unavailable; HR unavailable/stale; preparing presentation; preview-only Intervals and Weekly Zones Auto values; compact-width portrait, compact-height, regular-width, light/dark, and accessibility sizes.
+- Acceptance criteria: Start calls the existing `startHrControl()` and preserves affordance parity; `Intervals · Скоро` cannot start; idle accumulated metrics and Watch-first readiness are removed; global HR-zone editing remains in Settings; Start needs no scrolling; no control/runtime/telemetry/persistence source changes; scope checker, focused tests, Swift suite, unsigned build, and visual QA pass.
+- Frozen non-goals: no provider/factory/registry/DI/coordinator; no second lifecycle; no future-mode runtime; no new sensor transport; no BLE, HR decision, safety, speed, cooldown/stop, HealthKit, Watch lifecycle, Telemetry V2, persistence, project, device, or hardware changes.

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -39,12 +39,20 @@ struct ContentView: View {
         )
     }
 
+    #if DEBUG
+    private var isTrainingHubPreviewLaunch: Bool {
+        ProcessInfo.processInfo.arguments.contains {
+            $0.hasPrefix("--training-hub-preview=")
+        }
+    }
+    #endif
+
     var body: some View {
         TabView(selection: rootTabSelection) {
             ControlSwipeView()
                 .environmentObject(manager)
                 .tabItem {
-                    Label("HR‑контроль", systemImage: "heart.circle")
+                    Label("Тренировка", systemImage: "figure.run.circle")
                 }
                 .tag(RootTab.control)
 
@@ -68,8 +76,16 @@ struct ContentView: View {
                 }
                 .tag(RootTab.debug)
         }
-        .onAppear { manager.start() }
+        .onAppear {
+            #if DEBUG
+            guard !isTrainingHubPreviewLaunch else { return }
+            #endif
+            manager.start()
+        }
         .onChange(of: scenePhase) { _, phase in
+            #if DEBUG
+            guard !isTrainingHubPreviewLaunch else { return }
+            #endif
             if phase == .active {
                 manager.pingWatch()
             } else {
@@ -84,12 +100,518 @@ struct ContentView: View {
     }
 }
 
+private struct TrainingHubPresentation {
+    struct Readiness: Identifiable {
+        let id: String
+        let title: String
+        let value: String
+        let sourceLabel: String?
+        let systemImage: String
+        let tint: Color
+        let isReady: Bool
+    }
+
+    struct Metric: Identifiable {
+        let id: String
+        let title: String
+        let value: String
+        let systemImage: String
+    }
+
+    struct TargetSegment: Identifiable {
+        let id: Int
+        let title: String
+        let rangeText: String
+        let tint: Color
+    }
+
+    let modeTitle: String
+    let modeSystemImage: String
+    let targetTitle: String
+    let targetValue: String
+    let targetSegments: [TargetSegment]
+    let selectedSegmentID: Int?
+    let metrics: [Metric]
+    let readiness: [Readiness]
+    let startEnabled: Bool
+    let startBlocker: String?
+    let isPreparing: Bool
+    let isPreview: Bool
+}
+
+private func makeHRControlTrainingHubPresentation(
+    treadmillConnected: Bool,
+    hrFresh: Bool,
+    currentHeartRateBPM: Int?,
+    heartRateSourceLabel: String?,
+    targetZoneIndex: Int,
+    zoneRanges: [ClosedRange<Int>],
+    durationMinutes: Int,
+    cooldownTargetBPM: Int,
+    startEnabled: Bool,
+    runtimeBlockReason: String?,
+    isPreparing: Bool = false,
+    isPreview: Bool = false
+) -> TrainingHubPresentation {
+    let safeZoneIndex = max(0, min(zoneRanges.count - 1, targetZoneIndex))
+    let targetRange = zoneRanges[safeZoneIndex]
+    let startBlocker: String? = {
+        guard !startEnabled, !isPreparing else { return nil }
+        if !treadmillConnected { return "Подключите дорожку" }
+        if !hrFresh { return "Дождитесь свежего пульса" }
+        guard let runtimeBlockReason, !runtimeBlockReason.isEmpty else {
+            return "Тренировка пока недоступна"
+        }
+        let normalized = runtimeBlockReason.lowercased()
+        if normalized.contains("час") || normalized.contains("apple watch") {
+            return "Пульс пока не готов к старту"
+        }
+        return runtimeBlockReason
+    }()
+
+    return TrainingHubPresentation(
+        modeTitle: "HR‑контроль",
+        modeSystemImage: "heart.text.square.fill",
+        targetTitle: "Зона \(safeZoneIndex + 1)",
+        targetValue: "\(targetRange.lowerBound)–\(targetRange.upperBound) bpm",
+        targetSegments: zoneRanges.enumerated().map { index, range in
+            TrainingHubPresentation.TargetSegment(
+                id: index,
+                title: "Z\(index + 1)",
+                rangeText: "\(range.lowerBound)–\(range.upperBound) bpm",
+                tint: hrZoneColor(index + 1)
+            )
+        },
+        selectedSegmentID: safeZoneIndex,
+        metrics: [
+            .init(id: "duration", title: "Время", value: "\(durationMinutes) мин", systemImage: "clock"),
+            .init(id: "cooldown", title: "Заминка", value: "до \(cooldownTargetBPM) bpm", systemImage: "wind")
+        ],
+        readiness: [
+            .init(
+                id: "treadmill",
+                title: "Дорожка",
+                value: treadmillConnected ? "Готова" : "Нет",
+                sourceLabel: nil,
+                systemImage: "figure.walk.motion",
+                tint: treadmillConnected ? .green : .orange,
+                isReady: treadmillConnected
+            ),
+            .init(
+                id: "heartRate",
+                title: "Пульс",
+                value: hrFresh
+                    ? currentHeartRateBPM.map { "\($0) bpm" } ?? "Доступен"
+                    : "Нет",
+                sourceLabel: hrFresh ? heartRateSourceLabel : nil,
+                systemImage: "heart.fill",
+                tint: hrFresh ? .green : .orange,
+                isReady: hrFresh
+            )
+        ],
+        startEnabled: startEnabled,
+        startBlocker: startBlocker,
+        isPreparing: isPreparing,
+        isPreview: isPreview
+    )
+}
+
+#if DEBUG
+private func trainingHubPreviewPresentation(named name: String) -> TrainingHubPresentation? {
+    let ranges = [60...134, 135...146, 147...158, 159...170, 171...220]
+    let base: (
+        Bool,
+        Bool,
+        Int?,
+        String?,
+        Bool,
+        Bool
+    ) -> TrainingHubPresentation = { treadmillReady, hrReady, bpm, source, startEnabled, preparing in
+        makeHRControlTrainingHubPresentation(
+            treadmillConnected: treadmillReady,
+            hrFresh: hrReady,
+            currentHeartRateBPM: bpm,
+            heartRateSourceLabel: source,
+            targetZoneIndex: 2,
+            zoneRanges: ranges,
+            durationMinutes: 30,
+            cooldownTargetBPM: 115,
+            startEnabled: startEnabled,
+            runtimeBlockReason: nil,
+            isPreparing: preparing,
+            isPreview: true
+        )
+    }
+
+    switch name {
+    case "ready-unknown-source":
+        return base(true, true, 138, nil, true, false)
+    case "ready-known-source":
+        return base(true, true, 138, "Apple Watch", true, false)
+    case "treadmill-unavailable":
+        return base(false, true, 138, nil, false, false)
+    case "hr-unavailable":
+        return base(true, false, nil, nil, false, false)
+    case "preparing":
+        return base(true, true, 138, nil, false, true)
+    case "intervals":
+        return TrainingHubPresentation(
+            modeTitle: "Интервалы",
+            modeSystemImage: "repeat",
+            targetTitle: "4 раунда",
+            targetValue: "3:00 / 2:00",
+            targetSegments: [],
+            selectedSegmentID: nil,
+            metrics: [
+                .init(id: "work", title: "Работа", value: "3 мин", systemImage: "figure.run"),
+                .init(id: "recovery", title: "Восстановление", value: "2 мин", systemImage: "figure.walk")
+            ],
+            readiness: base(true, true, 138, nil, false, false).readiness,
+            startEnabled: false,
+            startBlocker: "Только предпросмотр",
+            isPreparing: false,
+            isPreview: true
+        )
+    case "weekly-zones":
+        return TrainingHubPresentation(
+            modeTitle: "Недельные зоны",
+            modeSystemImage: "calendar",
+            targetTitle: "Осталось за неделю",
+            targetValue: "15 мин",
+            targetSegments: [],
+            selectedSegmentID: nil,
+            metrics: [
+                .init(id: "zone5", title: "Зона 5", value: "3 мин", systemImage: "heart.fill"),
+                .init(id: "zone4", title: "Зона 4", value: "12 мин", systemImage: "heart.fill")
+            ],
+            readiness: base(true, true, 138, nil, false, false).readiness,
+            startEnabled: false,
+            startBlocker: "Только предпросмотр",
+            isPreparing: false,
+            isPreview: true
+        )
+    default:
+        return nil
+    }
+}
+#endif
+
+private struct TrainingHubView: View {
+    let presentation: TrainingHubPresentation
+    let onTreadmillTap: () -> Void
+    let onZoneTap: (Int) -> Void
+    let onDurationTap: () -> Void
+    let onSettingsTap: () -> Void
+    let onStart: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 14) {
+                readinessRow
+                hero
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 4)
+            .padding(.bottom, 12)
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            startArea
+        }
+    }
+
+    private var readinessRow: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 8) {
+                readinessChips
+            }
+            VStack(spacing: 6) {
+                readinessChips
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var readinessChips: some View {
+        ForEach(presentation.readiness) { item in
+            let chip = readinessChip(item)
+            if item.id == "treadmill", !presentation.isPreview {
+                Button(action: onTreadmillTap) { chip }
+                    .buttonStyle(.plain)
+            } else {
+                chip
+            }
+        }
+    }
+
+    private func readinessChip(_ item: TrainingHubPresentation.Readiness) -> some View {
+        HStack(spacing: 7) {
+            Image(systemName: item.systemImage)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(item.tint)
+
+            VStack(alignment: .leading, spacing: 1) {
+                HStack(spacing: 4) {
+                    Text(item.title)
+                        .font(.caption.weight(.semibold))
+                        .lineLimit(1)
+                    Text(item.value)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .lineLimit(1)
+                }
+                if let sourceLabel = item.sourceLabel {
+                    Text(sourceLabel)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Image(systemName: item.isReady ? "checkmark.circle.fill" : "exclamationmark.circle.fill")
+                .font(.caption)
+                .foregroundStyle(item.tint)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(.thinMaterial, in: Capsule(style: .continuous))
+        .overlay {
+            Capsule(style: .continuous)
+                .stroke(item.tint.opacity(0.18), lineWidth: 1)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            [item.title, item.value, item.sourceLabel].compactMap { $0 }.joined(separator: ", ")
+        )
+        .accessibilityValue(item.isReady ? "Готово" : "Недоступно")
+    }
+
+    private var hero: some View {
+        VStack(spacing: 18) {
+            modeSelector
+
+            VStack(spacing: 4) {
+                Text(presentation.targetTitle)
+                    .font(.system(.largeTitle, design: .rounded, weight: .bold))
+                    .multilineTextAlignment(.center)
+                Text(presentation.targetValue)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            .accessibilityElement(children: .combine)
+
+            if !presentation.targetSegments.isEmpty {
+                targetScale
+            }
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 8) { metricItems }
+                VStack(spacing: 8) { metricItems }
+            }
+
+            if !presentation.isPreview {
+                Button(action: onSettingsTap) {
+                    HStack {
+                        Label("Параметры", systemImage: "slider.horizontal.3")
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption.weight(.semibold))
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityHint("Открывает параметры HR-контроля")
+            }
+        }
+        .padding(18)
+        .background {
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(.regularMaterial)
+                .overlay {
+                    LinearGradient(
+                        colors: [Color.accentColor.opacity(0.13), .clear, hrZoneColor((presentation.selectedSegmentID ?? 0) + 1).opacity(0.08)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                }
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .stroke(Color.accentColor.opacity(0.18), lineWidth: 1)
+        }
+    }
+
+    private var modeSelector: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("РЕЖИМ ТРЕНИРОВКИ")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            if presentation.isPreview {
+                modeSelectorLabel
+            } else {
+                Menu {
+                    Button(action: {}) {
+                        Label("HR‑контроль", systemImage: "checkmark")
+                    }
+                    Button(action: {}) {
+                        Label("Интервалы · Скоро", systemImage: "hourglass")
+                    }
+                    .disabled(true)
+                } label: {
+                    modeSelectorLabel
+                }
+                .accessibilityLabel("Режим тренировки, HR-контроль")
+                .accessibilityHint("Интервальные тренировки появятся позже")
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var modeSelectorLabel: some View {
+        HStack(spacing: 10) {
+            Image(systemName: presentation.modeSystemImage)
+                .foregroundStyle(Color.accentColor)
+            Text(presentation.modeTitle)
+                .font(.headline)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+            Spacer()
+            if !presentation.isPreview {
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .foregroundStyle(.primary)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Color(.systemBackground).opacity(0.62), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private var targetScale: some View {
+        HStack(spacing: 5) {
+            ForEach(presentation.targetSegments) { segment in
+                let isSelected = segment.id == presentation.selectedSegmentID
+                Button {
+                    guard !presentation.isPreview else { return }
+                    onZoneTap(segment.id)
+                } label: {
+                    VStack(spacing: 5) {
+                        Text(segment.title)
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(isSelected ? Color.primary : Color.secondary)
+                        Capsule(style: .continuous)
+                            .fill(segment.tint.opacity(isSelected ? 0.92 : 0.24))
+                            .frame(height: isSelected ? 16 : 10)
+                            .overlay {
+                                if isSelected {
+                                    Capsule(style: .continuous)
+                                        .stroke(Color.primary.opacity(0.65), lineWidth: 2)
+                                }
+                            }
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 44)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Зона \(segment.id + 1), \(segment.rangeText)")
+                .accessibilityValue(isSelected ? "Выбрана" : "Не выбрана")
+                .accessibilityHint("Выбирает целевой диапазон пульса")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var metricItems: some View {
+        ForEach(presentation.metrics) { metric in
+            let content = HStack(spacing: 8) {
+                Image(systemName: metric.systemImage)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color.accentColor)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(metric.title)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(metric.value)
+                        .font(.subheadline.weight(.semibold))
+                        .monospacedDigit()
+                }
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(Color(.systemBackground).opacity(0.55), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+
+            if metric.id == "duration", !presentation.isPreview {
+                Button(action: onDurationTap) { content }
+                    .buttonStyle(.plain)
+                    .accessibilityHint("Изменяет длительность тренировки")
+            } else {
+                content
+            }
+        }
+    }
+
+    private var startArea: some View {
+        VStack(spacing: 7) {
+            if let blocker = presentation.startBlocker {
+                Label(blocker, systemImage: "exclamationmark.circle.fill")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.orange)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if presentation.isPreparing {
+                HStack(spacing: 10) {
+                    ProgressView()
+                    Text("Подготовка…")
+                        .font(.headline)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(Color.accentColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Подготовка тренировки")
+            } else {
+                Button {
+                    guard !presentation.isPreview else { return }
+                    onStart()
+                } label: {
+                    Label("Начать тренировку", systemImage: "play.fill")
+                        .font(.headline.weight(.semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.65)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 6)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(!presentation.startEnabled)
+                .accessibilityHint("Запускает HR-контроль с выбранной целевой зоной")
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 10)
+        .padding(.bottom, 8)
+        .background(.ultraThinMaterial)
+    }
+}
+
 private struct ControlSwipeView: View {
     @EnvironmentObject private var manager: BluetoothManager
     @State private var showDevicePicker = false
     @State private var showConnectError = false
     @State private var presentSuggestedPicker = false
     @State private var showInfoToast = false
+    @State private var showDurationSheet = false
+    @State private var showParameters = false
     private let heroAccent: Color = .orange
 
     private var watchStatusLabel: String {
@@ -109,6 +631,37 @@ private struct ControlSwipeView: View {
 
     private var watchStatusColor: Color {
         manager.hrStreamingActive ? .green : (manager.watchReachable ? .orange : .secondary)
+    }
+
+    private var productionTrainingHubPresentation: TrainingHubPresentation {
+        makeHRControlTrainingHubPresentation(
+            treadmillConnected: manager.isConnected,
+            hrFresh: manager.hrStreamingActive,
+            currentHeartRateBPM: manager.hrStreamingActive && manager.heartRateBPM > 0
+                ? manager.heartRateBPM
+                : nil,
+            heartRateSourceLabel: nil,
+            targetZoneIndex: hrZoneIndex(for: manager.hrTargetBPM, manager: manager),
+            zoneRanges: hrZoneRanges(for: manager),
+            durationMinutes: manager.hrDurationMinutes,
+            cooldownTargetBPM: manager.hrCooldownTargetBpm,
+            startEnabled: manager.isHrControlStartAffordanceAvailable,
+            runtimeBlockReason: manager.hrControlStartBlockReasonText
+        )
+    }
+
+    private var trainingHubPresentation: TrainingHubPresentation {
+        #if DEBUG
+        if let argument = ProcessInfo.processInfo.arguments.first(where: {
+            $0.hasPrefix("--training-hub-preview=")
+        }) {
+            let name = String(argument.dropFirst("--training-hub-preview=".count))
+            if let preview = trainingHubPreviewPresentation(named: name) {
+                return preview
+            }
+        }
+        #endif
+        return productionTrainingHubPresentation
     }
 
     var body: some View {
@@ -135,99 +688,97 @@ private struct ControlSwipeView: View {
                     .offset(x: -140, y: 220)
                     .allowsHitTesting(false)
 
-                VStack(spacing: 12) {
-                    VStack(alignment: .leading, spacing: 12) {
+                if manager.isHrControlRunning {
+                    VStack(spacing: 12) {
                         HStack(spacing: 10) {
                             controlHeroMetric(
                                 icon: "antenna.radiowaves.left.and.right",
                                 title: "Дорожка",
                                 value: connectionStatusLabel,
-                                tint: connectionStatusColor,
-                                action: {
-                                    showDevicePicker = true
-                                }
+                                tint: connectionStatusColor
                             )
                             controlHeroMetric(
                                 icon: "applewatch",
                                 title: "Часы",
                                 value: watchStatusLabel,
-                                tint: watchStatusColor,
-                                action: {
-                                    manager.pingWatch()
-                                }
+                                tint: watchStatusColor
                             )
                         }
-                    }
-                    .padding(12)
-                    .background(
-                        RoundedRectangle(cornerRadius: 20, style: .continuous)
-                            .fill(
-                                LinearGradient(
-                                    colors: [
-                                        heroAccent.opacity(0.2),
-                                        Color(.secondarySystemGroupedBackground).opacity(0.95)
-                                    ],
-                                    startPoint: .topLeading,
-                                    endPoint: .bottomTrailing
-                                )
-                            )
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 20, style: .continuous)
-                            .stroke(heroAccent.opacity(0.3), lineWidth: 1)
-                    )
-                    .sheet(isPresented: $showDevicePicker) {
-                        DevicePickerView()
-                            .environmentObject(manager)
-                    }
-                    .onChange(of: manager.connectErrorMessage) { _, newValue in
-                        if newValue != nil {
-                            showConnectError = true
-                        }
-                    }
-                    .alert("Проблема с подключением", isPresented: $showConnectError, presenting: manager.connectErrorMessage) { _ in
-                        Button("Выбрать другую дорожку") { showDevicePicker = true }
-                        Button("OK", role: .cancel) {}
-                    } message: { msg in
-                        Text(msg)
-                    }
-                    .onChange(of: manager.suggestDevicePicker) { _, newValue in
-                        if newValue {
-                            presentSuggestedPicker = true
-                        }
-                    }
-                    .sheet(isPresented: $presentSuggestedPicker, onDismiss: {
-                        manager.suggestDevicePicker = false
-                    }) {
-                        DevicePickerView()
-                            .environmentObject(manager)
-                    }
-                    .onChange(of: manager.infoToastMessage) { _, newValue in
-                        if newValue != nil {
-                            showInfoToast = true
-                        }
-                    }
-                    .alert("Информация", isPresented: $showInfoToast, presenting: manager.infoToastMessage) { _ in
-                        Button("Открыть выбор") { showDevicePicker = true }
-                        Button("OK", role: .cancel) {}
-                    } message: { msg in
-                        Text(msg)
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.top, 8)
-
-                    CommonInfoCard()
-                        .environmentObject(manager)
                         .padding(.horizontal, 12)
+                        .padding(.top, 8)
 
-                    ScrollView {
-                        HRControlPanel()
+                        CommonInfoCard()
                             .environmentObject(manager)
                             .padding(.horizontal, 12)
-                            .padding(.bottom)
+
+                        ScrollView {
+                            HRControlPanel()
+                                .environmentObject(manager)
+                                .padding(.horizontal, 12)
+                                .padding(.bottom)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                     }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                } else {
+                    TrainingHubView(
+                        presentation: trainingHubPresentation,
+                        onTreadmillTap: { showDevicePicker = true },
+                        onZoneTap: { zoneIndex in
+                            let ranges = hrZoneRanges(for: manager)
+                            guard ranges.indices.contains(zoneIndex) else { return }
+                            manager.hrTargetBPM = hrZoneTargetBpm(
+                                zone: zoneIndex + 1,
+                                range: ranges[zoneIndex]
+                            )
+                        },
+                        onDurationTap: { showDurationSheet = true },
+                        onSettingsTap: { showParameters = true },
+                        onStart: { manager.startHrControl() }
+                    )
                 }
+            }
+            .navigationTitle("Тренировка")
+            .navigationBarTitleDisplayMode(.large)
+            .navigationDestination(isPresented: $showParameters) {
+                HRParametersFormView()
+                    .environmentObject(manager)
+            }
+            .sheet(isPresented: $showDurationSheet) {
+                HRDurationWheelSheet(minutes: Binding(
+                    get: { manager.hrDurationMinutes },
+                    set: { manager.hrDurationMinutes = max(1, min(120, $0)) }
+                ))
+            }
+            .sheet(isPresented: $showDevicePicker) {
+                DevicePickerView()
+                    .environmentObject(manager)
+            }
+            .onChange(of: manager.connectErrorMessage) { _, newValue in
+                if newValue != nil { showConnectError = true }
+            }
+            .alert("Проблема с подключением", isPresented: $showConnectError, presenting: manager.connectErrorMessage) { _ in
+                Button("Выбрать другую дорожку") { showDevicePicker = true }
+                Button("OK", role: .cancel) {}
+            } message: { msg in
+                Text(msg)
+            }
+            .onChange(of: manager.suggestDevicePicker) { _, newValue in
+                if newValue { presentSuggestedPicker = true }
+            }
+            .sheet(isPresented: $presentSuggestedPicker, onDismiss: {
+                manager.suggestDevicePicker = false
+            }) {
+                DevicePickerView()
+                    .environmentObject(manager)
+            }
+            .onChange(of: manager.infoToastMessage) { _, newValue in
+                if newValue != nil { showInfoToast = true }
+            }
+            .alert("Информация", isPresented: $showInfoToast, presenting: manager.infoToastMessage) { _ in
+                Button("Открыть выбор") { showDevicePicker = true }
+                Button("OK", role: .cancel) {}
+            } message: { msg in
+                Text(msg)
             }
         }
     }
@@ -436,20 +987,6 @@ private struct ManualView: View {
     }
 }
 
-private struct HrWatchIssue: Identifiable {
-    let id: String
-    let title: String
-    let message: String
-    let color: Color
-
-    init(title: String, message: String, color: Color) {
-        self.id = "\(title)|\(message)"
-        self.title = title
-        self.message = message
-        self.color = color
-    }
-}
-
 private func hrZoneColor(_ zone: Int) -> Color {
     switch zone {
     case 1: return .blue
@@ -497,42 +1034,6 @@ private func hrZoneIndex(for bpm: Int, manager: BluetoothManager) -> Int {
         return index
     }
     return max(0, min(4, ranges.count - 1))
-}
-
-private func hrWatchIssue(for manager: BluetoothManager) -> HrWatchIssue? {
-    if !manager.watchPaired {
-        return HrWatchIssue(
-            title: "Часы не сопряжены",
-            message: "Apple Watch не сопряжены с этим iPhone. Сопрягите часы в приложении Watch.",
-            color: .red
-        )
-    }
-
-    if !manager.watchAppInstalled {
-        return HrWatchIssue(
-            title: "Нет приложения на часах",
-            message: "Установите приложение WalkingPadRemote на Apple Watch и откройте его.",
-            color: .red
-        )
-    }
-
-    if manager.watchReachable && !manager.hrStreamingActive {
-        return HrWatchIssue(
-            title: "Нет пульса с часов",
-            message: "Часы подключены, но пульс не поступает. Запустите экран часов и дождитесь данных HR.",
-            color: .orange
-        )
-    }
-
-    if !manager.watchReachable {
-        return HrWatchIssue(
-            title: "Часы недоступны",
-            message: "Сейчас нет активного канала с Apple Watch. Откройте приложение на часах и держите его на экране.",
-            color: .orange
-        )
-    }
-
-    return nil
 }
 
 private struct HrAdaptiveUiThresholds {
@@ -915,10 +1416,7 @@ private func hrAdaptiveDecisionPreview(
 private struct HRControlPanel: View {
     @EnvironmentObject private var manager: BluetoothManager
     private let debugPreview: HRControlPanelPreviewState?
-    @State private var showExportButton = false
-    @State private var hrFailureBaselineCount = 0
     @State private var showExtendConfirm = false
-    @State private var selectedWatchIssue: HrWatchIssue?
 
     init(debugPreview: HRControlPanelPreviewState? = nil) {
         self.debugPreview = debugPreview
@@ -926,7 +1424,6 @@ private struct HRControlPanel: View {
 
     var body: some View {
         let isPreviewMode = (debugPreview != nil)
-        let isHrControlRunning = debugPreview?.isHrControlRunning ?? manager.isHrControlRunning
         let hrNextDecisionSeconds = debugPreview?.hrNextDecisionSeconds ?? manager.hrNextDecisionSeconds
         let hrPredictorStatusLine = debugPreview?.hrPredictorStatusLine ?? manager.hrPredictorStatusLine
         let hrDecisionDetails = debugPreview?.hrDecisionDetails ?? manager.hrDecisionDetails
@@ -938,201 +1435,23 @@ private struct HRControlPanel: View {
         let hrStatusLine = debugPreview?.hrStatusLine ?? manager.hrStatusLine
         let canExtendHrSession = debugPreview?.canExtendHrSession ?? manager.canExtendHrSession
         let hrSessionMaxMinutes = debugPreview?.hrSessionMaxMinutes ?? manager.hrSessionMaxMinutes
-        let canStartHrControl = manager.isHrControlStartAffordanceAvailable
-        let headerTint: Color = isHrControlRunning ? .accentColor : (hrStreamingActive ? .green : .orange)
-        let hrStartSubtitle: String = {
-            if isPreviewMode {
-                return "Preview mode: команды на дорожку отключены"
-            }
-            if let blockReason = manager.hrControlStartBlockReasonText {
-                return blockReason
-            }
-            if canStartHrControl {
-                return "Автоподстройка скорости по пульсу и зоне"
-            }
-            return manager.hrControlStartBlockReasonText ?? "Проверьте дорожку и Apple Watch"
-        }()
 
         Card {
-            let watchIssue = hrWatchIssue(for: manager)
             VStack(alignment: .leading, spacing: 14) {
-                if !isHrControlRunning {
-                    VStack(alignment: .leading, spacing: 10) {
-                        HRControlHeaderRow(watchIssue: watchIssue) { issue in
-                            selectedWatchIssue = issue
-                        }
-                        HStack(spacing: 8) {
-                            hrInfoChip(title: "Цель", value: "\(manager.hrTargetBPM) bpm", tint: .red)
-                            hrInfoChip(
-                                title: "Шаг",
-                                value: manager.hrAdaptiveStepEnabled
-                                    ? "Адаптивный"
-                                    : String(format: "%.1f км/ч", manager.hrSpeedStepKmh),
-                                tint: .blue
-                            )
-                            hrInfoChip(title: "Заминка", value: "\(manager.hrCooldownTargetBpm) bpm", tint: .mint)
-                        }
-                    }
-                    .alert(item: $selectedWatchIssue) { issue in
-                        Alert(
-                            title: Text(issue.title),
-                            message: Text(issue.message),
-                            dismissButton: .cancel(Text("OK"))
-                        )
-                    }
-                    .padding(12)
-                    .background(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .fill(
-                                LinearGradient(
-                                    colors: [headerTint.opacity(0.2), Color(.secondarySystemGroupedBackground)],
-                                    startPoint: .topLeading,
-                                    endPoint: .bottomTrailing
-                                )
-                            )
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .stroke(headerTint.opacity(0.25), lineWidth: 1)
-                    )
-                }
+                runningStatusSection(
+                    isPreviewMode: isPreviewMode,
+                    hrNextDecisionSeconds: hrNextDecisionSeconds,
+                    hrPredictorStatusLine: hrPredictorStatusLine,
+                    hrDecisionDetails: hrDecisionDetails,
+                    hrRemainingSeconds: hrRemainingSeconds,
+                    hrCooldownRemainingSeconds: hrCooldownRemainingSeconds,
+                    hrProgress: hrProgress,
+                    hrCooldownProgress: hrCooldownProgress,
+                    canExtendHrSession: canExtendHrSession,
+                    hrSessionMaxMinutes: hrSessionMaxMinutes
+                )
 
-                if isHrControlRunning {
-                    runningStatusSection(
-                        isPreviewMode: isPreviewMode,
-                        hrNextDecisionSeconds: hrNextDecisionSeconds,
-                        hrPredictorStatusLine: hrPredictorStatusLine,
-                        hrDecisionDetails: hrDecisionDetails,
-                        hrRemainingSeconds: hrRemainingSeconds,
-                        hrCooldownRemainingSeconds: hrCooldownRemainingSeconds,
-                        hrProgress: hrProgress,
-                        hrCooldownProgress: hrCooldownProgress,
-                        canExtendHrSession: canExtendHrSession,
-                        hrSessionMaxMinutes: hrSessionMaxMinutes
-                    )
-                }
-
-                if !isHrControlRunning && showExportButton && !manager.hrFailureReports.isEmpty {
-                    Button("Экспорт логов HR ошибок") {
-                        #if canImport(UIKit)
-                        exportHrFailures(reports: manager.hrFailureReports)
-                        #endif
-                        showExportButton = false
-                    }
-                    .buttonStyle(.borderedProminent)
-                }
-
-                if !isHrControlRunning {
-                    VStack(alignment: .leading, spacing: 10) {
-                        let ranges = hrZoneRanges(for: manager)
-                        let selectedZone = hrZoneIndex(for: manager.hrTargetBPM, manager: manager) + 1
-                        let zoneColumns = [GridItem(.adaptive(minimum: 96), spacing: 8)]
-
-                        Text("Целевая зона")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-
-                        LazyVGrid(columns: zoneColumns, spacing: 8) {
-                            ForEach(1...5, id: \.self) { zone in
-                                let range = ranges[zone - 1]
-                                let target = hrZoneTargetBpm(zone: zone, range: range)
-                                let isSelected = zone == selectedZone
-                                let zoneColorValue = hrZoneColor(zone)
-                                Button {
-                                    manager.hrTargetBPM = target
-                                } label: {
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text("Зона \(zone)")
-                                            .font(.caption.weight(.semibold))
-                                        Text("\(range.lowerBound)–\(range.upperBound)")
-                                            .font(.caption2)
-                                            .monospacedDigit()
-                                    }
-                                    .foregroundColor(isSelected ? .white : .primary)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.horizontal, 10)
-                                    .padding(.vertical, 8)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                            .fill(
-                                                LinearGradient(
-                                                    colors: [
-                                                        zoneColorValue.opacity(isSelected ? 0.95 : 0.12),
-                                                        zoneColorValue.opacity(isSelected ? 0.75 : 0.08)
-                                                    ],
-                                                    startPoint: .topLeading,
-                                                    endPoint: .bottomTrailing
-                                                )
-                                            )
-                                    )
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                            .stroke(
-                                                isSelected ? Color.white.opacity(0.9) : zoneColorValue.opacity(0.35),
-                                                lineWidth: isSelected ? 2 : 1
-                                            )
-                                    )
-                                    .overlay(alignment: .topTrailing) {
-                                        if isSelected {
-                                            Image(systemName: "checkmark.circle.fill")
-                                                .font(.system(size: 14, weight: .semibold))
-                                                .foregroundColor(.white)
-                                                .padding(6)
-                                        }
-                                    }
-                                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-                                    .scaleEffect(isSelected ? 1.03 : 1.0)
-                                    .shadow(color: zoneColorValue.opacity(isSelected ? 0.35 : 0), radius: isSelected ? 8 : 0, x: 0, y: 4)
-                                }
-                                .buttonStyle(.plain)
-                            }
-                            HRDurationMenuTile(minutes: Binding(
-                                get: { manager.hrDurationMinutes },
-                                set: { manager.hrDurationMinutes = max(1, min(120, $0)) }
-                            ))
-                        }
-
-                    }
-                    .padding(12)
-                    .background(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .fill(Color(.secondarySystemGroupedBackground))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .stroke(Color(.tertiarySystemFill), lineWidth: 1)
-                    )
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        NavigationLink {
-                            HRParametersFormView()
-                                .environmentObject(manager)
-                        } label: {
-                            HStack(spacing: 8) {
-                                Text("Параметры")
-                                    .font(.subheadline)
-                                Spacer()
-                                Image(systemName: "chevron.right")
-                                    .foregroundColor(.secondary)
-                            }
-                        }
-
-                        Text("Ограничения заминки: ≥\(String(format: "%.1f", manager.hrCooldownMinSpeed)) км/ч, до \(manager.hrCooldownMaxMinutes) мин")
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                    }
-                    .padding(12)
-                    .background(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .fill(Color(.secondarySystemGroupedBackground))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .stroke(Color(.tertiarySystemFill), lineWidth: 1)
-                    )
-                }
-
-                if isHrControlRunning && !hrStreamingActive {
+                if !hrStreamingActive {
                     Label("Нет сигнала пульса", systemImage: "waveform.path.ecg")
                         .font(.caption2.weight(.semibold))
                         .foregroundColor(.orange)
@@ -1146,22 +1465,6 @@ private struct HRControlPanel: View {
                             Capsule(style: .continuous)
                                 .stroke(Color.orange.opacity(0.3), lineWidth: 1)
                         )
-                }
-
-                if !isHrControlRunning {
-                    PrimaryActionButton(
-                        title: isPreviewMode ? "HR‑контроль (preview)" : "Запустить HR‑контроль",
-                        subtitle: hrStartSubtitle,
-                        systemImage: "heart.circle.fill",
-                        enabled: !isPreviewMode && canStartHrControl,
-                        tint: .accentColor,
-                        accessibilityLabel: "Запустить HR-контроль",
-                        accessibilityHint: "Запускает автоматическую тренировку с контролем по пульсу"
-                    ) {
-                        if !isPreviewMode {
-                            manager.startHrControl()
-                        }
-                    }
                 }
 
                 if !hrStatusLine.isEmpty {
@@ -1181,43 +1484,6 @@ private struct HRControlPanel: View {
                 }
             }
         }
-        .onChange(of: manager.isHrControlRunning) { _, newValue in
-            guard !isPreviewMode else { return }
-            if newValue {
-                hrFailureBaselineCount = manager.hrFailureReports.count
-                showExportButton = false
-            } else {
-                let newCount = manager.hrFailureReports.count
-                if newCount > hrFailureBaselineCount {
-                    showExportButton = true
-                }
-            }
-        }
-    }
-
-    private func hrInfoChip(title: String, value: String, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(title)
-                .font(.caption2)
-                .foregroundColor(.secondary)
-            Text(value)
-                .font(.caption.weight(.semibold))
-                .monospacedDigit()
-                .foregroundColor(.primary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.8)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 6)
-        .background(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(Color(.systemBackground).opacity(0.68))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(tint.opacity(0.24), lineWidth: 1)
-        )
     }
 
     @ViewBuilder
@@ -1463,87 +1729,6 @@ private struct HRControlPanel: View {
         return String(format: "%02d:%02d", minutes, seconds)
     }
 
-}
-
-private struct HRControlHeaderRow: View {
-    let watchIssue: HrWatchIssue?
-    let onWatchIssueTap: (HrWatchIssue) -> Void
-
-    var body: some View {
-        HStack(spacing: 10) {
-            HStack(spacing: 6) {
-                Image(systemName: "heart.text.square.fill")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Color.accentColor)
-                Text("HR‑контроль")
-                    .font(.headline)
-            }
-            Spacer()
-            if let watchIssue {
-                Button {
-                    onWatchIssueTap(watchIssue)
-                } label: {
-                    ZStack {
-                        Circle()
-                            .fill(watchIssue.color.opacity(0.2))
-                            .frame(width: 30, height: 30)
-                        Image(systemName: "applewatch")
-                            .imageScale(.medium)
-                            .foregroundColor(watchIssue.color)
-                    }
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Проблема подключения часов")
-            }
-        }
-    }
-}
-
-private struct HRDurationMenuTile: View {
-    @Binding var minutes: Int
-    @State private var showDurationSheet = false
-
-    var body: some View {
-        Button {
-            showDurationSheet = true
-        } label: {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Время")
-                        .font(.caption.weight(.semibold))
-                    Text("\(minutes) мин")
-                        .font(.caption2)
-                        .monospacedDigit()
-                }
-                Spacer(minLength: 4)
-                Image(systemName: "clock.fill")
-                    .font(.caption)
-                    .foregroundColor(.accentColor)
-            }
-            .foregroundColor(.primary)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 8)
-            .background(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .fill(
-                        LinearGradient(
-                            colors: [Color.accentColor.opacity(0.16), Color.accentColor.opacity(0.08)],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .stroke(Color.accentColor.opacity(0.35), lineWidth: 1)
-            )
-        }
-        .buttonStyle(.plain)
-        .sheet(isPresented: $showDurationSheet) {
-            HRDurationWheelSheet(minutes: $minutes)
-        }
-    }
 }
 
 private struct HRDurationWheelSheet: View {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -204,7 +204,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
 
         XCTAssertTrue(
             contentViewSource.contains(
-                "let canStartHrControl = manager.isHrControlStartAffordanceAvailable"
+                "startEnabled: manager.isHrControlStartAffordanceAvailable"
             )
         )
         XCTAssertFalse(
@@ -212,7 +212,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
                 "manager.isHrControlStartAllowed && manager.watchReachable && manager.hrStreamingActive"
             )
         )
-        XCTAssertTrue(contentViewSource.contains("enabled: !isPreviewMode && canStartHrControl"))
+        XCTAssertTrue(contentViewSource.contains("onStart: { manager.startHrControl() }"))
 
         assertOrdered(
             [
@@ -228,6 +228,82 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
                 "startWithSpeed",
             ],
             in: start
+        )
+    }
+
+    func testTrainingHubPresentationStaysGenericAndPreviewOnlyModesCannotStart() throws {
+        let mapping = try functionBody(
+            "private func makeHRControlTrainingHubPresentation(",
+            in: contentViewSource
+        )
+        let production = try functionBody(
+            "private var productionTrainingHubPresentation: TrainingHubPresentation",
+            in: contentViewSource
+        )
+        let previewFixtures = try functionBody(
+            "private func trainingHubPreviewPresentation(named name: String)",
+            in: contentViewSource
+        )
+        let hubBody = try functionBody(
+            "private struct TrainingHubView: View",
+            in: contentViewSource
+        )
+        let contentBody = try functionBody(
+            "struct ContentView: View",
+            in: contentViewSource
+        )
+
+        XCTAssertTrue(mapping.contains("targetTitle: \"Зона "))
+        XCTAssertTrue(mapping.contains("targetValue: \"\\(targetRange.lowerBound)–\\(targetRange.upperBound) bpm\""))
+        XCTAssertTrue(mapping.contains("title: \"Пульс\""))
+        XCTAssertTrue(mapping.contains("heartRateSourceLabel"))
+        XCTAssertFalse(mapping.contains("watchReachable"))
+        XCTAssertFalse(mapping.contains("Apple Watch"))
+        XCTAssertFalse(mapping.contains("Telemetry"))
+        XCTAssertFalse(mapping.contains("history"))
+
+        XCTAssertTrue(production.contains("startEnabled: manager.isHrControlStartAffordanceAvailable"))
+        XCTAssertTrue(production.contains("heartRateSourceLabel: nil"))
+        XCTAssertFalse(production.contains("watchReachable"))
+        XCTAssertFalse(production.contains("telemetry"))
+
+        for fixture in [
+            "ready-unknown-source",
+            "ready-known-source",
+            "treadmill-unavailable",
+            "hr-unavailable",
+            "preparing",
+            "intervals",
+            "weekly-zones",
+        ] {
+            XCTAssertTrue(previewFixtures.contains("case \"\(fixture)\""), fixture)
+        }
+        XCTAssertTrue(previewFixtures.contains("modeTitle: \"Интервалы\""))
+        XCTAssertTrue(previewFixtures.contains("modeTitle: \"Недельные зоны\""))
+        XCTAssertTrue(previewFixtures.contains("startEnabled: false"))
+        XCTAssertTrue(previewFixtures.contains("isPreview: true"))
+        XCTAssertFalse(previewFixtures.contains("startHrControl"))
+        XCTAssertFalse(previewFixtures.contains("sendTreadmill"))
+
+        XCTAssertTrue(hubBody.contains("Label(\"Интервалы · Скоро\""))
+        XCTAssertTrue(hubBody.contains(".disabled(true)"))
+        XCTAssertTrue(hubBody.contains("guard !presentation.isPreview else { return }"))
+        XCTAssertTrue(hubBody.contains("onStart()"))
+        XCTAssertFalse(hubBody.contains("BluetoothManager"))
+
+        XCTAssertTrue(contentBody.contains("private var isTrainingHubPreviewLaunch: Bool"))
+        XCTAssertEqual(
+            contentBody.components(separatedBy: "guard !isTrainingHubPreviewLaunch else { return }").count - 1,
+            2
+        )
+        assertOrdered(
+            [
+                "guard !isTrainingHubPreviewLaunch else { return }",
+                "manager.start()",
+                "guard !isTrainingHubPreviewLaunch else { return }",
+                "manager.pingWatch()",
+            ],
+            in: contentBody
         )
     }
 


### PR DESCRIPTION
## Summary

- replace the idle HR-control dashboard with the approved native SwiftUI Training Hub hierarchy
- add a small immutable presentation value and pure HR-control mapping with generic Heart Rate readiness
- keep HR Control functional, expose disabled `Intervals · Скоро`, show the selected zone range, and retain the existing active-workout UI
- remove obsolete Watch-first idle presentation and duplicated idle controls

Closes #56

## Verification

- `swift test --filter HeartRateLegacyBehaviorContractTests` — 16 tests passed
- `swift test` — 188 tests passed
- redesign scope checker against `22bd8bdbccf1be82e3b66c3b17e4fb0b22099caa` — passed
- `git diff --check` — passed
- iPhone 17 simulator builds and fixture launches — passed
- generic iOS unsigned `xcodebuild` — `BUILD SUCCEEDED`
- visual QA: ready known/unknown HR source, unavailable treadmill/HR, preparing, preview-only Intervals/Weekly Zones, production unavailable, light/dark, Accessibility XL, and iPad regular width
- fresh independent final review — no P0–P2 findings

## Risks / Notes

- presentation-only change: no HR-control, BLE, treadmill command, safety, cooldown/stop, Watch lifecycle, HealthKit, Telemetry V2, persistence, or analysis semantics changed
- DEBUG fixture launches skip manager lifecycle startup so mock QA cannot reach transport; Release lifecycle is unchanged
- compact-height rotation was unavailable in the current headless Simulator environment and is recorded as a P3 QA limitation; small-screen portrait scrolling and the pinned Start action passed
- no migrations, configuration changes, deployment steps, or backward-compatibility changes; rollback is a single commit revert