### PR TITLE
Streamline ChatGPT → GitHub → Codex workflow

### DIFF
--- a/.agents/skills/walkingpad-ios-redesign/SKILL.md
+++ b/.agents/skills/walkingpad-ios-redesign/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: walkingpad-ios-redesign
-description: Route one PM-scoped native SwiftUI screen or flow through a token-bounded, presentation-only redesign process. Use for iOS visual/interaction redesign; never cross into BLE, stop, speed, HR, units, telemetry, or persistence behavior.
+description: Route one PM-scoped native SwiftUI screen or flow through a token-bounded presentation-only redesign process. Use for iOS visual/interaction redesign; never cross into BLE, stop, speed, HR, units, telemetry, or persistence behavior.
 ---
 
 # WalkingPad iOS redesign
 
-Read only the phase-specific reference named below; do not load the whole pack or duplicate external specialist knowledge.
+Read only the phase-specific reference needed for the active phase; do not load the whole pack or duplicate external specialist knowledge.
 
-1. **Scope and safety:** define one screen/flow, exact writable paths, read-only boundaries, simulator/mock fixtures, and done criteria using [`references/safety-boundary.md`](references/safety-boundary.md). Run `scripts/check-ui-scope.sh` against the exact base; it checks committed, staged, unstaged, and untracked paths.
+## Choose the path
+
+**Narrow follow-up:** if the current Issue/active PM decision already freezes the visual direction and explicitly describes a bounded correction, skip audit, two-concept ideation, and freeze. Establish scope/safety, then run **Implement → Verify → Correct**. Do not create concept docs merely to restate an already-selected direction.
+
+**New design direction:** otherwise use the full flow below and stop for PM selection after two concepts.
+
+## Full design flow
+
+1. **Scope and safety:** define one screen/flow, exact writable paths, read-only boundaries, simulator/mock fixtures, and done criteria using [`references/safety-boundary.md`](references/safety-boundary.md). Run `scripts/check-ui-scope.sh` against the exact base.
 2. **Audit:** use Product Design `audit` alone by default and return at most 8 actionable findings. Freeze the problem before ideation.
 3. **Ideate:** use Product Design `ideate` plus at most one relevant SwiftUI specialist. Produce exactly 2 concepts maximum, record them in `docs/design/redesign-brief.md`, and stop for PM selection.
 4. **Freeze:** record one selected direction in `docs/design/selected-direction.md`. Do not implement without that PM choice.
-5. **Implement:** activate only 1–2 focused specialists for the phase. Use Wholiver `swiftui-design-skill` for native composition and Paul Hudson/twostraws `swiftui-pro` only for relevant partial references. Do not use Product Design `image-to-code` in the default native SwiftUI path.
-6. **Verify:** build/test safely, summarize failures with `scripts/summarize-build-log.sh`, and avoid re-feeding complete successful logs. Use [`references/qa-contract.md`](references/qa-contract.md) and Product Design `design-qa` for normal visual QA. After changing the scope checker, run `scripts/test-check-ui-scope.sh`.
+5. **Implement:** activate only 1–2 focused specialists when they materially reduce risk. Prefer native SwiftUI and the existing presentation seams.
+6. **Verify:** build/test safely, summarize failures with `scripts/summarize-build-log.sh`, and avoid re-feeding complete successful logs. Use [`references/qa-contract.md`](references/qa-contract.md) and design QA appropriate to the scope. After changing the scope checker, run `scripts/test-check-ui-scope.sh`.
 7. **Correct:** allow at most 2 visual QA correction passes. If P0–P2 findings remain, stop for PM instead of extending the loop.
 
-Run `ios-debugger-agent` only for an actual iOS build/runtime-debug question. Add performance, accessibility, or animation/layout specialists only when the screen/task triggers them. Use Liquid Glass only after an explicit PM design decision. Add a second-opinion critic only for a deliberate red-team pass.
+Run debugger/performance/accessibility/animation specialists only for a concrete question that needs them. Use Liquid Glass only after an explicit PM design decision. Add a second-opinion critic only for a deliberate red-team pass.
 
-Store stable brief, selected direction, tokens, and QA outcomes in `docs/design/`; keep conversational context concise. Ordinary redesign never authorizes install, device launch, BLE, or treadmill activity.
+Store only stable decisions/QA evidence that future work actually needs in `docs/design/`; keep conversational context concise. Ordinary redesign never authorizes install, device launch, BLE, or treadmill activity.

--- a/.agents/skills/walkingpad-minimal-code/SKILL.md
+++ b/.agents/skills/walkingpad-minimal-code/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: walkingpad-minimal-code
+description: Use for any WalkingPad code-writing, bug-fix, or refactor task and for code review when simplicity matters. Prefer reuse, Apple/Swift platform capabilities, deletion, and the smallest maintainable diff without weakening safety, telemetry truth, persistence, or required tests.
+---
+
+# WalkingPad minimal-code discipline
+
+Goal: the smallest maintainable change that satisfies the contract. This is not code golf; correctness, clarity, and treadmill safety win ties.
+
+Before adding code, stop at the first option that works:
+
+1. No change needed.
+2. Existing owner/helper/component/pattern.
+3. Swift, SwiftUI, Foundation, HealthKit, CoreBluetooth, or another already-used Apple/platform capability.
+4. An already-installed dependency that cleanly owns the need.
+5. Otherwise the smallest local implementation.
+
+Rules:
+
+- Prefer deletion and consolidation over addition.
+- Fix the root cause at the established owner rather than patching each caller.
+- No speculative abstraction: avoid one-implementation protocols, factories, coordinators, pass-through wrappers, parallel state machines, or scaffolding for hypothetical modes.
+- Do not add a dependency when the existing stack or a few clear lines suffice.
+- Prefer fewer files, branches, state transitions, timers, passes, allocations, persistence operations, and transport round trips when behavior remains equally clear and correct.
+- Keep SwiftUI presentation-focused; deterministic reusable rules belong in an existing focused seam, not in a new layer by default and not in `BluetoothManager` merely for convenience.
+- Do not split a file solely to reduce line count. Extract only when ownership, reuse, testability, or readability materially improves.
+- Keep comments for non-obvious constraints/invariants/reasons, not narration.
+- Preserve fail-safe behavior, factual telemetry semantics, stop evidence, HR gates, unit semantics, persistence compatibility, privacy, and useful regression coverage.
+
+Before handoff, inspect every added file, dependency, abstraction, state variable, branch, and meaningful block. If removing it still satisfies the Issue and tests, remove it.
+
+Report base-to-head production LOC delta and any new file/dependency when practical. Fewer LOC alone is never evidence of faster runtime.

