### PR TITLE
Unify Training Hub preflight layout

### DIFF
--- a/docs/design/qa-ledger.md
+++ b/docs/design/qa-ledger.md
@@ -1,6 +1,21 @@
 # Redesign QA ledger
 
-Status: passed for the frozen Issue #59 presentation scope.
+Status: passed for the binding Issue #64 compact continuous preflight correction.
+
+## Issue #64 — compact continuous preflight
+
+| Pass | State / form factor | Severity | Finding | Evidence | Owner path | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| Baseline | Ready / iPhone 17 Pro Max / light | P0 | The idle navigation title is absent; readiness, configuration, and Start form one top-aligned scroll composition with no flexible band between the card and CTA. | `/private/tmp/issue64-qa/tall-ready-unknown-source-light.png` plus source contract | `ContentView.swift` | Pass |
+| Baseline | Treadmill unavailable and HR unavailable / iPhone 17 Pro Max / light | P0 | The blocker remains immediately above the disabled primary action and is visually continuous with the configuration card. | `/private/tmp/issue64-qa/tall-treadmill-unavailable-light.png`, `/private/tmp/issue64-qa/tall-hr-unavailable-light.png` | `ContentView.swift` | Pass |
+| Baseline | Ready / iPhone 17 Pro Max / dark | P1 | The continuous hierarchy, configuration material, and primary action retain semantic contrast without recreating a detached footer. | `/private/tmp/issue64-qa/tall-ready-dark.png` | `ContentView.swift` | Pass |
+| Baseline | Ready / iPhone 17 Pro Max / Accessibility XL | P1 | Readiness, the full configuration, and Start remain readable and reachable in the natural scroll flow with no clipped text. | `/private/tmp/issue64-qa/tall-ready-axxl.png` | `ContentView.swift` | Pass |
+| Baseline | Ready / iPhone SE (3rd generation) / default type | P1 | The shorter portrait layout keeps the full preflight and primary action coherent; the existing scroll view provides overflow behavior rather than fixed spacer geometry. | `/private/tmp/issue64-qa/short-ready-light.png` plus source inspection | `ContentView.swift` | Pass |
+| Baseline | Treadmill unavailable / iPhone SE (3rd generation) / Accessibility XL | P1 | Large content naturally exceeds the compact viewport without horizontal clipping; blocker and Start remain later in the same scroll source order. | `/private/tmp/issue64-qa/short-treadmill-unavailable-axxl.png` plus source contract | `ContentView.swift` | Pass |
+| Regression | Active, cooldown, ending, and summary / iPhone 17 Pro Max / light | P0 | Non-idle shells preserve their accepted content, fixed actions, and compact `Тренировка` navigation behavior; only the idle Hub hides the navigation bar. | `/private/tmp/issue64-qa/tall-active-in-zone-light.png`, `/private/tmp/issue64-qa/tall-cooldown-above-light.png`, `/private/tmp/issue64-qa/tall-ending-confirming-light-retry.png`, `/private/tmp/issue64-qa/tall-summary-complete-light.png` | `ContentView.swift` | Pass |
+| Final review | Runtime and transport boundary | P0 | The diff is limited to SwiftUI composition, one source-contract test, and this ledger; Start still invokes the existing callback and no runtime, BLE, telemetry, persistence, or safety file changed. | Scope checker and base-to-head diff | `ContentView.swift`, `HeartRateLegacyBehaviorContractTests.swift` | Pass |
+
+No visual correction pass was required. The compact-height Accessibility XL screenshot records the expected initial viewport; reachability is additionally enforced by the unchanged outer `ScrollView` and the source-order contract (`readiness → hero → startArea`).
 
 ## Issue #59 — workout ending and result
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -984,13 +984,12 @@ private struct TrainingHubView: View {
                     onTreadmillTap: onTreadmillTap
                 )
                 hero
+                startArea
+                    .padding(.top, 6)
             }
             .padding(.horizontal, 16)
             .padding(.top, 4)
