### PR TITLE
Preserve second-level zone plan progress

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -148,6 +148,7 @@ let package = Package(
                 "StopTruthExperimentSessionService.swift",
                 "TreadmillTestRunService.swift",
                 "TrainingTelemetryWriter.swift",
+                "ZonePlanProgress.swift",
                 "CommandQueueService.swift",
                 "TreadmillSpeedBoundsService.swift",
                 "TreadmillCommandTelemetrySidecar.swift"

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -3462,18 +3462,16 @@ private struct WorkoutStatsView: View {
         VStack(alignment: .leading, spacing: 10) {
             ForEach(0..<5, id: \.self) { idx in
                 let seconds = zoneSeconds.flatMap { idx < $0.count ? $0[idx] : nil }
-                let actualMinutes = seconds.map { Int($0 / 60.0) }
                 let monthPlan = idx < manager.zonePlanMinutes.count ? manager.zonePlanMinutes[idx] : 0
-                let planMinutes = scope == .week ? Int(round(Double(monthPlan) / 4.0)) : monthPlan
-                let progress = actualMinutes.map {
-                    planMinutes > 0 ? min(1.0, Double($0) / Double(planMinutes)) : 0
-                }
+                let planSeconds = ZonePlanProgress.planSeconds(
+                    monthlyPlanMinutes: monthPlan,
+                    isWeekly: scope == .week
+                )
                 ZoneSummaryRow(
                     title: "Зона \(idx + 1)",
                     rangeText: zoneRangeText(index: idx),
-                    actualMinutes: actualMinutes,
-                    planMinutes: planMinutes,
-                    progress: progress,
+                    actualSeconds: seconds,
+                    planSeconds: planSeconds,
                     color: zoneColor(index: idx)
                 )
             }
@@ -3580,13 +3578,19 @@ private struct WorkoutStatsView: View {
 private struct ZoneSummaryRow: View {
     let title: String
     let rangeText: String
-    let actualMinutes: Int?
-    let planMinutes: Int
-    let progress: Double?
+    let actualSeconds: Double?
+    let planSeconds: Double
     let color: Color
 
     var body: some View {
-        let achieved = planMinutes > 0 && (actualMinutes ?? -1) >= planMinutes
+        let progress = ZonePlanProgress.rawProgress(
+            actualSeconds: actualSeconds,
+            planSeconds: planSeconds
+        )
+        let achieved = ZonePlanProgress.isAchieved(
+            actualSeconds: actualSeconds,
+            planSeconds: planSeconds
+        )
         VStack(alignment: .leading, spacing: 6) {
             HStack {
                 Text(title)
@@ -3603,14 +3607,14 @@ private struct ZoneSummaryRow: View {
                 }
             }
             HStack(spacing: 6) {
-                Text(actualMinutes.map { "Факт \($0) мин" } ?? "Факт —")
+                Text("Факт \(ZonePlanProgress.durationText(seconds: actualSeconds))")
                     .font(.caption2)
                     .foregroundColor(.secondary)
                 Text("·")
                     .font(.caption2)
                     .foregroundColor(.secondary)
-                if planMinutes > 0 {
-                    Text("План \(planMinutes) мин")
+                if planSeconds > 0 {
+                    Text("План \(ZonePlanProgress.durationText(seconds: planSeconds))")
                         .font(.caption2)
                         .foregroundColor(.secondary)
                 } else {
@@ -3619,8 +3623,8 @@ private struct ZoneSummaryRow: View {
                         .foregroundColor(.secondary)
                 }
             }
-            if planMinutes > 0, let progress {
-                ProgressView(value: min(1.0, max(0.0, progress)))
+            if let displayedProgress = ZonePlanProgress.displayedProgress(progress) {
+                ProgressView(value: displayedProgress)
                     .progressViewStyle(.linear)
                     .tint(color)
             }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ZonePlanProgress.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ZonePlanProgress.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+enum ZonePlanProgress {
+    static func planSeconds(monthlyPlanMinutes: Int, isWeekly: Bool) -> Double {
+        let monthlySeconds = Double(max(0, monthlyPlanMinutes)) * 60.0
+        return isWeekly ? monthlySeconds / 4.0 : monthlySeconds
+    }
+
+    static func rawProgress(actualSeconds: Double?, planSeconds: Double) -> Double? {
+        guard let actualSeconds,
+              actualSeconds.isFinite,
+              actualSeconds >= 0,
+              planSeconds.isFinite,
+              planSeconds > 0 else {
+            return nil
+        }
+        return actualSeconds / planSeconds
+    }
+
+    static func displayedProgress(_ rawProgress: Double?) -> Double? {
+        rawProgress.map { min(1.0, max(0.0, $0)) }
+    }
+
+    static func isAchieved(actualSeconds: Double?, planSeconds: Double) -> Bool {
+        guard let actualSeconds,
+              actualSeconds.isFinite,
+              actualSeconds >= 0,
+              planSeconds.isFinite,
+              planSeconds > 0 else {
+            return false
+        }
+        return actualSeconds >= planSeconds
+    }
+
+    static func durationText(seconds: Double?) -> String {
+        guard let seconds, seconds.isFinite, seconds >= 0 else { return "—" }
+        let totalSeconds = Int(seconds.rounded(.down))
+        let hours = totalSeconds / 3_600
+        let minutes = (totalSeconds % 3_600) / 60
+        let remainingSeconds = totalSeconds % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, remainingSeconds)
+        }
+        return String(format: "%d:%02d", minutes, remainingSeconds)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ZonePlanProgressTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ZonePlanProgressTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class ZonePlanProgressTests: XCTestCase {
+    func testFiftyNineSecondsContributeWithoutTruncation() {
+        let progress = ZonePlanProgress.rawProgress(
+            actualSeconds: 59,
+            planSeconds: 60
+        )
+
+        XCTAssertEqual(progress ?? -1, 59.0 / 60.0, accuracy: 0.000_001)
+        XCTAssertEqual(ZonePlanProgress.durationText(seconds: 59), "0:59")
+    }
+
+    func testNinetySecondsContributeWithoutTruncation() {
+        let progress = ZonePlanProgress.rawProgress(
+            actualSeconds: 90,
+            planSeconds: 120
+        )
+
+        XCTAssertEqual(progress ?? -1, 0.75, accuracy: 0.000_001)
+        XCTAssertEqual(ZonePlanProgress.durationText(seconds: 90), "1:30")
+    }
+
+    func testCompletionUsesExactSecondBoundary() {
+        let planSeconds = ZonePlanProgress.planSeconds(
+            monthlyPlanMinutes: 90,
+            isWeekly: false
+        )
+
+        XCTAssertFalse(
+            ZonePlanProgress.isAchieved(
+                actualSeconds: 89 * 60 + 59,
+                planSeconds: planSeconds
+            )
+        )
+        XCTAssertTrue(
+            ZonePlanProgress.isAchieved(
+                actualSeconds: 90 * 60,
+                planSeconds: planSeconds
+            )
+        )
+    }
+
+    func testNinetyMinuteMonthProducesExactWeeklyTarget() {
+        let sixtyMinutePlanSeconds = ZonePlanProgress.planSeconds(
+            monthlyPlanMinutes: 60,
+            isWeekly: true
+        )
+        let planSeconds = ZonePlanProgress.planSeconds(
+            monthlyPlanMinutes: 90,
+            isWeekly: true
+        )
+
+        XCTAssertEqual(sixtyMinutePlanSeconds, 15 * 60)
+        XCTAssertEqual(
+            ZonePlanProgress.durationText(seconds: sixtyMinutePlanSeconds),
+            "15:00"
+        )
+        XCTAssertEqual(planSeconds, 22 * 60 + 30)
+        XCTAssertEqual(ZonePlanProgress.durationText(seconds: planSeconds), "22:30")
+    }
+
+    func testHundredOneMinuteMonthProducesExactWeeklyTarget() {
+        let planSeconds = ZonePlanProgress.planSeconds(
+            monthlyPlanMinutes: 101,
+            isWeekly: true
+        )
+
+        XCTAssertEqual(planSeconds, 25 * 60 + 15)
+        XCTAssertEqual(ZonePlanProgress.durationText(seconds: planSeconds), "25:15")
+    }
+
+    func testUnavailableExposureRemainsUnavailable() {
+        let progress = ZonePlanProgress.rawProgress(
+            actualSeconds: nil,
+            planSeconds: 60
+        )
+
+        XCTAssertNil(progress)
+        XCTAssertNil(ZonePlanProgress.displayedProgress(progress))
+        XCTAssertFalse(ZonePlanProgress.isAchieved(actualSeconds: nil, planSeconds: 60))
+        XCTAssertEqual(ZonePlanProgress.durationText(seconds: nil), "—")
+    }
+
+    func testDisplayedProgressCapsWithoutChangingFactualSeconds() {
+        let actualSeconds = 121.0
+        let progress = ZonePlanProgress.rawProgress(
+            actualSeconds: actualSeconds,
+            planSeconds: 60
+        )
+
+        XCTAssertEqual(progress ?? -1, 121.0 / 60.0, accuracy: 0.000_001)
+        XCTAssertEqual(ZonePlanProgress.displayedProgress(progress), 1.0)
+        XCTAssertEqual(actualSeconds, 121)
+        XCTAssertTrue(
+            ZonePlanProgress.isAchieved(
+                actualSeconds: actualSeconds,
+                planSeconds: 60
+            )
+        )
+    }
+
+    func testDurationFormattingBelowAndAboveOneHour() {
+        XCTAssertEqual(ZonePlanProgress.durationText(seconds: 42 * 60 + 17), "42:17")
+        XCTAssertEqual(
+            ZonePlanProgress.durationText(seconds: 60 * 60 + 2 * 60 + 14),
+            "1:02:14"
+        )
+        XCTAssertEqual(ZonePlanProgress.durationText(seconds: 90 * 60), "1:30:00")
+    }
+
+    func testStatisticsViewUsesFactualZoneSecondsWithoutMinuteRounding() throws {
+        let packageDirectory = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let contentViewURL = packageDirectory
+            .appendingPathComponent("WalkingPadRemote/ContentView.swift")
+        let source = try String(contentsOf: contentViewURL, encoding: .utf8)
+
+        XCTAssertTrue(source.contains("zoneSeconds: stats?.zoneSeconds"))
+        XCTAssertTrue(source.contains("actualSeconds: seconds"))
+        XCTAssertTrue(source.contains("ZonePlanProgress.planSeconds("))
+        XCTAssertTrue(source.contains("monthlyPlanMinutes: monthPlan"))
+        XCTAssertTrue(source.contains("isWeekly: scope == .week"))
+        XCTAssertTrue(source.contains("ZonePlanProgress.rawProgress("))
+        XCTAssertTrue(source.contains("ZonePlanProgress.isAchieved("))
+        XCTAssertTrue(source.contains("ZonePlanProgress.displayedProgress(progress)"))
+        XCTAssertTrue(source.contains("ZonePlanProgress.durationText(seconds: actualSeconds)"))
+        XCTAssertFalse(source.contains("Int($0 / 60.0)"))
+        XCTAssertFalse(source.contains("Int(round(Double(monthPlan) / 4.0))"))
+    }
+}


### PR DESCRIPTION
## Summary

- keep factual `WorkoutStatisticsProjection.zoneSeconds` as seconds through Statistics progress and completion
- derive monthly and weekly targets in seconds, with the weekly target as an exact quarter
- display factual and planned durations as `m:ss` or `h:mm:ss`, preserving unavailable values
- cap only the rendered progress bar while comparing achieved state against uncapped factual seconds

Closes #65

## Verification

- `swift test --filter ZonePlanProgressTests` — 9/9 passed
- full `swift test` in a fresh scratch directory — 444/444 passed
- unsigned `xcodebuild -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build` — `BUILD SUCCEEDED`
- `git diff --check` — passed
- independent exact-head review — no P0–P3 findings
- the first focused compile exposed optional values passed to non-optional XCTest accuracy assertions; test-only assertions were corrected and the focused/full suites then passed
- an independent alternative `-sdk iphoneos` build invocation hit the existing Watch AppIcon asset-catalog limitation; the repository-required generic iOS/watchOS build command above passed on the exact head

## Risks / Notes

- production code changes are limited to Statistics presentation wiring and one stateless pure helper
- monthly plan persistence remains integer minutes; no migration or configuration change is required
- Telemetry V2 schema/persistence, analyzer, workout inclusion, HR-zone semantics, runtime/control/BLE/treadmill/safety behavior are unchanged
- no physical-device, BLE, treadmill, deploy, or release activity was performed
- Draft only; do not mark Ready or merge