--- a/.agents/skills/walkingpad-performance/SKILL.md
+++ b/.agents/skills/walkingpad-performance/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: walkingpad-performance
+description: Use only when a WalkingPad task explicitly targets or demonstrates runtime speed, latency, CPU, memory, persistence throughput, telemetry throughput, battery cost, or command/UI responsiveness. Measure first, fix the dominant bottleneck with the smallest safe change, and remeasure.
+---
+
+# WalkingPad performance optimization
+
+Optimize evidence, not aesthetics. A smaller diff can be easier to maintain but does not prove faster runtime.
+
+## Diagnose first
+
+Use the narrowest trustworthy evidence available: existing timings/signposts, Instruments, XCTest metrics, a deterministic benchmark/soak, queue-depth/drop counters, persistence timings, or a reproducible workload. Identify the dominant class before rewriting code.
+
+If no trustworthy measurement exists, add the smallest measurement needed first.
+
+## Optimization order
+
+Prefer, when supported by evidence:
+
+1. remove unnecessary/repeated work;
+2. fix bad asymptotics or redundant passes;
+3. reduce excessive timers/events/serialization and transport or persistence round trips;
+4. batch work only where latency/safety semantics permit;
+5. reduce unnecessary allocations, copies, parsing, formatting, or view recomputation;
+6. cache only when repeated reuse is measured and invalidation is explicit;
+7. add concurrency only when the measured bottleneck benefits and ordering/safety remain correct;
+8. micro-optimize only after higher-leverage options are exhausted.
+
+Do not change BLE pacing, command ordering, stop confirmation, telemetry truth, HR safety gates, or persistence semantics merely for speed without the appropriate safety/data contract.
+
+## Evidence gate
+
+Measure the same representative workload before and after. Report metric, workload, result, and complexity cost. If speed cannot be measured, say so; never claim a speedup from LOC reduction or subjective smoothness alone.

--- a/.agents/skills/walkingpad-pr-lifecycle/SKILL.md
+++ b/.agents/skills/walkingpad-pr-lifecycle/SKILL.md
@@ -1,101 +1,58 @@
 ---
 name: walkingpad-pr-lifecycle
-description: Implement one WalkingPad GitHub issue from an exact main SHA through an isolated worktree, verified feature branch, fresh independent review, and Draft PR. Delivery stops at Draft; a later PM review may merge only under the repository's conditional standing authorization.
+description: Implement one scoped WalkingPad Issue from live main through an isolated worktree, verification, and one exact-head Draft PR. Use for normal implementation; pair with minimal-code for code changes and only the conditional domain skills the Issue actually triggers.
 ---
 
-# WalkingPad PR lifecycle
+# WalkingPad implementation lifecycle
 
-This skill is the canonical owner of the repository's implementation delivery
-workflow. Root `AGENTS.md` owns global authority and safety boundaries; the
-current Issue and active PM decisions own task-specific behavior.
+Root `AGENTS.md` owns repository-wide boundaries. The current Issue and active PM decisions own task-specific behavior, tests, non-goals, and hard stops.
 
-## Context and contract
+## 1. Establish the contract
 
-1. Read the complete current Issue and every active PM decision. Record scope,
-   non-goals, done criteria, risks, safe checks, and hard stops before editing.
-2. Use current code/tests and directly relevant canonical docs as the default
-   context. Read predecessor Issues, PRs, commits, or historical notes only when
-   a concrete ambiguity remains.
-3. When a later PM decision supersedes body wording, follow the decision and
-   preserve its link in the Issue's `Current binding decisions` index. Do not
-   erase historical comments.
-4. Before relying on non-trivial or unstable external behavior, consult the
-   applicable primary official documentation and retain only the finding that
-   affected the implementation.
+- Read the current Issue, active decisions, root/nested `AGENTS.md`, and only directly relevant canonical docs/code/tests.
+- Record goal, non-goals, done criteria, risk, safe checks, and accepted `main` SHA or permission to use live `main`.
+- Read history only to resolve a concrete ambiguity.
+- For code changes also use [`walkingpad-minimal-code`](../walkingpad-minimal-code/SKILL.md).
+- Add redesign, performance, safety, hardware, or evidence skills only when the task triggers them.
 
-## Implementation and verification
+## 2. Work from the exact base
 
-1. Fetch GitHub `main`, resolve its exact live SHA, and compare it with the
-   approved contract before editing. Stop for PM on ambiguous or invalidating
-   base drift.
-2. Use exactly one `codex/...` branch in one isolated worktree created from that
-   SHA. Never reset, stash, clean, or reuse the user's dirty worktree.
-3. Keep the parent/Goal agent as sole writer. Mapper or research agents are
-   conditional and read-only. Use a safety challenger and a fresh independent
-   final reviewer whenever the Issue, risk class, or repository contract
-   requires them.
-   For substantial work, select `gpt-5.6-sol` with `high` reasoning for the
-   parent when the client exposes that choice. Route repository mapping or
-   narrow primary-source research to Luna/medium and safety challenge or final
-   review to Terra/high by default. Report the effective model, effort, role,
-   outcome, and any fallback; never claim an unexposed selection.
-4. Make the smallest in-scope change. Run focused checks while iterating and the
-   full applicable safe suite once the coherent change is ready. Repeat a
-   successful full suite only after a relevant change or failure.
-5. Inspect the complete base-to-head diff for correctness, scope, safety,
-   secrets, private data, generated artifacts, and missing tests. Summarize long
-   successful logs instead of carrying their full output forward.
-6. Give the final reviewer the authoritative contract, exact base and head,
-   complete base-to-head diff, and concise check evidence. Review the diff, not
-   the implementation transcript.
-7. Correct material in-scope findings from the finding and changed delta. Use a
-   fresh reviewer after a correction. After two correction cycles with material
-   findings still open, stop for PM direction.
+1. Preserve the user's existing worktree and unrelated changes.
+2. Fetch `main`, resolve its exact SHA, and stop on invalidating base drift.
+3. Create one isolated worktree and one `codex/...` branch from that SHA.
 
