### PR TITLE
Separate treadmill control readiness from BLE link

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -152,6 +152,7 @@ let package = Package(
                 "ZonePlanProgress.swift",
                 "CommandQueueService.swift",
                 "TreadmillSpeedBoundsService.swift",
+                "TreadmillControlReadinessPolicy.swift",
                 "TreadmillCommandTelemetrySidecar.swift"
             ]
         ),

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -2229,6 +2229,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             appendLog("AutoConnect skipped: suppressed by user action")
             return
         }
+        if let cancellingConnectionPeripheralId {
+            appendLog("AutoConnect skipped: cancellation pending for \(cancellingConnectionPeripheralId.uuidString)")
+            return
+        }
 
         // If we have known peripherals saved, prefer connecting to them
         if !knownPeripherals.isEmpty {
@@ -2420,8 +2424,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 central.cancelPeripheralConnection(peripheral)
                 return
             }
-            if self.cancellingConnectionPeripheralId == peripheralID || self.autoConnectSuppressed {
-                self.cancellingConnectionPeripheralId = peripheralID
+            if self.cancellingConnectionPeripheralId != nil || self.autoConnectSuppressed {
+                if self.cancellingConnectionPeripheralId == nil {
+                    self.cancellingConnectionPeripheralId = peripheralID
+                }
                 self.connectTimeoutWorkItem?.cancel()
                 self.connectTimeoutWorkItem = nil
                 self.appendLog("Rejecting completed connection after cancellation for \(peripheralID.uuidString)")
@@ -2666,6 +2672,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         autoConnectSuppressed = false
         // Prevent duplicate connection attempts
         if isConnected { appendLog("Connect known skipped: already connected"); return }
+        if let cancellingConnectionPeripheralId {
+            appendLog("Connect known skipped: cancellation pending for \(cancellingConnectionPeripheralId.uuidString)")
+            return
+        }
         if let inProgress = connectingPeripheralId {
             appendLog("Connect known skipped: connection in progress to \(inProgress.uuidString)")
             if inProgress == id { return }
@@ -2716,6 +2726,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
         // Prevent duplicate connection attempts
         if isConnected { appendLog("Connect discovered skipped: already connected"); return }
+        if let cancellingConnectionPeripheralId {
+            appendLog("Connect discovered skipped: cancellation pending for \(cancellingConnectionPeripheralId.uuidString)")
+            return
+        }
         if let inProgress = connectingPeripheralId {
             // Ignore repeated taps while a connection is in progress (including same target)
             appendLog("Connect discovered skipped: connection in progress to \(inProgress.uuidString)")

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -47,6 +47,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var treadmillProtocolConnection: TreadmillControlConnectionIdentity?
     private var ftmsHasControl: Bool = false
     private var ftmsControlRequestInFlight: Bool = false
+    private var ftmsControlRequestConnection: TreadmillControlConnectionIdentity?
     private var ftmsDidReadSupportedSpeedRange: Bool = false
     private var fitShowDidRequestInitialStatus: Bool = false
     private var shouldBeScanning: Bool = false
@@ -100,6 +101,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var notifyCharacteristic: CBCharacteristic?
     private var notifyCharacteristicConnection: TreadmillControlConnectionIdentity?
     private var rememberedValidatedTreadmillConnection: TreadmillControlConnectionIdentity?
+    private var characteristicConnections: [ObjectIdentifier: TreadmillControlConnectionIdentity] = [:]
     private var extraNotifyCharacteristics: [CBCharacteristic] = []
     private var supportedServiceUuids: [CBUUID] { [serviceFE00, serviceFTMS, serviceFitShow] }
 
@@ -5189,6 +5191,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         treadmillProtocolConnection = nil
         ftmsHasControl = false
         ftmsControlRequestInFlight = false
+        ftmsControlRequestConnection = nil
         ftmsDidReadSupportedSpeedRange = false
         fitShowDidRequestInitialStatus = false
         commandCharacteristic = nil
@@ -5196,6 +5199,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         notifyCharacteristic = nil
         notifyCharacteristicConnection = nil
         rememberedValidatedTreadmillConnection = nil
+        characteristicConnections.removeAll()
         extraNotifyCharacteristics.removeAll()
         lastLoggedActualSpeedKmh = nil
         treadmillMinSpeedKmh = 0.5
@@ -5317,7 +5321,22 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
         commandCharacteristicConnection = nil
         notifyCharacteristicConnection = nil
+        ftmsHasControl = false
+        ftmsControlRequestInFlight = false
+        ftmsControlRequestConnection = nil
         recomputeTreadmillControlReadiness()
+    }
+
+    private func registerCurrentCharacteristic(_ characteristic: CBCharacteristic) {
+        guard let connection = currentTreadmillControlConnection else { return }
+        characteristicConnections[ObjectIdentifier(characteristic)] = connection
+    }
+
+    private func isCurrentCharacteristicCallback(_ characteristic: CBCharacteristic) -> Bool {
+        TreadmillControlReadinessPolicy.isCurrentCallback(
+            characteristicConnections[ObjectIdentifier(characteristic)],
+            currentConnection: currentTreadmillControlConnection
+        )
     }
 
     private func rememberCurrentValidatedTreadmill() {
@@ -5541,7 +5560,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             appendLog("FTMS request control skipped: control point not ready")
             return
         }
+        guard let connection = currentTreadmillControlConnection,
+              commandCharacteristicConnection == connection else {
+            appendLog("FTMS request control skipped: stale control point context")
+            return
+        }
         ftmsControlRequestInFlight = true
+        ftmsControlRequestConnection = connection
         writeCommand(
             buildFtmsRequestControlPacket(),
             label: "FTMS REQUEST CONTROL",
@@ -6612,6 +6637,11 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         commandCharacteristicConnection = nil
         notifyCharacteristic = nil
         notifyCharacteristicConnection = nil
+        characteristicConnections.removeAll()
+        extraNotifyCharacteristics.removeAll()
+        ftmsHasControl = false
+        ftmsControlRequestInFlight = false
+        ftmsControlRequestConnection = nil
 
         switch treadmillProtocol {
         case .walkingPad:
@@ -6621,6 +6651,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
             if let n = notify {
                 notifyCharacteristic = n
+                registerCurrentCharacteristic(n)
                 stopObservationStreamID = UUID()
                 subscribe(peripheral, to: n, label: "FE01")
             } else {
@@ -6628,6 +6659,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             }
             if let w = write {
                 commandCharacteristic = w
+                registerCurrentCharacteristic(w)
                 commandCharacteristicConnection = currentTreadmillControlConnection
                 appendLog("WalkingPad: command characteristic set to \(w.uuid.uuidString)")
                 requestInitialControllerUnitsTruthIfReady()
@@ -6639,11 +6671,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             guard service.uuid == serviceFTMS else { return }
             if let dataChar = chars.first(where: { $0.uuid == ftmsCharTreadmillData && ($0.properties.contains(.notify) || $0.properties.contains(.indicate)) }) {
                 notifyCharacteristic = dataChar
+                registerCurrentCharacteristic(dataChar)
                 subscribe(peripheral, to: dataChar, label: "FTMS treadmill data")
             } else {
                 appendLog("FTMS: treadmill data characteristic not found")
             }
             if let statusChar = chars.first(where: { $0.uuid == ftmsCharMachineStatus && ($0.properties.contains(.notify) || $0.properties.contains(.indicate)) }) {
+                registerCurrentCharacteristic(statusChar)
                 subscribe(peripheral, to: statusChar, label: "FTMS machine status")
             }
             if let cpChar = chars.first(where: {
@@ -6652,6 +6686,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     && ($0.properties.contains(.notify) || $0.properties.contains(.indicate))
             }) {
                 commandCharacteristic = cpChar
+                registerCurrentCharacteristic(cpChar)
                 appendLog("FTMS: control point set to \(cpChar.uuid.uuidString)")
                 subscribe(peripheral, to: cpChar, label: "FTMS control point indications")
             } else {
@@ -6660,6 +6695,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             if !ftmsDidReadSupportedSpeedRange {
                 if let rangeChar = chars.first(where: { $0.uuid == ftmsCharSupportedSpeedRange && $0.properties.contains(.read) }) {
                     ftmsDidReadSupportedSpeedRange = true
+                    registerCurrentCharacteristic(rangeChar)
                     appendLog("FTMS: reading supported speed range (2AD4)")
                     peripheral.readValue(for: rangeChar)
                 } else if chars.contains(where: { $0.uuid == ftmsCharSupportedSpeedRange }) {
@@ -6672,12 +6708,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             guard service.uuid == serviceFitShow else { return }
             if let rx = chars.first(where: { $0.uuid == fitShowCharRx && ($0.properties.contains(.notify) || $0.properties.contains(.indicate)) }) {
                 notifyCharacteristic = rx
+                registerCurrentCharacteristic(rx)
                 subscribe(peripheral, to: rx, label: "FitShow RX")
             } else {
                 appendLog("FitShow: RX characteristic (FFF1) not found")
             }
             if let tx = chars.first(where: { $0.uuid == fitShowCharTx && ($0.properties.contains(.write) || $0.properties.contains(.writeWithoutResponse)) }) {
                 commandCharacteristic = tx
+                registerCurrentCharacteristic(tx)
                 commandCharacteristicConnection = currentTreadmillControlConnection
                 appendLog("FitShow: TX characteristic set to \(tx.uuid.uuidString)")
                 if !fitShowDidRequestInitialStatus {
@@ -6705,7 +6743,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let isFtmsControlPoint = treadmillProtocol == .ftms
             && characteristic === commandCharacteristic
             && characteristic.uuid == ftmsCharControlPoint
-        guard isRequiredTelemetry || isFtmsControlPoint else { return }
+        guard (isRequiredTelemetry || isFtmsControlPoint),
+              isCurrentCharacteristicCallback(characteristic) else {
+            return
+        }
         if let error {
             appendLog("Notify state error for \(characteristic.uuid.uuidString): \(error.localizedDescription)")
             if isRequiredTelemetry { notifyCharacteristicConnection = nil }
@@ -6734,7 +6775,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
         guard peripheral === connectedPeripheral,
-              peripheral.identifier == connectedPeripheralId else {
+              peripheral.identifier == connectedPeripheralId,
+              isCurrentCharacteristicCallback(characteristic) else {
             appendLog("Ignoring value update from stale peripheral \(peripheral.identifier.uuidString)")
             return
         }
@@ -7012,7 +7054,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 ])
             } else if characteristic.uuid == ftmsCharControlPoint, let resp = parseFtmsControlPointResponse(data) {
                 if resp.requestedOpcode == 0x00 {
+                    guard ftmsControlRequestInFlight,
+                          ftmsControlRequestConnection == currentTreadmillControlConnection,
+                          characteristic === commandCharacteristic else {
+                        appendLog("Ignoring FTMS control response without a current pending request")
+                        return
+                    }
                     ftmsControlRequestInFlight = false
+                    ftmsControlRequestConnection = nil
                     if resp.resultCode == 0x01 {
                         ftmsHasControl = true
                     }
@@ -7052,6 +7101,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+        guard peripheral === connectedPeripheral,
+              peripheral.identifier == connectedPeripheralId,
+              characteristic === commandCharacteristic,
+              isCurrentCharacteristicCallback(characteristic) else {
+            appendLog("Ignoring write result from stale treadmill transport")
+            return
+        }
         if let error {
             appendLog("Write to \(characteristic.uuid.uuidString) failed: \(error.localizedDescription)")
             logTrainingEvent("command_write_result", fields: [
@@ -7079,6 +7135,22 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 )
             )
         }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didModifyServices invalidatedServices: [CBService]) {
+        guard peripheral === connectedPeripheral,
+              peripheral.identifier == connectedPeripheralId,
+              let selectedService = treadmillProtocolService,
+              invalidatedServices.contains(where: { $0 === selectedService }) else {
+            return
+        }
+        appendLog("Selected treadmill service invalidated")
+        treadmillProtocolService = nil
+        commandCharacteristic = nil
+        notifyCharacteristic = nil
+        extraNotifyCharacteristics.removeAll()
+        characteristicConnections.removeAll()
+        invalidateTreadmillControlReadinessEvidence(includingProtocol: true)
     }
 }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -43,6 +43,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     private var treadmillProtocol: TreadmillProtocol = .unknown
+    private var treadmillProtocolService: CBService?
+    private var treadmillProtocolConnection: TreadmillControlConnectionIdentity?
     private var ftmsHasControl: Bool = false
     private var ftmsControlRequestInFlight: Bool = false
     private var ftmsDidReadSupportedSpeedRange: Bool = false
@@ -94,7 +96,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     // Peripheral/characteristics
     private var connectedPeripheral: CBPeripheral?
     private var commandCharacteristic: CBCharacteristic?
+    private var commandCharacteristicConnection: TreadmillControlConnectionIdentity?
     private var notifyCharacteristic: CBCharacteristic?
+    private var notifyCharacteristicConnection: TreadmillControlConnectionIdentity?
+    private var rememberedValidatedTreadmillConnection: TreadmillControlConnectionIdentity?
     private var extraNotifyCharacteristics: [CBCharacteristic] = []
     private var supportedServiceUuids: [CBUUID] { [serviceFE00, serviceFTMS, serviceFitShow] }
 
@@ -103,6 +108,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @Published var displayDeviceName: String? = nil
     @Published var deviceName: String = ""
     @Published var isConnected: Bool = false
+    @Published private(set) var isTreadmillControlReady: Bool = false
     @Published var connectedPeripheralId: UUID? = nil
     // Best-effort capabilities (defaults are safe fallbacks; FTMS can override them).
     @Published var treadmillMinSpeedKmh: Double = 0.5
@@ -942,7 +948,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     var isHrControlStartAffordanceAvailable: Bool {
         HRDomainService.heartRateStartAffordanceAvailable(
-            treadmillConnected: isConnected,
+            treadmillConnected: isTreadmillControlReady,
             currentHeartRateVisible: hrStreamingActive
         )
     }
@@ -1195,6 +1201,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             hrCooldownProgress = presentation.progress
 
         case .setSpeed(let speedEffect):
+            guard isTreadmillControlReady else {
+                appendLog("Cooldown speed skipped: treadmill control not ready")
+                return
+            }
             let old = deviceTargetSpeedKmh
             desiredSpeedKmh = speedEffect.targetKmh
             deviceTargetSpeedKmh = speedEffect.targetKmh
@@ -2330,6 +2340,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             case .poweredOff:
                 self.appendLog("Bluetooth poweredOff; stopping scan and clearing discoveries")
                 self.cancelTreadmillTestRunForConnectionInvalidation()
+                self.resetProtocolState()
+                self.recomputeHrStartAllowed()
                 self.stopDiscoveryScan()
                 self.discoveredPeripherals = []
                 self.discoveredMap.removeAll()
@@ -2451,12 +2463,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             self.connectionStateText = "Connected"
             self.startTelemetry()
             self.recomputeHrStartAllowed()
-            if !self.knownPeripherals.contains(where: { $0.id == peripheral.identifier }) {
-                let display = peripheral.name ?? "Device"
-                self.knownPeripherals.append(KnownPeripheral(id: peripheral.identifier, name: display))
-                self.saveKnownPeripherals()
-            }
-            self.saveLastSuccessfulPeripheral(peripheral.identifier)
         }
     }
 
@@ -2627,6 +2633,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         connectTimeoutWorkItem = nil
         DispatchQueue.main.async {
             self.isConnected = false
+            self.resetProtocolState()
             self.connectedPeripheralId = nil
             self.connectionStateText = "Disconnected"
             self.displayDeviceName = nil
@@ -2635,6 +2642,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             self.resetSessionStats()
             self.stopTelemetry()
             self.isHrControlRunning = false
+            self.recomputeHrStartAllowed()
             _ = self.telemetryV2Coordinator.observeEvent(
                 .connectionTransition(
                     ConnectionTransition(
@@ -3014,11 +3022,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         )
         guard !treadmillTestRunService.isActive,
               !isHrControlRunning,
-              isConnected,
+              isTreadmillControlReady,
               connectedPeripheralId != nil,
               controllerUnitsConnectionEpoch != nil,
-              commandCharacteristic != nil,
-              treadmillProtocol != .unknown,
               unitsDecision.allowed,
               treadmillMinSpeedKmh <= 1.0,
               treadmillMaxSpeedKmh >= 3.0 else {
@@ -3040,7 +3046,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         if isHrControlRunning {
             return "Недоступно во время HR-контроля"
         }
-        if commandCharacteristic == nil || treadmillProtocol == .unknown {
+        if !isTreadmillControlReady {
             return "Дождитесь готовности управления"
         }
         let unitsDecision = ControllerUnitsSafetyPolicy.evaluate(
@@ -3102,7 +3108,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     private func currentTreadmillTestRunContext() -> TreadmillTestRunConnectionContext? {
-        guard isConnected,
+        guard isTreadmillControlReady,
               let peripheralID = connectedPeripheralId,
               let connectionEpoch = controllerUnitsConnectionEpoch else {
             return nil
@@ -3206,8 +3212,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     func startWithSpeed(_ kmh: Double) {
-        guard isConnected else {
-            infoToastMessage = "Не подключено к дорожке"
+        guard isTreadmillControlReady else {
+            infoToastMessage = isConnected
+                ? "Дождитесь готовности управления дорожкой"
+                : "Не подключено к дорожке"
             return
         }
         endStopObservationForNewMotion()
@@ -3234,6 +3242,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 writeCommand(
                     modePacket,
                     label: "MODE MANUAL",
+                    requiresControlReadiness: true,
                     telemetryRequest: treadmillCommandRequest(
                         kind: .other("mode_manual"),
                         decision: telemetryDecision
@@ -3246,6 +3255,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     startPacket,
                     label: "START",
                     after: 0.2,
+                    requiresControlReadiness: true,
                     telemetryRequest: treadmillCommandRequest(
                         kind: .other("start"),
                         decision: telemetryDecision
@@ -3255,6 +3265,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     buildWalkingPadSetSpeedPacket(kmh: v),
                     label: String(format: "SPEED %.1f km/h", v),
                     after: 0.45,
+                    requiresControlReadiness: true,
                     telemetryRequest: treadmillCommandRequest(
                         kind: treadmillSetSpeedCommandKind(v),
                         decision: telemetryDecision
@@ -3265,6 +3276,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     buildWalkingPadSetSpeedPacket(kmh: v),
                     label: String(format: "SPEED %.1f km/h", v),
                     after: 0.2,
+                    requiresControlReadiness: true,
                     telemetryRequest: treadmillCommandRequest(
                         kind: treadmillSetSpeedCommandKind(v),
                         decision: telemetryDecision
@@ -3279,6 +3291,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     buildFtmsStartOrResumePacket(),
                     label: "FTMS START/RESUME",
                     after: 0.2,
+                    requiresControlReadiness: true,
                     telemetryRequest: treadmillCommandRequest(
                         kind: .other("start"),
                         decision: telemetryDecision
@@ -3288,6 +3301,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     buildFtmsSetSpeedPacket(kmh: v),
                     label: String(format: "SPEED %.1f km/h (FTMS)", v),
                     after: 0.45,
+                    requiresControlReadiness: true,
                     telemetryRequest: treadmillCommandRequest(
                         kind: treadmillSetSpeedCommandKind(v),
                         decision: telemetryDecision
@@ -3298,6 +3312,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     buildFtmsSetSpeedPacket(kmh: v),
                     label: String(format: "SPEED %.1f km/h (FTMS)", v),
                     after: 0.2,
+                    requiresControlReadiness: true,
                     telemetryRequest: treadmillCommandRequest(
                         kind: treadmillSetSpeedCommandKind(v),
                         decision: telemetryDecision
@@ -3310,6 +3325,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 writeCommand(
                     buildFitShowStartOrResumePacket(),
                     label: "FitShow START/RESUME",
+                    requiresControlReadiness: true,
                     telemetryRequest: treadmillCommandRequest(
                         kind: .other("start"),
                         decision: telemetryDecision
@@ -3319,6 +3335,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     buildFitShowSetSpeedPacket(kmh: v, incline: 0),
                     label: String(format: "SPEED %.1f km/h (FitShow)", v),
                     after: 0.35,
+                    requiresControlReadiness: true,
                     telemetryRequest: treadmillCommandRequest(
                         kind: treadmillSetSpeedCommandKind(v),
                         decision: telemetryDecision
@@ -3329,6 +3346,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     buildFitShowSetSpeedPacket(kmh: v, incline: 0),
                     label: String(format: "SPEED %.1f km/h (FitShow)", v),
                     after: 0.2,
+                    requiresControlReadiness: true,
                     telemetryRequest: treadmillCommandRequest(
                         kind: treadmillSetSpeedCommandKind(v),
                         decision: telemetryDecision
@@ -3929,7 +3947,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     func setTargetSpeedFromSlider(_ kmh: Double) {
         let v = clampRunningSpeedKmh(kmh)
         desiredSpeedKmh = v
-        guard isConnected else { return }
+        guard isTreadmillControlReady else { return }
         let isRunning = deviceTargetSpeedKmh > 0.1 || speedKmh > 0.2
         guard isRunning else { return }
         let old = deviceTargetSpeedKmh
@@ -3949,7 +3967,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         )
     }
     func adjustSpeed(delta: Double) {
-        guard isConnected else { return }
+        guard isTreadmillControlReady else { return }
         let base = (deviceTargetSpeedKmh > 0.1) ? deviceTargetSpeedKmh : (speedKmh > 0.1 ? speedKmh : desiredSpeedKmh)
         let v = clampAnySpeedKmh(base + delta)
         guard abs(v - base) >= 0.01 else { return }
@@ -3998,7 +4016,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         // legacy WalkingPad units gate before any automated motion can start.
         let existingGatesAllowStart = HRDomainService
             .heartRateRuntimePrerequisitesAllowStart(
-                treadmillConnected: isConnected,
+                treadmillConnected: isTreadmillControlReady,
                 watchReachable: watchReachable,
                 currentHeartRateVisible: hrStreamingActive
             )
@@ -4006,6 +4024,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             isHrControlRunning = false
             if !isConnected {
                 hrControlStartBlockReasonText = "Нет подключения к дорожке"
+            } else if !isTreadmillControlReady {
+                hrControlStartBlockReasonText = "Дождитесь готовности управления дорожкой"
             } else if !watchReachable {
                 hrControlStartBlockReasonText = "Часы недоступны — откройте приложение на Apple Watch и дождитесь соединения."
             } else if !hrStreamingActive {
@@ -4145,7 +4165,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let now = Date()
         let existingGatesAllowStart = HRDomainService
             .heartRateRuntimePrerequisitesAllowStart(
-                treadmillConnected: isConnected,
+                treadmillConnected: isTreadmillControlReady,
                 watchReachable: watchReachable,
                 currentHeartRateVisible: hrStreamingActive
             )
@@ -4167,6 +4187,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             )
             if !isConnected {
                 hrControlStartBlockReasonText = "Нет подключения к дорожке"
+            } else if !isTreadmillControlReady {
+                hrControlStartBlockReasonText = "Дождитесь готовности управления дорожкой"
             } else if !watchReachable {
                 hrControlStartBlockReasonText = "Часы недоступны — откройте приложение на Apple Watch и дождитесь соединения."
             } else if !hrStreamingActive {
@@ -4331,18 +4353,18 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 if hrNextDecisionSeconds <= 0 {
                     hrNextDecisionSeconds = hrDecisionIntervalSeconds
 
-                    guard isConnected else {
+                    guard isTreadmillControlReady else {
                         let elapsed = hrControlStartedAt.map { Int(Date().timeIntervalSince($0)) }
                         logTrainingEvent("hr_control_failed", fields: [
-                            "reason": "no_connection",
+                            "reason": "control_not_ready",
                             "elapsed_s": elapsed ?? 0
                         ])
-                        stopTrainingStructuredLog(reason: "hr_no_connection")
+                        stopTrainingStructuredLog(reason: "hr_control_not_ready")
                         hrControlFailed = true
-                        infoToastMessage = "HR‑контроль остановлен — нет подключения. Остановка дорожки запрошена, но ещё не подтверждена."
-                        appendLog("HR control stopped: no connection")
+                        infoToastMessage = "HR‑контроль остановлен — дорожка не готова к управлению. Остановка запрошена, но ещё не подтверждена."
+                        appendLog("HR control stopped: treadmill control not ready")
                         isHrControlRunning = false
-                        hrStatusLine = "HR‑контроль остановлен — нет подключения"
+                        hrStatusLine = "HR‑контроль остановлен — дорожка не готова"
                         hrNextDecisionSeconds = 0
                         hrRemainingSeconds = 0
                         hrProgress = 0
@@ -4354,8 +4376,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                         hrControlStartedAt = nil
                         hrControlStartedBelt = false
                         sendWatchCommand("stop_hr")
-                        stopBeltWithToggle(reason: "hr_no_connection")
-                        endTelemetryV2Session(reason: "hr_no_connection")
+                        stopBeltWithToggle(reason: "hr_control_not_ready")
+                        endTelemetryV2Session(reason: "hr_control_not_ready")
                         return
                     }
                     guard hrStreamingActive, heartRateBPM > 0 else {
@@ -4691,6 +4713,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         _ data: Data,
         label: String,
         highPriority: Bool = false,
+        requiresControlReadiness: Bool = false,
         telemetryRequest: TreadmillCommandTelemetryRequest? = nil
     ) {
 #if STOP_TRUTH_EXPERIMENT_CAPABILITY
@@ -4703,6 +4726,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             data,
             label: label,
             highPriority: highPriority,
+            requiresControlReadiness: requiresControlReadiness,
             telemetryRequest: telemetryRequest
         )
     }
@@ -4739,9 +4763,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         _ data: Data,
         label: String,
         highPriority: Bool,
+        requiresControlReadiness: Bool,
         telemetryRequest: TreadmillCommandTelemetryRequest?
     ) {
-        let command = CommandQueueService.Command(data: data, label: label)
+        let command = CommandQueueService.Command(
+            data: data,
+            label: label,
+            requiresControlReadiness: requiresControlReadiness
+        )
         let request = telemetryRequest ?? treadmillCommandRequest(kind: .other(label))
         let telemetryEvidence = treadmillTelemetryConnectionEpoch.map {
             TreadmillCommandEnqueuedEvidence(
@@ -4911,6 +4940,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 contentsOf: self.performWrite(
                     next.data,
                     label: next.label,
+                    requiresControlReadiness: next.requiresControlReadiness,
                     telemetryEvidence: telemetryEvidence
                 )
             )
@@ -4928,8 +4958,24 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private func performWrite(
         _ data: Data,
         label: String,
+        requiresControlReadiness: Bool,
         telemetryEvidence: TreadmillCommandEnqueuedEvidence?
     ) -> [TreadmillTelemetryEvidence] {
+        if requiresControlReadiness && !isTreadmillControlReady {
+            appendLog("WRITE SKIPPED (control not ready): \(label)")
+            return [
+                .commandFailed(
+                    TreadmillCommandFailureObservation(
+                        commandID: telemetryEvidence?.commandID,
+                        decisionID: telemetryEvidence?.decisionID,
+                        attemptID: nil,
+                        connectionEpoch: telemetryEvidence?.connectionEpoch,
+                        occurredAt: Date(),
+                        reason: .transportUnavailable
+                    )
+                )
+            ]
+        }
         guard isConnected else {
             appendLog("WRITE SKIPPED (not connected): \(label)")
             if label == "STOP" {
@@ -5131,17 +5177,25 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     private func resetProtocolState() {
-        let cancelledTelemetry = treadmillCommandTelemetrySidecar.clear()
+        let cancelledTelemetry = resetCommandQueue(
+            reason: "connection epoch reset",
+            observeTelemetryImmediately: false
+        )
         treadmillCommandAttemptNumbers.removeAll()
         latestTreadmillObservationEvidence = nil
         activeTreadmillStopTelemetryChain = nil
         treadmillProtocol = .unknown
+        treadmillProtocolService = nil
+        treadmillProtocolConnection = nil
         ftmsHasControl = false
         ftmsControlRequestInFlight = false
         ftmsDidReadSupportedSpeedRange = false
         fitShowDidRequestInitialStatus = false
         commandCharacteristic = nil
+        commandCharacteristicConnection = nil
         notifyCharacteristic = nil
+        notifyCharacteristicConnection = nil
+        rememberedValidatedTreadmillConnection = nil
         extraNotifyCharacteristics.removeAll()
         lastLoggedActualSpeedKmh = nil
         treadmillMinSpeedKmh = 0.5
@@ -5161,10 +5215,126 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         controllerUnitsTruth = controllerUnitsTruthTracker.state
         lastControllerUnitsQueryAt = nil
         lastControllerUnitsQueryTrigger = nil
+        isTreadmillControlReady = false
         observeCancelledTreadmillCommands(
             cancelledTelemetry,
             reason: .other("connection_epoch_reset")
         )
+    }
+
+    private var currentTreadmillControlConnection: TreadmillControlConnectionIdentity? {
+        guard isConnected,
+              let peripheralID = connectedPeripheralId,
+              connectedPeripheral?.identifier == peripheralID,
+              let epoch = controllerUnitsConnectionEpoch else {
+            return nil
+        }
+        return TreadmillControlConnectionIdentity(
+            peripheralID: peripheralID,
+            epoch: epoch
+        )
+    }
+
+    private var treadmillControlProtocolKind: TreadmillControlProtocolKind {
+        switch treadmillProtocol {
+        case .walkingPad: return .walkingPad
+        case .ftms: return .ftms
+        case .fitShow: return .fitShow
+        case .unknown: return .unknown
+        }
+    }
+
+    private var treadmillControlTelemetryRole: TreadmillControlTransportRole? {
+        switch treadmillProtocol {
+        case .walkingPad where notifyCharacteristic?.uuid == charFE01:
+            return .walkingPadTelemetry
+        case .ftms where notifyCharacteristic?.uuid == ftmsCharTreadmillData:
+            return .ftmsTelemetry
+        case .fitShow where notifyCharacteristic?.uuid == fitShowCharRx:
+            return .fitShowTelemetry
+        case .walkingPad, .ftms, .fitShow, .unknown:
+            return nil
+        }
+    }
+
+    private var treadmillControlCommandRole: TreadmillControlTransportRole? {
+        switch treadmillProtocol {
+        case .walkingPad where commandCharacteristic?.uuid == charFE02:
+            return .walkingPadCommand
+        case .ftms where commandCharacteristic?.uuid == ftmsCharControlPoint:
+            return .ftmsCommand
+        case .fitShow where commandCharacteristic?.uuid == fitShowCharTx:
+            return .fitShowCommand
+        case .walkingPad, .ftms, .fitShow, .unknown:
+            return nil
+        }
+    }
+
+    private func recomputeTreadmillControlReadiness() {
+        let telemetryEvidence = treadmillControlTelemetryRole.flatMap { role in
+            notifyCharacteristicConnection.map {
+                TreadmillControlTransportEvidence(
+                    role: role,
+                    connection: $0,
+                    isUsable: notifyCharacteristic?.isNotifying == true
+                )
+            }
+        }
+        let commandEvidence = treadmillControlCommandRole.flatMap { role in
+            commandCharacteristicConnection.map {
+                TreadmillControlTransportEvidence(
+                    role: role,
+                    connection: $0,
+                    isUsable: commandCharacteristic.map {
+                        $0.properties.contains(.write) || $0.properties.contains(.writeWithoutResponse)
+                    } ?? false
+                )
+            }
+        }
+        let ready = TreadmillControlReadinessPolicy.isReady(
+            TreadmillControlReadinessSnapshot(
+                currentConnection: currentTreadmillControlConnection,
+                protocolKind: treadmillControlProtocolKind,
+                protocolConnection: treadmillProtocolConnection,
+                telemetry: telemetryEvidence,
+                command: commandEvidence
+            )
+        )
+        let becameReady = ready && !isTreadmillControlReady
+        isTreadmillControlReady = ready
+        recomputeHrStartAllowed()
+        if becameReady {
+            rememberCurrentValidatedTreadmill()
+        }
+    }
+
+    private func invalidateTreadmillControlReadinessEvidence(
+        includingProtocol: Bool = false
+    ) {
+        if includingProtocol {
+            treadmillProtocolService = nil
+            treadmillProtocolConnection = nil
+        }
+        commandCharacteristicConnection = nil
+        notifyCharacteristicConnection = nil
+        recomputeTreadmillControlReadiness()
+    }
+
+    private func rememberCurrentValidatedTreadmill() {
+        guard isTreadmillControlReady,
+              let connection = currentTreadmillControlConnection,
+              rememberedValidatedTreadmillConnection != connection,
+              let peripheral = connectedPeripheral,
+              peripheral.identifier == connectedPeripheralId else {
+            return
+        }
+        rememberedValidatedTreadmillConnection = connection
+        if !knownPeripherals.contains(where: { $0.id == peripheral.identifier }) {
+            let display = peripheral.name ?? "Device"
+            knownPeripherals.append(KnownPeripheral(id: peripheral.identifier, name: display))
+            saveKnownPeripherals()
+        }
+        saveLastSuccessfulPeripheral(peripheral.identifier)
     }
 
     private var controllerUnitsTruthRequired: Bool {
@@ -5408,6 +5578,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         label: String,
         decision: TreadmillControlDecisionEvidence? = nil
     ) {
+        guard isTreadmillControlReady else {
+            appendLog("Set speed skipped: treadmill control not ready")
+            return
+        }
         if kmh > 0.1 {
             endStopObservationForNewMotion()
         }
@@ -5416,6 +5590,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             writeCommand(
                 buildWalkingPadSetSpeedPacket(kmh: kmh),
                 label: label,
+                requiresControlReadiness: true,
                 telemetryRequest: treadmillCommandRequest(
                     kind: treadmillSetSpeedCommandKind(kmh),
                     decision: decision
@@ -5427,6 +5602,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 writeCommand(
                     buildFtmsStartOrResumePacket(),
                     label: "FTMS START/RESUME (auto)",
+                    requiresControlReadiness: true,
                     telemetryRequest: treadmillCommandRequest(
                         kind: .other("auto_start"),
                         decision: decision
@@ -5436,6 +5612,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             writeCommand(
                 buildFtmsSetSpeedPacket(kmh: kmh),
                 label: label,
+                requiresControlReadiness: true,
                 telemetryRequest: treadmillCommandRequest(
                     kind: treadmillSetSpeedCommandKind(kmh),
                     decision: decision
@@ -5446,6 +5623,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 writeCommand(
                     buildFitShowStartOrResumePacket(),
                     label: "FitShow START/RESUME (auto)",
+                    requiresControlReadiness: true,
                     telemetryRequest: treadmillCommandRequest(
                         kind: .other("auto_start"),
                         decision: decision
@@ -5455,6 +5633,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             writeCommand(
                 buildFitShowSetSpeedPacket(kmh: kmh, incline: 0),
                 label: label,
+                requiresControlReadiness: true,
                 telemetryRequest: treadmillCommandRequest(
                     kind: treadmillSetSpeedCommandKind(kmh),
                     decision: decision
@@ -6316,6 +6495,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         _ data: Data,
         label: String,
         after delay: TimeInterval,
+        requiresControlReadiness: Bool = false,
         telemetryRequest: TreadmillCommandTelemetryRequest? = nil
     ) {
         let epoch = commandQueueEpoch
@@ -6325,6 +6505,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             self.writeCommand(
                 data,
                 label: label,
+                requiresControlReadiness: requiresControlReadiness,
                 telemetryRequest: telemetryRequest
             )
         }
@@ -6363,13 +6544,32 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     // MARK: - CBPeripheralDelegate
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-        if let error { appendLog("Discover services error: \(error.localizedDescription)") }
+        guard peripheral === connectedPeripheral,
+              peripheral.identifier == connectedPeripheralId else {
+            appendLog("Ignoring services from stale peripheral \(peripheral.identifier.uuidString)")
+            return
+        }
+        if let error {
+            appendLog("Discover services error: \(error.localizedDescription)")
+            invalidateTreadmillControlReadinessEvidence(includingProtocol: true)
+            return
+        }
         guard let services = peripheral.services, !services.isEmpty else {
             appendLog("No services discovered")
+            invalidateTreadmillControlReadinessEvidence(includingProtocol: true)
             return
         }
         let discoveredUuids = Set(services.map { $0.uuid })
         let selected = selectTreadmillProtocol(from: discoveredUuids)
+        treadmillProtocolService = services.first { service in
+            switch selected {
+            case .walkingPad: return service.uuid == serviceFE00
+            case .ftms: return service.uuid == serviceFTMS
+            case .fitShow: return service.uuid == serviceFitShow
+            case .unknown: return false
+            }
+        }
+        treadmillProtocolConnection = currentTreadmillControlConnection
         if treadmillProtocol != selected {
             treadmillProtocol = selected
             appendLog("Treadmill protocol selected: \(selected.rawValue)")
@@ -6379,6 +6579,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             ])
             recomputeHrStartAllowed()
         }
+        recomputeTreadmillControlReadiness()
         for s in services {
             appendLog("Service discovered: \(s.uuid.uuidString)")
             if supportedServiceUuids.contains(s.uuid) {
@@ -6388,14 +6589,29 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
-        if let error { appendLog("Discover characteristics error: \(error.localizedDescription)") }
+        guard peripheral === connectedPeripheral,
+              peripheral.identifier == connectedPeripheralId,
+              service === treadmillProtocolService else {
+            appendLog("Ignoring characteristics outside current treadmill transport")
+            return
+        }
+        if let error {
+            appendLog("Discover characteristics error: \(error.localizedDescription)")
+            invalidateTreadmillControlReadinessEvidence()
+            return
+        }
         guard let chars = service.characteristics else {
             appendLog("No characteristics for service \(service.uuid.uuidString)")
+            invalidateTreadmillControlReadinessEvidence()
             return
         }
         for c in chars {
             appendLog("Char: \(c.uuid.uuidString) props=\(c.properties)")
         }
+        commandCharacteristic = nil
+        commandCharacteristicConnection = nil
+        notifyCharacteristic = nil
+        notifyCharacteristicConnection = nil
 
         switch treadmillProtocol {
         case .walkingPad:
@@ -6412,6 +6628,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             }
             if let w = write {
                 commandCharacteristic = w
+                commandCharacteristicConnection = currentTreadmillControlConnection
                 appendLog("WalkingPad: command characteristic set to \(w.uuid.uuidString)")
                 requestInitialControllerUnitsTruthIfReady()
             } else {
@@ -6421,6 +6638,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         case .ftms:
             guard service.uuid == serviceFTMS else { return }
             if let dataChar = chars.first(where: { $0.uuid == ftmsCharTreadmillData && ($0.properties.contains(.notify) || $0.properties.contains(.indicate)) }) {
+                notifyCharacteristic = dataChar
                 subscribe(peripheral, to: dataChar, label: "FTMS treadmill data")
             } else {
                 appendLog("FTMS: treadmill data characteristic not found")
@@ -6428,12 +6646,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             if let statusChar = chars.first(where: { $0.uuid == ftmsCharMachineStatus && ($0.properties.contains(.notify) || $0.properties.contains(.indicate)) }) {
                 subscribe(peripheral, to: statusChar, label: "FTMS machine status")
             }
-            if let cpChar = chars.first(where: { $0.uuid == ftmsCharControlPoint && ($0.properties.contains(.write) || $0.properties.contains(.writeWithoutResponse)) }) {
+            if let cpChar = chars.first(where: {
+                $0.uuid == ftmsCharControlPoint
+                    && $0.properties.contains(.write)
+                    && ($0.properties.contains(.notify) || $0.properties.contains(.indicate))
+            }) {
                 commandCharacteristic = cpChar
                 appendLog("FTMS: control point set to \(cpChar.uuid.uuidString)")
-                if cpChar.properties.contains(.notify) || cpChar.properties.contains(.indicate) {
-                    subscribe(peripheral, to: cpChar, label: "FTMS control point indications")
-                }
+                subscribe(peripheral, to: cpChar, label: "FTMS control point indications")
             } else {
                 appendLog("FTMS: control point characteristic not found")
             }
@@ -6451,12 +6671,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         case .fitShow:
             guard service.uuid == serviceFitShow else { return }
             if let rx = chars.first(where: { $0.uuid == fitShowCharRx && ($0.properties.contains(.notify) || $0.properties.contains(.indicate)) }) {
+                notifyCharacteristic = rx
                 subscribe(peripheral, to: rx, label: "FitShow RX")
             } else {
                 appendLog("FitShow: RX characteristic (FFF1) not found")
             }
             if let tx = chars.first(where: { $0.uuid == fitShowCharTx && ($0.properties.contains(.write) || $0.properties.contains(.writeWithoutResponse)) }) {
                 commandCharacteristic = tx
+                commandCharacteristicConnection = currentTreadmillControlConnection
                 appendLog("FitShow: TX characteristic set to \(tx.uuid.uuidString)")
                 if !fitShowDidRequestInitialStatus {
                     fitShowDidRequestInitialStatus = true
@@ -6471,25 +6693,51 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             // No-op. We only support known treadmill protocols.
             return
         }
+        recomputeTreadmillControlReadiness()
     }
 
     func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
+        guard peripheral === connectedPeripheral,
+              peripheral.identifier == connectedPeripheralId else {
+            return
+        }
+        let isRequiredTelemetry = characteristic === notifyCharacteristic
+        let isFtmsControlPoint = treadmillProtocol == .ftms
+            && characteristic === commandCharacteristic
+            && characteristic.uuid == ftmsCharControlPoint
+        guard isRequiredTelemetry || isFtmsControlPoint else { return }
         if let error {
             appendLog("Notify state error for \(characteristic.uuid.uuidString): \(error.localizedDescription)")
+            if isRequiredTelemetry { notifyCharacteristicConnection = nil }
+            if isFtmsControlPoint { commandCharacteristicConnection = nil }
+            recomputeTreadmillControlReadiness()
             return
         }
-        guard treadmillProtocol == .walkingPad,
-              characteristic.uuid == charFE01,
-              characteristic.isNotifying,
-              peripheral.identifier == connectedPeripheralId,
-              characteristic === notifyCharacteristic else {
-            return
+        if isRequiredTelemetry {
+            notifyCharacteristicConnection = characteristic.isNotifying
+                ? currentTreadmillControlConnection
+                : nil
         }
-        appendLog("WalkingPad: FE01 notifications active")
-        requestInitialControllerUnitsTruthIfReady()
+        if isFtmsControlPoint {
+            commandCharacteristicConnection = characteristic.isNotifying
+                ? currentTreadmillControlConnection
+                : nil
+        }
+        recomputeTreadmillControlReadiness()
+        if treadmillProtocol == .walkingPad,
+           characteristic.uuid == charFE01,
+           characteristic.isNotifying {
+            appendLog("WalkingPad: FE01 notifications active")
+            requestInitialControllerUnitsTruthIfReady()
+        }
     }
 
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        guard peripheral === connectedPeripheral,
+              peripheral.identifier == connectedPeripheralId else {
+            appendLog("Ignoring value update from stale peripheral \(peripheral.identifier.uuidString)")
+            return
+        }
         if let error {
             appendLog("Notify update error from \(characteristic.uuid.uuidString): \(error.localizedDescription)")
             logTrainingEvent("notify_update_error", fields: [

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/CommandQueueService.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/CommandQueueService.swift
@@ -4,6 +4,13 @@ enum CommandQueueService {
     struct Command: Equatable {
         let data: Data
         let label: String
+        let requiresControlReadiness: Bool
+
+        init(data: Data, label: String, requiresControlReadiness: Bool = false) {
+            self.data = data
+            self.label = label
+            self.requiresControlReadiness = requiresControlReadiness
+        }
     }
 
     struct EnqueueResult {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -1872,7 +1872,7 @@ private struct ControlSwipeView: View {
 
     private var productionTrainingHubPresentation: TrainingHubPresentation {
         makeHRControlTrainingHubPresentation(
-            treadmillConnected: manager.isConnected,
+            treadmillConnected: manager.isTreadmillControlReady,
             hrFresh: manager.hrStreamingActive,
             currentHeartRateBPM: manager.hrStreamingActive && manager.heartRateBPM > 0
                 ? manager.heartRateBPM
@@ -1913,7 +1913,7 @@ private struct ControlSwipeView: View {
         }()
 
         return makeHRControlActivePresentation(
-            treadmillConnected: manager.isConnected,
+            treadmillConnected: manager.isTreadmillControlReady,
             hrFresh: manager.hrStreamingActive,
             currentHeartRateBPM: manager.hrStreamingActive && manager.heartRateBPM > 0
                 ? manager.heartRateBPM

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TreadmillControlReadinessPolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TreadmillControlReadinessPolicy.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+enum TreadmillControlProtocolKind: Equatable {
+    case walkingPad
+    case ftms
+    case fitShow
+    case unknown
+}
+
+enum TreadmillControlTransportRole: Equatable {
+    case walkingPadTelemetry
+    case walkingPadCommand
+    case ftmsTelemetry
+    case ftmsCommand
+    case fitShowTelemetry
+    case fitShowCommand
+}
+
+struct TreadmillControlConnectionIdentity: Equatable {
+    let peripheralID: UUID
+    let epoch: UUID
+}
+
+struct TreadmillControlTransportEvidence: Equatable {
+    let role: TreadmillControlTransportRole
+    let connection: TreadmillControlConnectionIdentity
+    let isUsable: Bool
+}
+
+struct TreadmillControlReadinessSnapshot: Equatable {
+    let currentConnection: TreadmillControlConnectionIdentity?
+    let protocolKind: TreadmillControlProtocolKind
+    let protocolConnection: TreadmillControlConnectionIdentity?
+    let telemetry: TreadmillControlTransportEvidence?
+    let command: TreadmillControlTransportEvidence?
+}
+
+enum TreadmillControlReadinessPolicy {
+    static func isReady(_ snapshot: TreadmillControlReadinessSnapshot) -> Bool {
+        guard let currentConnection = snapshot.currentConnection,
+              snapshot.protocolConnection == currentConnection,
+              let telemetry = snapshot.telemetry,
+              telemetry.connection == currentConnection,
+              telemetry.isUsable,
+              let command = snapshot.command,
+              command.connection == currentConnection,
+              command.isUsable else {
+            return false
+        }
+
+        switch snapshot.protocolKind {
+        case .walkingPad:
+            return telemetry.role == .walkingPadTelemetry
+                && command.role == .walkingPadCommand
+        case .ftms:
+            return telemetry.role == .ftmsTelemetry
+                && command.role == .ftmsCommand
+        case .fitShow:
+            return telemetry.role == .fitShowTelemetry
+                && command.role == .fitShowCommand
+        case .unknown:
+            return false
+        }
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TreadmillControlReadinessPolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TreadmillControlReadinessPolicy.swift
@@ -36,6 +36,14 @@ struct TreadmillControlReadinessSnapshot: Equatable {
 }
 
 enum TreadmillControlReadinessPolicy {
+    static func isCurrentCallback(
+        _ callbackConnection: TreadmillControlConnectionIdentity?,
+        currentConnection: TreadmillControlConnectionIdentity?
+    ) -> Bool {
+        guard let currentConnection else { return false }
+        return callbackConnection == currentConnection
+    }
+
     static func isReady(_ snapshot: TreadmillControlReadinessSnapshot) -> Bool {
         guard let currentConnection = snapshot.currentConnection,
               snapshot.protocolConnection == currentConnection,

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
@@ -409,6 +409,14 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
             "func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?)",
             in: managerSource
         )
+        let writeUpdate = try functionBody(
+            "func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?)",
+            in: managerSource
+        )
+        let modifiedServices = try functionBody(
+            "func peripheral(_ peripheral: CBPeripheral, didModifyServices invalidatedServices: [CBService])",
+            in: managerSource
+        )
 
         XCTAssertTrue(managerSource.contains("@Published private(set) var isTreadmillControlReady: Bool = false"))
         assertOrdered(
@@ -432,7 +440,13 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
         XCTAssertTrue(notification.contains("characteristic.isNotifying"))
         XCTAssertTrue(notification.contains("recomputeTreadmillControlReadiness()"))
         XCTAssertTrue(valueUpdate.contains("peripheral === connectedPeripheral"))
+        XCTAssertTrue(valueUpdate.contains("isCurrentCharacteristicCallback(characteristic)"))
         XCTAssertTrue(valueUpdate.contains("Ignoring value update from stale peripheral"))
+        XCTAssertTrue(valueUpdate.contains("ftmsControlRequestConnection == currentTreadmillControlConnection"))
+        XCTAssertTrue(writeUpdate.contains("characteristic === commandCharacteristic"))
+        XCTAssertTrue(writeUpdate.contains("isCurrentCharacteristicCallback(characteristic)"))
+        XCTAssertTrue(modifiedServices.contains("$0 === selectedService"))
+        XCTAssertTrue(modifiedServices.contains("invalidateTreadmillControlReadinessEvidence(includingProtocol: true)"))
     }
 
     func testProductionMotionUsesReadinessWhileStopRemainsLinkBased() throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
@@ -46,6 +46,10 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
             "func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral)",
             in: managerSource
         )
+        let rememberValidated = try functionBody(
+            "private func rememberCurrentValidatedTreadmill()",
+            in: managerSource
+        )
         let forget = try functionBody("func forgetKnownPeripheral(id: UUID)", in: managerSource)
         let disconnect = try functionBody(
             "private func disconnect(userInitiated: Bool = false)",
@@ -59,13 +63,15 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
         XCTAssertTrue(loadPreference.contains("knownPeripherals.contains"))
         XCTAssertTrue(loadPreference.contains("lastSuccessfulPeripheralID = peripheralID"))
         XCTAssertTrue(candidateOrder.contains("ordered.insert(lastSuccessfulPeripheralID, at: 0)"))
+        XCTAssertFalse(didConnect.contains("self.knownPeripherals.append"))
+        XCTAssertFalse(didConnect.contains("self.saveLastSuccessfulPeripheral"))
         assertOrdered(
             [
-                "guard self.connectingPeripheralId == peripheralID",
-                "self.knownPeripherals.append",
-                "self.saveLastSuccessfulPeripheral(peripheral.identifier)",
+                "guard isTreadmillControlReady",
+                "knownPeripherals.append",
+                "saveLastSuccessfulPeripheral(peripheral.identifier)",
             ],
-            in: didConnect
+            in: rememberValidated
         )
         XCTAssertTrue(forget.contains("if self.lastSuccessfulPeripheralID == id"))
         XCTAssertTrue(forget.contains("removeObject(forKey: self.lastSuccessfulPeripheralStoreKey)"))
@@ -311,10 +317,10 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
                 "self.logTrainingEvent(\"ble_connection_event\"",
                 "self.isConnected = true",
                 "central.stopScan()",
-                "self.knownPeripherals.append",
             ],
             in: didConnect
         )
+        XCTAssertFalse(didConnect.contains("knownPeripherals.append"))
         XCTAssertEqual(didConnect.components(separatedBy: "central.stopScan()").count - 1, 1)
     }
 
@@ -383,6 +389,74 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
                 "self.knownPeripherals.isEmpty && self.allowAutoConnectUnknown && !self.autoConnectSuppressed"
             )
         )
+    }
+
+    func testControlReadinessUsesCurrentSubscribedTransportAndResetsTheQueue() throws {
+        let reset = try functionBody("private func resetProtocolState()", in: managerSource)
+        let services = try functionBody(
+            "func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?)",
+            in: managerSource
+        )
+        let characteristics = try functionBody(
+            "func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?)",
+            in: managerSource
+        )
+        let notification = try functionBody(
+            "func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?)",
+            in: managerSource
+        )
+        let valueUpdate = try functionBody(
+            "func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?)",
+            in: managerSource
+        )
+
+        XCTAssertTrue(managerSource.contains("@Published private(set) var isTreadmillControlReady: Bool = false"))
+        assertOrdered(
+            [
+                "resetCommandQueue(",
+                "treadmillProtocolConnection = nil",
+                "commandCharacteristicConnection = nil",
+                "notifyCharacteristicConnection = nil",
+                "isTreadmillControlReady = false",
+            ],
+            in: reset
+        )
+        XCTAssertTrue(services.contains("peripheral === connectedPeripheral"))
+        XCTAssertTrue(services.contains("treadmillProtocolConnection = currentTreadmillControlConnection"))
+        XCTAssertTrue(services.contains("invalidateTreadmillControlReadinessEvidence(includingProtocol: true)"))
+        XCTAssertTrue(characteristics.contains("commandCharacteristicConnection = currentTreadmillControlConnection"))
+        XCTAssertTrue(characteristics.contains("notifyCharacteristic = dataChar"))
+        XCTAssertTrue(characteristics.contains("notifyCharacteristic = rx"))
+        XCTAssertTrue(characteristics.contains("invalidateTreadmillControlReadinessEvidence()"))
+        XCTAssertTrue(notification.contains("characteristic === notifyCharacteristic"))
+        XCTAssertTrue(notification.contains("characteristic.isNotifying"))
+        XCTAssertTrue(notification.contains("recomputeTreadmillControlReadiness()"))
+        XCTAssertTrue(valueUpdate.contains("peripheral === connectedPeripheral"))
+        XCTAssertTrue(valueUpdate.contains("Ignoring value update from stale peripheral"))
+    }
+
+    func testProductionMotionUsesReadinessWhileStopRemainsLinkBased() throws {
+        let start = try functionBody("func startWithSpeed(_ kmh: Double)", in: managerSource)
+        let slider = try functionBody("func setTargetSpeedFromSlider(_ kmh: Double)", in: managerSource)
+        let adjust = try functionBody("func adjustSpeed(delta: Double)", in: managerSource)
+        let hrStart = try functionBody("func startHrControl()", in: managerSource)
+        let testRun = try functionBody("var canStartTreadmillTestRun: Bool", in: managerSource)
+        let speedWrite = try functionBody("private func sendTreadmillSetSpeed(", in: managerSource)
+        let performWrite = try functionBody("private func performWrite(", in: managerSource)
+        let stop = try functionBody("func stopBelt()", in: managerSource)
+
+        XCTAssertTrue(start.contains("guard isTreadmillControlReady"))
+        XCTAssertTrue(slider.contains("guard isTreadmillControlReady"))
+        XCTAssertTrue(adjust.contains("guard isTreadmillControlReady"))
+        XCTAssertTrue(hrStart.contains("treadmillConnected: isTreadmillControlReady"))
+        XCTAssertTrue(testRun.contains("isTreadmillControlReady"))
+        XCTAssertTrue(speedWrite.contains("guard isTreadmillControlReady"))
+        XCTAssertTrue(performWrite.contains("requiresControlReadiness && !isTreadmillControlReady"))
+        XCTAssertTrue(stop.contains("guard isConnected"))
+        XCTAssertFalse(stop.contains("isTreadmillControlReady"))
+
+        let content = source(relativePath: "WalkingPadRemote/ContentView.swift")
+        XCTAssertTrue(content.contains("treadmillConnected: manager.isTreadmillControlReady"))
     }
 
     private func source(relativePath: String) -> String {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
@@ -223,6 +223,7 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
         assertOrdered(
             [
                 "if isConnected",
+                "if let cancellingConnectionPeripheralId",
                 "if let inProgress = connectingPeripheralId",
                 "connectingPeripheralId = id",
                 "central.connect(p, options: nil)",
@@ -312,7 +313,7 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
         assertOrdered(
             [
                 "guard self.connectingPeripheralId == peripheralID",
-                "if self.cancellingConnectionPeripheralId == peripheralID || self.autoConnectSuppressed",
+                "if self.cancellingConnectionPeripheralId != nil || self.autoConnectSuppressed",
                 "central.cancelPeripheralConnection(peripheral)",
                 "self.logTrainingEvent(\"ble_connection_event\"",
                 "self.isConnected = true",
@@ -321,6 +322,9 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
             in: didConnect
         )
         XCTAssertFalse(didConnect.contains("knownPeripherals.append"))
+        XCTAssertTrue(managerSource.contains("Connect known skipped: cancellation pending"))
+        XCTAssertTrue(managerSource.contains("Connect discovered skipped: cancellation pending"))
+        XCTAssertTrue(managerSource.contains("AutoConnect skipped: cancellation pending"))
         XCTAssertEqual(didConnect.components(separatedBy: "central.stopScan()").count - 1, 1)
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -195,7 +195,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         }
 
         XCTAssertTrue(affordance.contains("HRDomainService.heartRateStartAffordanceAvailable"))
-        XCTAssertTrue(affordance.contains("treadmillConnected: isConnected"))
+        XCTAssertTrue(affordance.contains("treadmillConnected: isTreadmillControlReady"))
         XCTAssertTrue(affordance.contains("currentHeartRateVisible: hrStreamingActive"))
         XCTAssertFalse(affordance.contains("watchReachable"))
         XCTAssertFalse(affordance.contains("controllerUnits"))

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TreadmillControlReadinessPolicyTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TreadmillControlReadinessPolicyTests.swift
@@ -128,6 +128,35 @@ final class TreadmillControlReadinessPolicyTests: XCTestCase {
         ))
     }
 
+    func testCallbackContextMustMatchTheCurrentPeripheralAndEpoch() {
+        XCTAssertTrue(TreadmillControlReadinessPolicy.isCurrentCallback(
+            current,
+            currentConnection: current
+        ))
+
+        let stalePeripheral = TreadmillControlConnectionIdentity(
+            peripheralID: UUID(uuidString: "99999999-8888-7777-6666-555555555555")!,
+            epoch: current.epoch
+        )
+        XCTAssertFalse(TreadmillControlReadinessPolicy.isCurrentCallback(
+            stalePeripheral,
+            currentConnection: current
+        ))
+
+        let staleEpoch = TreadmillControlConnectionIdentity(
+            peripheralID: current.peripheralID,
+            epoch: UUID(uuidString: "00000000-1111-2222-3333-444444444444")!
+        )
+        XCTAssertFalse(TreadmillControlReadinessPolicy.isCurrentCallback(
+            staleEpoch,
+            currentConnection: current
+        ))
+        XCTAssertFalse(TreadmillControlReadinessPolicy.isCurrentCallback(
+            nil,
+            currentConnection: current
+        ))
+    }
+
     private func readySnapshot(
         protocolKind: TreadmillControlProtocolKind,
         telemetryRole: TreadmillControlTransportRole,

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TreadmillControlReadinessPolicyTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TreadmillControlReadinessPolicyTests.swift
@@ -1,0 +1,181 @@
+import Foundation
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class TreadmillControlReadinessPolicyTests: XCTestCase {
+    private let current = TreadmillControlConnectionIdentity(
+        peripheralID: UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!,
+        epoch: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+    )
+
+    func testEachSupportedProtocolRequiresItsMatchingCurrentUsableTransportPair() {
+        let cases: [(
+            TreadmillControlProtocolKind,
+            TreadmillControlTransportRole,
+            TreadmillControlTransportRole
+        )] = [
+            (.walkingPad, .walkingPadTelemetry, .walkingPadCommand),
+            (.ftms, .ftmsTelemetry, .ftmsCommand),
+            (.fitShow, .fitShowTelemetry, .fitShowCommand),
+        ]
+
+        for (protocolKind, telemetryRole, commandRole) in cases {
+            let snapshot = readySnapshot(
+                protocolKind: protocolKind,
+                telemetryRole: telemetryRole,
+                commandRole: commandRole
+            )
+
+            XCTAssertTrue(
+                TreadmillControlReadinessPolicy.isReady(snapshot),
+                "Expected \(protocolKind) to be ready with its current usable transports"
+            )
+        }
+    }
+
+    func testMissingOrUnusableTransportFailsClosedForEverySupportedProtocol() {
+        let cases: [(
+            TreadmillControlProtocolKind,
+            TreadmillControlTransportRole,
+            TreadmillControlTransportRole
+        )] = [
+            (.walkingPad, .walkingPadTelemetry, .walkingPadCommand),
+            (.ftms, .ftmsTelemetry, .ftmsCommand),
+            (.fitShow, .fitShowTelemetry, .fitShowCommand),
+        ]
+
+        for (protocolKind, telemetryRole, commandRole) in cases {
+            let ready = readySnapshot(
+                protocolKind: protocolKind,
+                telemetryRole: telemetryRole,
+                commandRole: commandRole
+            )
+            XCTAssertFalse(TreadmillControlReadinessPolicy.isReady(replacingTelemetry(in: ready, with: nil)))
+            XCTAssertFalse(TreadmillControlReadinessPolicy.isReady(replacingCommand(in: ready, with: nil)))
+            XCTAssertFalse(TreadmillControlReadinessPolicy.isReady(replacingTelemetry(
+                in: ready,
+                with: evidence(role: telemetryRole, isUsable: false)
+            )))
+            XCTAssertFalse(TreadmillControlReadinessPolicy.isReady(replacingCommand(
+                in: ready,
+                with: evidence(role: commandRole, isUsable: false)
+            )))
+        }
+    }
+
+    func testProtocolTransportMismatchAndUnknownProtocolFailClosed() {
+        XCTAssertFalse(TreadmillControlReadinessPolicy.isReady(readySnapshot(
+            protocolKind: .walkingPad,
+            telemetryRole: .ftmsTelemetry,
+            commandRole: .ftmsCommand
+        )))
+        XCTAssertFalse(TreadmillControlReadinessPolicy.isReady(readySnapshot(
+            protocolKind: .unknown,
+            telemetryRole: .walkingPadTelemetry,
+            commandRole: .walkingPadCommand
+        )))
+    }
+
+    func testMissingLinkAndStalePeripheralOrEpochFailClosed() {
+        let ready = readySnapshot(
+            protocolKind: .walkingPad,
+            telemetryRole: .walkingPadTelemetry,
+            commandRole: .walkingPadCommand
+        )
+        XCTAssertFalse(TreadmillControlReadinessPolicy.isReady(
+            TreadmillControlReadinessSnapshot(
+                currentConnection: nil,
+                protocolKind: ready.protocolKind,
+                protocolConnection: ready.protocolConnection,
+                telemetry: ready.telemetry,
+                command: ready.command
+            )
+        ))
+
+        let stalePeripheral = TreadmillControlConnectionIdentity(
+            peripheralID: UUID(uuidString: "99999999-8888-7777-6666-555555555555")!,
+            epoch: current.epoch
+        )
+        XCTAssertFalse(TreadmillControlReadinessPolicy.isReady(replacingTelemetry(
+            in: ready,
+            with: TreadmillControlTransportEvidence(
+                role: .walkingPadTelemetry,
+                connection: stalePeripheral,
+                isUsable: true
+            )
+        )))
+        XCTAssertFalse(TreadmillControlReadinessPolicy.isReady(replacingCommand(
+            in: ready,
+            with: TreadmillControlTransportEvidence(
+                role: .walkingPadCommand,
+                connection: stalePeripheral,
+                isUsable: true
+            )
+        )))
+
+        let staleEpoch = TreadmillControlConnectionIdentity(
+            peripheralID: current.peripheralID,
+            epoch: UUID(uuidString: "00000000-1111-2222-3333-444444444444")!
+        )
+        XCTAssertFalse(TreadmillControlReadinessPolicy.isReady(
+            TreadmillControlReadinessSnapshot(
+                currentConnection: current,
+                protocolKind: ready.protocolKind,
+                protocolConnection: staleEpoch,
+                telemetry: ready.telemetry,
+                command: ready.command
+            )
+        ))
+    }
+
+    private func readySnapshot(
+        protocolKind: TreadmillControlProtocolKind,
+        telemetryRole: TreadmillControlTransportRole,
+        commandRole: TreadmillControlTransportRole
+    ) -> TreadmillControlReadinessSnapshot {
+        TreadmillControlReadinessSnapshot(
+            currentConnection: current,
+            protocolKind: protocolKind,
+            protocolConnection: current,
+            telemetry: evidence(role: telemetryRole),
+            command: evidence(role: commandRole)
+        )
+    }
+
+    private func evidence(
+        role: TreadmillControlTransportRole,
+        isUsable: Bool = true
+    ) -> TreadmillControlTransportEvidence {
+        TreadmillControlTransportEvidence(
+            role: role,
+            connection: current,
+            isUsable: isUsable
+        )
+    }
+
+    private func replacingTelemetry(
+        in snapshot: TreadmillControlReadinessSnapshot,
+        with telemetry: TreadmillControlTransportEvidence?
+    ) -> TreadmillControlReadinessSnapshot {
+        TreadmillControlReadinessSnapshot(
+            currentConnection: snapshot.currentConnection,
+            protocolKind: snapshot.protocolKind,
+            protocolConnection: snapshot.protocolConnection,
+            telemetry: telemetry,
+            command: snapshot.command
+        )
+    }
+
+    private func replacingCommand(
+        in snapshot: TreadmillControlReadinessSnapshot,
+        with command: TreadmillControlTransportEvidence?
+    ) -> TreadmillControlReadinessSnapshot {
+        TreadmillControlReadinessSnapshot(
+            currentConnection: snapshot.currentConnection,
+            protocolKind: snapshot.protocolKind,
+            protocolConnection: snapshot.protocolConnection,
+            telemetry: snapshot.telemetry,
+            command: command
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Derive treadmill control readiness from the current peripheral/connection epoch, selected protocol, required telemetry subscription, and writable command transport for WalkingPad, FTMS, and FitShow.
- Gate the Training Hub and every production start/motion path, including queued and delayed writes, on that readiness while keeping Stop link-based.
- Bind characteristic callbacks and FTMS Request Control responses to the current connection context, and persist a treadmill only after current transport validation.

## Why

A BLE link alone does not prove that the app can safely control the connected treadmill. This change makes control authorization fail closed when protocol discovery, required characteristics, notification state, peripheral identity, connection epoch, or selected service validity is missing or stale.

## Verification

- [x] `python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py`
- [x] `cd ios/WalkingPadRemote/WalkingPadRemote && swift test`
- [x] `cd ios/WalkingPadRemote/WalkingPadRemote && swift test --filter 'TreadmillControlReadinessPolicyTests|BluetoothAutoConnectBehaviorContractTests|CommandQueueServiceTests'` (27 tests)
- [x] `xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
- [x] `python3 scripts/check_codex_governance.py`
- [x] `git diff --check`

## Hardware / environment

- Treadmill model: Not exercised; physical BLE testing is outside this issue.
- Protocol: Deterministic coverage for WalkingPad, FTMS, and FitShow.
- iPhone / iOS: Unsigned generic iOS build only.
- Apple Watch / watchOS: Not exercised; behavior is unchanged.

## Screenshots or logs

No UI layout changes. Local test and unsigned-build evidence are listed above.

## Risks / Notes

- No migrations, configuration changes, dependency changes, or deployment steps.
- Existing saved devices remain connection candidates, but a current connection is not control-ready until its protocol transport is validated.
- FTMS readiness proves a writable control point with an active response subscription; the existing Request Control/start procedure and timing remain unchanged.
- Current-epoch callback binding relies on CoreBluetooth's documented disconnect boundary: after the disconnect delegate callback, no further peripheral delegate callbacks occur and discovered attributes are invalidated.
- Packet formats, speed policy, units policy, HR algorithm, cooldown policy, Stop behavior, HealthKit/Watch behavior, and Telemetry V2 meaning are unchanged.
- The unsigned build retains the pre-existing `BluetoothManager.swift` weak-capture warning.
- Rollback: revert commits `722040429f6f40f1da264b25b4916783f754b255`, `54809e56650ce1d555368d94424c037b90ae2ce3`, and `8989810d703f5f19009fc0eba8ccee90d24f8ed6` in reverse order.

Closes #74