-            .padding(.bottom, 12)
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            startArea
+            .padding(.bottom, 20)
         }
     }
 
@@ -1182,10 +1181,6 @@ private struct TrainingHubView: View {
                 .accessibilityHint("Запускает HR-контроль с выбранной целевой зоной")
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.top, 10)
-        .padding(.bottom, 8)
-        .background(.ultraThinMaterial)
     }
 }
 
@@ -2120,7 +2115,8 @@ private struct ControlSwipeView: View {
                 value: flowTransitionID
             )
             .navigationTitle("Тренировка")
-            .navigationBarTitleDisplayMode(usesCompactNavigationTitle ? .inline : .large)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar(usesCompactNavigationTitle ? .visible : .hidden, for: .navigationBar)
             .navigationDestination(isPresented: $showParameters) {
                 HRParametersFormView()
                     .environmentObject(manager)

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -290,6 +290,33 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         XCTAssertTrue(hubBody.contains("guard !presentation.isPreview else { return }"))
         XCTAssertTrue(hubBody.contains("onStart()"))
         XCTAssertFalse(hubBody.contains("BluetoothManager"))
+        XCTAssertFalse(hubBody.contains(".safeAreaInset"))
+        assertOrdered(
+            [
+                "TrainingReadinessStrip(",
+                "hero",
+                "startArea",
+                ".padding(.top, 6)",
+            ],
+            in: hubBody
+        )
+
+        let controlView = try functionBody(
+            "private struct ControlSwipeView: View",
+            in: contentViewSource
+        )
+        XCTAssertTrue(controlView.contains(".navigationTitle(\"Тренировка\")"))
+        XCTAssertTrue(controlView.contains(".navigationBarTitleDisplayMode(.inline)"))
+        XCTAssertTrue(
+            controlView.contains(
+                ".toolbar(usesCompactNavigationTitle ? .visible : .hidden, for: .navigationBar)"
+            )
+        )
+        XCTAssertFalse(
+            controlView.contains(
+                ".navigationBarTitleDisplayMode(usesCompactNavigationTitle ? .inline : .large)"
+            )
+        )
 
         XCTAssertTrue(contentBody.contains("private var isTrainingPreviewLaunch: Bool"))
         XCTAssertTrue(contentBody.contains("--training-hub-preview="))


### PR DESCRIPTION
## Summary

- hide the `Тренировка` navigation bar only on the idle Training Hub while preserving compact navigation for non-idle phases
- move blocker and Start from the bottom safe-area footer into the normal preflight scroll flow after the configuration card
- add a focused source contract and record simulator QA for the selected PM direction

Closes #64

## Verification

- `swift test --package-path ios/WalkingPadRemote/WalkingPadRemote --filter HeartRateLegacyBehaviorContractTests/testTrainingHubPresentationStaysGenericAndPreviewOnlyModesCannotStart` — passed
- `swift test --scratch-path /private/tmp/issue64-swiftpm-full` from the package directory — 435 tests passed across package test bundles
- iPhone 17 Pro Max and iPhone SE (3rd generation) DEBUG-fixture QA: ready, treadmill unavailable, HR unavailable, dark mode, Accessibility XL, active, cooldown, ending, and summary — passed
- simulator build for iPhone 17 Pro Max with code signing disabled — passed
- unsigned generic iOS/watchOS app build — passed
- redesign scope checker — passed
- `git diff --check` — passed
- one intermediate focused-test invocation from the repository root omitted `--package-path` and failed to locate `Package.swift`; the corrected command above passed

## Risks / Notes

- production SwiftUI diff is +5/-9 lines and is limited to idle/preflight composition plus conditional navigation visibility
- Start authorization, blocker mapping, runtime/control/BLE/HR/cooldown/Telemetry/persistence behavior are unchanged
- no physical-device launch, install, BLE, or treadmill activity was performed
- Draft only; do not mark Ready or merge