-## Draft PR and exact-head gate
+Never clean, stash, reset, or reuse a dirty user worktree for task edits.
 
-1. Commit intentionally, push only the feature branch, and open exactly one
-   Draft PR into `main` with the required closing reference.
-2. Do not mark Ready, merge, force-push, deploy, install, launch on a device,
-   perform hardware/BLE activity, or start another Issue during delivery.
-   Custom GitHub labels are never a delivery dependency.
-3. Fetch `main` again. Confirm that it still equals the approved base, the live
-   PR head equals the reviewed local head, mergeability is acceptable, and every
-   required CI result is successful for that exact head and base.
-4. Missing, queued, cancelled, stale, failed, or wrong-head required CI blocks
-   `READY FOR PM REVIEW`.
-5. Report exact base/head, branch, changed files, preserved history, checks, CI,
-   independent review, agent roles and effective model/effort when exposed,
-   assumptions, and remaining risks.
+## 3. Implement narrowly
 
-## Token observability
+- Trace the existing owner and relevant callers/tests before editing.
+- Make the smallest maintainable in-scope change; do not add adjacent cleanup.
+- Preserve runtime, safety, API/data, telemetry, persistence, and device contracts unless the Issue explicitly changes them.
+- Add focused regression coverage when existing tests do not prove the contract.
+- Ordinary implementation never authorizes install, launch, deploy, BLE/hardware activity, or destructive cleanup.
 
-Token usage is post-hoc observability. It is never by itself a reason to stop,
-request continuation, skip required verification, or reduce safety assurance.
-Report token and elapsed-time usage when the client exposes them; otherwise mark
-those fields unverifiable.
+## 4. Verify
 
-## PM review and standing merge authorization
+Run focused checks while iterating, then only the applicable repository gates. Typical gates are:
 
-Implementation delivery always stops at a Draft PR. If the user later hands the
-completed Draft PR to PM with a completion report and asks for GitHub review,
-that request authorizes merge in the same PM review turn only after an explicit
-final `GO` or `APPROVED` verdict.
+```bash
+python3 scripts/check_codex_governance.py
+python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py
+cd ios/WalkingPadRemote/WalkingPadRemote && swift test
+git diff --check
+```
 
-PM may then refresh the PR and live `main`; verify exact base/head, no base
-drift, exact-head required CI, any contract-required real app build, and no open
-P0/P1/material P2; perform metadata-only PR cleanup; mark Ready; squash-merge
-using the exact expected head SHA; verify new `main`; and verify or, when needed,
-close the linked completed Issue.
+Run unsigned app builds, UI scope checks, simulator QA, telemetry soak, or domain-specific checks only when the touched scope requires them. Summarize successful logs.
 
-The authorization is cancelled by any non-`GO`/non-`APPROVED` verdict, moved
-head, base drift, conflict, non-clean merge, missing/queued/stale/cancelled/
-failed/wrong-head required CI, missing required build, unresolved material
-finding, scope or safety violation, unresolved safety uncertainty requiring an
-explicit decision, or a more specific gate requiring separate approval.
+## 5. Inspect and publish
 
-It never covers hardware/BLE/treadmill experiments or physical commands;
-install/device launch outside explicit scope; deploy/release; firmware, OTA, or
-service-menu actions; controller preference or unit writes outside their own
-contract; force-push; branch/tag deletion; destructive cleanup; or work on the
-next Issue.
+- Re-fetch `main` and confirm the accepted base still holds.
+- Inspect the complete base-to-head diff and changed-file list for scope, correctness, unnecessary complexity, secrets/private data, generated artifacts, and missing tests.
+- Stage only scoped files, commit intentionally, push only the task branch, and open exactly one Draft PR into `main` with the required closing reference.
+- Verify server-side changed files and exact PR head. Required CI must be green for that exact head before declaring the Draft ready for PM review.
+
+## Handoff boundary
+
+Return only the concise review packet: Issue, Draft PR, exact base/head, changed files, checks/CI actually run, and remaining risks. Do not replay the implementation transcript.
+
+Stop at the verified Draft PR. Mark-Ready, merge, deploy/install, device launch, BLE/hardware activity, force-push, destructive cleanup, or the next Issue require the applicable separate role/authorization.

