### PR TITLE
Prefer last treadmill and protect startup latency

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -131,6 +131,7 @@ let package = Package(
                 "WalkingPadRemoteApp.swift"
             ],
             sources: [
+                "AutoConnectRetryPolicy.swift",
                 "BLETransportCodec.swift",
                 "ControllerUnitsSafetyPolicy.swift",
                 "CooldownRuntimeEngine.swift",

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/AutoConnectRetryPolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/AutoConnectRetryPolicy.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+struct AutoConnectRetryPolicy {
+    private(set) var failedPeripheralIDs: Set<UUID> = []
+    private var retryNotBefore: [UUID: Date] = [:]
+    private let cooldownSeconds: TimeInterval
+
+    init(cooldownSeconds: TimeInterval = 3.0) {
+        self.cooldownSeconds = max(0, cooldownSeconds)
+    }
+
+    mutating func reset() {
+        failedPeripheralIDs.removeAll()
+        retryNotBefore.removeAll()
+    }
+
+    mutating func markFailed(_ peripheralID: UUID, now: Date = Date()) {
+        failedPeripheralIDs.insert(peripheralID)
+        retryNotBefore[peripheralID] = now.addingTimeInterval(cooldownSeconds)
+    }
+
+    mutating func rearmAfterFreshDiscovery(
+        peripheralID: UUID,
+        knownPeripheralIDs: Set<UUID>,
+        now: Date = Date()
+    ) -> Bool {
+        guard knownPeripheralIDs.contains(peripheralID),
+              !knownPeripheralIDs.isEmpty,
+              knownPeripheralIDs.isSubset(of: failedPeripheralIDs),
+              let threshold = retryNotBefore[peripheralID],
+              now >= threshold else {
+            return false
+        }
+
+        failedPeripheralIDs.remove(peripheralID)
+        retryNotBefore.removeValue(forKey: peripheralID)
+        return true
+    }
+
+    mutating func forget(_ peripheralID: UUID) {
+        failedPeripheralIDs.remove(peripheralID)
+        retryNotBefore.removeValue(forKey: peripheralID)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -52,7 +52,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var autoConnectPendingWorkItem: DispatchWorkItem?
     private var knownDiscoveryGraceWorkItem: DispatchWorkItem?
     private var knownDiscoveryGraceCompleted = false
-    private var autoConnectFailedPeripheralIDs: Set<UUID> = []
+    private var autoConnectRetryPolicy = AutoConnectRetryPolicy()
     private var connectTimeoutWorkItem: DispatchWorkItem?
 #if canImport(WatchConnectivity)
     private var wcSession: WCSession?
@@ -2006,7 +2006,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     func start() {
         ensureCentral()
         autoConnectSuppressed = false
-        autoConnectFailedPeripheralIDs.removeAll()
+        autoConnectRetryPolicy.reset()
         knownDiscoveryGraceWorkItem?.cancel()
         knownDiscoveryGraceWorkItem = nil
         knownDiscoveryGraceCompleted = false
@@ -2130,7 +2130,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     // Auto-connect policy helper
     private var orderedAutoConnectCandidateIDs: [UUID] {
         var ordered = knownPeripherals.map(\.id).filter {
-            !autoConnectFailedPeripheralIDs.contains($0)
+            !autoConnectRetryPolicy.failedPeripheralIDs.contains($0)
         }
         if let lastSuccessfulPeripheralID,
            let index = ordered.firstIndex(of: lastSuccessfulPeripheralID) {
@@ -2138,6 +2138,24 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             ordered.insert(lastSuccessfulPeripheralID, at: 0)
         }
         return ordered
+    }
+
+    private func markAutoConnectCandidateFailed(_ peripheralID: UUID) {
+        autoConnectRetryPolicy.markFailed(peripheralID)
+    }
+
+    private func rearmAutoConnectCandidateAfterFreshDiscovery(
+        peripheralID: UUID,
+        now: Date = Date()
+    ) -> Bool {
+        let didRearm = autoConnectRetryPolicy.rearmAfterFreshDiscovery(
+            peripheralID: peripheralID,
+            knownPeripheralIDs: Set(knownPeripherals.map(\.id)),
+            now: now
+        )
+        guard didRearm else { return false }
+        appendLog("AutoConnect: re-armed known candidate after fresh discovery id=\(peripheralID.uuidString)")
+        return true
     }
 
     private func preferredKnownPeripheral(from peripherals: [CBPeripheral]) -> CBPeripheral? {
@@ -2346,7 +2364,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 if self.autoConnectSuppressed {
                     return
                 }
-                if self.preferredKnownDiscoveredPeripheral() != nil {
+                let rearmedKnownCandidate = self.rearmAutoConnectCandidateAfterFreshDiscovery(
+                    peripheralID: id
+                )
+                if rearmedKnownCandidate || self.preferredKnownDiscoveredPeripheral() != nil {
                     self.autoConnectPendingWorkItem?.cancel()
                     self.autoConnectPendingWorkItem = nil
                     self.attemptAutoConnectIfNeeded()
@@ -2408,7 +2429,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             self.connectingPeripheral = nil
             self.cancellingConnectionPeripheralId = nil
             self.connectingAttemptIsAutomatic = false
-            self.autoConnectFailedPeripheralIDs.removeAll()
+            self.autoConnectRetryPolicy.reset()
             self.connectErrorMessage = nil
             self.isConnected = true
             central.stopScan()
@@ -2454,7 +2475,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             self.isConnected = false
             self.connectionStateText = "Disconnected"
             if wasAutomatic {
-                self.autoConnectFailedPeripheralIDs.insert(peripheral.identifier)
+                self.markAutoConnectCandidateFailed(peripheral.identifier)
             } else {
                 self.connectErrorMessage = error?.localizedDescription ?? "Failed to connect"
             }
@@ -2495,7 +2516,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 let shouldContinueAutoConnect = self.connectingAttemptIsAutomatic
                     && !self.autoConnectSuppressed
                 if shouldContinueAutoConnect {
-                    self.autoConnectFailedPeripheralIDs.insert(peripheralID)
+                    self.markAutoConnectCandidateFailed(peripheralID)
                 }
                 self.connectingPeripheralId = nil
                 self.connectingPeripheral = nil
@@ -2725,6 +2746,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 self.lastSuccessfulPeripheralID = nil
                 UserDefaults.standard.removeObject(forKey: self.lastSuccessfulPeripheralStoreKey)
             }
+            self.autoConnectRetryPolicy.forget(id)
             self.discoveredPeripherals = self.discoveredPeripherals.map { item in
                 guard item.id == id else { return item }
                 return DiscoveredPeripheral(

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -50,6 +50,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var shouldBeScanning: Bool = false
     private var discoveredMap: [UUID: CBPeripheral] = [:]
     private var autoConnectPendingWorkItem: DispatchWorkItem?
+    private var knownDiscoveryGraceWorkItem: DispatchWorkItem?
+    private var knownDiscoveryGraceCompleted = false
+    private var autoConnectFailedPeripheralIDs: Set<UUID> = []
     private var connectTimeoutWorkItem: DispatchWorkItem?
 #if canImport(WatchConnectivity)
     private var wcSession: WCSession?
@@ -58,6 +61,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var connectingPeripheralId: UUID? = nil
     private var connectingPeripheral: CBPeripheral? = nil
     private var cancellingConnectionPeripheralId: UUID? = nil
+    private var connectingAttemptIsAutomatic = false
     private var controllerUnitsConnectionEpoch: UUID? = nil
     private var controllerUnitsTruthTracker = ControllerUnitsTruthTracker()
     private var lastControllerUnitsQueryAt: Date? = nil
@@ -130,6 +134,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let activeProfileID: UUID?
     }
     private let knownStoreKey = "known_peripherals_store_v1"
+    private let lastSuccessfulPeripheralStoreKey = "last_successful_known_peripheral_id_v1"
     private let userProfilesStoreKey = "user_profiles_state_v1"
     private let installationIDStoreKey = "installation_id_v1"
     private let hrSettingsStoreKey = "hr_settings_v1"
@@ -137,6 +142,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private let workoutHistoryStoreKey = "workout_history_v1"
     private var isLoadingHrSettings: Bool = false
     private var autoConnectSuppressed: Bool = false
+    private var lastSuccessfulPeripheralID: UUID? = nil
     private var hrSessionTotalSeconds: Int = 0
     private var hrControlStartedBelt: Bool = false
     private var cooldownRuntimeState: CooldownRuntimeEngine.State? = nil
@@ -282,6 +288,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var trainingLogSessionId: String? = nil
     private var trainingLogFileURL: URL? = nil
     private var trainingLogFileHandle: FileHandle? = nil
+    private var trainingLogsInventoryRefreshID = UUID()
 
     private func loadKnownPeripherals() {
         guard let data = UserDefaults.standard.data(forKey: knownStoreKey) else { return }
@@ -295,6 +302,22 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         if let data = try? JSONEncoder().encode(list) {
             UserDefaults.standard.set(data, forKey: knownStoreKey)
         }
+    }
+
+    private func loadLastSuccessfulPeripheral() {
+        guard let rawValue = UserDefaults.standard.string(forKey: lastSuccessfulPeripheralStoreKey),
+              let peripheralID = UUID(uuidString: rawValue),
+              knownPeripherals.contains(where: { $0.id == peripheralID }) else {
+            lastSuccessfulPeripheralID = nil
+            UserDefaults.standard.removeObject(forKey: lastSuccessfulPeripheralStoreKey)
+            return
+        }
+        lastSuccessfulPeripheralID = peripheralID
+    }
+
+    private func saveLastSuccessfulPeripheral(_ peripheralID: UUID) {
+        lastSuccessfulPeripheralID = peripheralID
+        UserDefaults.standard.set(peripheralID.uuidString, forKey: lastSuccessfulPeripheralStoreKey)
     }
 
     private struct WorkoutEntryDTO: Codable {
@@ -1413,19 +1436,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         TrainingTelemetryWriter.pruneJsonlFiles(in: directory, maxFiles: trainingLogMaxFiles)
     }
 
-    private func synchronizeTrainingLogFileIfNeeded() {
-        trainingLogQueue.sync {
-            trainingLogFileHandle?.synchronizeFile()
-        }
-    }
-
-    private func currentProtectedTrainingLogFiles() -> Set<URL> {
-        let activeLogFile: URL? = trainingLogQueue.sync {
-            trainingLogFileURL?.standardizedFileURL
-        }
-        return Set(activeLogFile.map { [$0] } ?? [])
-    }
-
     private func scheduleTrainingLogsInventoryRefresh() {
         trainingLogQueue.async { [weak self] in
             DispatchQueue.main.async {
@@ -1721,27 +1731,29 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     func refreshTrainingLogsInventory() {
-        synchronizeTrainingLogFileIfNeeded()
-        let protectedFiles = currentProtectedTrainingLogFiles()
-        guard let allJsonlFiles = allTrainingJsonlFiles(),
-              !allJsonlFiles.isEmpty else {
-            trainingLogsInventory = .empty
-            lastTrainingLogPath = ""
-            return
-        }
+        let refreshID = UUID()
+        trainingLogsInventoryRefreshID = refreshID
+        let profileID = activeUserProfileID?.uuidString
+        let fallbackProfileID = legacyFallbackProfileID
 
-        let filteredFiles = TrainingTelemetryWriter.filterJsonlFiles(
-            allJsonlFiles,
-            matchingProfileID: activeUserProfileID?.uuidString,
-            legacyFallbackProfileID: legacyFallbackProfileID
-        )
-        trainingLogsInventory = TrainingTelemetryWriter.trainingLogsInventory(
-            allJsonlFiles,
-            matchingProfileID: activeUserProfileID?.uuidString,
-            legacyFallbackProfileID: legacyFallbackProfileID,
-            keeping: protectedFiles
-        )
-        lastTrainingLogPath = filteredFiles.last?.path ?? ""
+        trainingLogQueue.async { [weak self] in
+            guard let self else { return }
+            self.trainingLogFileHandle?.synchronizeFile()
+            let protectedFiles = Set(
+                self.trainingLogFileURL.map { [$0.standardizedFileURL] } ?? []
+            )
+            let snapshot = TrainingTelemetryWriter.trainingLogsInventorySnapshot(
+                self.allTrainingJsonlFiles() ?? [],
+                matchingProfileID: profileID,
+                legacyFallbackProfileID: fallbackProfileID,
+                keeping: protectedFiles
+            )
+            DispatchQueue.main.async {
+                guard self.trainingLogsInventoryRefreshID == refreshID else { return }
+                self.trainingLogsInventory = snapshot.inventory
+                self.lastTrainingLogPath = snapshot.latestMatchingProfileFile?.path ?? ""
+            }
+        }
     }
 
     func trainingLogsExportCount(
@@ -1783,6 +1795,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @Published var connectErrorMessage: String? = nil
     @Published var suggestDevicePicker: Bool = false
     @Published var infoToastMessage: String? = nil
+
+    func consumeConnectErrorMessage() {
+        connectErrorMessage = nil
+    }
 
     // History
     private struct LegacyShadowWorkoutEntry: Identifiable {
@@ -1990,8 +2006,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     func start() {
         ensureCentral()
         autoConnectSuppressed = false
+        autoConnectFailedPeripheralIDs.removeAll()
+        knownDiscoveryGraceWorkItem?.cancel()
+        knownDiscoveryGraceWorkItem = nil
+        knownDiscoveryGraceCompleted = false
         manualModeSet = false
         loadKnownPeripherals()
+        loadLastSuccessfulPeripheral()
         loadProfilesState()
         loadHrSettings()
         loadZonePlan()
@@ -2107,22 +2128,61 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 #endif
 
     // Auto-connect policy helper
+    private var orderedAutoConnectCandidateIDs: [UUID] {
+        var ordered = knownPeripherals.map(\.id).filter {
+            !autoConnectFailedPeripheralIDs.contains($0)
+        }
+        if let lastSuccessfulPeripheralID,
+           let index = ordered.firstIndex(of: lastSuccessfulPeripheralID) {
+            ordered.remove(at: index)
+            ordered.insert(lastSuccessfulPeripheralID, at: 0)
+        }
+        return ordered
+    }
+
     private func preferredKnownPeripheral(from peripherals: [CBPeripheral]) -> CBPeripheral? {
-        knownPeripherals.lazy.compactMap { known in
-            peripherals.first(where: { $0.identifier == known.id })
+        orderedAutoConnectCandidateIDs.lazy.compactMap { candidateID in
+            peripherals.first(where: { $0.identifier == candidateID })
         }.first
     }
 
     private func preferredKnownDiscoveredPeripheral() -> DiscoveredPeripheral? {
-        let knownIDs = Set(knownPeripherals.map(\.id))
-        return discoveredPeripherals.filter { knownIDs.contains($0.id) }.max { lhs, rhs in
+        let candidateIDs = orderedAutoConnectCandidateIDs
+        let eligible = discoveredPeripherals.filter { candidateIDs.contains($0.id) }
+        if let lastSuccessfulPeripheralID,
+           let preferred = eligible.first(where: { $0.id == lastSuccessfulPeripheralID }) {
+            return preferred
+        }
+        return eligible.max { lhs, rhs in
             if lhs.rssi != rhs.rssi {
                 return lhs.rssi < rhs.rssi
             }
-            let lhsIndex = knownPeripherals.firstIndex(where: { $0.id == lhs.id }) ?? .max
-            let rhsIndex = knownPeripherals.firstIndex(where: { $0.id == rhs.id }) ?? .max
+            let lhsIndex = candidateIDs.firstIndex(of: lhs.id) ?? .max
+            let rhsIndex = candidateIDs.firstIndex(of: rhs.id) ?? .max
             return lhsIndex > rhsIndex
         }
+    }
+
+    private func completeKnownDiscoveryGrace() {
+        knownDiscoveryGraceWorkItem?.cancel()
+        knownDiscoveryGraceWorkItem = nil
+        knownDiscoveryGraceCompleted = true
+    }
+
+    private func scheduleKnownDiscoveryFallbackIfNeeded() {
+        guard !knownDiscoveryGraceCompleted,
+              knownDiscoveryGraceWorkItem == nil else { return }
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.knownDiscoveryGraceWorkItem = nil
+            self.knownDiscoveryGraceCompleted = true
+            self.appendLog("AutoConnect: known discovery grace completed")
+            self.attemptAutoConnectIfNeeded()
+        }
+        knownDiscoveryGraceWorkItem = work
+        appendLog("AutoConnect: waiting 1.0s for known-device discovery")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: work)
     }
 
     private func attemptAutoConnectIfNeeded() {
@@ -2142,22 +2202,53 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
         // If we have known peripherals saved, prefer connecting to them
         if !knownPeripherals.isEmpty {
-            // Prefer a discovered known with strongest RSSI
             if let candidate = preferredKnownDiscoveredPeripheral() {
-                appendLog("AutoConnect: connecting strongest known discovered \(candidate.name) id=\(candidate.id.uuidString) rssi=\(candidate.rssi)")
+                if !knownDiscoveryGraceCompleted,
+                   let lastSuccessfulPeripheralID,
+                   orderedAutoConnectCandidateIDs.contains(lastSuccessfulPeripheralID),
+                   candidate.id != lastSuccessfulPeripheralID {
+                    scheduleKnownDiscoveryFallbackIfNeeded()
+                    return
+                }
+                completeKnownDiscoveryGrace()
+                appendLog("AutoConnect: connecting preferred known discovered \(candidate.name) id=\(candidate.id.uuidString) rssi=\(candidate.rssi)")
                 connectToDiscovered(id: candidate.id, clearsAutoConnectSuppression: false)
                 return
             }
-            // Try already connected peripherals that match our service and are known
+
             let connectedList = central.retrieveConnectedPeripherals(withServices: supportedServiceUuids)
-            if let p = preferredKnownPeripheral(from: connectedList) {
+            if let lastSuccessfulPeripheralID,
+               orderedAutoConnectCandidateIDs.contains(lastSuccessfulPeripheralID),
+               let p = connectedList.first(where: { $0.identifier == lastSuccessfulPeripheralID }) {
+                completeKnownDiscoveryGrace()
+                discoveredMap[p.identifier] = p
+                appendLog("AutoConnect: connecting to system-connected last-successful id=\(p.identifier.uuidString) name=\(p.name ?? "")")
+                connectToDiscovered(id: p.identifier, clearsAutoConnectSuppression: false)
+                return
+            }
+
+            if lastSuccessfulPeripheralID == nil,
+               let p = preferredKnownPeripheral(from: connectedList) {
+                completeKnownDiscoveryGrace()
                 discoveredMap[p.identifier] = p
                 appendLog("AutoConnect: connecting to system-connected known id=\(p.identifier.uuidString) name=\(p.name ?? "")")
                 connectToDiscovered(id: p.identifier, clearsAutoConnectSuppression: false)
                 return
             }
-            // Try retrieve by identifiers for known devices
-            let ids = knownPeripherals.map { $0.id }
+
+            guard knownDiscoveryGraceCompleted else {
+                scheduleKnownDiscoveryFallbackIfNeeded()
+                return
+            }
+
+            if let p = preferredKnownPeripheral(from: connectedList) {
+                discoveredMap[p.identifier] = p
+                appendLog("AutoConnect: connecting to fallback system-connected known id=\(p.identifier.uuidString) name=\(p.name ?? "")")
+                connectToDiscovered(id: p.identifier, clearsAutoConnectSuppression: false)
+                return
+            }
+
+            let ids = orderedAutoConnectCandidateIDs
             if !ids.isEmpty {
                 let list = central.retrievePeripherals(withIdentifiers: ids)
                 if let p = preferredKnownPeripheral(from: list) {
@@ -2248,23 +2339,17 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 self.discoveredPeripherals.append(item)
             }
             // Auto-connect policy:
-            // - If any known discovered -> connect immediately to the strongest known
+            // - Prefer the last successful known device during the bounded discovery grace
+            // - After grace, fall back through the remaining known devices serially
             // - Else if allowAutoConnectUnknown -> debounce and connect strongest unknown
             if !self.isConnected {
                 if self.autoConnectSuppressed {
                     return
                 }
                 if self.preferredKnownDiscoveredPeripheral() != nil {
-                    let candidate = self.preferredKnownDiscoveredPeripheral()
-                    if let candidate {
-                        self.autoConnectPendingWorkItem?.cancel()
-                        self.autoConnectPendingWorkItem = nil
-                        self.appendLog("AutoConnect (discover): connecting strongest known \(candidate.name) id=\(candidate.id.uuidString) rssi=\(candidate.rssi)")
-                        self.connectToDiscovered(
-                            id: candidate.id,
-                            clearsAutoConnectSuppression: false
-                        )
-                    }
+                    self.autoConnectPendingWorkItem?.cancel()
+                    self.autoConnectPendingWorkItem = nil
+                    self.attemptAutoConnectIfNeeded()
                 } else if self.allowAutoConnectUnknown {
                     if self.autoConnectPendingWorkItem == nil {
                         let work = DispatchWorkItem { [weak self] in
@@ -2316,11 +2401,15 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             ])
             self.autoConnectPendingWorkItem?.cancel()
             self.autoConnectPendingWorkItem = nil
+            self.completeKnownDiscoveryGrace()
             self.connectTimeoutWorkItem?.cancel()
             self.connectTimeoutWorkItem = nil
             self.connectingPeripheralId = nil
             self.connectingPeripheral = nil
             self.cancellingConnectionPeripheralId = nil
+            self.connectingAttemptIsAutomatic = false
+            self.autoConnectFailedPeripheralIDs.removeAll()
+            self.connectErrorMessage = nil
             self.isConnected = true
             central.stopScan()
             self.connectedPeripheralId = peripheral.identifier
@@ -2346,6 +2435,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 self.knownPeripherals.append(KnownPeripheral(id: peripheral.identifier, name: display))
                 self.saveKnownPeripherals()
             }
+            self.saveLastSuccessfulPeripheral(peripheral.identifier)
         }
     }
 
@@ -2355,6 +2445,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 self.appendLog("Ignoring stale connect failure for \(peripheral.identifier.uuidString)")
                 return
             }
+            let wasAutomatic = self.connectingAttemptIsAutomatic
             self.logTrainingEvent("ble_connection_event", fields: [
                 "status": "failed_to_connect",
                 "peripheral_id": peripheral.identifier.uuidString,
@@ -2362,9 +2453,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             ])
             self.isConnected = false
             self.connectionStateText = "Disconnected"
-            self.connectErrorMessage = error?.localizedDescription ?? "Failed to connect"
+            if wasAutomatic {
+                self.autoConnectFailedPeripheralIDs.insert(peripheral.identifier)
+            } else {
+                self.connectErrorMessage = error?.localizedDescription ?? "Failed to connect"
+            }
             self.connectingPeripheralId = nil
             self.connectingPeripheral = nil
+            self.connectingAttemptIsAutomatic = false
             if self.cancellingConnectionPeripheralId == peripheral.identifier {
                 self.cancellingConnectionPeripheralId = nil
             }
@@ -2372,6 +2468,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             self.connectTimeoutWorkItem = nil
             self.appendLog("Failed to connect to \(peripheral.identifier.uuidString): \(error?.localizedDescription ?? "unknown error")")
             self.resumeDiscoveryScanIfNeeded()
+            if wasAutomatic && !self.autoConnectSuppressed {
+                self.attemptAutoConnectIfNeeded()
+            }
         }
     }
 
@@ -2393,8 +2492,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 "error": error?.localizedDescription ?? "none"
             ])
             if endedConnectionAttempt {
+                let shouldContinueAutoConnect = self.connectingAttemptIsAutomatic
+                    && !self.autoConnectSuppressed
+                if shouldContinueAutoConnect {
+                    self.autoConnectFailedPeripheralIDs.insert(peripheralID)
+                }
                 self.connectingPeripheralId = nil
                 self.connectingPeripheral = nil
+                self.connectingAttemptIsAutomatic = false
                 if self.cancellingConnectionPeripheralId == peripheralID {
                     self.cancellingConnectionPeripheralId = nil
                 }
@@ -2403,6 +2508,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 self.connectionStateText = "Disconnected"
                 self.appendLog("Connection attempt ended for \(peripheralID.uuidString)")
                 self.resumeDiscoveryScanIfNeeded()
+                if shouldContinueAutoConnect {
+                    self.attemptAutoConnectIfNeeded()
+                }
                 return
             }
             self.cancelTreadmillTestRunForConnectionInvalidation()
@@ -2429,6 +2537,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             self.resetSessionStats()
             self.connectingPeripheralId = nil
             self.connectingPeripheral = nil
+            self.connectingAttemptIsAutomatic = false
             if self.cancellingConnectionPeripheralId == peripheralID {
                 self.cancellingConnectionPeripheralId = nil
             }
@@ -2535,6 +2644,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             DispatchQueue.main.async { self.connectionStateText = "Connecting..." }
             connectingPeripheralId = id
             connectingPeripheral = p
+            connectingAttemptIsAutomatic = false
+            connectErrorMessage = nil
             appendLog("Connecting to known discovered id=\(id.uuidString) name=\(p.name ?? "")")
             central.stopScan()
             central.connect(p, options: nil)
@@ -2547,6 +2658,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             DispatchQueue.main.async { self.connectionStateText = "Connecting..." }
             connectingPeripheralId = id
             connectingPeripheral = p
+            connectingAttemptIsAutomatic = false
+            connectErrorMessage = nil
             appendLog("Connecting to known retrieved id=\(id.uuidString) name=\(p.name ?? "")")
             central.stopScan()
             central.connect(p, options: nil)
@@ -2568,6 +2681,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         guard let central else { return }
         if clearsAutoConnectSuppression {
             autoConnectSuppressed = false
+            connectErrorMessage = nil
         }
         // Prevent duplicate connection attempts
         if isConnected { appendLog("Connect discovered skipped: already connected"); return }
@@ -2581,6 +2695,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             DispatchQueue.main.async { self.connectionStateText = "Connecting..." }
             connectingPeripheralId = id
             connectingPeripheral = p
+            connectingAttemptIsAutomatic = !clearsAutoConnectSuppression
             appendLog("Connecting to discovered id=\(id.uuidString) name=\(p.name ?? "")")
             central.stopScan()
             central.connect(p, options: nil)
@@ -2592,6 +2707,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 DispatchQueue.main.async { self.connectionStateText = "Connecting..." }
                 connectingPeripheralId = id
                 connectingPeripheral = p
+                connectingAttemptIsAutomatic = !clearsAutoConnectSuppression
                 appendLog("Connecting to retrieved id=\(id.uuidString) name=\(p.name ?? "")")
                 central.stopScan()
                 central.connect(p, options: nil)
@@ -2605,6 +2721,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         DispatchQueue.main.async {
             self.autoConnectSuppressed = true
             self.knownPeripherals.removeAll { $0.id == id }
+            if self.lastSuccessfulPeripheralID == id {
+                self.lastSuccessfulPeripheralID = nil
+                UserDefaults.standard.removeObject(forKey: self.lastSuccessfulPeripheralStoreKey)
+            }
             self.discoveredPeripherals = self.discoveredPeripherals.map { item in
                 guard item.id == id else { return item }
                 return DiscoveredPeripheral(
@@ -3990,7 +4110,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             }
             self.isConnected = false
             self.connectionStateText = "Disconnecting..."
-            self.connectErrorMessage = "Connection timeout"
+            if !self.connectingAttemptIsAutomatic {
+                self.connectErrorMessage = "Connection timeout"
+            }
             self.connectTimeoutWorkItem = nil
         }
         connectTimeoutWorkItem = work

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -2238,8 +2238,13 @@ private struct ControlSwipeView: View {
                 if newValue != nil { showConnectError = true }
             }
             .alert("Проблема с подключением", isPresented: $showConnectError, presenting: manager.connectErrorMessage) { _ in
-                Button("Выбрать другую дорожку") { showDevicePicker = true }
-                Button("OK", role: .cancel) {}
+                Button("Выбрать другую дорожку") {
+                    manager.consumeConnectErrorMessage()
+                    showDevicePicker = true
+                }
+                Button("OK", role: .cancel) {
+                    manager.consumeConnectErrorMessage()
+                }
             } message: { msg in
                 Text(msg)
             }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/StatusPillsRow.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/StatusPillsRow.swift
@@ -84,8 +84,13 @@ struct StatusPillsRow: View {
                 if newValue != nil { showConnectError = true }
             }
             .alert("Проблема с подключением", isPresented: $showConnectError, presenting: manager.connectErrorMessage) { _ in
-                Button("Выбрать другую дорожку") { showDevicePicker = true }
-                Button("OK", role: .cancel) {}
+                Button("Выбрать другую дорожку") {
+                    manager.consumeConnectErrorMessage()
+                    showDevicePicker = true
+                }
+                Button("OK", role: .cancel) {
+                    manager.consumeConnectErrorMessage()
+                }
             } message: { msg in
                 Text(msg)
             }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TrainingTelemetryWriter.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TrainingTelemetryWriter.swift
@@ -79,6 +79,11 @@ enum TrainingTelemetryWriter {
         let clearableBytes: Int64
     }
 
+    struct TrainingLogsInventorySnapshot: Equatable {
+        let inventory: TrainingLogsInventory
+        let latestMatchingProfileFile: URL?
+    }
+
     private struct SessionSummary {
         let values: [String]
     }
@@ -419,15 +424,12 @@ enum TrainingTelemetryWriter {
         }
 
         return files.filter { file in
-            guard let summary = summarizeJsonlFile(file) else {
-                return false
-            }
-
-            if let fileProfileID = summary.profileID, !fileProfileID.isEmpty {
-                return fileProfileID == profileID
-            }
-
-            return legacyFallbackProfileID == profileID
+            guard let summary = summarizeJsonlFile(file) else { return false }
+            return sessionSummaryMatchesProfile(
+                summary,
+                matchesProfileID: profileID,
+                legacyFallbackProfileID: legacyFallbackProfileID
+            )
         }
     }
 
@@ -437,42 +439,58 @@ enum TrainingTelemetryWriter {
         legacyFallbackProfileID: String? = nil,
         keeping protectedFiles: Set<URL> = []
     ) -> TrainingLogsInventory {
-        let summaries = files.compactMap(summarizeJsonlFile)
-        let profileFiltered = summaries.filter { summary in
-            guard let profileID, !profileID.isEmpty else {
-                return true
-            }
-
-            if let fileProfileID = summary.profileID, !fileProfileID.isEmpty {
-                return fileProfileID == profileID
-            }
-
-            return legacyFallbackProfileID == profileID
-        }
-        let clearable = selectJsonlFilesForClear(
+        trainingLogsInventorySnapshot(
             files,
             matchingProfileID: profileID,
             legacyFallbackProfileID: legacyFallbackProfileID,
             keeping: protectedFiles
-        )
-        let clearablePaths = Set(clearable.map { $0.standardizedFileURL.path })
-        let clearableBytes = profileFiltered.reduce(Int64(0)) { partial, summary in
-            guard clearablePaths.contains(summary.fileURL.standardizedFileURL.path) else {
-                return partial
-            }
-            return partial + summary.fileSizeBytes
+        ).inventory
+    }
+
+    nonisolated static func trainingLogsInventorySnapshot(
+        _ files: [URL],
+        matchingProfileID profileID: String?,
+        legacyFallbackProfileID: String? = nil,
+        keeping protectedFiles: Set<URL> = []
+    ) -> TrainingLogsInventorySnapshot {
+        let summaries = files.compactMap(summarizeJsonlFile)
+        let profileFiltered = summaries.filter { sessionSummary in
+            sessionSummaryMatchesProfile(
+                sessionSummary,
+                matchesProfileID: profileID,
+                legacyFallbackProfileID: legacyFallbackProfileID
+            )
+        }
+        let protectedPaths = Set(protectedFiles.map { $0.standardizedFileURL.path })
+        let clearable = profileFiltered.filter { sessionSummary in
+            !protectedPaths.contains(sessionSummary.fileURL.standardizedFileURL.path)
         }
 
-        return TrainingLogsInventory(
-            totalSessionFiles: summaries.count,
-            completedWorkoutFiles: summaries.filter(\.containsSavedWorkout).count,
-            matchingProfileSessionFiles: profileFiltered.count,
-            matchingProfileCompletedWorkoutFiles: profileFiltered.filter(\.containsSavedWorkout).count,
-            clearableSessionFiles: clearable.count,
-            totalBytes: summaries.reduce(0) { $0 + $1.fileSizeBytes },
-            matchingProfileBytes: profileFiltered.reduce(0) { $0 + $1.fileSizeBytes },
-            clearableBytes: clearableBytes
+        return TrainingLogsInventorySnapshot(
+            inventory: TrainingLogsInventory(
+                totalSessionFiles: summaries.count,
+                completedWorkoutFiles: summaries.filter(\.containsSavedWorkout).count,
+                matchingProfileSessionFiles: profileFiltered.count,
+                matchingProfileCompletedWorkoutFiles: profileFiltered.filter(\.containsSavedWorkout).count,
+                clearableSessionFiles: clearable.count,
+                totalBytes: summaries.reduce(0) { $0 + $1.fileSizeBytes },
+                matchingProfileBytes: profileFiltered.reduce(0) { $0 + $1.fileSizeBytes },
+                clearableBytes: clearable.reduce(0) { $0 + $1.fileSizeBytes }
+            ),
+            latestMatchingProfileFile: profileFiltered.last?.fileURL
         )
+    }
+
+    private nonisolated static func sessionSummaryMatchesProfile(
+        _ summary: SessionLogSummary,
+        matchesProfileID profileID: String?,
+        legacyFallbackProfileID: String?
+    ) -> Bool {
+        guard let profileID, !profileID.isEmpty else { return true }
+        if let fileProfileID = summary.profileID, !fileProfileID.isEmpty {
+            return fileProfileID == profileID
+        }
+        return legacyFallbackProfileID == profileID
     }
 
     nonisolated static func csvString(_ value: Any?) -> String {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/AutoConnectRetryPolicyTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/AutoConnectRetryPolicyTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+@testable import WalkingPadCoreLogic
+import XCTest
+
+final class AutoConnectRetryPolicyTests: XCTestCase {
+    func testExhaustedRoundRearmsFreshPreferredDiscoveryExactlyOnceAfterCooldown() {
+        let preferredID = UUID()
+        let fallbackID = UUID()
+        let knownIDs: Set<UUID> = [preferredID, fallbackID]
+        let startedAt = Date(timeIntervalSinceReferenceDate: 1_000)
+        var policy = AutoConnectRetryPolicy(cooldownSeconds: 3)
+
+        policy.markFailed(preferredID, now: startedAt)
+        policy.markFailed(fallbackID, now: startedAt)
+
+        XCTAssertFalse(policy.rearmAfterFreshDiscovery(
+            peripheralID: preferredID,
+            knownPeripheralIDs: knownIDs,
+            now: startedAt.addingTimeInterval(2.9)
+        ))
+        XCTAssertTrue(policy.rearmAfterFreshDiscovery(
+            peripheralID: preferredID,
+            knownPeripheralIDs: knownIDs,
+            now: startedAt.addingTimeInterval(3)
+        ))
+        XCTAssertFalse(policy.rearmAfterFreshDiscovery(
+            peripheralID: preferredID,
+            knownPeripheralIDs: knownIDs,
+            now: startedAt.addingTimeInterval(3)
+        ))
+        XCTAssertEqual(policy.failedPeripheralIDs, Set([fallbackID]))
+    }
+
+    func testFreshDiscoveryCannotInterruptCurrentFallbackRound() {
+        let preferredID = UUID()
+        let fallbackID = UUID()
+        let now = Date(timeIntervalSinceReferenceDate: 2_000)
+        var policy = AutoConnectRetryPolicy(cooldownSeconds: 0)
+
+        policy.markFailed(preferredID, now: now)
+
+        XCTAssertFalse(policy.rearmAfterFreshDiscovery(
+            peripheralID: preferredID,
+            knownPeripheralIDs: [preferredID, fallbackID],
+            now: now
+        ))
+        XCTAssertEqual(policy.failedPeripheralIDs, Set([preferredID]))
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
@@ -122,7 +122,7 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
             [
                 "let wasAutomatic = self.connectingAttemptIsAutomatic",
                 "if wasAutomatic",
-                "self.autoConnectFailedPeripheralIDs.insert",
+                "self.markAutoConnectCandidateFailed",
                 "self.connectErrorMessage = error?.localizedDescription",
                 "self.connectingPeripheralId = nil",
                 "self.attemptAutoConnectIfNeeded()",
@@ -132,8 +132,41 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
         XCTAssertTrue(timeout.contains("if !self.connectingAttemptIsAutomatic"))
         XCTAssertTrue(timeout.contains("self.connectErrorMessage = \"Connection timeout\""))
         XCTAssertTrue(disconnect.contains("shouldContinueAutoConnect"))
-        XCTAssertTrue(disconnect.contains("self.autoConnectFailedPeripheralIDs.insert"))
+        XCTAssertTrue(disconnect.contains("self.markAutoConnectCandidateFailed"))
         XCTAssertTrue(disconnect.contains("self.attemptAutoConnectIfNeeded()"))
+    }
+
+    func testExhaustedKnownRoundRearmsOneFreshDiscoveryAfterCooldown() throws {
+        let markFailed = try functionBody(
+            "private func markAutoConnectCandidateFailed(_ peripheralID: UUID)",
+            in: managerSource
+        )
+        let rearm = try functionBody(
+            "private func rearmAutoConnectCandidateAfterFreshDiscovery(",
+            in: managerSource
+        )
+        let discovery = try functionBody(
+            "func centralManager(_ central: CBCentralManager,\n                        didDiscover peripheral: CBPeripheral,",
+            in: managerSource
+        )
+
+        XCTAssertTrue(markFailed.contains("autoConnectRetryPolicy.markFailed(peripheralID)"))
+        XCTAssertTrue(rearm.contains("autoConnectRetryPolicy.rearmAfterFreshDiscovery"))
+        XCTAssertTrue(rearm.contains("knownPeripheralIDs: Set(knownPeripherals.map(\\.id))"))
+        XCTAssertEqual(
+            discovery.components(separatedBy: "rearmAutoConnectCandidateAfterFreshDiscovery(").count - 1,
+            1
+        )
+        XCTAssertTrue(
+            discovery.contains("if rearmedKnownCandidate || self.preferredKnownDiscoveredPeripheral() != nil")
+        )
+        assertOrdered(
+            [
+                "rearmAutoConnectCandidateAfterFreshDiscovery(",
+                "self.attemptAutoConnectIfNeeded()",
+            ],
+            in: discovery
+        )
     }
 
     func testSuccessfulConnectionAndAlertDismissalConsumeStaleErrors() throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
@@ -21,15 +21,158 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
         XCTAssertTrue(autoConnect.contains("retrievePeripherals(withIdentifiers: ids)"))
         XCTAssertEqual(
             autoConnect.components(separatedBy: "preferredKnownPeripheral(from:").count - 1,
-            2
+            3
         )
         XCTAssertGreaterThanOrEqual(
             autoConnect.components(separatedBy: "connectToDiscovered(id:").count - 1,
             3
         )
-        XCTAssertTrue(preferredKnown.contains("knownPeripherals.lazy.compactMap"))
-        XCTAssertTrue(preferredKnown.contains("$0.identifier == known.id"))
+        XCTAssertTrue(preferredKnown.contains("orderedAutoConnectCandidateIDs.lazy.compactMap"))
+        XCTAssertTrue(preferredKnown.contains("$0.identifier == candidateID"))
         XCTAssertTrue(autoConnect.contains("clearsAutoConnectSuppression: false"))
+    }
+
+    func testLastSuccessfulKnownPeripheralOwnsStartupPriorityAndPersistence() throws {
+        let start = try functionBody("func start()", in: managerSource)
+        let loadPreference = try functionBody(
+            "private func loadLastSuccessfulPeripheral()",
+            in: managerSource
+        )
+        let candidateOrder = try functionBody(
+            "private var orderedAutoConnectCandidateIDs: [UUID]",
+            in: managerSource
+        )
+        let didConnect = try functionBody(
+            "func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral)",
+            in: managerSource
+        )
+        let forget = try functionBody("func forgetKnownPeripheral(id: UUID)", in: managerSource)
+        let disconnect = try functionBody(
+            "private func disconnect(userInitiated: Bool = false)",
+            in: managerSource
+        )
+
+        assertOrdered(
+            ["loadKnownPeripherals()", "loadLastSuccessfulPeripheral()"],
+            in: start
+        )
+        XCTAssertTrue(loadPreference.contains("knownPeripherals.contains"))
+        XCTAssertTrue(loadPreference.contains("lastSuccessfulPeripheralID = peripheralID"))
+        XCTAssertTrue(candidateOrder.contains("ordered.insert(lastSuccessfulPeripheralID, at: 0)"))
+        assertOrdered(
+            [
+                "guard self.connectingPeripheralId == peripheralID",
+                "self.knownPeripherals.append",
+                "self.saveLastSuccessfulPeripheral(peripheral.identifier)",
+            ],
+            in: didConnect
+        )
+        XCTAssertTrue(forget.contains("if self.lastSuccessfulPeripheralID == id"))
+        XCTAssertTrue(forget.contains("removeObject(forKey: self.lastSuccessfulPeripheralStoreKey)"))
+        XCTAssertFalse(disconnect.contains("lastSuccessfulPeripheral"))
+    }
+
+    func testKnownStartupGivesScanGraceBeforeRetrievedFallback() throws {
+        let start = try functionBody("func start()", in: managerSource)
+        let autoConnect = try functionBody(
+            "private func attemptAutoConnectIfNeeded()",
+            in: managerSource
+        )
+        let grace = try functionBody(
+            "private func scheduleKnownDiscoveryFallbackIfNeeded()",
+            in: managerSource
+        )
+        let discovery = try functionBody(
+            "func centralManager(_ central: CBCentralManager,\n                        didDiscover peripheral: CBPeripheral,",
+            in: managerSource
+        )
+
+        assertOrdered(["startDiscoveryScan()", "attemptAutoConnectIfNeeded()"], in: start)
+        assertOrdered(
+            [
+                "retrieveConnectedPeripherals",
+                "connectedList.first(where: { $0.identifier == lastSuccessfulPeripheralID })",
+                "guard knownDiscoveryGraceCompleted",
+                "scheduleKnownDiscoveryFallbackIfNeeded()",
+                "retrievePeripherals(withIdentifiers: ids)",
+            ],
+            in: autoConnect
+        )
+        XCTAssertTrue(grace.contains("DispatchQueue.main.asyncAfter(deadline: .now() + 1.0"))
+        XCTAssertTrue(grace.contains("self.attemptAutoConnectIfNeeded()"))
+        XCTAssertTrue(discovery.contains("self.attemptAutoConnectIfNeeded()"))
+        XCTAssertFalse(discovery.contains("central.connect("))
+    }
+
+    func testAutomaticFailuresStaySilentAndFallBackSerially() throws {
+        let failure = try functionBody(
+            "func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?)",
+            in: managerSource
+        )
+        let timeout = try functionBody(
+            "private func scheduleConnectTimeout(for id: UUID, seconds: TimeInterval = 12)",
+            in: managerSource
+        )
+        let disconnect = try functionBody(
+            "func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?)",
+            in: managerSource
+        )
+
+        assertOrdered(
+            [
+                "let wasAutomatic = self.connectingAttemptIsAutomatic",
+                "if wasAutomatic",
+                "self.autoConnectFailedPeripheralIDs.insert",
+                "self.connectErrorMessage = error?.localizedDescription",
+                "self.connectingPeripheralId = nil",
+                "self.attemptAutoConnectIfNeeded()",
+            ],
+            in: failure
+        )
+        XCTAssertTrue(timeout.contains("if !self.connectingAttemptIsAutomatic"))
+        XCTAssertTrue(timeout.contains("self.connectErrorMessage = \"Connection timeout\""))
+        XCTAssertTrue(disconnect.contains("shouldContinueAutoConnect"))
+        XCTAssertTrue(disconnect.contains("self.autoConnectFailedPeripheralIDs.insert"))
+        XCTAssertTrue(disconnect.contains("self.attemptAutoConnectIfNeeded()"))
+    }
+
+    func testSuccessfulConnectionAndAlertDismissalConsumeStaleErrors() throws {
+        let didConnect = try functionBody(
+            "func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral)",
+            in: managerSource
+        )
+        let consume = try functionBody("func consumeConnectErrorMessage()", in: managerSource)
+        let contentSource = source(relativePath: "WalkingPadRemote/ContentView.swift")
+        let statusSource = source(relativePath: "WalkingPadRemote/StatusPillsRow.swift")
+
+        assertOrdered(
+            ["guard self.connectingPeripheralId == peripheralID", "self.connectErrorMessage = nil", "self.isConnected = true"],
+            in: didConnect
+        )
+        XCTAssertTrue(consume.contains("connectErrorMessage = nil"))
+        XCTAssertEqual(
+            contentSource.components(separatedBy: "manager.consumeConnectErrorMessage()").count - 1,
+            2
+        )
+        XCTAssertEqual(
+            statusSource.components(separatedBy: "manager.consumeConnectErrorMessage()").count - 1,
+            2
+        )
+    }
+
+    func testStartupInventoryParsingRunsOffTheFirstFramePath() throws {
+        let refresh = try functionBody("func refreshTrainingLogsInventory()", in: managerSource)
+
+        assertOrdered(
+            [
+                "trainingLogQueue.async",
+                "TrainingTelemetryWriter.trainingLogsInventorySnapshot",
+                "DispatchQueue.main.async",
+                "self.trainingLogsInventory = snapshot.inventory",
+                "self.lastTrainingLogPath = snapshot.latestMatchingProfileFile?.path",
+            ],
+            in: refresh
+        )
     }
 
     func testConnectionPathPreventsParallelAttemptsAndSchedulesTimeouts() throws {
@@ -185,9 +328,10 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
         )
 
         XCTAssertTrue(preferredKnown.contains("if lhs.rssi != rhs.rssi"))
-        XCTAssertTrue(preferredKnown.contains("let knownIDs = Set(knownPeripherals.map(\\.id))"))
-        XCTAssertTrue(preferredKnown.contains("knownIDs.contains($0.id)"))
-        XCTAssertTrue(preferredKnown.contains("knownPeripherals.firstIndex"))
+        XCTAssertTrue(preferredKnown.contains("let candidateIDs = orderedAutoConnectCandidateIDs"))
+        XCTAssertTrue(preferredKnown.contains("candidateIDs.contains($0.id)"))
+        XCTAssertTrue(preferredKnown.contains("lastSuccessfulPeripheralID"))
+        XCTAssertTrue(preferredKnown.contains("candidateIDs.firstIndex"))
         XCTAssertTrue(preferredKnown.contains("return lhsIndex > rhsIndex"))
         XCTAssertTrue(autoConnect.contains("preferredKnownDiscoveredPeripheral()"))
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TrainingTelemetryWriterTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TrainingTelemetryWriterTests.swift
@@ -286,11 +286,12 @@ final class TrainingTelemetryWriterTests: XCTestCase {
         let profileA2 = try makeFile(name: "profile-a-2.jsonl", start: "2026-03-17T10:00:00.000Z", profileID: "profile-a", hasWorkoutSaved: false)
         let profileB = try makeFile(name: "profile-b.jsonl", start: "2026-03-18T10:00:00.000Z", profileID: "profile-b", hasWorkoutSaved: true)
 
-        let inventory = TrainingTelemetryWriter.trainingLogsInventory(
+        let snapshot = TrainingTelemetryWriter.trainingLogsInventorySnapshot(
             [legacy, profileA1, profileA2, profileB],
             matchingProfileID: "profile-a",
             legacyFallbackProfileID: "profile-a"
         )
+        let inventory = snapshot.inventory
 
         let expectedTotalBytes = [legacy, profileA1, profileA2, profileB].reduce(Int64(0)) { partial, file in
             partial + Int64((try? file.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
@@ -307,6 +308,7 @@ final class TrainingTelemetryWriterTests: XCTestCase {
         XCTAssertEqual(inventory.totalBytes, expectedTotalBytes)
         XCTAssertEqual(inventory.matchingProfileBytes, expectedMatchingBytes)
         XCTAssertEqual(inventory.clearableBytes, expectedMatchingBytes)
+        XCTAssertEqual(snapshot.latestMatchingProfileFile, profileA2)
     }
 
     func testSelectJsonlFilesForClearRespectsProfileAndProtection() throws {


### PR DESCRIPTION
## Summary

- Persist the last successfully connected known treadmill and prioritize it during startup recovery.
- Start scanning immediately, give the preferred treadmill a bounded discovery grace, and fall back through other known treadmills serially.
- Bound automatic failures to the current serial fallback round: after all known candidates fail, a fresh known-device discovery can re-arm that candidate once after a 3-second cooldown.
- Keep automatic failures and timeouts silent while preserving blocking errors for manual picker attempts; consume stale errors on success or alert dismissal.
- Move training-log inventory parsing off the synchronous startup path and reuse one summary pass without changing the resulting inventory or latest-log path.

Fixes #76

## Why

Startup should recover the treadmill that last worked without racing to a different known device, permanently blacklisting temporarily unavailable known treadmills, or blocking the first rendered frame on retained JSONL history.

## Verification

- P1 regression test failed against the previous head before the correction.
- swift test on corrected exact head: passed all suites; 216 core tests passed and the configured 1000-hour telemetry profile was skipped as expected.
- swift test --filter AutoConnectRetryPolicyTests: 2 passed.
- swift test --filter BluetoothAutoConnectBehaviorContractTests: 14 passed.
- xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination generic/platform=iOS Simulator -derivedDataPath /tmp/walkingpad-issue76-p1-exact-head CODE_SIGNING_ALLOWED=NO build: succeeded on corrected exact head.
- git diff --check: passed.
- Two full-suite runs launched concurrently with a heavy Xcode build reported a TelemetryRuntime timing failure. The isolated TelemetryRuntimeTests suite passed 18/18, and standalone full-suite reruns passed; hosted exact-head CI remains the final gate.
- Performance workload: 40 realistic JSONL files x 750 events, five warm-cache runs on the same fixture. Inventory median improved from 682.9 ms to 222.9 ms, a 67.4% reduction.
- Same iPhone 17e Simulator fixture: synchronous manager start returned in 7.9 ms versus 1360.0 ms at baseline; deferred inventory completed in 259.8 ms. Construction was 33.7 ms versus 17.8 ms in single-launch instrumentation and remained outside the dominant inventory path.

## Hardware / environment

- Treadmill model: not exercised; no physical BLE or motion commands.
- Protocol: deterministic retry-policy tests and source-contract coverage only.
- iPhone / iOS: iPhone 17e Simulator, iOS 26.4.1 runtime.
- Apple Watch / watchOS: not exercised.

## Risks / Notes

- BLE timing and callback behavior still require normal physical-device validation before release; this Draft PR intentionally stops before deploy or hardware testing.
- No migrations, dependencies, configuration changes, HealthKit changes, telemetry semantic changes, movement-command changes, or Issue #74 readiness/start changes.
- Backward compatibility: existing known treadmill storage remains valid; retry cooldown state is in-memory only and the last-success preference remains additive.
- Deployment: none. Rollback is a normal revert of the two commits; persisted preference data is harmless if left behind.
- Docs updated: no.
- Follow-up work: none in this PR.