### PR TITLE
Fix known treadmill startup auto-connect

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -2380,7 +2380,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             let peripheralID = peripheral.identifier
             let endedConnectionAttempt = self.connectingPeripheralId == peripheralID
                 && self.connectedPeripheralId != peripheralID
-            guard endedConnectionAttempt || self.connectedPeripheralId == peripheralID else {
+            let endedEstablishedConnection = self.connectedPeripheralId == peripheralID
+                || (self.cancellingConnectionPeripheralId == peripheralID
+                    && self.connectingPeripheralId != peripheralID)
+            guard endedConnectionAttempt || endedEstablishedConnection else {
                 self.appendLog("Ignoring stale disconnect for \(peripheralID.uuidString)")
                 return
             }
@@ -2481,6 +2484,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
         if let central {
             if let id = connectedPeripheralId, let p = discoveredMap[id] {
+                cancellingConnectionPeripheralId = id
                 central.cancelPeripheralConnection(p)
             } else if let id = connectingPeripheralId,
                       let p = connectingPeripheral,

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -56,6 +56,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var pendingWatchCommand: String? = nil
 #endif
     private var connectingPeripheralId: UUID? = nil
+    private var connectingPeripheral: CBPeripheral? = nil
+    private var cancellingConnectionPeripheralId: UUID? = nil
     private var controllerUnitsConnectionEpoch: UUID? = nil
     private var controllerUnitsTruthTracker = ControllerUnitsTruthTracker()
     private var lastControllerUnitsQueryAt: Date? = nil
@@ -2105,6 +2107,24 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 #endif
 
     // Auto-connect policy helper
+    private func preferredKnownPeripheral(from peripherals: [CBPeripheral]) -> CBPeripheral? {
+        knownPeripherals.lazy.compactMap { known in
+            peripherals.first(where: { $0.identifier == known.id })
+        }.first
+    }
+
+    private func preferredKnownDiscoveredPeripheral() -> DiscoveredPeripheral? {
+        let knownIDs = Set(knownPeripherals.map(\.id))
+        return discoveredPeripherals.filter { knownIDs.contains($0.id) }.max { lhs, rhs in
+            if lhs.rssi != rhs.rssi {
+                return lhs.rssi < rhs.rssi
+            }
+            let lhsIndex = knownPeripherals.firstIndex(where: { $0.id == lhs.id }) ?? .max
+            let rhsIndex = knownPeripherals.firstIndex(where: { $0.id == rhs.id }) ?? .max
+            return lhsIndex > rhsIndex
+        }
+    }
+
     private func attemptAutoConnectIfNeeded() {
         guard let central, central.state == .poweredOn else {
             appendLog("AutoConnect skipped: Bluetooth not poweredOn or central nil")
@@ -2123,31 +2143,27 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         // If we have known peripherals saved, prefer connecting to them
         if !knownPeripherals.isEmpty {
             // Prefer a discovered known with strongest RSSI
-            if let candidate = discoveredPeripherals.filter({ $0.isKnown }).max(by: { $0.rssi < $1.rssi }) {
+            if let candidate = preferredKnownDiscoveredPeripheral() {
                 appendLog("AutoConnect: connecting strongest known discovered \(candidate.name) id=\(candidate.id.uuidString) rssi=\(candidate.rssi)")
-                connectToDiscovered(id: candidate.id)
+                connectToDiscovered(id: candidate.id, clearsAutoConnectSuppression: false)
                 return
             }
             // Try already connected peripherals that match our service and are known
             let connectedList = central.retrieveConnectedPeripherals(withServices: supportedServiceUuids)
-            if let p = connectedList.first(where: { kp in self.knownPeripherals.contains(where: { $0.id == kp.identifier }) }) {
+            if let p = preferredKnownPeripheral(from: connectedList) {
                 discoveredMap[p.identifier] = p
-                DispatchQueue.main.async { self.connectionStateText = "Connecting..." }
                 appendLog("AutoConnect: connecting to system-connected known id=\(p.identifier.uuidString) name=\(p.name ?? "")")
-                central.stopScan()
-                central.connect(p, options: nil)
+                connectToDiscovered(id: p.identifier, clearsAutoConnectSuppression: false)
                 return
             }
             // Try retrieve by identifiers for known devices
             let ids = knownPeripherals.map { $0.id }
             if !ids.isEmpty {
                 let list = central.retrievePeripherals(withIdentifiers: ids)
-                if let p = list.first {
+                if let p = preferredKnownPeripheral(from: list) {
                     discoveredMap[p.identifier] = p
-                    DispatchQueue.main.async { self.connectionStateText = "Connecting..." }
                     appendLog("AutoConnect: retrieve and connect known id=\(p.identifier.uuidString) name=\(p.name ?? "")")
-                    central.stopScan()
-                    central.connect(p, options: nil)
+                    connectToDiscovered(id: p.identifier, clearsAutoConnectSuppression: false)
                     return
                 }
             }
@@ -2159,7 +2175,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         if allowAutoConnectUnknown {
             if let candidate = discoveredPeripherals.max(by: { $0.rssi < $1.rssi }) {
                 appendLog("AutoConnect: connecting strongest unknown \(candidate.name) id=\(candidate.id.uuidString) rssi=\(candidate.rssi)")
-                connectToDiscovered(id: candidate.id)
+                connectToDiscovered(id: candidate.id, clearsAutoConnectSuppression: false)
                 return
             }
         }
@@ -2171,7 +2187,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 if !self.isConnected && self.knownPeripherals.isEmpty && self.allowAutoConnectUnknown && !self.autoConnectSuppressed {
                     if let candidate = self.discoveredPeripherals.max(by: { $0.rssi < $1.rssi }) {
                         self.appendLog("AutoConnect (retry): connecting strongest unknown \(candidate.name) id=\(candidate.id.uuidString) rssi=\(candidate.rssi)")
-                        self.connectToDiscovered(id: candidate.id)
+                        self.connectToDiscovered(
+                            id: candidate.id,
+                            clearsAutoConnectSuppression: false
+                        )
                     } else {
                         self.appendLog("AutoConnect (retry): still no candidates")
                     }
@@ -2235,13 +2254,16 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 if self.autoConnectSuppressed {
                     return
                 }
-                if self.discoveredPeripherals.contains(where: { $0.isKnown }) {
-                    let candidate = self.discoveredPeripherals.filter { $0.isKnown }.max(by: { $0.rssi < $1.rssi })
+                if self.preferredKnownDiscoveredPeripheral() != nil {
+                    let candidate = self.preferredKnownDiscoveredPeripheral()
                     if let candidate {
                         self.autoConnectPendingWorkItem?.cancel()
                         self.autoConnectPendingWorkItem = nil
                         self.appendLog("AutoConnect (discover): connecting strongest known \(candidate.name) id=\(candidate.id.uuidString) rssi=\(candidate.rssi)")
-                        self.connectToDiscovered(id: candidate.id)
+                        self.connectToDiscovered(
+                            id: candidate.id,
+                            clearsAutoConnectSuppression: false
+                        )
                     }
                 } else if self.allowAutoConnectUnknown {
                     if self.autoConnectPendingWorkItem == nil {
@@ -2250,7 +2272,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                             if !self.isConnected && self.allowAutoConnectUnknown && !self.autoConnectSuppressed {
                                 let candidate = self.discoveredPeripherals.max(by: { $0.rssi < $1.rssi })
                                 if let candidate {
-                                    self.connectToDiscovered(id: candidate.id)
+                                    self.connectToDiscovered(
+                                        id: candidate.id,
+                                        clearsAutoConnectSuppression: false
+                                    )
                                 }
                             }
                             self.autoConnectPendingWorkItem = nil
@@ -2265,19 +2290,39 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
-        appendLog("Connected; discovering services…")
-        logTrainingEvent("ble_connection_event", fields: [
-            "status": "connected",
-            "peripheral_id": peripheral.identifier.uuidString,
-            "name": peripheral.name ?? ""
-        ])
         DispatchQueue.main.async {
+            let peripheralID = peripheral.identifier
+            if self.connectedPeripheralId == peripheralID {
+                return
+            }
+            guard self.connectingPeripheralId == peripheralID else {
+                self.appendLog("Ignoring unexpected connection callback for \(peripheralID.uuidString)")
+                central.cancelPeripheralConnection(peripheral)
+                return
+            }
+            if self.cancellingConnectionPeripheralId == peripheralID || self.autoConnectSuppressed {
+                self.cancellingConnectionPeripheralId = peripheralID
+                self.connectTimeoutWorkItem?.cancel()
+                self.connectTimeoutWorkItem = nil
+                self.appendLog("Rejecting completed connection after cancellation for \(peripheralID.uuidString)")
+                central.cancelPeripheralConnection(peripheral)
+                return
+            }
+            self.appendLog("Connected; discovering services…")
+            self.logTrainingEvent("ble_connection_event", fields: [
+                "status": "connected",
+                "peripheral_id": peripheralID.uuidString,
+                "name": peripheral.name ?? ""
+            ])
             self.autoConnectPendingWorkItem?.cancel()
             self.autoConnectPendingWorkItem = nil
             self.connectTimeoutWorkItem?.cancel()
             self.connectTimeoutWorkItem = nil
             self.connectingPeripheralId = nil
+            self.connectingPeripheral = nil
+            self.cancellingConnectionPeripheralId = nil
             self.isConnected = true
+            central.stopScan()
             self.connectedPeripheralId = peripheral.identifier
             let defaultName = peripheral.name
             if let kp = self.knownPeripherals.first(where: { $0.id == peripheral.identifier }) {
@@ -2302,37 +2347,61 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 self.saveKnownPeripherals()
             }
         }
-        central.stopScan()
     }
 
     func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
-        logTrainingEvent("ble_connection_event", fields: [
-            "status": "failed_to_connect",
-            "peripheral_id": peripheral.identifier.uuidString,
-            "error": error?.localizedDescription ?? "unknown error"
-        ])
         DispatchQueue.main.async {
+            guard self.connectingPeripheralId == peripheral.identifier else {
+                self.appendLog("Ignoring stale connect failure for \(peripheral.identifier.uuidString)")
+                return
+            }
+            self.logTrainingEvent("ble_connection_event", fields: [
+                "status": "failed_to_connect",
+                "peripheral_id": peripheral.identifier.uuidString,
+                "error": error?.localizedDescription ?? "unknown error"
+            ])
             self.isConnected = false
             self.connectionStateText = "Disconnected"
             self.connectErrorMessage = error?.localizedDescription ?? "Failed to connect"
             self.connectingPeripheralId = nil
+            self.connectingPeripheral = nil
+            if self.cancellingConnectionPeripheralId == peripheral.identifier {
+                self.cancellingConnectionPeripheralId = nil
+            }
             self.connectTimeoutWorkItem?.cancel()
             self.connectTimeoutWorkItem = nil
             self.appendLog("Failed to connect to \(peripheral.identifier.uuidString): \(error?.localizedDescription ?? "unknown error")")
-        }
-        if shouldBeScanning {
-            central.scanForPeripherals(withServices: supportedServiceUuids,
-                                       options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
+            self.resumeDiscoveryScanIfNeeded()
         }
     }
 
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
-        logTrainingEvent("ble_connection_event", fields: [
-            "status": "disconnected",
-            "peripheral_id": peripheral.identifier.uuidString,
-            "error": error?.localizedDescription ?? "none"
-        ])
         DispatchQueue.main.async {
+            let peripheralID = peripheral.identifier
+            let endedConnectionAttempt = self.connectingPeripheralId == peripheralID
+                && self.connectedPeripheralId != peripheralID
+            guard endedConnectionAttempt || self.connectedPeripheralId == peripheralID else {
+                self.appendLog("Ignoring stale disconnect for \(peripheralID.uuidString)")
+                return
+            }
+            self.logTrainingEvent("ble_connection_event", fields: [
+                "status": "disconnected",
+                "peripheral_id": peripheralID.uuidString,
+                "error": error?.localizedDescription ?? "none"
+            ])
+            if endedConnectionAttempt {
+                self.connectingPeripheralId = nil
+                self.connectingPeripheral = nil
+                if self.cancellingConnectionPeripheralId == peripheralID {
+                    self.cancellingConnectionPeripheralId = nil
+                }
+                self.connectTimeoutWorkItem?.cancel()
+                self.connectTimeoutWorkItem = nil
+                self.connectionStateText = "Disconnected"
+                self.appendLog("Connection attempt ended for \(peripheralID.uuidString)")
+                self.resumeDiscoveryScanIfNeeded()
+                return
+            }
             self.cancelTreadmillTestRunForConnectionInvalidation()
 #if STOP_TRUTH_EXPERIMENT_CAPABILITY
             self.stopTruthExperimentController?.connectionContextInvalidated()
@@ -2356,6 +2425,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             self.recomputeHrStartAllowed()
             self.resetSessionStats()
             self.connectingPeripheralId = nil
+            self.connectingPeripheral = nil
+            if self.cancellingConnectionPeripheralId == peripheralID {
+                self.cancellingConnectionPeripheralId = nil
+            }
             self.connectTimeoutWorkItem?.cancel()
             self.connectTimeoutWorkItem = nil
             self.manualModeSet = false
@@ -2370,10 +2443,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 occurredAt: Date()
             )
             self.endTelemetryV2Session(reason: "ble_disconnected")
-        }
-        if shouldBeScanning, central.state == .poweredOn {
-            central.scanForPeripherals(withServices: supportedServiceUuids,
-                                       options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
+            self.resumeDiscoveryScanIfNeeded()
         }
     }
 
@@ -2409,8 +2479,15 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         if isHrControlRunning {
             stopTrainingStructuredLog(reason: userInitiated ? "disconnect_user" : "disconnect")
         }
-        if let central, let id = connectedPeripheralId, let p = discoveredMap[id] {
-            central.cancelPeripheralConnection(p)
+        if let central {
+            if let id = connectedPeripheralId, let p = discoveredMap[id] {
+                central.cancelPeripheralConnection(p)
+            } else if let id = connectingPeripheralId,
+                      let p = connectingPeripheral,
+                      p.identifier == id {
+                cancellingConnectionPeripheralId = id
+                central.cancelPeripheralConnection(p)
+            }
         }
         connectTimeoutWorkItem?.cancel()
         connectTimeoutWorkItem = nil
@@ -2453,6 +2530,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         if let p = discoveredMap[id] {
             DispatchQueue.main.async { self.connectionStateText = "Connecting..." }
             connectingPeripheralId = id
+            connectingPeripheral = p
             appendLog("Connecting to known discovered id=\(id.uuidString) name=\(p.name ?? "")")
             central.stopScan()
             central.connect(p, options: nil)
@@ -2464,6 +2542,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             discoveredMap[id] = p
             DispatchQueue.main.async { self.connectionStateText = "Connecting..." }
             connectingPeripheralId = id
+            connectingPeripheral = p
             appendLog("Connecting to known retrieved id=\(id.uuidString) name=\(p.name ?? "")")
             central.stopScan()
             central.connect(p, options: nil)
@@ -2477,10 +2556,15 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             appendLog("Connecting to known id=\(id.uuidString): scanning to discover")
         }
     }
-    func connectToDiscovered(id: UUID) {
+    func connectToDiscovered(
+        id: UUID,
+        clearsAutoConnectSuppression: Bool = true
+    ) {
         ensureCentral()
         guard let central else { return }
-        autoConnectSuppressed = false
+        if clearsAutoConnectSuppression {
+            autoConnectSuppressed = false
+        }
         // Prevent duplicate connection attempts
         if isConnected { appendLog("Connect discovered skipped: already connected"); return }
         if let inProgress = connectingPeripheralId {
@@ -2492,6 +2576,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         if let p = discoveredMap[id] {
             DispatchQueue.main.async { self.connectionStateText = "Connecting..." }
             connectingPeripheralId = id
+            connectingPeripheral = p
             appendLog("Connecting to discovered id=\(id.uuidString) name=\(p.name ?? "")")
             central.stopScan()
             central.connect(p, options: nil)
@@ -2502,6 +2587,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 discoveredMap[id] = p
                 DispatchQueue.main.async { self.connectionStateText = "Connecting..." }
                 connectingPeripheralId = id
+                connectingPeripheral = p
                 appendLog("Connecting to retrieved id=\(id.uuidString) name=\(p.name ?? "")")
                 central.stopScan()
                 central.connect(p, options: nil)
@@ -2515,8 +2601,25 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         DispatchQueue.main.async {
             self.autoConnectSuppressed = true
             self.knownPeripherals.removeAll { $0.id == id }
+            self.discoveredPeripherals = self.discoveredPeripherals.map { item in
+                guard item.id == id else { return item }
+                return DiscoveredPeripheral(
+                    id: item.id,
+                    name: item.name,
+                    rssi: item.rssi,
+                    isKnown: false
+                )
+            }
             if self.connectedPeripheralId == id {
                 self.disconnect(userInitiated: true)
+            } else if self.connectingPeripheralId == id,
+                      let central = self.central,
+                      let peripheral = self.connectingPeripheral,
+                      peripheral.identifier == id {
+                self.cancellingConnectionPeripheralId = id
+                self.connectTimeoutWorkItem?.cancel()
+                self.connectTimeoutWorkItem = nil
+                central.cancelPeripheralConnection(peripheral)
             }
             self.saveKnownPeripherals()
         }
@@ -3856,21 +3959,35 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
     }
 
+    private func resumeDiscoveryScanIfNeeded() {
+        guard shouldBeScanning,
+              let central,
+              central.state == .poweredOn else { return }
+        central.scanForPeripherals(
+            withServices: supportedServiceUuids,
+            options: [CBCentralManagerScanOptionAllowDuplicatesKey: true]
+        )
+        if !isConnected {
+            connectionStateText = "Scanning..."
+        }
+    }
+
     private func scheduleConnectTimeout(for id: UUID, seconds: TimeInterval = 12) {
         connectTimeoutWorkItem?.cancel()
         let work = DispatchWorkItem { [weak self] in
             guard let self else { return }
             guard self.connectingPeripheralId == id else { return }
             self.appendLog("Connection timeout for \(id.uuidString)")
-            if let central, let p = self.discoveredMap[id] {
+            if let central,
+               let p = self.connectingPeripheral,
+               p.identifier == id {
+                self.cancellingConnectionPeripheralId = id
                 central.cancelPeripheralConnection(p)
             }
-            DispatchQueue.main.async {
-                self.isConnected = false
-                self.connectionStateText = "Disconnected"
-                self.connectErrorMessage = "Connection timeout"
-                self.connectingPeripheralId = nil
-            }
+            self.isConnected = false
+            self.connectionStateText = "Disconnecting..."
+            self.connectErrorMessage = "Connection timeout"
+            self.connectTimeoutWorkItem = nil
         }
         connectTimeoutWorkItem = work
         DispatchQueue.main.asyncAfter(deadline: .now() + seconds, execute: work)

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
@@ -142,6 +142,38 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
         XCTAssertEqual(didConnect.components(separatedBy: "central.stopScan()").count - 1, 1)
     }
 
+    func testEstablishedUserDisconnectRetainsIdentityUntilNormalCleanup() throws {
+        let disconnect = try functionBody(
+            "private func disconnect(userInitiated: Bool = false)",
+            in: managerSource
+        )
+        let didDisconnect = try functionBody(
+            "func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?)",
+            in: managerSource
+        )
+
+        assertOrdered(
+            [
+                "if let id = connectedPeripheralId, let p = discoveredMap[id]",
+                "cancellingConnectionPeripheralId = id",
+                "central.cancelPeripheralConnection(p)",
+            ],
+            in: disconnect
+        )
+        assertOrdered(
+            [
+                "let endedEstablishedConnection",
+                "self.cancellingConnectionPeripheralId == peripheralID",
+                "guard endedConnectionAttempt || endedEstablishedConnection",
+                "if endedConnectionAttempt",
+                "self.resetProtocolState()",
+                "self.connectedPeripheral = nil",
+                "self.manualModeSet = false",
+            ],
+            in: didDisconnect
+        )
+    }
+
     func testEqualRssiKnownCandidatesUsePersistedOrderAsTieBreak() throws {
         let preferredKnown = try functionBody(
             "private func preferredKnownDiscoveredPeripheral()",

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
@@ -1,0 +1,229 @@
+import Foundation
+import XCTest
+
+final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
+    private lazy var managerSource = source(
+        relativePath: "WalkingPadRemote/BluetoothManager.swift"
+    )
+
+    func testRetrievedKnownPeripheralsReuseTheProtectedConnectionPath() throws {
+        let autoConnect = try functionBody(
+            "private func attemptAutoConnectIfNeeded()",
+            in: managerSource
+        )
+        let preferredKnown = try functionBody(
+            "private func preferredKnownPeripheral(from peripherals: [CBPeripheral])",
+            in: managerSource
+        )
+
+        XCTAssertFalse(autoConnect.contains("central.connect("))
+        XCTAssertTrue(autoConnect.contains("retrieveConnectedPeripherals"))
+        XCTAssertTrue(autoConnect.contains("retrievePeripherals(withIdentifiers: ids)"))
+        XCTAssertEqual(
+            autoConnect.components(separatedBy: "preferredKnownPeripheral(from:").count - 1,
+            2
+        )
+        XCTAssertGreaterThanOrEqual(
+            autoConnect.components(separatedBy: "connectToDiscovered(id:").count - 1,
+            3
+        )
+        XCTAssertTrue(preferredKnown.contains("knownPeripherals.lazy.compactMap"))
+        XCTAssertTrue(preferredKnown.contains("$0.identifier == known.id"))
+        XCTAssertTrue(autoConnect.contains("clearsAutoConnectSuppression: false"))
+    }
+
+    func testConnectionPathPreventsParallelAttemptsAndSchedulesTimeouts() throws {
+        let connect = try functionBody(
+            "func connectToDiscovered(",
+            in: managerSource
+        )
+
+        assertOrdered(
+            [
+                "if isConnected",
+                "if let inProgress = connectingPeripheralId",
+                "connectingPeripheralId = id",
+                "central.connect(p, options: nil)",
+                "scheduleConnectTimeout(for: id)",
+            ],
+            in: connect
+        )
+        XCTAssertEqual(connect.components(separatedBy: "central.connect(p, options: nil)").count - 1, 2)
+        XCTAssertEqual(connect.components(separatedBy: "scheduleConnectTimeout(for: id)").count - 1, 2)
+        XCTAssertTrue(managerSource.contains("clearsAutoConnectSuppression: Bool = true"))
+        XCTAssertTrue(connect.contains("if clearsAutoConnectSuppression"))
+    }
+
+    func testTimeoutAndFailureReturnToFilteredDiscoveryScan() throws {
+        let timeout = try functionBody(
+            "private func scheduleConnectTimeout(for id: UUID, seconds: TimeInterval = 12)",
+            in: managerSource
+        )
+        let failure = try functionBody(
+            "func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?)",
+            in: managerSource
+        )
+        let disconnect = try functionBody(
+            "func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?)",
+            in: managerSource
+        )
+        let resumeScan = try functionBody(
+            "private func resumeDiscoveryScanIfNeeded()",
+            in: managerSource
+        )
+
+        assertOrdered(
+            [
+                "guard self.connectingPeripheralId == id",
+                "self.cancellingConnectionPeripheralId = id",
+                "central.cancelPeripheralConnection(p)",
+            ],
+            in: timeout
+        )
+        XCTAssertFalse(timeout.contains("self.connectingPeripheralId = nil"))
+        XCTAssertTrue(timeout.contains("self.connectTimeoutWorkItem = nil"))
+        XCTAssertTrue(timeout.contains("self.connectingPeripheral"))
+        XCTAssertTrue(failure.contains("guard self.connectingPeripheralId == peripheral.identifier"))
+        XCTAssertTrue(failure.contains("self.connectingPeripheralId = nil"))
+        XCTAssertTrue(failure.contains("self.resumeDiscoveryScanIfNeeded()"))
+        XCTAssertTrue(disconnect.contains("self.connectingPeripheralId == peripheralID"))
+        XCTAssertTrue(disconnect.contains("self.resumeDiscoveryScanIfNeeded()"))
+        XCTAssertTrue(resumeScan.contains("shouldBeScanning"))
+        XCTAssertTrue(resumeScan.contains("central.state == .poweredOn"))
+        XCTAssertTrue(resumeScan.contains("scanForPeripherals"))
+        XCTAssertTrue(resumeScan.contains("supportedServiceUuids"))
+    }
+
+    func testKnownDiscoveryAndUserSuppressionPolicyRemainIntact() throws {
+        let discovery = try functionBody(
+            "func centralManager(_ central: CBCentralManager,\n                        didDiscover peripheral: CBPeripheral,",
+            in: managerSource
+        )
+        let disconnect = try functionBody(
+            "private func disconnect(userInitiated: Bool = false)",
+            in: managerSource
+        )
+        let forget = try functionBody(
+            "func forgetKnownPeripheral(id: UUID)",
+            in: managerSource
+        )
+
+        XCTAssertTrue(discovery.contains("if self.autoConnectSuppressed"))
+        XCTAssertTrue(discovery.contains("self.preferredKnownDiscoveredPeripheral() != nil"))
+        XCTAssertTrue(discovery.contains("self.connectToDiscovered("))
+        XCTAssertTrue(discovery.contains("clearsAutoConnectSuppression: false"))
+        XCTAssertTrue(disconnect.contains("if userInitiated"))
+        XCTAssertTrue(disconnect.contains("autoConnectSuppressed = true"))
+        XCTAssertTrue(forget.contains("self.autoConnectSuppressed = true"))
+        XCTAssertTrue(forget.contains("self.connectingPeripheralId == id"))
+        XCTAssertTrue(forget.contains("self.connectingPeripheral"))
+        XCTAssertTrue(forget.contains("self.cancellingConnectionPeripheralId = id"))
+        XCTAssertTrue(forget.contains("central.cancelPeripheralConnection(peripheral)"))
+    }
+
+    func testLateConnectionAfterCancellationCannotBecomeConnectedOrKnown() throws {
+        let didConnect = try functionBody(
+            "func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral)",
+            in: managerSource
+        )
+
+        assertOrdered(
+            [
+                "guard self.connectingPeripheralId == peripheralID",
+                "if self.cancellingConnectionPeripheralId == peripheralID || self.autoConnectSuppressed",
+                "central.cancelPeripheralConnection(peripheral)",
+                "self.logTrainingEvent(\"ble_connection_event\"",
+                "self.isConnected = true",
+                "central.stopScan()",
+                "self.knownPeripherals.append",
+            ],
+            in: didConnect
+        )
+        XCTAssertEqual(didConnect.components(separatedBy: "central.stopScan()").count - 1, 1)
+    }
+
+    func testEqualRssiKnownCandidatesUsePersistedOrderAsTieBreak() throws {
+        let preferredKnown = try functionBody(
+            "private func preferredKnownDiscoveredPeripheral()",
+            in: managerSource
+        )
+        let autoConnect = try functionBody(
+            "private func attemptAutoConnectIfNeeded()",
+            in: managerSource
+        )
+
+        XCTAssertTrue(preferredKnown.contains("if lhs.rssi != rhs.rssi"))
+        XCTAssertTrue(preferredKnown.contains("let knownIDs = Set(knownPeripherals.map(\\.id))"))
+        XCTAssertTrue(preferredKnown.contains("knownIDs.contains($0.id)"))
+        XCTAssertTrue(preferredKnown.contains("knownPeripherals.firstIndex"))
+        XCTAssertTrue(preferredKnown.contains("return lhsIndex > rhsIndex"))
+        XCTAssertTrue(autoConnect.contains("preferredKnownDiscoveredPeripheral()"))
+    }
+
+    func testUnknownAutoConnectRemainsExplicitlyOptIn() throws {
+        let autoConnect = try functionBody(
+            "private func attemptAutoConnectIfNeeded()",
+            in: managerSource
+        )
+
+        XCTAssertTrue(managerSource.contains("@Published var allowAutoConnectUnknown: Bool = false"))
+        XCTAssertTrue(autoConnect.contains("if allowAutoConnectUnknown"))
+        XCTAssertTrue(autoConnect.contains("clearsAutoConnectSuppression: false"))
+        XCTAssertTrue(
+            autoConnect.contains(
+                "self.knownPeripherals.isEmpty && self.allowAutoConnectUnknown && !self.autoConnectSuppressed"
+            )
+        )
+    }
+
+    private func source(relativePath: String) -> String {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let root = testsDirectory.deletingLastPathComponent()
+        return (try? String(
+            contentsOf: root.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )) ?? ""
+    }
+
+    private func functionBody(_ signature: String, in source: String) throws -> String {
+        guard let signatureRange = source.range(of: signature),
+              let openingBrace = source[signatureRange.upperBound...].firstIndex(of: "{")
+        else {
+            throw NSError(domain: "BluetoothAutoConnectBehaviorContractTests", code: 1)
+        }
+        var depth = 0
+        var index = openingBrace
+        while index < source.endIndex {
+            switch source[index] {
+            case "{": depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 {
+                    return String(source[openingBrace...index])
+                }
+            default: break
+            }
+            index = source.index(after: index)
+        }
+        throw NSError(domain: "BluetoothAutoConnectBehaviorContractTests", code: 2)
+    }
+
+    private func assertOrdered(
+        _ fragments: [String],
+        in source: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        var lowerBound = source.startIndex
+        for fragment in fragments {
+            guard let range = source.range(
+                of: fragment,
+                range: lowerBound..<source.endIndex
+            ) else {
+                XCTFail("Missing or out-of-order fragment: \(fragment)", file: file, line: line)
+                return
+            }
+            lowerBound = range.upperBound
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Route startup recovery for discovered, system-connected, and retrieved known treadmills through one duplicate-protected connection path.
- Select multiple known candidates deterministically, keep unknown-device auto-connect opt-in, and resume filtered discovery after failed or timed-out attempts.
- Preserve cancellation ownership across asynchronous CoreBluetooth callbacks so disconnect/forget suppression cannot be bypassed by late callbacks.

Fixes #73.

## Verification

- `cd ios/WalkingPadRemote/WalkingPadRemote && swift test --filter BluetoothAutoConnectBehaviorContractTests`
- `cd ios/WalkingPadRemote/WalkingPadRemote && swift test`
- `cd ios/WalkingPadRemote/WalkingPadRemote && xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build`

## Risks / Notes

- Scope is limited to BLE connection orchestration in `BluetoothManager` plus focused source-contract tests. Treadmill movement commands, HR control, units, telemetry schema/semantics, HealthKit, workout persistence, and UI are unchanged.
- Unknown-device auto-connect remains disabled by default and requires explicit opt-in.
- No physical-device or treadmill verification was performed, as required by the issue contract.
- No migrations, configuration/environment changes, dependencies, deployment steps, or new runtime files are introduced. The change is backward-compatible; rollback is a revert of the single commit.