--- a/.agents/skills/walkingpad-pr-review/SKILL.md
+++ b/.agents/skills/walkingpad-pr-review/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: walkingpad-pr-review
+description: Independently review one WalkingPad Draft PR against its current Issue using the exact base/head diff and concise verification evidence. Use for PM review; code diffs also use minimal-code, and conditional redesign/performance/safety skills only when the diff triggers them.
+---
+
+# WalkingPad Draft PR review
+
+## Review
+
+1. Read the current Issue, active binding decisions, root/nested `AGENTS.md`, and only directly applicable domain contracts.
+2. Resolve exact PR base/head, live `main`, changed-file list, complete base-to-head diff, and checks/CI for that exact head. Review the diff, not the implementation transcript.
+3. Check scope first: every changed file/behavior must be authorized and required behavior must not be missing. Treat unrelated cleanup, generated artifacts, secrets, private health/device data, or production data as findings.
+4. Review correctness against architecture, safety boundaries, telemetry/persistence truth, runtime contracts, accessibility/UX contract when relevant, and tests.
+5. For code diffs also apply [`walkingpad-minimal-code`](../walkingpad-minimal-code/SKILL.md). Add `walkingpad-performance` only for measured/explicit performance scope; add redesign/safety skills only when triggered by the Issue/diff.
+6. Missing, stale, failed, cancelled, queued, or wrong-head required CI is not a pass. Do not infer verification from the implementation report.
+7. Findings use P0/P1/P2/P3 with exact file/line or GitHub metadata, consequence, evidence, and the smallest safe correction.
+8. After a material correction, review the new exact head and changed delta fresh.
+
+Return `NO-GO` while any material scope/correctness/safety/data finding or required gate is unresolved. Return `GO` only when the exact reviewed head satisfies the contract and evidence.
+
+## PM merge authorization
+
+When the user hands a completed Draft PR to PM for review, the same review turn may mark Ready and merge only after an explicit final `GO`, provided all of the following remain true on a fresh check:
+
+- live `main` still matches the accepted base or the Issue explicitly permits the resolved drift;
+- PR head equals the reviewed head;
+- mergeability is clean/acceptable;
+- all required exact-head CI/build gates are green;
+- no open P0/P1/material P2 or unresolved safety uncertainty remains.
+
+Use an exact expected-head guard when merging, then verify the new `main` and linked Issue closure.
+
+Any non-`GO` verdict, moved head, invalidating base drift, conflict, stale/missing CI, unresolved material finding, or more-specific gate cancels merge authorization.
+
+This standing authorization never covers deploy/install/device launch, BLE/treadmill experiments, controller preference/unit writes outside their own contract, firmware/OTA/service-menu actions, force-push, destructive cleanup, or work on the next Issue.

--- a/.github/ISSUE_TEMPLATE/codex-implementation.md
+++ b/.github/ISSUE_TEMPLATE/codex-implementation.md
@@ -18,8 +18,7 @@ Describe the task-specific outcome.
 
 ## Accepted behavior contract
 
-State the current owner, behavior to preserve, allowed mutations, failure
-behavior, and positive/negative regression requirements.
+State the current owner, behavior to preserve/change, allowed mutations, failure behavior, and important regressions.
 
 ## Required changes
 
@@ -42,14 +41,13 @@ behavior, and positive/negative regression requirements.
 - [Repository constitution](../../AGENTS.md)
 - [Codex/GitHub workflow ownership](../../docs/engineering/codex-github-workflow.md)
 - [WalkingPad PR lifecycle](../../.agents/skills/walkingpad-pr-lifecycle/SKILL.md)
-- Add only directly relevant subsystem and domain contracts.
+- For code changes add `walkingpad-minimal-code`.
+- Add `walkingpad-ios-redesign`, `walkingpad-performance`, `walkingpad-safety-change`, hardware/evidence skills, or domain docs only when this Issue actually triggers them.
 
 ## Current binding decisions
 
-- None at creation. Add links to later active PM decisions and integrate their
-  settled task-specific requirements into this body without deleting comments.
+- None at creation. Link later active PM decisions and integrate settled task-specific requirements without deleting comment history.
 
 ## Task-specific hard stops
 
-- Stop for PM when satisfying this Issue requires scope or behavior not
-  explicitly authorized above.
+- Stop for PM when satisfying this Issue requires scope, behavior, hardware/device action, or destructive work not explicitly authorized above.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Validate Codex governance
+        run: python scripts/check_codex_governance.py
+
       - name: Compile Python entrypoints
         run: |
           python -m compileall \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,83 +2,56 @@
 
 ## Scope and authority
 
-- GitHub `main` is the canonical development base. Resolve its exact live SHA
-  before implementation; planning-time SHAs are context, not authority.
-- Change only files and external metadata authorized by the current Issue and
-  active PM decisions. Preserve unrelated work and stop when a required change
-  would exceed that scope.
-- Read-only work does not authorize code changes, GitHub mutations, deployment,
-  device access, BLE/controller commands, or other external writes.
-- The parent/Goal agent is the sole writer unless the Issue explicitly says
-  otherwise. Subagents are read-only and conditional on a concrete reduction in
-  mapping, research, safety-review, or final-review risk.
+- GitHub `main` is the canonical development base. Resolve its exact live SHA before implementation; planning-time SHAs are context, not authority.
+- Change only files and external metadata authorized by the current Issue and active PM decisions. Preserve unrelated work and stop when a required change would exceed that scope.
+- Read-only work does not authorize code changes, GitHub mutations, deployment, device access, BLE/controller commands, or other external writes.
+- The parent/Goal agent is the sole writer unless the Issue explicitly says otherwise. Subagents are read-only and conditional on a concrete reduction in mapping, research, safety-review, or final-review risk.
 
-## Context ownership and precedence
+## Skill routing
 
-- Default working context is the current Issue, its active PM decisions, directly
-  relevant canonical docs, and current code/tests.
-- Read predecessor Issues, PRs, commits, or historical notes only to resolve a
-  concrete ambiguity that current authoritative sources leave open.
-- Root `AGENTS.md` owns repository-wide authority, safety, and boundary rules.
-  Nested `AGENTS.md` files add only subtree-specific constraints.
-- [`walkingpad-pr-lifecycle`](.agents/skills/walkingpad-pr-lifecycle/SKILL.md)
-  exclusively owns the detailed implementation, review, Draft PR, exact-head CI,
-  correction, token-observability, and conditional PM merge workflow.
-- Canonical domain docs own cross-Issue semantics. Issue bodies own task-specific
-  goals, accepted behavior, tests, non-goals, and hard stops. Later active PM
-  decisions override stale wording without erasing the historical comments.
+Load only the skills required by the current role and scope:
 
-## Implementation entry point
+- normal implementation -> [`walkingpad-pr-lifecycle`](.agents/skills/walkingpad-pr-lifecycle/SKILL.md);
+- any code writing/fix/refactor -> also [`walkingpad-minimal-code`](.agents/skills/walkingpad-minimal-code/SKILL.md);
+- independent Draft PR / PM review -> [`walkingpad-pr-review`](.agents/skills/walkingpad-pr-review/SKILL.md); code diffs also use `walkingpad-minimal-code`;
+- explicit or measured runtime-performance work -> also [`walkingpad-performance`](.agents/skills/walkingpad-performance/SKILL.md);
+- native iOS visual/interaction redesign -> also [`walkingpad-ios-redesign`](.agents/skills/walkingpad-ios-redesign/SKILL.md);
+- safety-critical runtime/control/telemetry/persistence change -> [`walkingpad-safety-change`](.agents/skills/walkingpad-safety-change/SKILL.md);
+- physical treadmill/controller experiment -> [`walkingpad-hardware-experiment`](.agents/skills/walkingpad-hardware-experiment/SKILL.md);
+- read-only capture/evidence analysis -> [`walkingpad-evidence-analysis`](.agents/skills/walkingpad-evidence-analysis/SKILL.md).
 
-Use [`walkingpad-pr-lifecycle`](.agents/skills/walkingpad-pr-lifecycle/SKILL.md)
-for normal Issue implementation. Delivery stops at one Draft PR for PM review;
-it does not mark Ready or merge. Do not force-push, deploy, release, install,
-launch on a physical device, or start the next Issue unless a separate explicit
-authorization covers that action.
+Do not preload unrelated skills. Detailed context ownership lives in [`docs/engineering/codex-github-workflow.md`](docs/engineering/codex-github-workflow.md).
+
+## Context discipline
+
+- Default working context is the current Issue/task, active PM decisions, directly relevant canonical docs, and current code/tests.
+- Read predecessor Issues, PRs, commits, archived notes, broad docs, or long logs only to resolve a concrete ambiguity.
+- Do not repeat repository rules, lifecycle steps, successful logs, or history in launch prompts and Issues. Link to canonical owners and summarize evidence.
+- Review base-to-head diffs, not implementation transcripts. Corrections start from the exact finding and changed delta.
 
 ## Treadmill safety invariants
 
-- Ordinary implementation and design work must not connect to a treadmill or
-  send BLE/controller commands.
-- Stop/start/speed behavior, command retries and confirmation, controller
-  units/preferences, HR safety gates, persistent BLE writes, telemetry semantics,
-  and persistence behavior are safety-critical. Change them only through
-  [`walkingpad-safety-change`](.agents/skills/walkingpad-safety-change/SKILL.md)
-  with an explicit PM-approved behavior contract.
-- Real controller experiments require
-  [`walkingpad-hardware-experiment`](.agents/skills/walkingpad-hardware-experiment/SKILL.md)
-  and a separate PM-approved experiment contract. Never infer hardware authority
-  from implementation scope.
-- A PM-approved controller unit/preference change is allowed only through the
-  safety-change workflow. Any physical validation additionally requires a fixed
-  packet whitelist and read-back verification in its own approved hardware-
-  experiment contract.
-- Do not use or promote arbitrary `raw`/`seq` commands, unknown packet replay,
-  service-menu writes, silent controller-unit changes, firmware/OTA actions, or
-  unlock attempts.
-- Debug and simulator paths must not bypass production safety gates. Missing,
-  stale, or ambiguous telemetry is not proof of a safe stopped state or valid
-  unit semantics.
-- Use [`walkingpad-evidence-analysis`](.agents/skills/walkingpad-evidence-analysis/SKILL.md)
-  for read-only JSONL/CSV, capture, protocol, and stop-forensics analysis.
+- Ordinary implementation and design work must not connect to a treadmill or send BLE/controller commands.
+- Stop/start/speed behavior, command retries and confirmation, controller units/preferences, HR safety gates, persistent BLE writes, telemetry semantics, and persistence behavior are safety-critical. Change them only through `walkingpad-safety-change` with an explicit PM-approved behavior contract.
+- Real controller experiments require `walkingpad-hardware-experiment` and a separate PM-approved experiment contract. Never infer hardware authority from implementation scope.
+- A PM-approved controller unit/preference change is allowed only through the safety-change workflow. Any physical validation additionally requires a fixed packet whitelist and read-back verification in its own approved hardware-experiment contract.
+- Do not use or promote arbitrary `raw`/`seq` commands, unknown packet replay, service-menu writes, silent controller-unit changes, firmware/OTA actions, or unlock attempts.
+- Debug and simulator paths must not bypass production safety gates. Missing, stale, or ambiguous telemetry is not proof of a safe stopped state or valid unit semantics.
 
 ## Repository boundaries and verification
 
-- Never commit secrets, pairing material, device identifiers, private
-  health/workout exports, local captures, or generated diagnostic logs.
-- Governance/docs-only work must not touch Swift runtime sources, Xcode project
-  settings, BLE Python tools, command helpers, or runtime persistence code unless
-  the Issue explicitly authorizes them.
-- Run the narrowest applicable checks and report only commands actually run.
-  Standard safe checks are:
+- Never commit secrets, pairing material, device identifiers, private health/workout exports, local captures, or generated diagnostic logs.
+- Governance/docs-only work must not touch Swift runtime sources, Xcode project settings, BLE Python tools, command helpers, or runtime persistence code unless the Issue explicitly authorizes them.
+- Run the narrowest applicable checks and report only commands actually run. Standard safe checks include:
   - `python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py`
+  - `python3 scripts/check_codex_governance.py`
   - `cd ios/WalkingPadRemote/WalkingPadRemote && swift test`
   - unsigned generic builds only when app/project changes require them.
 - A build never authorizes install, launch, BLE, or hardware activity.
 
 ## Documentation map
 
-- Codex/GitHub contract ownership: [`docs/engineering/codex-github-workflow.md`](docs/engineering/codex-github-workflow.md)
+- Codex/GitHub ownership and thin-prompt contract: [`docs/engineering/codex-github-workflow.md`](docs/engineering/codex-github-workflow.md)
 - Telemetry V2 reading routes and precedence: [`docs/telemetry-v2/index.md`](docs/telemetry-v2/index.md)
 - Swift/iOS extensions: [`ios/WalkingPadRemote/WalkingPadRemote/AGENTS.md`](ios/WalkingPadRemote/WalkingPadRemote/AGENTS.md)
 - Contributor setup and checks: [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`ios/README.md`](ios/README.md)

--- a/docs/engineering/codex-github-workflow.md
+++ b/docs/engineering/codex-github-workflow.md
@@ -1,85 +1,94 @@
 # Codex and GitHub contract ownership
 
-Status: canonical governance map for repository work.
+Status: canonical governance map for ChatGPT -> GitHub -> Codex development.
 
-This document explains where project knowledge belongs. It intentionally does
-not duplicate the implementation sequence owned by
-[`walkingpad-pr-lifecycle`](../../.agents/skills/walkingpad-pr-lifecycle/SKILL.md).
+This document defines where project knowledge and workflow rules belong. It links to canonical owners instead of duplicating their procedures.
 
 ## Canonical owners
 
 | Concern | Canonical owner | Keep out of |
 | --- | --- | --- |
-| Repository authority, safety boundaries, documentation map | root [`AGENTS.md`](../../AGENTS.md) | child Issues and launch prompts |
-| Detailed branch/worktree/review/Draft PR/CI/correction workflow | [`walkingpad-pr-lifecycle`](../../.agents/skills/walkingpad-pr-lifecycle/SKILL.md) | root instructions and Issue bodies |
-| Subtree-specific engineering rules | nearest nested `AGENTS.md` | unrelated subtrees and root history |
+| Repository authority and treadmill safety boundaries | root [`AGENTS.md`](../../AGENTS.md) | Issue boilerplate and launch prompts |
+| Normal exact-base implementation through one Draft PR | [`walkingpad-pr-lifecycle`](../../.agents/skills/walkingpad-pr-lifecycle/SKILL.md) | root instructions and Issue bodies |
+| Minimal code discipline | [`walkingpad-minimal-code`](../../.agents/skills/walkingpad-minimal-code/SKILL.md) | docs-only work |
+| Independent Draft PR / PM review and conditional merge | [`walkingpad-pr-review`](../../.agents/skills/walkingpad-pr-review/SKILL.md) | implementation context/transcripts |
+| Evidence-based runtime optimization | [`walkingpad-performance`](../../.agents/skills/walkingpad-performance/SKILL.md) | ordinary changes without a measured/explicit performance goal |
+| Native iOS redesign | [`walkingpad-ios-redesign`](../../.agents/skills/walkingpad-ios-redesign/SKILL.md) | non-UI work |
+| Safety-critical runtime/control/data changes | [`walkingpad-safety-change`](../../.agents/skills/walkingpad-safety-change/SKILL.md) | ordinary UI/logic changes |
+| Physical controller experiments | [`walkingpad-hardware-experiment`](../../.agents/skills/walkingpad-hardware-experiment/SKILL.md) | normal implementation/review |
+| Read-only captures/evidence | [`walkingpad-evidence-analysis`](../../.agents/skills/walkingpad-evidence-analysis/SKILL.md) | code-writing tasks |
 | Cross-Issue Telemetry V2 semantics | [`docs/telemetry-v2/`](../telemetry-v2/index.md) | repeated Issue boilerplate |
-| Task goal, accepted behavior, tests, non-goals, hard stops | current Issue body | global docs unless the decision is durable across Issues |
-| Later task-specific PM decisions | linked owner comments and integrated current body | rewritten or deleted comment history |
-| Historical implementation context | Git/Issue/PR history and archived docs | default launch context |
+| Task behavior/tests/non-goals/hard stops | current Issue/task | global docs unless durable across tasks |
+| Later task-specific decisions | linked PM/user comments plus integrated current body | rewritten/deleted comment history |
+| Historical context | Git/Issue/PR history and archive | default launch context |
 
-When two sources differ, apply the precedence rules in the root constitution and
-the relevant domain index. Escalate instead of guessing when the difference
-changes safety, scope, or accepted behavior.
+When authoritative current sources materially conflict, stop and surface the conflict rather than silently choosing one.
 
 ## Progressive disclosure
 
-Start with the current Issue, its `Current binding decisions`, the applicable
-contract links, and current code/tests. Read a predecessor Issue, PR, commit, or
-archived document only when a named ambiguity cannot be resolved from those
-sources. Record the ambiguity that justified the historical lookup.
+Start with the current Issue/task, active decisions, root/nested instructions, current code/tests, and only the skills/domain docs required by the current role.
 
-Successful logs are evidence to summarize, not context to reproduce. A review
-packet should contain the contract, exact base/head, complete diff, changed-file
-scope, and concise check results. A correction should start from the exact
-finding and inspect the resulting delta; accepted repository archaeology is not
-repeated without a new reason.
+Read predecessor Issues, PRs, commits, archived notes, broad docs, or long logs only when a named ambiguity cannot be resolved from current authoritative sources. Successful logs are evidence to summarize, not context to reproduce.
 
-## Issue body shape
+A review packet contains the task contract, exact base/head, complete base-to-head diff, changed-file scope, and concise verification evidence. A correction starts from the exact finding and changed delta rather than replaying repository archaeology or the implementation transcript.
 
-Implementation Issues should contain only task-specific material plus:
+## Task-to-skill routing
 
-- `Applicable contracts`: links to root/subsystem instructions, the lifecycle
-  skill, and relevant canonical domain docs;
-- `Current binding decisions`: links to active comments whose decisions remain
-  relevant, with settled requirements integrated into the body;
-- explicit predecessor/dependency state, behavior contract, tests, non-goals,
-  done criteria, and hard stops where the task needs them.
+- code `implement`: `walkingpad-pr-lifecycle` + `walkingpad-minimal-code`;
+- docs/governance-only `implement`: `walkingpad-pr-lifecycle` only;
+- visual/interaction `implement`: add `walkingpad-ios-redesign`;
+- explicit/measured runtime optimization: add `walkingpad-performance`;
+- safety-critical implementation/review: add `walkingpad-safety-change`;
+- physical experiment: `walkingpad-hardware-experiment` under its own authorization;
+- evidence/capture investigation: `walkingpad-evidence-analysis`;
+- `review`: `walkingpad-pr-review`; code diffs also use `walkingpad-minimal-code`.
 
-Do not paste repository-global Telemetry invariants or the standard lifecycle
-into each Issue. Comments remain audit history; integrating a decision into the
-body does not delete or rewrite the original comment.
+Do not load all skills preemptively. A skill is conditional context, not a repository handbook.
 
-The template at
-[`codex-implementation.md`](../../.github/ISSUE_TEMPLATE/codex-implementation.md)
-implements this shape.
+## Implementation Issue shape
 
-## Thin launch prompt
+Implementation Issues contain task-specific material plus:
 
-A launch prompt identifies the repository, Issue number, execution role, and
-required terminal verdict. It directs Codex to the current Issue, active
-decisions, root/nested instructions, and applicable skill. It may restate a
-task-specific hard boundary when omission would be risky, but does not copy the
-Issue body, global invariants, or detailed lifecycle.
+- goal and accepted behavior;
+- required changes/tests;
+- non-goals and definition of done;
+- `Applicable contracts` linking only directly relevant owners;
+- `Current binding decisions` linking later active decisions;
+- task-specific hard stops.
 
-## Review and correction evidence
+Do not paste standard lifecycle, global safety/Telemetry invariants, or unrelated domain rules into each Issue. Use [`.github/ISSUE_TEMPLATE/codex-implementation.md`](../../.github/ISSUE_TEMPLATE/codex-implementation.md).
 
-Review findings use priority and exact file/line or GitHub metadata references.
-The reviewer receives the base-to-head diff rather than a full transcript.
-Corrections describe the finding, the bounded delta, and checks rerun because of
-that delta. Required full checks and exact-head CI remain mandatory regardless
-of context size or token use.
+## Thin launch prompts
 
-## GitHub metadata updates
+A launch prompt identifies repository, task, role, base policy, and terminal outcome. It points to the Issue and repository routing instead of copying them.
 
-For an authorized Issue-body change:
+Normal implementation:
 
-1. read the complete current body and comments;
-2. record the pre-update body identity;
-3. update only the authorized Issue;
-4. read it back and verify the expected sections, links, and task semantics;
-5. never delete PM comments to make the body appear cleaner.
+```text
+Repository: tourvald/walkingpad-remote
+Issue: #<N>
+Role: implement
+Base: live main  # or exact SHA when fixed
+Follow Issue + AGENTS routing. Stop at one verified Draft PR.
+```
 
-GitHub does not provide one transaction spanning multiple Issues. A multi-Issue
-governance edit is auditable when every Issue is verified individually and the
-handoff enumerates the changed Issue numbers.
+PM review:
+
+```text
+Repository: tourvald/walkingpad-remote
+PR: #<N>
+Role: review
+Review exact base/head via walkingpad-pr-review.
+```
+
+Only add an unusual task-specific hard stop when omission would be risky. Do not repeat the Issue body, global invariants, standard checks, or lifecycle steps.
+
+## Review, correction, and handoff
+
+Review uses exact base/head and the complete diff, not implementation transcripts. Findings identify priority, exact location/metadata, consequence, evidence, and smallest safe correction. After a correction, inspect the new delta and rerun only checks invalidated by the delta plus mandatory gates.
+
+Implementation handoff is concise: Issue/PR, exact base/head, changed files, checks/CI, and remaining risks. Required full checks and exact-head CI remain mandatory regardless of context size or token use.
+
+## GitHub metadata discipline
+
+For an authorized Issue-body update, read the complete current body and relevant active comments, update only the authorized Issue, preserve comment history, and read the result back. One task should normally map to one Issue, one `codex/...` branch, and one Draft PR.

--- a/scripts/check_codex_governance.py
+++ b/scripts/check_codex_governance.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Validate the repository's Codex governance ownership and local Markdown links."""
+"""Validate Codex governance ownership, links, and active AGENTS context size."""
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -12,8 +13,25 @@ from urllib.parse import unquote
 ROOT = Path(__file__).resolve().parents[1]
 ROOT_AGENTS = ROOT / "AGENTS.md"
 LIFECYCLE = ROOT / ".agents/skills/walkingpad-pr-lifecycle/SKILL.md"
+MINIMAL_CODE = ROOT / ".agents/skills/walkingpad-minimal-code/SKILL.md"
+PR_REVIEW = ROOT / ".agents/skills/walkingpad-pr-review/SKILL.md"
+PERFORMANCE = ROOT / ".agents/skills/walkingpad-performance/SKILL.md"
 ISSUE_TEMPLATE = ROOT / ".github/ISSUE_TEMPLATE/codex-implementation.md"
 TELEMETRY_INDEX = ROOT / "docs/telemetry-v2/index.md"
+
+DEFAULT_MAX_INSTRUCTION_BYTES = 32 * 1024
+INSTRUCTION_FILENAMES = ("AGENTS.override.md", "AGENTS.md")
+EXCLUDED_DIRECTORIES = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+    "venv",
+}
+FORBIDDEN_HISTORY_HEADINGS = ("## Последние заметки",)
 
 LOCAL_LINK = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
 NUMERIC_TOKEN_CONTROL = re.compile(
@@ -24,15 +42,7 @@ NUMERIC_TOKEN_CONTROL = re.compile(
 
 def tracked_markdown_files() -> list[Path]:
     result = subprocess.run(
-        [
-            "git",
-            "ls-files",
-            "--cached",
-            "--others",
-            "--exclude-standard",
-            "--",
-            "*.md",
-        ],
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard", "--", "*.md"],
         cwd=ROOT,
         check=True,
         capture_output=True,
@@ -52,10 +62,54 @@ def local_target(raw_target: str) -> str | None:
     return unquote(target.split("#", maxsplit=1)[0]) or None
 
 
+def discover_instruction_files() -> list[Path]:
+    files: list[Path] = []
+    for current_root, directory_names, file_names in os.walk(ROOT):
+        directory_names[:] = sorted(
+            name for name in directory_names if name not in EXCLUDED_DIRECTORIES
+        )
+        directory = Path(current_root)
+        for filename in INSTRUCTION_FILENAMES:
+            if filename in file_names:
+                files.append(directory / filename)
+    return sorted(files)
+
+
+def active_instruction(directory: Path) -> Path | None:
+    for filename in INSTRUCTION_FILENAMES:
+        candidate = directory / filename
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def instruction_chain(target_directory: Path) -> list[Path]:
+    relative = target_directory.resolve().relative_to(ROOT.resolve())
+    directories = [ROOT]
+    current = ROOT
+    for part in relative.parts:
+        current /= part
+        directories.append(current)
+    return [path for directory in directories if (path := active_instruction(directory))]
+
+
+def instruction_chain_size(chain: list[Path]) -> int:
+    return sum(path.stat().st_size for path in chain) + max(0, len(chain) - 1) * 2
+
+
 def main() -> int:
     errors: list[str] = []
 
-    for required in (ROOT_AGENTS, LIFECYCLE, ISSUE_TEMPLATE, TELEMETRY_INDEX):
+    required_files = (
+        ROOT_AGENTS,
+        LIFECYCLE,
+        MINIMAL_CODE,
+        PR_REVIEW,
+        PERFORMANCE,
+        ISSUE_TEMPLATE,
+        TELEMETRY_INDEX,
+    )
+    for required in required_files:
         if not required.is_file():
             errors.append(f"missing required governance file: {required.relative_to(ROOT)}")
 
@@ -63,24 +117,40 @@ def main() -> int:
         if policy_file.is_file() and NUMERIC_TOKEN_CONTROL.search(
             policy_file.read_text(encoding="utf-8")
         ):
-            errors.append(
-                f"numeric token control remains in {policy_file.relative_to(ROOT)}"
-            )
+            errors.append(f"numeric token control remains in {policy_file.relative_to(ROOT)}")
 
     if ISSUE_TEMPLATE.is_file():
         template = ISSUE_TEMPLATE.read_text(encoding="utf-8")
-        for duplicated_heading in (
-            "## Global Telemetry V2 invariants",
-            "## Binding execution contract",
-        ):
+        for duplicated_heading in ("## Global Telemetry V2 invariants", "## Binding execution contract"):
             if duplicated_heading in template:
                 errors.append(f"issue template repeats {duplicated_heading!r}")
-        for required_heading in (
-            "## Applicable contracts",
-            "## Current binding decisions",
-        ):
+        for required_heading in ("## Applicable contracts", "## Current binding decisions"):
             if required_heading not in template:
                 errors.append(f"issue template is missing {required_heading!r}")
+
+    instruction_files = discover_instruction_files()
+    target_directories = {ROOT, *(path.parent for path in instruction_files)}
+    largest_chain_bytes = 0
+    largest_chain_directory = ROOT
+    for path in instruction_files:
+        text = path.read_text(encoding="utf-8")
+        for heading in FORBIDDEN_HISTORY_HEADINGS:
+            if heading in text:
+                errors.append(
+                    f"forbidden history section in {path.relative_to(ROOT)}: {heading}"
+                )
+    for directory in sorted(target_directories):
+        chain = instruction_chain(directory)
+        chain_bytes = instruction_chain_size(chain)
+        if chain_bytes > largest_chain_bytes:
+            largest_chain_bytes = chain_bytes
+            largest_chain_directory = directory
+        if chain_bytes > DEFAULT_MAX_INSTRUCTION_BYTES:
+            chain_label = " + ".join(str(path.relative_to(ROOT)) for path in chain)
+            errors.append(
+                f"instruction chain too large at {directory.relative_to(ROOT)}: "
+                f"{chain_bytes}/{DEFAULT_MAX_INSTRUCTION_BYTES} bytes ({chain_label})"
+            )
 
     for markdown_file in tracked_markdown_files():
         text = markdown_file.read_text(encoding="utf-8")
@@ -99,7 +169,12 @@ def main() -> int:
             print(f"ERROR: {error}")
         return 1
 
-    print("Codex governance ownership and local Markdown links: OK")
+    directory_label = largest_chain_directory.relative_to(ROOT)
+    print(
+        "Codex governance OK: "
+        f"{len(instruction_files)} AGENTS files, largest active chain "
+        f"{largest_chain_bytes}/{DEFAULT_MAX_INSTRUCTION_BYTES} bytes at {directory_label}"
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary

- add conditional minimal-code, performance, and Draft-PR review skills
- slim ordinary implementation context and formalize thin launch prompts
- add a narrow UI follow-up path that can skip already-settled concept discovery
- extend governance validation with a 32 KiB active-AGENTS chain guard and run it in CI

Closes #70

Base: `6665eddf861b9a7f77e84a61007be27079489634`
Head: `09bce84d045f9d4c07c3b017d6e63f00848099a3`

## Verification

- exact-head CI run `32633733392`: success
- governance validator: success; largest active AGENTS chain `8512/32768` bytes
- Python compile checks: success
- Swift Package tests + deterministic Telemetry V2 soak: success on exact-head rerun
- Xcode project metadata: success
- unsigned iOS/watchOS build: success
- initial Swift attempt had one timeout in an untouched Telemetry runtime test; rerunning the same exact head passed without code changes

## Scope

Governance/docs/CI only. No Swift/runtime, BLE, HR-control, telemetry, persistence, Xcode project, device, deploy, or product behavior changes.

Draft only; not Ready and not merged.