### PR TITLE
Add two-phase native HealthKit HR start

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -140,6 +140,7 @@ let package = Package(
                 "HRDomainService.swift",
                 "HRSettingsDefaults.swift",
                 "IPhoneHealthKitHeartRateProviderCore.swift",
+                "NativeHeartRatePreflightEngine.swift",
                 "StopObservationService.swift",
                 "StopTruthExperimentBuildIdentity.swift",
                 "StopTruthExperimentClock.swift",

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
@@ -1460,10 +1460,7 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
             source = lifecycle.source
         case let .controlUse(controlUse):
             occurredAt = controlUse.occurredAt
-            source = HeartRateProviderIdentity(
-                kind: .legacyWatchWorkoutStream,
-                stableLocalKey: descriptor.configuration.heartRateProviderStableLocalKey
-            )
+            source = configuredHeartRateProvider
         }
         let sourceIdentity = heartRateSource(source)
         emitSourceIfNeeded(sourceIdentity, observedAt: occurredAt)
@@ -1477,12 +1474,7 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
     func observeHeartRateControlDecision(
         _ evidence: TelemetryV2RuntimeCoordinator.PendingHeartRateControlDecision
     ) -> TelemetryYieldDisposition {
-        let source = heartRateSource(
-            HeartRateProviderIdentity(
-                kind: .legacyWatchWorkoutStream,
-                stableLocalKey: descriptor.configuration.heartRateProviderStableLocalKey
-            )
-        )
+        let source = heartRateSource(configuredHeartRateProvider)
         emitSourceIfNeeded(source, observedAt: evidence.occurredAt)
         let decision = ControlDecision(
             decisionID: evidence.decisionID,
@@ -1675,6 +1667,15 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
         )
     }
 
+    private var configuredHeartRateProvider: HeartRateProviderIdentity {
+        HeartRateProviderIdentity(
+            kind: Self.heartRateProviderKind(
+                descriptor.configuration.heartRateProviderKind
+            ),
+            stableLocalKey: descriptor.configuration.heartRateProviderStableLocalKey
+        )
+    }
+
     private func treadmillSource(
         for evidence: TreadmillTelemetryEvidence
     ) -> SignalSourceIdentity? {
@@ -1780,6 +1781,18 @@ private final class TelemetryV2ActiveSession: @unchecked Sendable {
         case .bluetooth: .bluetooth
         case .unknown: .unknown
         case let .other(value): .other(value)
+        }
+    }
+
+    private static func heartRateProviderKind(_ value: String) -> HeartRateProviderKind {
+        switch value {
+        case "legacyWatchWorkoutStream": .legacyWatchWorkoutStream
+        case "healthKitSelected": .healthKitSelected
+        case "mirroredWatchWorkout": .mirroredWatchWorkout
+        case "phoneHealthKit": .phoneHealthKit
+        case "bluetooth": .bluetooth
+        case "unknown": .unknown
+        default: .other(value)
         }
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
@@ -15,7 +15,11 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
             factoryGate.wait()
             return persistence
         }
-        coordinator.beginSession(Self.descriptor(startedAt: startedAt))
+        coordinator.beginSession(Self.descriptor(
+            startedAt: startedAt,
+            heartRateProviderKind: "healthKitSelected",
+            heartRateProviderStableLocalKey: "iphone-healthkit-selected"
+        ))
 
         let canonicalID = HeartRateCanonicalObservationID(
             rawValue: UUID(uuidString: "61000000-0000-0000-0000-000000000001")!
@@ -23,10 +27,10 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
         let deliveryID = HeartRateDeliveryID(
             rawValue: UUID(uuidString: "62000000-0000-0000-0000-000000000001")!
         )
-        let measuredAt = startedAt.addingTimeInterval(0.25)
-        let callbackAt = startedAt.addingTimeInterval(0.4)
-        let receivedAt = startedAt.addingTimeInterval(0.5)
-        let recordedAt = startedAt.addingTimeInterval(0.6)
+        let measuredAt = startedAt.addingTimeInterval(-0.4)
+        let callbackAt = startedAt.addingTimeInterval(-0.3)
+        let receivedAt = startedAt.addingTimeInterval(-0.2)
+        let recordedAt = startedAt.addingTimeInterval(-0.1)
         var normalizer = HeartRateObservationNormalizer()
         let exactResult = normalizer.normalize(
             HeartRateProviderObservation(
@@ -54,6 +58,17 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
             inputs: [exactResult.delivery.causalReference],
             occurredAt: startedAt.addingTimeInterval(0.7)
         )), .accepted)
+        let decisionID = DecisionID(
+            rawValue: UUID(uuidString: "63000000-0000-0000-0000-000000000001")!
+        )
+        XCTAssertEqual(coordinator.observeHeartRateControlDecision(
+            decisionID: decisionID,
+            targetBeatsPerMinute: 143,
+            action: .noCommand,
+            reason: .withinTarget,
+            heartRateInputs: [exactResult.delivery.causalReference],
+            occurredAt: startedAt.addingTimeInterval(0.8)
+        ), .enqueued)
 
         factoryGate.signal()
         try await eventually {
@@ -72,6 +87,20 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
         XCTAssertEqual(persistedHeartRate.timestamp.measuredAt, measuredAt)
         XCTAssertEqual(persistedHeartRate.timestamp.receivedAt, receivedAt)
         XCTAssertEqual(persistedHeartRate.timestamp.recordedAt, recordedAt)
+        XCTAssertEqual(persistedHeartRate.timestamp.measuredElapsed, .zero)
+        XCTAssertEqual(persistedHeartRate.timestamp.receivedElapsed, .zero)
+        XCTAssertEqual(persistedHeartRate.timestamp.recordedElapsed, .zero)
+
+        let sources = records.compactMap { record -> SignalSourceIdentity? in
+            guard case let .source(source) = record else { return nil }
+            return source.identity
+        }
+        let nativeSource = try XCTUnwrap(sources.first {
+            $0.providerKind == .healthKitSelected
+        })
+        XCTAssertEqual(nativeSource.stableLocalKey, "hr:iphone-healthkit-selected")
+        XCTAssertFalse(sources.contains { $0.providerKind == .watchMediated })
+        XCTAssertEqual(persistedHeartRate.source.id, nativeSource.id)
 
         let heartRateEvidence = records.compactMap { record -> HeartRateRuntimeEvidence? in
             guard case let .event(event) = record,
@@ -102,6 +131,25 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
             return XCTFail("Expected causal use after delivery")
         }
         XCTAssertEqual(controlUse.inputs, [exactResult.delivery.causalReference])
+
+        let events = records.compactMap { record -> WorkoutEvent? in
+            guard case let .event(event) = record else { return nil }
+            return event
+        }
+        let controlUseEvent = try XCTUnwrap(events.first { event in
+            guard case .heartRateEvidence(.controlUse) = event.payload.payload else {
+                return false
+            }
+            return true
+        })
+        XCTAssertEqual(controlUseEvent.sourceID, nativeSource.id)
+        let decisionEvent = try XCTUnwrap(events.first { event in
+            guard case let .controlDecision(decision) = event.payload.payload else {
+                return false
+            }
+            return decision.decisionID == decisionID
+        })
+        XCTAssertEqual(decisionEvent.sourceID, nativeSource.id)
     }
 
     func testReadProjectionFailureCannotChangeRuntimeLifecycleOrSelectedControlOutput() async throws {
@@ -1172,7 +1220,9 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
 
     private static func descriptor(
         legacySessionID: UUID? = UUID(uuidString: "10000000-0000-0000-0000-000000000030"),
-        startedAt: Date = Date(timeIntervalSince1970: 1_000)
+        startedAt: Date = Date(timeIntervalSince1970: 1_000),
+        heartRateProviderKind: String = "legacyWatchWorkoutStream",
+        heartRateProviderStableLocalKey: String = "watch-session"
     ) -> TelemetryV2SessionDescriptor {
         TelemetryV2SessionDescriptor(
             sessionID: TelemetryV2SessionDescriptor.sessionID(
@@ -1198,8 +1248,8 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
                 cooldownTargetHeartRate: 100,
                 cooldownMinimumSpeedKilometresPerHour: 1,
                 cooldownMaximumMinutes: 5,
-                heartRateProviderKind: "legacyWatchWorkoutStream",
-                heartRateProviderStableLocalKey: "watch-session",
+                heartRateProviderKind: heartRateProviderKind,
+                heartRateProviderStableLocalKey: heartRateProviderStableLocalKey,
                 treadmill: TelemetryV2TreadmillContext(
                     stableLocalIdentifier: "treadmill-30",
                     model: "test",

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
@@ -7,6 +7,103 @@ import TelemetryRecorder
 import XCTest
 
 final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
+    func testQualifyingPreflightResultKeepsExactIDsAndPrecedesItsCausalUse() async throws {
+        let persistence = RuntimePersistence()
+        let factoryGate = DispatchSemaphore(value: 0)
+        let startedAt = Date(timeIntervalSince1970: 9_000)
+        let coordinator = TelemetryV2RuntimeCoordinator {
+            factoryGate.wait()
+            return persistence
+        }
+        coordinator.beginSession(Self.descriptor(startedAt: startedAt))
+
+        let canonicalID = HeartRateCanonicalObservationID(
+            rawValue: UUID(uuidString: "61000000-0000-0000-0000-000000000001")!
+        )
+        let deliveryID = HeartRateDeliveryID(
+            rawValue: UUID(uuidString: "62000000-0000-0000-0000-000000000001")!
+        )
+        let measuredAt = startedAt.addingTimeInterval(0.25)
+        let callbackAt = startedAt.addingTimeInterval(0.4)
+        let receivedAt = startedAt.addingTimeInterval(0.5)
+        let recordedAt = startedAt.addingTimeInterval(0.6)
+        var normalizer = HeartRateObservationNormalizer()
+        let exactResult = normalizer.normalize(
+            HeartRateProviderObservation(
+                source: HeartRateProviderIdentity(
+                    kind: .healthKitSelected,
+                    stableLocalKey: "iphone-healthkit-selected"
+                ),
+                beatsPerMinute: 143,
+                providerSequence: nil,
+                providerNativeIdentity: nil,
+                measuredAt: measuredAt,
+                sourceCallbackObservedAt: callbackAt,
+                sourceClockRelationship: .receiverComparable,
+                receivedAt: receivedAt,
+                metadataQuality: []
+            ),
+            canonicalObservationID: canonicalID,
+            deliveryID: deliveryID,
+            recordedAt: recordedAt
+        )
+
+        XCTAssertEqual(coordinator.observeHeartRate(exactResult), .accepted)
+        XCTAssertEqual(coordinator.observeControlUse(HeartRateControlUseEvidence(
+            kind: .speedDecision,
+            inputs: [exactResult.delivery.causalReference],
+            occurredAt: startedAt.addingTimeInterval(0.7)
+        )), .accepted)
+
+        factoryGate.signal()
+        try await eventually {
+            if case .active = coordinator.status { return true }
+            return false
+        }
+        coordinator.endSession(reason: "preflight-evidence-test")
+        try await eventually { await persistence.finalizations.count == 1 }
+
+        let records = await persistence.snapshot().records
+        let persistedHeartRate = try XCTUnwrap(records.compactMap { record -> HeartRateObservation? in
+            guard case let .heartRate(observation) = record else { return nil }
+            return observation
+        }.first)
+        XCTAssertEqual(persistedHeartRate.observationID.rawValue, canonicalID.rawValue)
+        XCTAssertEqual(persistedHeartRate.timestamp.measuredAt, measuredAt)
+        XCTAssertEqual(persistedHeartRate.timestamp.receivedAt, receivedAt)
+        XCTAssertEqual(persistedHeartRate.timestamp.recordedAt, recordedAt)
+
+        let heartRateEvidence = records.compactMap { record -> HeartRateRuntimeEvidence? in
+            guard case let .event(event) = record,
+                  case let .heartRateEvidence(evidence) = event.payload.payload else {
+                return nil
+            }
+            return evidence
+        }
+        guard case let .delivery(persistedResult) = heartRateEvidence.first else {
+            return XCTFail("Expected exact delivery before causal use")
+        }
+        XCTAssertEqual(persistedResult.delivery.deliveryID, deliveryID)
+        XCTAssertEqual(
+            persistedResult.delivery.canonicalObservationID,
+            canonicalID
+        )
+        XCTAssertEqual(persistedResult.delivery.sourceCallbackObservedAt, callbackAt)
+        XCTAssertEqual(persistedResult.delivery.receivedAt, receivedAt)
+        XCTAssertEqual(persistedResult.delivery.recordedAt, recordedAt)
+        XCTAssertEqual(persistedResult.canonicalObservation?.measuredAt, measuredAt)
+        XCTAssertEqual(
+            persistedResult.canonicalObservation?.sourceCallbackObservedAt,
+            callbackAt
+        )
+        XCTAssertEqual(persistedResult.canonicalObservation?.receivedAt, receivedAt)
+        XCTAssertEqual(persistedResult.canonicalObservation?.recordedAt, recordedAt)
+        guard case let .controlUse(controlUse) = heartRateEvidence.last else {
+            return XCTFail("Expected causal use after delivery")
+        }
+        XCTAssertEqual(controlUse.inputs, [exactResult.delivery.causalReference])
+    }
+
     func testReadProjectionFailureCannotChangeRuntimeLifecycleOrSelectedControlOutput() async throws {
         let persistence = RuntimePersistence()
         let coordinator = TelemetryV2RuntimeCoordinator { persistence }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -30,10 +30,11 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         provider.onObservation = { [weak self] observation in
             self?.handleNativeHeartRateObservation(observation)
         }
-        provider.onFailure = { [weak self] in
+        provider.onFailure = { [weak self] context in
             guard let self else { return }
             self.nativeHeartRateProviderFailed(
-                generation: self.nativeHeartRateProviderLifecycle.generation
+                generation: context.providerGeneration,
+                attemptID: context.attemptID
             )
         }
         return provider
@@ -225,13 +226,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var pendingHealthkitWorkoutProfileID: UUID? = nil
     private var activeTelemetryV2SessionID: SessionID? = nil
     private var pendingHealthkitTelemetryV2SessionID: SessionID? = nil
-    private struct DeferredNativeHealthKitLinkage: Codable, Equatable {
-        let acquisitionStartedAt: Date
-        let finishRequestedAt: Date
-        let profileID: UUID?
-        let telemetrySessionID: UUID?
-        let linksLegacyWorkout: Bool
-    }
     private let deferredNativeHealthKitLinkageStoreKey = "deferred_native_healthkit_linkage_v1"
     private var deferredNativeHealthKitLinkages: [DeferredNativeHealthKitLinkage] = []
     private var nativeHealthKitAcquisitionStartedAt: Date?
@@ -4341,7 +4335,11 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             guard let self else { return }
             do {
                 try await iPhoneHealthKitHeartRateProvider.prepare(
-                    configuration: configuration
+                    configuration: configuration,
+                    failureContext: IPhoneHealthKitRuntimeFailureContext(
+                        providerGeneration: providerGeneration,
+                        attemptID: nativeHeartRateProviderLifecycle.attemptID
+                    )
                 )
                 guard nativeHeartRateProviderLifecycle.acceptsProviderCompletion(
                     generation: providerGeneration
@@ -4365,6 +4363,12 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
+                iPhoneHealthKitHeartRateProvider.bindRuntimeFailureContext(
+                    IPhoneHealthKitRuntimeFailureContext(
+                        providerGeneration: providerGeneration,
+                        attemptID: intent.id
+                    )
+                )
                 try await iPhoneHealthKitHeartRateProvider.start(at: acquisitionStartedAt)
                 guard nativeHeartRateProviderLifecycle.acceptsProviderCompletion(
                     generation: providerGeneration,
@@ -6607,7 +6611,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         _ linkage: DeferredNativeHealthKitLinkage
     ) {
         deferredNativeHealthKitLinkages.removeAll { $0 == linkage }
-        nativeHealthKitAcquisitionStartedAt = nil
         if deferredNativeHealthKitLinkages.isEmpty {
             UserDefaults.standard.removeObject(forKey: deferredNativeHealthKitLinkageStoreKey)
         } else if let data = try? JSONEncoder().encode(deferredNativeHealthKitLinkages) {
@@ -6650,15 +6653,11 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                         && abs(workout.endDate.timeIntervalSince(linkage.finishRequestedAt)) <= 15
                 }
                 guard let workout else { return }
-                linkNativeHealthKitWorkout(
+                guard linkDeferredNativeHealthKitWorkout(
                     uuid: workout.uuid,
                     endedAt: workout.endDate,
-                    profileID: linkage.profileID,
-                    telemetrySessionID: linkage.telemetrySessionID.map {
-                        SessionID(rawValue: $0)
-                    },
-                    linksLegacyWorkout: linkage.linksLegacyWorkout
-                )
+                    linkage: linkage
+                ) else { return }
                 appendLog("Deferred native HealthKit workout linked: \(workout.uuid.uuidString)")
                 nativeHeartRateLogger.info("deferred_link_resolved")
                 clearDeferredNativeHealthKitLinkage(linkage)
@@ -6666,6 +6665,47 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             }
         }
         healthStore.execute(query)
+    }
+
+    @discardableResult
+    private func linkDeferredNativeHealthKitWorkout(
+        uuid: UUID,
+        endedAt: Date,
+        linkage: DeferredNativeHealthKitLinkage
+    ) -> Bool {
+        if linkage.linksLegacyWorkout {
+            guard let profileID = linkage.profileID else { return false }
+            var entries = loadLegacyShadowWorkoutHistory(profileID: profileID)
+            let matchWindow: TimeInterval = 15 * 60
+            guard let index = entries.firstIndex(where: {
+                $0.healthkitWorkoutUUID == nil
+                    && abs($0.date.timeIntervalSince(endedAt)) <= matchWindow
+            }) else { return false }
+            let entry = entries[index]
+            entries[index] = LegacyShadowWorkoutEntry(
+                id: entry.id,
+                date: entry.date,
+                beatsPerMeter: entry.beatsPerMeter,
+                targetBpm: entry.targetBpm,
+                durationSeconds: entry.durationSeconds,
+                avgBpm: entry.avgBpm,
+                avgSpeedKmh: entry.avgSpeedKmh,
+                healthkitWorkoutUUID: uuid.uuidString,
+                zoneSeconds: entry.zoneSeconds
+            )
+            saveLegacyShadowWorkoutHistory(entries, profileID: profileID)
+            if activeUserProfileID == profileID {
+                legacyShadowWorkoutHistory = entries
+            }
+        }
+
+        if let telemetrySessionID = linkage.telemetrySessionID {
+            associateHealthKitWorkoutWithTelemetryV2(
+                sessionID: SessionID(rawValue: telemetrySessionID),
+                workoutIdentifier: uuid
+            )
+        }
+        return true
     }
 
     private func linkNativeHealthKitWorkout(

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import Combine
 import CoreBluetooth
 import HealthKit
+import OSLog
 import TelemetryDomain
 import TelemetryPersistence
 import TelemetryRuntime
@@ -16,10 +17,24 @@ import WatchConnectivity
 // Minimal stub to satisfy references in the UI. Replace with real implementation.
 final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeripheralDelegate {
     private let telemetryPerformanceObservation = TelemetryV2PerformanceObservation()
+    private let nativeHeartRateLogger = Logger(
+        subsystem: "sw.WalkingPadRemote",
+        category: "NativeHeartRatePreflight"
+    )
 
     // CoreBluetooth
     private var central: CBCentralManager?
     private let healthStore = HKHealthStore()
+    private lazy var iPhoneHealthKitHeartRateProvider: IPhoneHealthKitLiveHeartRateProvider = {
+        let provider = IPhoneHealthKitLiveHeartRateProvider(healthStore: healthStore)
+        provider.onObservation = { [weak self] observation in
+            self?.handleNativeHeartRateObservation(observation)
+        }
+        provider.onFailure = { [weak self] in
+            self?.nativeHeartRateProviderFailed()
+        }
+        return provider
+    }()
     private let serviceFE00 = CBUUID(string: "FE00")
     private let serviceFTMS = CBUUID(string: "1826") // Fitness Machine Service
     private let serviceFitShow = CBUUID(string: "FFF0") // Common FitShow/FitMonster service
@@ -207,6 +222,17 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var pendingHealthkitWorkoutProfileID: UUID? = nil
     private var activeTelemetryV2SessionID: SessionID? = nil
     private var pendingHealthkitTelemetryV2SessionID: SessionID? = nil
+    private struct DeferredNativeHealthKitLinkage: Codable, Equatable {
+        let acquisitionStartedAt: Date
+        let finishRequestedAt: Date
+        let profileID: UUID?
+        let telemetrySessionID: UUID?
+        let linksLegacyWorkout: Bool
+    }
+    private let deferredNativeHealthKitLinkageStoreKey = "deferred_native_healthkit_linkage_v1"
+    private var deferredNativeHealthKitLinkages: [DeferredNativeHealthKitLinkage] = []
+    private var nativeHealthKitAcquisitionStartedAt: Date?
+    private var nativeHealthKitLinkageQueryInFlight = false
     private var hrControlFailed: Bool = false
     private let legacyWatchHeartRateSource = HeartRateProviderIdentity(
         kind: .legacyWatchWorkoutStream,
@@ -947,12 +973,23 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @Published var isHrControlRunning: Bool = false
     @Published var isHrControlStartAllowed: Bool = false
     @Published var hrControlStartBlockReasonText: String? = nil
+    @Published private(set) var isNativeHeartRatePreflightActive: Bool = false
+    @Published private(set) var isNativeHeartRateCurrent: Bool = false
+
+    private var nativeHeartRatePreflightEngine = NativeHeartRatePreflightEngine()
+    private var nativeHeartRateAppActivity: NativeHeartRatePreflightEngine.AppActivity = .inactive
+    private var isTrainingHubVisible = false
+    private var nativeHeartRateFlowOwnsController = false
+    private var nativeHealthKitWorkoutCommitted = false
+    private var nativeHealthKitWorkoutFinishInFlight = false
+    private var nativePreflightCommitTimestamps: (
+        acquisitionStartedAt: Date,
+        measuredAt: Date?,
+        receivedAt: Date
+    )?
 
     var isHrControlStartAffordanceAvailable: Bool {
-        HRDomainService.heartRateStartAffordanceAvailable(
-            treadmillConnected: isTreadmillControlReady,
-            currentHeartRateVisible: hrStreamingActive
-        )
+        isHrControlStartAllowed && !isNativeHeartRatePreflightActive
     }
 
     @Published var hrNextDecisionSeconds: Int = 0
@@ -1243,7 +1280,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             }
             stopTrainingStructuredLog(reason: completionEffect.structuredLogReason)
             if completionEffect.shouldStopWatch {
-                sendWatchCommand("stop_hr")
+                stopLegacyWatchHeartRateIfNeeded()
             }
             if completionEffect.shouldStopBelt {
                 stopBeltWithToggle(reason: "hr_cooldown_done")
@@ -4027,82 +4064,413 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     func startHrControl() {
+        guard !isHrControlRunning,
+              !nativeHeartRatePreflightEngine.hasStartIntent else { return }
+        let now = Date()
+        let intent = NativeHeartRatePreflightEngine.Intent(
+            id: UUID(),
+            targetBPM: hrTargetBPM,
+            durationMinutes: hrDurationMinutes,
+            requestedAt: now
+        )
+        let effects = nativeHeartRatePreflightEngine.requestStart(
+            intent: intent,
+            safety: nativeHeartRateSafetyFacts(now: now)
+        )
+        guard nativeHeartRatePreflightEngine.hasStartIntent else {
+            recomputeHrStartAllowed()
+            return
+        }
+        nativeHeartRateFlowOwnsController = true
+        isNativeHeartRateCurrent = false
+        hrStreamingActive = false
+        hrLastValueAt = nil
+        heartRateBPM = 0
+        nativeHeartRateLogger.info("preflight_requested")
+        appendLog("Native HR preflight requested: intent=\(intent.id.uuidString)")
+        applyNativeHeartRatePreflightEffects(effects)
+    }
+
+    func cancelNativeHeartRatePreflight() {
+        applyNativeHeartRatePreflightEffects(
+            nativeHeartRatePreflightEngine.cancel(reason: .user)
+        )
+    }
+
+    func trainingHubDidAppear() {
+        isTrainingHubVisible = true
+        warmNativeHeartRateProviderIfPossible()
+    }
+
+    func trainingHubDidDisappear() {
+        isTrainingHubVisible = false
         guard !isHrControlRunning else { return }
-        // Preserve the existing connection/watch/fresh-HR gates, then compose the
-        // legacy WalkingPad units gate before any automated motion can start.
-        let existingGatesAllowStart = HRDomainService
-            .heartRateRuntimePrerequisitesAllowStart(
-                treadmillConnected: isTreadmillControlReady,
-                watchReachable: watchReachable,
-                currentHeartRateVisible: hrStreamingActive
+        applyNativeHeartRatePreflightEffects(
+            nativeHeartRatePreflightEngine.cancel(reason: .hubLeft)
+        )
+    }
+
+    func nativeHeartRateAppBecameActive() {
+        nativeHeartRateAppActivity = .active
+        applyNativeHeartRatePreflightEffects(
+            nativeHeartRatePreflightEngine.safetyChanged(
+                nativeHeartRateSafetyFacts(),
+                now: Date(),
+                freshnessLimit: TimeInterval(hrStaleThresholdSeconds)
             )
-        guard existingGatesAllowStart else {
-            isHrControlRunning = false
-            if !isConnected {
-                hrControlStartBlockReasonText = "Нет подключения к дорожке"
-            } else if !isTreadmillControlReady {
-                hrControlStartBlockReasonText = "Дождитесь готовности управления дорожкой"
-            } else if !watchReachable {
-                hrControlStartBlockReasonText = "Часы недоступны — откройте приложение на Apple Watch и дождитесь соединения."
-            } else if !hrStreamingActive {
-                hrControlStartBlockReasonText = "Пульс недоступен — откройте приложение на Apple Watch и дождитесь передачи пульса."
-            }
-            return
-        }
+        )
+        warmNativeHeartRateProviderIfPossible()
+        resolveDeferredNativeHealthKitLinkageIfPossible()
+        recomputeHrStartAllowed()
+    }
 
+    func nativeHeartRateAppBecameInactive() {
+        nativeHeartRateAppActivity = .inactive
+        applyNativeHeartRatePreflightEffects(
+            nativeHeartRatePreflightEngine.safetyChanged(
+                nativeHeartRateSafetyFacts(),
+                now: Date(),
+                freshnessLimit: TimeInterval(hrStaleThresholdSeconds)
+            )
+        )
+        recomputeHrStartAllowed()
+    }
+
+    func nativeHeartRateAppEnteredBackground() {
+        nativeHeartRateAppActivity = .background
+        applyNativeHeartRatePreflightEffects(
+            nativeHeartRatePreflightEngine.safetyChanged(
+                nativeHeartRateSafetyFacts(),
+                now: Date(),
+                freshnessLimit: TimeInterval(hrStaleThresholdSeconds)
+            )
+        )
+        recomputeHrStartAllowed()
+    }
+
+    private func commitExistingHrControl(preflightLatencySeconds: TimeInterval) {
         let unitsDecision = controllerUnitsGateDecision()
-        guard unitsDecision.allowed else {
-            isHrControlRunning = false
-            hrControlStartBlockReasonText = unitsDecision.blockReason?.userMessage ?? "Единицы контроллера не подтверждены"
-            persistBlockedControllerUnitsStart(decision: unitsDecision)
-            retryControllerUnitsQueryAfterBlockedStart()
+        guard nativeHeartRateSafetyFacts().permitsCommit,
+              unitsDecision.allowed,
+              nativeHealthKitWorkoutCommitted else {
+            if !unitsDecision.allowed {
+                persistBlockedControllerUnitsStart(decision: unitsDecision)
+                retryControllerUnitsQueryAfterBlockedStart()
+            }
+            abortNativeHeartRateFlow(reason: .superseded)
             return
         }
 
-        if existingGatesAllowStart {
-            let adaptiveStepDescription = hrAdaptiveStepEnabled
-                ? "adaptive_levels=0.1/0.2/0.3/0.4"
-                : "step=\(String(format: "%.2f", hrSpeedStepKmh))"
-            appendLog("HR start: target=\(hrTargetBPM) duration=\(hrDurationMinutes)m interval=\(hrDecisionIntervalSeconds)s \(adaptiveStepDescription)")
-            // Reset all per-session counters before writing session_start telemetry snapshot.
-            resetSessionStats()
-            let legacySessionID = startTrainingStructuredLog(trigger: "start_hr")
-            isHrControlRunning = true
-            hrStatusLine = "HR‑контроль запущен"
-            hrSessionTotalSeconds = max(60, hrDurationMinutes * 60)
-            hrRemainingSeconds = hrSessionTotalSeconds
-            hrNextDecisionSeconds = hrDecisionIntervalSeconds
-            hrProgress = 0
-            hrControlStartedAt = Date()
-            hrDecisionDetails = ""
-            hrPredictorStatusLine = ""
-            hrWorkoutRecorded = false
-            hrTrendSamples.removeAll()
-            hrTrendEmaBpm = nil
-            hrNoDataSeconds = 0
-            hrControlFailed = false
-            clearCooldownRuntimeState()
-            // Ensure treadmill is running when HR control starts
-            hrControlStartedBelt = false
-            let adaptiveLevels: [Double] = [0.1, 0.2, 0.3, 0.4]
-            logTrainingEvent("hr_control_started", fields: [
-                "target_bpm": hrTargetBPM,
-                "duration_s": hrSessionTotalSeconds,
-                "decision_interval_s": hrDecisionIntervalSeconds,
-                "adaptive_step_enabled": hrAdaptiveStepEnabled,
-                "max_step_kmh": hrSpeedStepKmh,
-                "adaptive_levels_kmh": adaptiveLevels,
-                "start_speed_kmh": speedKmh,
-                "device_target_kmh": deviceTargetSpeedKmh
-            ].merging(controllerUnitsTelemetryFields(action: "hr_control_start")) { current, _ in current })
-            beginTelemetryV2Session(legacySessionID: legacySessionID)
-            if deviceTargetSpeedKmh <= 0.1 && speedKmh <= 0.2 {
-                hrControlStartedBelt = true
-                startWithSpeed(3.0)
-            } else if deviceTargetSpeedKmh <= 0.1 {
-                hrControlStartedBelt = true
-                startWithSpeed(desiredSpeedKmh)
+        let adaptiveStepDescription = hrAdaptiveStepEnabled
+            ? "adaptive_levels=0.1/0.2/0.3/0.4"
+            : "step=\(String(format: "%.2f", hrSpeedStepKmh))"
+        appendLog("HR start: target=\(hrTargetBPM) duration=\(hrDurationMinutes)m interval=\(hrDecisionIntervalSeconds)s \(adaptiveStepDescription)")
+        // Reset all per-session counters before writing session_start telemetry snapshot.
+        resetSessionStats()
+        let legacySessionID = startTrainingStructuredLog(trigger: "start_hr")
+        isHrControlRunning = true
+        hrStatusLine = "HR‑контроль запущен"
+        hrSessionTotalSeconds = max(60, hrDurationMinutes * 60)
+        hrRemainingSeconds = hrSessionTotalSeconds
+        hrNextDecisionSeconds = hrDecisionIntervalSeconds
+        hrProgress = 0
+        hrControlStartedAt = Date()
+        hrDecisionDetails = ""
+        hrPredictorStatusLine = ""
+        hrWorkoutRecorded = false
+        hrTrendSamples.removeAll()
+        hrTrendEmaBpm = nil
+        hrNoDataSeconds = 0
+        hrControlFailed = false
+        clearCooldownRuntimeState()
+        hrControlStartedBelt = false
+        let adaptiveLevels: [Double] = [0.1, 0.2, 0.3, 0.4]
+        logTrainingEvent("hr_control_started", fields: [
+            "target_bpm": hrTargetBPM,
+            "duration_s": hrSessionTotalSeconds,
+            "decision_interval_s": hrDecisionIntervalSeconds,
+            "adaptive_step_enabled": hrAdaptiveStepEnabled,
+            "max_step_kmh": hrSpeedStepKmh,
+            "adaptive_levels_kmh": adaptiveLevels,
+            "start_speed_kmh": speedKmh,
+            "device_target_kmh": deviceTargetSpeedKmh,
+            "native_hr_preflight_latency_s": preflightLatencySeconds,
+            "native_hr_acquisition_started_at": nativePreflightCommitTimestamps?.acquisitionStartedAt.timeIntervalSince1970 ?? -1,
+            "native_hr_first_measured_at": nativePreflightCommitTimestamps?.measuredAt?.timeIntervalSince1970 ?? -1,
+            "native_hr_first_received_at": nativePreflightCommitTimestamps?.receivedAt.timeIntervalSince1970 ?? -1
+        ].merging(controllerUnitsTelemetryFields(action: "hr_control_start")) { current, _ in current })
+        nativePreflightCommitTimestamps = nil
+        beginTelemetryV2Session(legacySessionID: legacySessionID)
+        if deviceTargetSpeedKmh <= 0.1 && speedKmh <= 0.2 {
+            hrControlStartedBelt = true
+            startWithSpeed(3.0)
+        } else if deviceTargetSpeedKmh <= 0.1 {
+            hrControlStartedBelt = true
+            startWithSpeed(desiredSpeedKmh)
+        }
+    }
+
+    private var nativeHeartRateTransportIsValid: Bool {
+        guard let currentConnection = currentTreadmillControlConnection else { return false }
+        return treadmillProtocol != .unknown
+            && treadmillProtocolConnection == currentConnection
+            && isTreadmillControlReady
+    }
+
+    private func nativeHeartRateSafetyFacts(
+        now: Date = Date()
+    ) -> NativeHeartRatePreflightEngine.SafetyFacts {
+        let effectiveAppActivity: NativeHeartRatePreflightEngine.AppActivity = {
+#if canImport(UIKit)
+            let systemActivity: NativeHeartRatePreflightEngine.AppActivity
+            switch UIApplication.shared.applicationState {
+            case .active: systemActivity = .active
+            case .inactive: systemActivity = .inactive
+            case .background: systemActivity = .background
+            @unknown default: systemActivity = .background
             }
+            if nativeHeartRateAppActivity == .background || systemActivity == .background {
+                return .background
+            }
+            if nativeHeartRateAppActivity == .inactive || systemActivity == .inactive {
+                return .inactive
+            }
+#endif
+            return nativeHeartRateAppActivity
+        }()
+        let stopInProgress = stopObservationLifecycle?.finalResult == nil
+            || unavailableStopAttempt != nil
+        return NativeHeartRatePreflightEngine.SafetyFacts(
+            appActivity: effectiveAppActivity,
+            treadmillControlReady: isTreadmillControlReady,
+            transportValid: nativeHeartRateTransportIsValid,
+            controllerUnitsAllowed: controllerUnitsGateDecision(now: now).allowed,
+            hasConflictingWorkout: isHrControlRunning
+                || treadmillTestRunIsActive
+                || nativeHealthKitWorkoutCommitted
+                || nativeHealthKitWorkoutFinishInFlight,
+            stopInProgress: stopInProgress,
+            telemetryAvailability: .healthy
+        )
+    }
+
+    private func warmNativeHeartRateProviderIfPossible() {
+        guard isTrainingHubVisible,
+              nativeHeartRateAppActivity == .active,
+              !isHrControlRunning,
+              IPhoneHealthKitLiveHeartRateProvider.isSupported else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let canPrepare = await iPhoneHealthKitHeartRateProvider
+                .canPrepareWithoutAuthorizationPrompt()
+            guard canPrepare,
+                  isTrainingHubVisible,
+                  nativeHeartRateAppActivity == .active,
+                  !isHrControlRunning else { return }
+            applyNativeHeartRatePreflightEffects(
+                nativeHeartRatePreflightEngine.requestWarmPreparation()
+            )
+        }
+    }
+
+    private func applyNativeHeartRatePreflightEffects(
+        _ effects: [NativeHeartRatePreflightEngine.Effect]
+    ) {
+        syncNativeHeartRatePreflightPresentation()
+        for effect in effects {
+            switch effect {
+            case .prepare:
+                prepareNativeHeartRateProvider()
+            case .startCollection(let intent, let acquisitionStartedAt):
+                startNativeHeartRateCollection(
+                    intent: intent,
+                    acquisitionStartedAt: acquisitionStartedAt
+                )
+            case .commit(let intent, let observation, let acquisitionStartedAt):
+                commitNativeHeartRatePreflight(
+                    intent: intent,
+                    observation: observation,
+                    acquisitionStartedAt: acquisitionStartedAt
+                )
+            case .discard(let reason):
+                discardNativeHeartRatePreflight(reason: reason)
+            }
+        }
+        syncNativeHeartRatePreflightPresentation()
+        recomputeHrStartAllowed()
+    }
+
+    private func syncNativeHeartRatePreflightPresentation() {
+        isNativeHeartRatePreflightActive = nativeHeartRatePreflightEngine.hasStartIntent
+    }
+
+    private func prepareNativeHeartRateProvider() {
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = .walking
+        configuration.locationType = .indoor
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await iPhoneHealthKitHeartRateProvider.prepare(
+                    configuration: configuration
+                )
+                appendLog("Native HR session prepared")
+                nativeHeartRateLogger.info("session_prepared")
+                applyNativeHeartRatePreflightEffects(
+                    nativeHeartRatePreflightEngine.providerPrepared(at: Date())
+                )
+            } catch {
+                guard nativeHeartRatePreflightEngine.ownsUncommittedWorkout else { return }
+                nativeHeartRateProviderFailed()
+            }
+        }
+    }
+
+    private func startNativeHeartRateCollection(
+        intent: NativeHeartRatePreflightEngine.Intent,
+        acquisitionStartedAt: Date
+    ) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await iPhoneHealthKitHeartRateProvider.start(at: acquisitionStartedAt)
+                nativeHeartRatePreflightEngine.collectionStarted(
+                    intentID: intent.id,
+                    acquisitionStartedAt: acquisitionStartedAt
+                )
+                nativeHealthKitAcquisitionStartedAt = acquisitionStartedAt
+                nativeHeartRateLogger.info("collection_started")
+                appendLog("Native HR collection started: intent=\(intent.id.uuidString)")
+                syncNativeHeartRatePreflightPresentation()
+            } catch {
+                guard nativeHeartRatePreflightEngine.ownsUncommittedWorkout else { return }
+                nativeHeartRateProviderFailed()
+            }
+        }
+    }
+
+    private func handleNativeHeartRateObservation(
+        _ observation: HeartRateProviderObservation
+    ) {
+        let now = Date()
+        let factualDate = observation.measuredAt ?? observation.receivedAt
+        let ageSeconds = max(0, Int(now.timeIntervalSince(factualDate)))
+        HRDomainService.applyHeartRateDelivery(
+            observation.beatsPerMinute,
+            now: { factualDate },
+            updateCurrent: { heartRateBPM = $0 },
+            updateLastKnown: { lastKnownHeartRateBPM = $0 },
+            updateLastReceivedAt: { hrLastValueAt = $0 },
+            recordPredictorInput: { recordHrSample($0, at: factualDate) }
+        )
+        hrDataStaleSeconds = ageSeconds
+        hrStreamingActive = HRDomainService.heartRateStreamIsActive(
+            beatsPerMinute: observation.beatsPerMinute,
+            hasLastReceivedAt: true,
+            ageSeconds: ageSeconds,
+            staleThresholdSeconds: hrStaleThresholdSeconds
+        )
+        isNativeHeartRateCurrent = hrStreamingActive
+        observeHeartRateDelivery(observation, recordedAt: now)
+        appendLog("Native HR value: \(observation.beatsPerMinute)")
+        logTrainingEvent("hr_sample", fields: [
+            "hr_bpm": observation.beatsPerMinute,
+            "source": "healthkit_selected"
+        ])
+
+        let preflightObservation = NativeHeartRatePreflightEngine.Observation(
+            source: .nativeHealthKit,
+            beatsPerMinute: observation.beatsPerMinute,
+            measuredAt: observation.measuredAt,
+            receivedAt: observation.receivedAt
+        )
+        applyNativeHeartRatePreflightEffects(
+            nativeHeartRatePreflightEngine.receive(
+                preflightObservation,
+                safety: nativeHeartRateSafetyFacts(now: now),
+                now: now,
+                freshnessLimit: TimeInterval(hrStaleThresholdSeconds)
+            )
+        )
+    }
+
+    private func commitNativeHeartRatePreflight(
+        intent: NativeHeartRatePreflightEngine.Intent,
+        observation: NativeHeartRatePreflightEngine.Observation,
+        acquisitionStartedAt: Date
+    ) {
+        let now = Date()
+        guard nativeHeartRateFlowOwnsController,
+              !nativeHealthKitWorkoutCommitted,
+              iPhoneHealthKitHeartRateProvider.state == .collecting,
+              observation.isQualifying(
+                collectionStartedAt: acquisitionStartedAt,
+                now: now,
+                freshnessLimit: TimeInterval(hrStaleThresholdSeconds)
+              ),
+              nativeHeartRateSafetyFacts(now: now).permitsCommit else {
+            abortNativeHeartRateFlow(reason: .superseded)
+            return
+        }
+
+        hrTargetBPM = intent.targetBPM
+        hrDurationMinutes = intent.durationMinutes
+        nativeHealthKitWorkoutCommitted = true
+        nativePreflightCommitTimestamps = (
+            acquisitionStartedAt: acquisitionStartedAt,
+            measuredAt: observation.measuredAt,
+            receivedAt: observation.receivedAt
+        )
+        let latency = max(0, now.timeIntervalSince(acquisitionStartedAt))
+        nativeHeartRateLogger.info("first_qualifying_hr_received")
+        nativeHeartRateLogger.info("preflight_committed")
+        appendLog("Native HR preflight committed: latency=\(String(format: "%.3f", latency))s")
+        commitExistingHrControl(preflightLatencySeconds: latency)
+    }
+
+    private func discardNativeHeartRatePreflight(
+        reason: NativeHeartRatePreflightEngine.CancellationReason
+    ) {
+        appendLog("Native HR preflight cancelled: \(reason.rawValue)")
+        nativeHeartRateLogger.info("preflight_cancelled reason=\(reason.rawValue, privacy: .public)")
+        nativeHeartRateFlowOwnsController = false
+        isNativeHeartRateCurrent = false
+        Task { @MainActor [weak self] in
+            await self?.iPhoneHealthKitHeartRateProvider.discard(at: Date())
+        }
+        if reason == .timeout || reason == .providerFailure {
+            infoToastMessage = "Пульс не получен. Проверьте подключение и посадку датчика, а также доступ к данным «Здоровье»."
+        }
+    }
+
+    private func abortNativeHeartRateFlow(
+        reason: NativeHeartRatePreflightEngine.CancellationReason
+    ) {
+        nativeHealthKitWorkoutCommitted = false
+        nativeHeartRateFlowOwnsController = false
+        isNativeHeartRateCurrent = false
+        nativePreflightCommitTimestamps = nil
+        appendLog("Native HR flow aborted before motion: \(reason.rawValue)")
+        nativeHeartRateLogger.info("preflight_aborted reason=\(reason.rawValue, privacy: .public)")
+        Task { @MainActor [weak self] in
+            await self?.iPhoneHealthKitHeartRateProvider.discard(at: Date())
+        }
+        syncNativeHeartRatePreflightPresentation()
+        recomputeHrStartAllowed()
+    }
+
+    private func nativeHeartRateProviderFailed() {
+        hrStreamingActive = false
+        isNativeHeartRateCurrent = false
+        hrLastValueAt = nil
+        heartRateBPM = 0
+        if nativeHeartRatePreflightEngine.ownsUncommittedWorkout {
+            applyNativeHeartRatePreflightEffects(
+                nativeHeartRatePreflightEngine.cancel(reason: .providerFailure)
+            )
+        } else if !nativeHealthKitWorkoutCommitted {
+            nativeHeartRateFlowOwnsController = false
+            recomputeHrStartAllowed()
         }
     }
     func stopHrControl() {
@@ -4129,8 +4497,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         hrControlStartedAt = nil
         hrControlStartedBelt = false
         stopBeltWithToggle(reason: "hr")
-        sendWatchCommand("stop_hr")
+        stopLegacyWatchHeartRateIfNeeded()
         endTelemetryV2Session(reason: "manual_stop")
+    }
+
+    private func stopLegacyWatchHeartRateIfNeeded() {
+        guard !nativeHeartRateFlowOwnsController else { return }
+        sendWatchCommand("stop_hr")
     }
 
     func clearHrFailureReports() { hrFailureReports.removeAll() }
@@ -4179,23 +4552,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     private func recomputeHrStartAllowed() {
         let now = Date()
-        let existingGatesAllowStart = HRDomainService
-            .heartRateRuntimePrerequisitesAllowStart(
-                treadmillConnected: isTreadmillControlReady,
-                watchReachable: watchReachable,
-                currentHeartRateVisible: hrStreamingActive
-            )
+        let safety = nativeHeartRateSafetyFacts(now: now)
+        let preflightGatesAllowStart = safety.permitsStartIntent
+            && IPhoneHealthKitLiveHeartRateProvider.isSupported
+            && !nativeHeartRatePreflightEngine.hasStartIntent
         let unitsDecision = controllerUnitsGateDecision(now: now)
-        let allowed = ControllerUnitsSafetyPolicy.allowsStart(
-            path: .hrControl,
-            existingGatesAllowStart: existingGatesAllowStart,
-            state: controllerUnitsTruth,
-            currentConnectionEpoch: controllerUnitsConnectionEpoch,
-            now: now,
-            requiresFreshMetricTruth: controllerUnitsTruthRequired
-        )
-        isHrControlStartAllowed = allowed
-        if !allowed {
+        isHrControlStartAllowed = preflightGatesAllowStart
+        if !preflightGatesAllowStart {
             let withinGrace = HRDomainService.isWithinInitialHeartRateGrace(
                 startedAt: hrControlStartedAt,
                 now: Date(),
@@ -4205,23 +4568,23 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 hrControlStartBlockReasonText = "Нет подключения к дорожке"
             } else if !isTreadmillControlReady {
                 hrControlStartBlockReasonText = "Дождитесь готовности управления дорожкой"
-            } else if !watchReachable {
-                hrControlStartBlockReasonText = "Часы недоступны — откройте приложение на Apple Watch и дождитесь соединения."
-            } else if !hrStreamingActive {
-                hrControlStartBlockReasonText = "Пульс недоступен — откройте приложение на Apple Watch и дождитесь передачи пульса."
-            } else if let unitsBlockReason = unitsDecision.blockReason {
-                hrControlStartBlockReasonText = unitsBlockReason.userMessage
+            } else if !IPhoneHealthKitLiveHeartRateProvider.isSupported {
+                hrControlStartBlockReasonText = "HealthKit недоступен на этом устройстве"
+            } else if nativeHeartRateAppActivity != .active {
+                hrControlStartBlockReasonText = "Вернитесь в приложение для старта"
+            } else if nativeHeartRatePreflightEngine.hasStartIntent {
+                hrControlStartBlockReasonText = nil
             } else {
                 hrControlStartBlockReasonText = "Недоступно"
             }
-            if isHrControlRunning && !withinGrace && !existingGatesAllowStart {
+            if isHrControlRunning && !withinGrace && !hrStreamingActive {
                 hrStatusLine = "HR‑контроль: нет сигнала"
             }
         } else {
             hrControlStartBlockReasonText = nil
         }
         refreshControllerUnitsTruthIfNeeded(
-            existingGatesAllowStart: existingGatesAllowStart,
+            existingGatesAllowStart: preflightGatesAllowStart,
             unitsDecision: unitsDecision,
             now: now
         )
@@ -4261,6 +4624,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     staleThresholdSeconds: self.hrStaleThresholdSeconds
                 )
                 self.hrStreamingActive = active
+                if self.nativeHeartRateFlowOwnsController {
+                    self.isNativeHeartRateCurrent = active
+                }
                 if active != wasActive {
                     self.appendLog("HR stream \(active ? "ACTIVE" : "INACTIVE") (bpm=\(self.heartRateBPM), last=\(hasLast ? "\(secs)s ago" : "none"))")
                     self.logTrainingEvent("hr_stream_state", fields: [
@@ -4270,7 +4636,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     ])
                 }
                 self.recomputeHrStartAllowed()
-                if active != wasActive {
+                if active != wasActive && !self.nativeHeartRateFlowOwnsController {
                     self.observeHeartRateSourceLifecycle(
                         active ? .recovered : .stale
                     )
@@ -4288,6 +4654,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     private func tickTelemetry() {
+        applyNativeHeartRatePreflightEffects(
+            nativeHeartRatePreflightEngine.tick(now: Date())
+        )
         defer {
             if isHrControlRunning {
                 _ = telemetryV2Coordinator.observeCurrentElapsedSecond()
@@ -4391,7 +4760,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                         recordHrWorkoutIfNeeded(durationOverride: elapsed, failed: true)
                         hrControlStartedAt = nil
                         hrControlStartedBelt = false
-                        sendWatchCommand("stop_hr")
+                        stopLegacyWatchHeartRateIfNeeded()
                         stopBeltWithToggle(reason: "hr_control_not_ready")
                         endTelemetryV2Session(reason: "hr_control_not_ready")
                         return
@@ -4438,7 +4807,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                         recordHrWorkoutIfNeeded(durationOverride: elapsed, failed: true)
                         hrControlStartedAt = nil
                         hrControlStartedBelt = false
-                        sendWatchCommand("stop_hr")
+                        stopLegacyWatchHeartRateIfNeeded()
                         stopBeltWithToggle(reason: "hr_no_signal")
                         endTelemetryV2Session(reason: "hr_no_signal")
                         return
@@ -5234,6 +5603,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         lastControllerUnitsQueryAt = nil
         lastControllerUnitsQueryTrigger = nil
         isTreadmillControlReady = false
+        applyNativeHeartRatePreflightEffects(
+            nativeHeartRatePreflightEngine.safetyChanged(
+                nativeHeartRateSafetyFacts(),
+                now: Date(),
+                freshnessLimit: TimeInterval(hrStaleThresholdSeconds)
+            )
+        )
         observeCancelledTreadmillCommands(
             cancelledTelemetry,
             reason: .other("connection_epoch_reset")
@@ -5320,6 +5696,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         )
         let becameReady = ready && !isTreadmillControlReady
         isTreadmillControlReady = ready
+        applyNativeHeartRatePreflightEffects(
+            nativeHeartRatePreflightEngine.safetyChanged(
+                nativeHeartRateSafetyFacts(),
+                now: Date(),
+                freshnessLimit: TimeInterval(hrStaleThresholdSeconds)
+            )
+        )
         recomputeHrStartAllowed()
         if becameReady {
             rememberCurrentValidatedTreadmill()
@@ -6034,8 +6417,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 cooldownTargetHeartRate: hrCooldownTargetBpm,
                 cooldownMinimumSpeedKilometresPerHour: hrCooldownMinSpeed,
                 cooldownMaximumMinutes: hrCooldownMaxMinutes,
-                heartRateProviderKind: "legacyWatchWorkoutStream",
-                heartRateProviderStableLocalKey: legacyWatchHeartRateSource.stableLocalKey,
+                heartRateProviderKind: "healthKitSelected",
+                heartRateProviderStableLocalKey: "iphone-healthkit-selected",
                 treadmill: TelemetryV2TreadmillContext(
                     stableLocalIdentifier: connectedPeripheralId?.uuidString,
                     model: displayDeviceName ?? (deviceName.isEmpty ? nil : deviceName),
@@ -6059,7 +6442,154 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     private func endTelemetryV2Session(reason: String) {
+        finishNativeHealthKitWorkoutIfNeeded()
         telemetryV2Coordinator.endSession(reason: reason)
+    }
+
+    private func finishNativeHealthKitWorkoutIfNeeded() {
+        guard nativeHealthKitWorkoutCommitted,
+              !nativeHealthKitWorkoutFinishInFlight else { return }
+        nativeHealthKitWorkoutFinishInFlight = true
+        let finishRequestedAt = Date()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                nativeHealthKitWorkoutCommitted = false
+                nativeHealthKitWorkoutFinishInFlight = false
+                nativeHeartRateFlowOwnsController = false
+                isNativeHeartRateCurrent = false
+                nativeHealthKitAcquisitionStartedAt = nil
+                recomputeHrStartAllowed()
+                warmNativeHeartRateProviderIfPossible()
+            }
+            do {
+                switch try await iPhoneHealthKitHeartRateProvider.finish(at: finishRequestedAt) {
+                case .saved(let workout):
+                    nativeHealthKitAcquisitionStartedAt = nil
+                    linkNativeHealthKitWorkout(
+                        uuid: workout.uuid,
+                        endedAt: workout.endDate,
+                        profileID: pendingHealthkitWorkoutProfileID ?? activeUserProfileID,
+                        telemetrySessionID: pendingHealthkitTelemetryV2SessionID
+                            ?? activeTelemetryV2SessionID,
+                        linksLegacyWorkout: hrWorkoutRecorded
+                    )
+                    appendLog("Native HealthKit workout linked: \(workout.uuid.uuidString)")
+                    nativeHeartRateLogger.info("workout_finished_direct_link")
+                case .savedWorkoutUnavailable:
+                    appendLog("Native HealthKit workout saved; direct UUID unavailable, deferred linkage retained")
+                    retainDeferredNativeHealthKitLinkage(
+                        finishRequestedAt: finishRequestedAt
+                    )
+                    resolveDeferredNativeHealthKitLinkageIfPossible()
+                    nativeHeartRateLogger.info("workout_finished_deferred_link")
+                }
+            } catch {
+                appendLog("Native HealthKit workout finish failed: \(error.localizedDescription)")
+                nativeHeartRateLogger.error("workout_finish_failed")
+            }
+        }
+    }
+
+    private func retainDeferredNativeHealthKitLinkage(finishRequestedAt: Date) {
+        guard let acquisitionStartedAt = nativeHealthKitAcquisitionStartedAt else { return }
+        let linkage = DeferredNativeHealthKitLinkage(
+            acquisitionStartedAt: acquisitionStartedAt,
+            finishRequestedAt: finishRequestedAt,
+            profileID: pendingHealthkitWorkoutProfileID ?? activeUserProfileID,
+            telemetrySessionID: (pendingHealthkitTelemetryV2SessionID ?? activeTelemetryV2SessionID)?.rawValue,
+            linksLegacyWorkout: hrWorkoutRecorded
+        )
+        if !deferredNativeHealthKitLinkages.contains(linkage) {
+            deferredNativeHealthKitLinkages.append(linkage)
+        }
+        if let data = try? JSONEncoder().encode(deferredNativeHealthKitLinkages) {
+            UserDefaults.standard.set(data, forKey: deferredNativeHealthKitLinkageStoreKey)
+        }
+    }
+
+    private func clearDeferredNativeHealthKitLinkage(
+        _ linkage: DeferredNativeHealthKitLinkage
+    ) {
+        deferredNativeHealthKitLinkages.removeAll { $0 == linkage }
+        nativeHealthKitAcquisitionStartedAt = nil
+        if deferredNativeHealthKitLinkages.isEmpty {
+            UserDefaults.standard.removeObject(forKey: deferredNativeHealthKitLinkageStoreKey)
+        } else if let data = try? JSONEncoder().encode(deferredNativeHealthKitLinkages) {
+            UserDefaults.standard.set(data, forKey: deferredNativeHealthKitLinkageStoreKey)
+        }
+    }
+
+    private func resolveDeferredNativeHealthKitLinkageIfPossible() {
+        guard nativeHeartRateAppActivity == .active,
+              !nativeHealthKitLinkageQueryInFlight else { return }
+        if deferredNativeHealthKitLinkages.isEmpty,
+           let data = UserDefaults.standard.data(forKey: deferredNativeHealthKitLinkageStoreKey) {
+            deferredNativeHealthKitLinkages = (try? JSONDecoder().decode(
+                [DeferredNativeHealthKitLinkage].self,
+                from: data
+            )) ?? []
+        }
+        guard let linkage = deferredNativeHealthKitLinkages.first else { return }
+
+        nativeHealthKitLinkageQueryInFlight = true
+        let predicate = HKQuery.predicateForSamples(
+            withStart: linkage.acquisitionStartedAt.addingTimeInterval(-2),
+            end: linkage.finishRequestedAt.addingTimeInterval(2),
+            options: []
+        )
+        let query = HKSampleQuery(
+            sampleType: HKObjectType.workoutType(),
+            predicate: predicate,
+            limit: 10,
+            sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)]
+        ) { [weak self] _, samples, _ in
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                nativeHealthKitLinkageQueryInFlight = false
+                let appBundleIdentifier = Bundle.main.bundleIdentifier
+                let workout = (samples as? [HKWorkout])?.first { workout in
+                    workout.workoutActivityType == .walking
+                        && workout.sourceRevision.source.bundleIdentifier == appBundleIdentifier
+                        && abs(workout.startDate.timeIntervalSince(linkage.acquisitionStartedAt)) <= 5
+                        && abs(workout.endDate.timeIntervalSince(linkage.finishRequestedAt)) <= 15
+                }
+                guard let workout else { return }
+                linkNativeHealthKitWorkout(
+                    uuid: workout.uuid,
+                    endedAt: workout.endDate,
+                    profileID: linkage.profileID,
+                    telemetrySessionID: linkage.telemetrySessionID.map {
+                        SessionID(rawValue: $0)
+                    },
+                    linksLegacyWorkout: linkage.linksLegacyWorkout
+                )
+                appendLog("Deferred native HealthKit workout linked: \(workout.uuid.uuidString)")
+                nativeHeartRateLogger.info("deferred_link_resolved")
+                clearDeferredNativeHealthKitLinkage(linkage)
+                resolveDeferredNativeHealthKitLinkageIfPossible()
+            }
+        }
+        healthStore.execute(query)
+    }
+
+    private func linkNativeHealthKitWorkout(
+        uuid: UUID,
+        endedAt: Date,
+        profileID: UUID?,
+        telemetrySessionID: SessionID?,
+        linksLegacyWorkout: Bool
+    ) {
+        if linksLegacyWorkout {
+            pendingHealthkitWorkoutProfileID = profileID
+            pendingHealthkitTelemetryV2SessionID = telemetrySessionID
+            attachHealthkitWorkoutUUID(uuid.uuidString, endedAt: endedAt)
+        } else if let telemetrySessionID {
+            associateHealthKitWorkoutWithTelemetryV2(
+                sessionID: telemetrySessionID,
+                workoutIdentifier: uuid
+            )
+        }
     }
 
     private var treadmillTelemetryConnectionEpoch: TreadmillConnectionEpoch? {
@@ -6264,6 +6794,21 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         latestHeartRateDelivery = result.delivery
         attachTelemetryDeliveryToLatestHrTrendSample(result.delivery)
         return heartRateTelemetrySink?.observeHeartRate(result) ?? .unavailable
+    }
+
+    private func observeHeartRateDelivery(
+        _ observation: HeartRateProviderObservation,
+        recordedAt: Date
+    ) {
+        let result = heartRateObservationNormalizer.normalize(
+            observation,
+            canonicalObservationID: HeartRateCanonicalObservationID(),
+            deliveryID: HeartRateDeliveryID(),
+            recordedAt: recordedAt
+        )
+        latestHeartRateDelivery = result.delivery
+        attachTelemetryDeliveryToLatestHrTrendSample(result.delivery)
+        _ = heartRateTelemetrySink?.observeHeartRate(result)
     }
 
     private func observeHeartRateSourceLifecycle(
@@ -7223,6 +7768,10 @@ extension BluetoothManager: WCSessionDelegate {
         let phoneReceivedAt = Date()
         if let decoded = WatchHeartRatePayloadDecoder.decode(payload) {
             DispatchQueue.main.async {
+                guard !self.nativeHeartRateFlowOwnsController else {
+                    self.appendLog("Ignored legacy Watch HR while native HealthKit owns HR")
+                    return
+                }
                 HeartRateObservationalTee.deliver(
                     decoded.beatsPerMinute,
                     toLegacyController: { bpm in
@@ -7258,6 +7807,10 @@ extension BluetoothManager: WCSessionDelegate {
                 return nil
             }()
             DispatchQueue.main.async {
+                guard !self.nativeHeartRateFlowOwnsController else {
+                    self.appendLog("Ignored legacy Watch workout UUID while native HealthKit owns workout")
+                    return
+                }
                 self.attachHealthkitWorkoutUUID(uuid, endedAt: endDate)
                 self.appendLog("Workout UUID received: \(uuid)")
                 self.logTrainingEvent("workout_uuid_received", fields: [
@@ -7268,6 +7821,7 @@ extension BluetoothManager: WCSessionDelegate {
         }
         if let status = payload["status"] as? String {
             DispatchQueue.main.async {
+                guard !self.nativeHeartRateFlowOwnsController else { return }
                 var lifecycleTransition: HeartRateSourceLifecycleInput?
                 switch status.lowercased() {
                 case "hr_started":

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -31,7 +31,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             self?.handleNativeHeartRateObservation(observation)
         }
         provider.onFailure = { [weak self] in
-            self?.nativeHeartRateProviderFailed()
+            guard let self else { return }
+            self.nativeHeartRateProviderFailed(
+                generation: self.nativeHeartRateProviderLifecycle.generation
+            )
         }
         return provider
     }()
@@ -980,6 +983,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var nativeHeartRateAppActivity: NativeHeartRatePreflightEngine.AppActivity = .inactive
     private var isTrainingHubVisible = false
     private var nativeHeartRateFlowOwnsController = false
+    private var nativeHeartRateProviderLifecycle = NativeHeartRateProviderLifecycle()
     private var nativeHealthKitWorkoutCommitted = false
     private var nativeHealthKitWorkoutFinishInFlight = false
     private var nativePreflightCommitTimestamps: (
@@ -987,6 +991,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         measuredAt: Date?,
         receivedAt: Date
     )?
+    private var pendingNativePreflightHeartRate: HeartRateNormalizationResult?
 
     var isHrControlStartAffordanceAvailable: Bool {
         isHrControlStartAllowed && !isNativeHeartRatePreflightActive
@@ -4065,7 +4070,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     func startHrControl() {
         guard !isHrControlRunning,
-              !nativeHeartRatePreflightEngine.hasStartIntent else { return }
+              !nativeHeartRatePreflightEngine.hasStartIntent,
+              !nativeHeartRateProviderLifecycle.cleanupInFlight else { return }
         let now = Date()
         let intent = NativeHeartRatePreflightEngine.Intent(
             id: UUID(),
@@ -4082,6 +4088,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             return
         }
         nativeHeartRateFlowOwnsController = true
+        nativeHeartRateProviderLifecycle.bindAttempt(intent.id)
         isNativeHeartRateCurrent = false
         hrStreamingActive = false
         hrLastValueAt = nil
@@ -4201,6 +4208,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         ].merging(controllerUnitsTelemetryFields(action: "hr_control_start")) { current, _ in current })
         nativePreflightCommitTimestamps = nil
         beginTelemetryV2Session(legacySessionID: legacySessionID)
+        persistQualifyingNativeHeartRateBeforeMotion()
         if deviceTargetSpeedKmh <= 0.1 && speedKmh <= 0.2 {
             hrControlStartedBelt = true
             startWithSpeed(3.0)
@@ -4262,7 +4270,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     private func warmNativeHeartRateProviderIfPossible() {
-        guard NativeHeartRatePreflightEngine.RuntimePolicy.canWarmPrepare(
+        guard !nativeHeartRateProviderLifecycle.cleanupInFlight,
+              NativeHeartRatePreflightEngine.RuntimePolicy.canWarmPrepare(
             isTrainingHubVisible: isTrainingHubVisible,
             appActivity: nativeHeartRateAppActivity,
             isHrControlRunning: isHrControlRunning,
@@ -4276,6 +4285,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             let canPrepare = await iPhoneHealthKitHeartRateProvider
                 .canPrepareWithoutAuthorizationPrompt()
             guard canPrepare,
+                  !nativeHeartRateProviderLifecycle.cleanupInFlight,
                   NativeHeartRatePreflightEngine.RuntimePolicy.canWarmPrepare(
                     isTrainingHubVisible: isTrainingHubVisible,
                     appActivity: nativeHeartRateAppActivity,
@@ -4323,6 +4333,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     private func prepareNativeHeartRateProvider() {
+        let providerGeneration = nativeHeartRateProviderLifecycle.beginProviderLifecycle()
         let configuration = HKWorkoutConfiguration()
         configuration.activityType = .walking
         configuration.locationType = .indoor
@@ -4332,14 +4343,16 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 try await iPhoneHealthKitHeartRateProvider.prepare(
                     configuration: configuration
                 )
+                guard nativeHeartRateProviderLifecycle.acceptsProviderCompletion(
+                    generation: providerGeneration
+                ) else { return }
                 appendLog("Native HR session prepared")
                 nativeHeartRateLogger.info("session_prepared")
                 applyNativeHeartRatePreflightEffects(
                     nativeHeartRatePreflightEngine.providerPrepared(at: Date())
                 )
             } catch {
-                guard nativeHeartRatePreflightEngine.ownsUncommittedWorkout else { return }
-                nativeHeartRateProviderFailed()
+                nativeHeartRateProviderFailed(generation: providerGeneration)
             }
         }
     }
@@ -4348,10 +4361,15 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         intent: NativeHeartRatePreflightEngine.Intent,
         acquisitionStartedAt: Date
     ) {
+        let providerGeneration = nativeHeartRateProviderLifecycle.generation
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
                 try await iPhoneHealthKitHeartRateProvider.start(at: acquisitionStartedAt)
+                guard nativeHeartRateProviderLifecycle.acceptsProviderCompletion(
+                    generation: providerGeneration,
+                    attemptID: intent.id
+                ) else { return }
                 let effects = nativeHeartRatePreflightEngine.collectionStarted(
                     intentID: intent.id,
                     acquisitionStartedAt: acquisitionStartedAt,
@@ -4364,8 +4382,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 appendLog("Native HR collection started: intent=\(intent.id.uuidString)")
                 syncNativeHeartRatePreflightPresentation()
             } catch {
-                guard nativeHeartRatePreflightEngine.ownsUncommittedWorkout else { return }
-                nativeHeartRateProviderFailed()
+                nativeHeartRateProviderFailed(
+                    generation: providerGeneration,
+                    attemptID: intent.id
+                )
             }
         }
     }
@@ -4373,6 +4393,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private func handleNativeHeartRateObservation(
         _ observation: HeartRateProviderObservation
     ) {
+        guard nativeHeartRateFlowOwnsController,
+              nativeHeartRateProviderLifecycle.acceptsObservation(
+                providerIsCollecting: iPhoneHealthKitHeartRateProvider.state == .collecting
+              ) else {
+            nativeHeartRateLogger.info("stale_observation_ignored")
+            return
+        }
         let now = Date()
         let factualDate = observation.measuredAt ?? observation.receivedAt
         let ageSeconds = max(0, Int(now.timeIntervalSince(factualDate)))
@@ -4392,7 +4419,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             staleThresholdSeconds: hrStaleThresholdSeconds
         )
         isNativeHeartRateCurrent = hrStreamingActive
-        observeHeartRateDelivery(observation, recordedAt: now)
+        let normalization = normalizeHeartRateDelivery(observation, recordedAt: now)
         appendLog("Native HR value: \(observation.beatsPerMinute)")
         logTrainingEvent("hr_sample", fields: [
             "hr_bpm": observation.beatsPerMinute,
@@ -4405,14 +4432,23 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             measuredAt: observation.measuredAt,
             receivedAt: observation.receivedAt
         )
-        applyNativeHeartRatePreflightEffects(
-            nativeHeartRatePreflightEngine.receive(
-                preflightObservation,
-                safety: nativeHeartRateSafetyFacts(now: now),
-                now: now,
-                freshnessLimit: TimeInterval(hrStaleThresholdSeconds)
-            )
+        let effects = nativeHeartRatePreflightEngine.receive(
+            preflightObservation,
+            safety: nativeHeartRateSafetyFacts(now: now),
+            now: now,
+            freshnessLimit: TimeInterval(hrStaleThresholdSeconds)
         )
+        if nativeHeartRatePreflightEngine.pendingObservation == preflightObservation
+            || effects.contains(where: { effect in
+                guard case .commit(_, let observation, _) = effect else { return false }
+                return observation == preflightObservation
+            })
+        {
+            pendingNativePreflightHeartRate = normalization
+        } else if !nativeHeartRatePreflightEngine.hasStartIntent {
+            publishHeartRateNormalization(normalization)
+        }
+        applyNativeHeartRatePreflightEffects(effects)
     }
 
     private func commitNativeHeartRatePreflight(
@@ -4461,8 +4497,20 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         nativeHeartRateLogger.info("preflight_cancelled reason=\(reason.rawValue, privacy: .public)")
         nativeHeartRateFlowOwnsController = false
         isNativeHeartRateCurrent = false
+        hrStreamingActive = false
+        hrLastValueAt = nil
+        heartRateBPM = 0
+        pendingNativePreflightHeartRate = nil
+        let cleanupGeneration = nativeHeartRateProviderLifecycle.beginCleanup()
         Task { @MainActor [weak self] in
-            await self?.iPhoneHealthKitHeartRateProvider.discard(at: Date())
+            guard let self else { return }
+            await iPhoneHealthKitHeartRateProvider.discard(at: Date())
+            guard nativeHeartRateProviderLifecycle.completeCleanup(
+                generation: cleanupGeneration,
+                providerIsIdle: iPhoneHealthKitHeartRateProvider.state == .idle
+            ) else { return }
+            recomputeHrStartAllowed()
+            warmNativeHeartRateProviderIfPossible()
         }
         if reason == .timeout || reason == .providerFailure {
             infoToastMessage = "Пульс не получен. Проверьте подключение и посадку датчика, а также доступ к данным «Здоровье»."
@@ -4475,17 +4523,36 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         nativeHealthKitWorkoutCommitted = false
         nativeHeartRateFlowOwnsController = false
         isNativeHeartRateCurrent = false
+        hrStreamingActive = false
+        hrLastValueAt = nil
+        heartRateBPM = 0
         nativePreflightCommitTimestamps = nil
+        pendingNativePreflightHeartRate = nil
         appendLog("Native HR flow aborted before motion: \(reason.rawValue)")
         nativeHeartRateLogger.info("preflight_aborted reason=\(reason.rawValue, privacy: .public)")
+        let cleanupGeneration = nativeHeartRateProviderLifecycle.beginCleanup()
         Task { @MainActor [weak self] in
-            await self?.iPhoneHealthKitHeartRateProvider.discard(at: Date())
+            guard let self else { return }
+            await iPhoneHealthKitHeartRateProvider.discard(at: Date())
+            guard nativeHeartRateProviderLifecycle.completeCleanup(
+                generation: cleanupGeneration,
+                providerIsIdle: iPhoneHealthKitHeartRateProvider.state == .idle
+            ) else { return }
+            recomputeHrStartAllowed()
+            warmNativeHeartRateProviderIfPossible()
         }
         syncNativeHeartRatePreflightPresentation()
         recomputeHrStartAllowed()
     }
 
-    private func nativeHeartRateProviderFailed() {
+    private func nativeHeartRateProviderFailed(
+        generation: UInt64,
+        attemptID: UUID? = nil
+    ) {
+        guard nativeHeartRateProviderLifecycle.acceptsProviderCompletion(
+            generation: generation,
+            attemptID: attemptID
+        ) else { return }
         hrStreamingActive = false
         isNativeHeartRateCurrent = false
         hrLastValueAt = nil
@@ -4582,6 +4649,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let preflightGatesAllowStart = safety.permitsStartIntent
             && IPhoneHealthKitLiveHeartRateProvider.isSupported
             && !nativeHeartRatePreflightEngine.hasStartIntent
+            && !nativeHeartRateProviderLifecycle.cleanupInFlight
         let unitsDecision = controllerUnitsGateDecision(now: now)
         isHrControlStartAllowed = preflightGatesAllowStart
         if !preflightGatesAllowStart {
@@ -6485,6 +6553,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 nativeHeartRateFlowOwnsController = false
                 isNativeHeartRateCurrent = false
                 nativeHealthKitAcquisitionStartedAt = nil
+                nativeHeartRateProviderLifecycle.releaseCommittedProvider()
                 recomputeHrStartAllowed()
                 warmNativeHeartRateProviderIfPossible()
             }
@@ -6826,15 +6895,50 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         _ observation: HeartRateProviderObservation,
         recordedAt: Date
     ) {
-        let result = heartRateObservationNormalizer.normalize(
+        publishHeartRateNormalization(
+            normalizeHeartRateDelivery(observation, recordedAt: recordedAt)
+        )
+    }
+
+    private func normalizeHeartRateDelivery(
+        _ observation: HeartRateProviderObservation,
+        recordedAt: Date
+    ) -> HeartRateNormalizationResult {
+        heartRateObservationNormalizer.normalize(
             observation,
             canonicalObservationID: HeartRateCanonicalObservationID(),
             deliveryID: HeartRateDeliveryID(),
             recordedAt: recordedAt
         )
+    }
+
+    private func publishHeartRateNormalization(
+        _ result: HeartRateNormalizationResult
+    ) {
         latestHeartRateDelivery = result.delivery
         attachTelemetryDeliveryToLatestHrTrendSample(result.delivery)
         _ = heartRateTelemetrySink?.observeHeartRate(result)
+    }
+
+    private func persistQualifyingNativeHeartRateBeforeMotion() {
+        guard let result = pendingNativePreflightHeartRate else { return }
+        pendingNativePreflightHeartRate = nil
+        let disposition = heartRateTelemetrySink?.observeHeartRate(result) ?? .unavailable
+        guard disposition == .accepted else {
+            latestHeartRateDelivery = nil
+            return
+        }
+
+        latestHeartRateDelivery = result.delivery
+        let sampleDate = result.canonicalObservation?.measuredAt
+            ?? result.delivery.receivedAt
+        recordHrSample(result.delivery.beatsPerMinute, at: sampleDate)
+        attachTelemetryDeliveryToLatestHrTrendSample(result.delivery)
+        observeHeartRateControlUse(HeartRateControlUseEvidence(
+            kind: .speedDecision,
+            inputs: [result.delivery.causalReference],
+            occurredAt: Date()
+        ))
     }
 
     private func observeHeartRateSourceLifecycle(

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -4238,35 +4238,53 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 #endif
             return nativeHeartRateAppActivity
         }()
-        let stopInProgress = stopObservationLifecycle?.finalResult == nil
-            || unavailableStopAttempt != nil
+        let stopInProgress = NativeHeartRatePreflightEngine.RuntimePolicy.stopInProgress(
+            hasObservationLifecycle: stopObservationLifecycle != nil,
+            observationHasFinalResult: stopObservationLifecycle?.finalResult != nil,
+            hasUnavailableAttempt: unavailableStopAttempt != nil
+        )
         return NativeHeartRatePreflightEngine.SafetyFacts(
             appActivity: effectiveAppActivity,
             treadmillControlReady: isTreadmillControlReady,
             transportValid: nativeHeartRateTransportIsValid,
             controllerUnitsAllowed: controllerUnitsGateDecision(now: now).allowed,
-            hasConflictingWorkout: isHrControlRunning
-                || treadmillTestRunIsActive
-                || nativeHealthKitWorkoutCommitted
-                || nativeHealthKitWorkoutFinishInFlight,
+            hasConflictingWorkout: NativeHeartRatePreflightEngine.RuntimePolicy
+                .hasConflictingWorkout(
+                    isHrControlRunning: isHrControlRunning,
+                    treadmillTestRunIsActive: treadmillTestRunIsActive,
+                    nativeWorkoutCommitted: nativeHealthKitWorkoutCommitted,
+                    nativeFlowOwnsController: nativeHeartRateFlowOwnsController,
+                    nativeWorkoutFinishInFlight: nativeHealthKitWorkoutFinishInFlight
+                ),
             stopInProgress: stopInProgress,
             telemetryAvailability: .healthy
         )
     }
 
     private func warmNativeHeartRateProviderIfPossible() {
-        guard isTrainingHubVisible,
-              nativeHeartRateAppActivity == .active,
-              !isHrControlRunning,
-              IPhoneHealthKitLiveHeartRateProvider.isSupported else { return }
+        guard NativeHeartRatePreflightEngine.RuntimePolicy.canWarmPrepare(
+            isTrainingHubVisible: isTrainingHubVisible,
+            appActivity: nativeHeartRateAppActivity,
+            isHrControlRunning: isHrControlRunning,
+            nativeWorkoutCommitted: nativeHealthKitWorkoutCommitted,
+            nativeWorkoutFinishInFlight: nativeHealthKitWorkoutFinishInFlight,
+            providerIsIdle: iPhoneHealthKitHeartRateProvider.state == .idle,
+            providerIsSupported: IPhoneHealthKitLiveHeartRateProvider.isSupported
+        ) else { return }
         Task { @MainActor [weak self] in
             guard let self else { return }
             let canPrepare = await iPhoneHealthKitHeartRateProvider
                 .canPrepareWithoutAuthorizationPrompt()
             guard canPrepare,
-                  isTrainingHubVisible,
-                  nativeHeartRateAppActivity == .active,
-                  !isHrControlRunning else { return }
+                  NativeHeartRatePreflightEngine.RuntimePolicy.canWarmPrepare(
+                    isTrainingHubVisible: isTrainingHubVisible,
+                    appActivity: nativeHeartRateAppActivity,
+                    isHrControlRunning: isHrControlRunning,
+                    nativeWorkoutCommitted: nativeHealthKitWorkoutCommitted,
+                    nativeWorkoutFinishInFlight: nativeHealthKitWorkoutFinishInFlight,
+                    providerIsIdle: iPhoneHealthKitHeartRateProvider.state == .idle,
+                    providerIsSupported: IPhoneHealthKitLiveHeartRateProvider.isSupported
+                  ) else { return }
             applyNativeHeartRatePreflightEffects(
                 nativeHeartRatePreflightEngine.requestWarmPreparation()
             )
@@ -4334,10 +4352,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             guard let self else { return }
             do {
                 try await iPhoneHealthKitHeartRateProvider.start(at: acquisitionStartedAt)
-                nativeHeartRatePreflightEngine.collectionStarted(
+                let effects = nativeHeartRatePreflightEngine.collectionStarted(
                     intentID: intent.id,
-                    acquisitionStartedAt: acquisitionStartedAt
+                    acquisitionStartedAt: acquisitionStartedAt,
+                    now: Date()
                 )
+                applyNativeHeartRatePreflightEffects(effects)
+                guard nativeHeartRatePreflightEngine.hasStartIntent else { return }
                 nativeHealthKitAcquisitionStartedAt = acquisitionStartedAt
                 nativeHeartRateLogger.info("collection_started")
                 appendLog("Native HR collection started: intent=\(intent.id.uuidString)")
@@ -4400,15 +4421,20 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         acquisitionStartedAt: Date
     ) {
         let now = Date()
-        guard nativeHeartRateFlowOwnsController,
-              !nativeHealthKitWorkoutCommitted,
-              iPhoneHealthKitHeartRateProvider.state == .collecting,
-              observation.isQualifying(
-                collectionStartedAt: acquisitionStartedAt,
-                now: now,
-                freshnessLimit: TimeInterval(hrStaleThresholdSeconds)
-              ),
-              nativeHeartRateSafetyFacts(now: now).permitsCommit else {
+        let observationIsQualifying = observation.isQualifying(
+            collectionStartedAt: acquisitionStartedAt,
+            now: now,
+            freshnessLimit: TimeInterval(hrStaleThresholdSeconds)
+        )
+        guard NativeHeartRatePreflightEngine.RuntimePolicy.permitsProductionCommit(
+            intent: intent,
+            now: now,
+            flowOwnsController: nativeHeartRateFlowOwnsController,
+            nativeWorkoutAlreadyCommitted: nativeHealthKitWorkoutCommitted,
+            providerIsCollecting: iPhoneHealthKitHeartRateProvider.state == .collecting,
+            observationIsQualifying: observationIsQualifying,
+            safety: nativeHeartRateSafetyFacts(now: now)
+        ) else {
             abortNativeHeartRateFlow(reason: .superseded)
             return
         }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -85,6 +85,7 @@ struct ContentView: View {
             guard !isTrainingPreviewLaunch else { return }
             #endif
             manager.start()
+            updateNativeHeartRateLifecycle(scenePhase)
         }
         .onChange(of: scenePhase) { _, phase in
             #if DEBUG
@@ -95,11 +96,25 @@ struct ContentView: View {
             } else {
                 manager.treadmillTestRunAppBecameInactive()
             }
+            updateNativeHeartRateLifecycle(phase)
 #if STOP_TRUTH_EXPERIMENT_CAPABILITY
             if phase != .active {
                 manager.stopTruthExperimentAppBecameInactive()
             }
 #endif
+        }
+    }
+
+    private func updateNativeHeartRateLifecycle(_ phase: ScenePhase) {
+        switch phase {
+        case .active:
+            manager.nativeHeartRateAppBecameActive()
+        case .inactive:
+            manager.nativeHeartRateAppBecameInactive()
+        case .background:
+            manager.nativeHeartRateAppEnteredBackground()
+        @unknown default:
+            manager.nativeHeartRateAppEnteredBackground()
         }
     }
 }
@@ -316,7 +331,6 @@ private func makeHRControlTrainingHubPresentation(
     let startBlocker: String? = {
         guard !startEnabled, !isPreparing else { return nil }
         if !treadmillConnected { return "Подключите дорожку" }
-        if !hrFresh { return "Дождитесь свежего пульса" }
         guard let runtimeBlockReason, !runtimeBlockReason.isEmpty else {
             return "Тренировка пока недоступна"
         }
@@ -351,7 +365,7 @@ private func makeHRControlTrainingHubPresentation(
                 title: "Пульс",
                 value: hrFresh
                     ? currentHeartRateBPM.map { "\($0) bpm" } ?? "Доступен"
-                    : "Нет",
+                    : (isPreparing ? "Ожидание" : "При старте"),
                 sourceLabel: hrFresh ? heartRateSourceLabel : nil,
                 systemImage: "heart.fill",
                 tint: hrFresh ? .green : .orange,
@@ -1062,13 +1076,14 @@ private struct TrainingHubView: View {
     let onDurationSelect: (Int) -> Void
     let onSettingsTap: () -> Void
     let onStart: () -> Void
+    let onCancel: () -> Void
 
     var body: some View {
         ScrollView {
             VStack(spacing: 14) {
                 TrainingReadinessStrip(
                     items: presentation.readiness,
-                    treadmillInteractive: !presentation.isPreview,
+                    treadmillInteractive: !presentation.isPreview && !presentation.isPreparing,
                     onTreadmillTap: onTreadmillTap
                 )
                 hero
@@ -1103,7 +1118,7 @@ private struct TrainingHubView: View {
             if let durationMinutes = presentation.durationMinutes {
                 TrainingDurationPresetSelector(
                     selectedMinutes: durationMinutes,
-                    interactive: !presentation.isPreview,
+                    interactive: !presentation.isPreview && !presentation.isPreparing,
                     onSelect: onDurationSelect
                 )
             }
@@ -1115,7 +1130,7 @@ private struct TrainingHubView: View {
                 }
             }
 
-            if !presentation.isPreview {
+            if !presentation.isPreview && !presentation.isPreparing {
                 Button(action: onSettingsTap) {
                     HStack {
                         Label("Параметры", systemImage: "slider.horizontal.3")
@@ -1204,7 +1219,7 @@ private struct TrainingHubView: View {
             selectedSegmentID: presentation.selectedSegmentID,
             liveMarkerBPM: nil,
             targetThresholdBPM: nil,
-            interactive: !presentation.isPreview,
+            interactive: !presentation.isPreview && !presentation.isPreparing,
             onSegmentTap: onZoneTap
         )
     }
@@ -1245,16 +1260,22 @@ private struct TrainingHubView: View {
             }
 
             if presentation.isPreparing {
-                HStack(spacing: 10) {
+                VStack(spacing: 10) {
                     ProgressView()
-                    Text("Подготовка…")
+                    Text("Получаем пульс…")
                         .font(.headline)
+                    Text("Дорожка запустится автоматически, когда появится пульс.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                    Button("Отмена", role: .cancel, action: onCancel)
+                        .buttonStyle(.bordered)
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 14)
                 .background(Color.accentColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
                 .accessibilityElement(children: .combine)
-                .accessibilityLabel("Подготовка тренировки")
+                .accessibilityLabel("Получаем пульс. Дорожка запустится автоматически, когда появится пульс.")
             } else {
                 Button {
                     guard !presentation.isPreview else { return }
@@ -1873,16 +1894,17 @@ private struct ControlSwipeView: View {
     private var productionTrainingHubPresentation: TrainingHubPresentation {
         makeHRControlTrainingHubPresentation(
             treadmillConnected: manager.isTreadmillControlReady,
-            hrFresh: manager.hrStreamingActive,
-            currentHeartRateBPM: manager.hrStreamingActive && manager.heartRateBPM > 0
+            hrFresh: manager.isNativeHeartRateCurrent && manager.hrStreamingActive,
+            currentHeartRateBPM: manager.isNativeHeartRateCurrent && manager.hrStreamingActive && manager.heartRateBPM > 0
                 ? manager.heartRateBPM
                 : nil,
-            heartRateSourceLabel: nil,
+            heartRateSourceLabel: manager.isNativeHeartRateCurrent ? "HealthKit" : nil,
             targetZoneIndex: hrZoneIndex(for: manager.hrTargetBPM, manager: manager),
             zoneRanges: hrZoneRanges(for: manager),
             durationMinutes: manager.hrDurationMinutes,
             startEnabled: manager.isHrControlStartAffordanceAvailable,
-            runtimeBlockReason: manager.hrControlStartBlockReasonText
+            runtimeBlockReason: manager.hrControlStartBlockReasonText,
+            isPreparing: manager.isNativeHeartRatePreflightActive
         )
     }
 
@@ -1914,11 +1936,11 @@ private struct ControlSwipeView: View {
 
         return makeHRControlActivePresentation(
             treadmillConnected: manager.isTreadmillControlReady,
-            hrFresh: manager.hrStreamingActive,
-            currentHeartRateBPM: manager.hrStreamingActive && manager.heartRateBPM > 0
+            hrFresh: manager.isNativeHeartRateCurrent && manager.hrStreamingActive,
+            currentHeartRateBPM: manager.isNativeHeartRateCurrent && manager.hrStreamingActive && manager.heartRateBPM > 0
                 ? manager.heartRateBPM
                 : nil,
-            heartRateSourceLabel: nil,
+            heartRateSourceLabel: manager.isNativeHeartRateCurrent ? "HealthKit" : nil,
             targetZoneIndex: hrZoneIndex(for: manager.hrTargetBPM, manager: manager),
             zoneRanges: hrZoneRanges(for: manager),
             factualSpeedKmh: factualSpeedKmh,
@@ -2039,8 +2061,11 @@ private struct ControlSwipeView: View {
             },
             onDurationSelect: { manager.hrDurationMinutes = $0 },
             onSettingsTap: { showParameters = true },
-            onStart: { manager.startHrControl() }
+            onStart: { manager.startHrControl() },
+            onCancel: { manager.cancelNativeHeartRatePreflight() }
         )
+        .onAppear { manager.trainingHubDidAppear() }
+        .onDisappear { manager.trainingHubDidDisappear() }
     }
 
     private func currentFactualDistanceReading() -> TrainingDistanceReading? {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/IPhoneHealthKitLiveHeartRateProvider.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/IPhoneHealthKitLiveHeartRateProvider.swift
@@ -6,6 +6,7 @@ import TelemetryDomain
 @MainActor
 final class IPhoneHealthKitLiveHeartRateProvider {
     typealias ObservationHandler = (HeartRateProviderObservation) -> Void
+    typealias FailureHandler = () -> Void
 
     private let driver: HealthKitLiveWorkoutDriver
     private let core: IPhoneHealthKitHeartRateProviderCore<HealthKitLiveWorkoutDriver>
@@ -14,6 +15,8 @@ final class IPhoneHealthKitLiveHeartRateProvider {
         get { core.onObservation }
         set { core.onObservation = newValue }
     }
+
+    var onFailure: FailureHandler?
 
     var state: IPhoneHealthKitHeartRateProviderState {
         core.state
@@ -29,11 +32,20 @@ final class IPhoneHealthKitLiveHeartRateProvider {
                 core?.receive(sample)
             }
         }
-        driver.onRuntimeFailure = { [weak core] in
+        driver.onRuntimeFailure = { [weak self, weak core] in
             Task { @MainActor in
                 await core?.resetAfterFailure()
+                self?.onFailure?()
             }
         }
+    }
+
+    static var isSupported: Bool {
+        HKHealthStore.isHealthDataAvailable()
+    }
+
+    func canPrepareWithoutAuthorizationPrompt() async -> Bool {
+        await driver.canPrepareWithoutAuthorizationPrompt()
     }
 
     func prepare(configuration: HKWorkoutConfiguration) async throws {
@@ -91,8 +103,25 @@ private final class HealthKitLiveWorkoutDriver: NSObject, IPhoneHealthKitWorkout
             read: typesToRead
         )
 
-        guard status != .unnecessary else { return }
-        try await healthStore.requestAuthorization(toShare: typesToShare, read: typesToRead)
+        if status != .unnecessary {
+            try await healthStore.requestAuthorization(toShare: typesToShare, read: typesToRead)
+        }
+        guard healthStore.authorizationStatus(for: HKObjectType.workoutType()) == .sharingAuthorized else {
+            throw HealthKitLiveWorkoutDriverError.authorizationNotGranted
+        }
+    }
+
+    func canPrepareWithoutAuthorizationPrompt() async -> Bool {
+        guard HKHealthStore.isHealthDataAvailable(),
+              let heartRateType = HKQuantityType.quantityType(forIdentifier: .heartRate),
+              healthStore.authorizationStatus(for: HKObjectType.workoutType()) == .sharingAuthorized else {
+            return false
+        }
+        let status = try? await healthStore.statusForAuthorizationRequest(
+            toShare: [HKObjectType.workoutType()],
+            read: [heartRateType]
+        )
+        return status == .unnecessary
     }
 
     func createWorkout(configuration: HKWorkoutConfiguration) throws {
@@ -105,10 +134,17 @@ private final class HealthKitLiveWorkoutDriver: NSObject, IPhoneHealthKitWorkout
             configuration: configuration
         )
         let builder = session.associatedWorkoutBuilder()
-        builder.dataSource = HKLiveWorkoutDataSource(
+        let dataSource = HKLiveWorkoutDataSource(
             healthStore: healthStore,
             workoutConfiguration: configuration
         )
+        if let heartRateType = HKQuantityType.quantityType(forIdentifier: .heartRate) {
+            for quantityType in dataSource.typesToCollect where quantityType != heartRateType {
+                dataSource.disableCollection(for: quantityType)
+            }
+            dataSource.enableCollection(for: heartRateType, predicate: nil)
+        }
+        builder.dataSource = dataSource
         session.delegate = self
         builder.delegate = self
         self.session = session
@@ -326,6 +362,7 @@ extension HealthKitLiveWorkoutDriver: HKWorkoutSessionDelegate, HKLiveWorkoutBui
 
 @available(iOS 26.0, *)
 private enum HealthKitLiveWorkoutDriverError: LocalizedError {
+    case authorizationNotGranted
     case healthDataUnavailable
     case missingWorkout
     case operationCancelled
@@ -334,6 +371,8 @@ private enum HealthKitLiveWorkoutDriverError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
+        case .authorizationNotGranted:
+            "HealthKit workout access was not granted."
         case .healthDataUnavailable:
             "HealthKit data is unavailable on this device."
         case .missingWorkout:

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/IPhoneHealthKitLiveHeartRateProvider.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/IPhoneHealthKitLiveHeartRateProvider.swift
@@ -6,10 +6,11 @@ import TelemetryDomain
 @MainActor
 final class IPhoneHealthKitLiveHeartRateProvider {
     typealias ObservationHandler = (HeartRateProviderObservation) -> Void
-    typealias FailureHandler = () -> Void
+    typealias FailureHandler = (IPhoneHealthKitRuntimeFailureContext) -> Void
 
     private let driver: HealthKitLiveWorkoutDriver
     private let core: IPhoneHealthKitHeartRateProviderCore<HealthKitLiveWorkoutDriver>
+    private var runtimeFailureContext: IPhoneHealthKitRuntimeFailureContext?
 
     var onObservation: ObservationHandler? {
         get { core.onObservation }
@@ -32,10 +33,20 @@ final class IPhoneHealthKitLiveHeartRateProvider {
                 core?.receive(sample)
             }
         }
-        driver.onRuntimeFailure = { [weak self, weak core] in
+        driver.onRuntimeFailure = { [weak self, weak core] context in
             Task { @MainActor in
+                guard let self else { return }
+                guard self.runtimeFailureContext == context else {
+                    self.onFailure?(context)
+                    return
+                }
                 await core?.resetAfterFailure()
-                self?.onFailure?()
+                guard self.runtimeFailureContext == context else {
+                    self.onFailure?(context)
+                    return
+                }
+                self.runtimeFailureContext = nil
+                self.onFailure?(context)
             }
         }
     }
@@ -48,8 +59,25 @@ final class IPhoneHealthKitLiveHeartRateProvider {
         await driver.canPrepareWithoutAuthorizationPrompt()
     }
 
-    func prepare(configuration: HKWorkoutConfiguration) async throws {
-        try await core.prepare(configuration: configuration)
+    func prepare(
+        configuration: HKWorkoutConfiguration,
+        failureContext: IPhoneHealthKitRuntimeFailureContext
+    ) async throws {
+        runtimeFailureContext = failureContext
+        driver.setNextRuntimeFailureContext(failureContext)
+        do {
+            try await core.prepare(configuration: configuration)
+        } catch {
+            if runtimeFailureContext == failureContext {
+                runtimeFailureContext = nil
+            }
+            throw error
+        }
+    }
+
+    func bindRuntimeFailureContext(_ context: IPhoneHealthKitRuntimeFailureContext) {
+        runtimeFailureContext = context
+        driver.updateCurrentRuntimeFailureContext(context)
     }
 
     func start(at date: Date = Date()) async throws {
@@ -57,13 +85,23 @@ final class IPhoneHealthKitLiveHeartRateProvider {
     }
 
     func discard(at date: Date = Date()) async {
+        let discardedContext = runtimeFailureContext
         await core.discard(at: date)
+        if runtimeFailureContext == discardedContext {
+            runtimeFailureContext = nil
+        }
     }
 
     func finish(
         at date: Date = Date()
     ) async throws -> IPhoneHealthKitWorkoutFinishOutcome<HKWorkout> {
-        try await core.finish(at: date)
+        let finishedContext = runtimeFailureContext
+        defer {
+            if runtimeFailureContext == finishedContext {
+                runtimeFailureContext = nil
+            }
+        }
+        return try await core.finish(at: date)
     }
 }
 
@@ -73,7 +111,7 @@ private final class HealthKitLiveWorkoutDriver: NSObject, IPhoneHealthKitWorkout
     typealias Workout = HKWorkout
 
     var onHeartRateSample: ((IPhoneHealthKitHeartRateSample) -> Void)?
-    var onRuntimeFailure: (() -> Void)?
+    var onRuntimeFailure: ((IPhoneHealthKitRuntimeFailureContext) -> Void)?
 
     private let healthStore: HKHealthStore
     private var session: HKWorkoutSession?
@@ -84,9 +122,21 @@ private final class HealthKitLiveWorkoutDriver: NSObject, IPhoneHealthKitWorkout
     private var stoppedAt: Date?
     private var endCollectionContinuation: CheckedContinuation<Void, Error>?
     private var finishContinuation: CheckedContinuation<HKWorkout?, Error>?
+    private var nextRuntimeFailureContext: IPhoneHealthKitRuntimeFailureContext?
+    private var runtimeFailureContexts: [ObjectIdentifier: IPhoneHealthKitRuntimeFailureContext] = [:]
+    private var runtimeFailureContextOrder: [ObjectIdentifier] = []
 
     init(healthStore: HKHealthStore) {
         self.healthStore = healthStore
+    }
+
+    func setNextRuntimeFailureContext(_ context: IPhoneHealthKitRuntimeFailureContext) {
+        nextRuntimeFailureContext = context
+    }
+
+    func updateCurrentRuntimeFailureContext(_ context: IPhoneHealthKitRuntimeFailureContext) {
+        guard let session else { return }
+        retainRuntimeFailureContext(context, for: session)
     }
 
     func requestAuthorization() async throws {
@@ -149,6 +199,10 @@ private final class HealthKitLiveWorkoutDriver: NSObject, IPhoneHealthKitWorkout
         builder.delegate = self
         self.session = session
         self.builder = builder
+        if let nextRuntimeFailureContext {
+            retainRuntimeFailureContext(nextRuntimeFailureContext, for: session)
+            self.nextRuntimeFailureContext = nil
+        }
     }
 
     func prepare() async throws {
@@ -284,6 +338,20 @@ private final class HealthKitLiveWorkoutDriver: NSObject, IPhoneHealthKitWorkout
             )
         }
     }
+
+    private func retainRuntimeFailureContext(
+        _ context: IPhoneHealthKitRuntimeFailureContext,
+        for session: HKWorkoutSession
+    ) {
+        let identifier = ObjectIdentifier(session)
+        runtimeFailureContexts[identifier] = context
+        runtimeFailureContextOrder.removeAll { $0 == identifier }
+        runtimeFailureContextOrder.append(identifier)
+        while runtimeFailureContextOrder.count > 8 {
+            let expiredIdentifier = runtimeFailureContextOrder.removeFirst()
+            runtimeFailureContexts.removeValue(forKey: expiredIdentifier)
+        }
+    }
 }
 
 @available(iOS 26.0, *)
@@ -316,14 +384,21 @@ extension HealthKitLiveWorkoutDriver: HKWorkoutSessionDelegate, HKLiveWorkoutBui
 
     func workoutSession(_ workoutSession: HKWorkoutSession, didFailWithError error: Error) {
         DispatchQueue.main.async { [weak self] in
-            guard let self, workoutSession === self.session else { return }
-            let continuation = self.prepareContinuation
-            self.prepareContinuation = nil
-            continuation?.resume(throwing: error)
-            let stoppedContinuation = self.stoppedTransitionContinuation
-            self.stoppedTransitionContinuation = nil
-            stoppedContinuation?.resume(throwing: error)
-            self.onRuntimeFailure?()
+            guard let self else { return }
+            let identifier = ObjectIdentifier(workoutSession)
+            guard let failureContext = self.runtimeFailureContexts.removeValue(
+                forKey: identifier
+            ) else { return }
+            self.runtimeFailureContextOrder.removeAll { $0 == identifier }
+            if workoutSession === self.session {
+                let continuation = self.prepareContinuation
+                self.prepareContinuation = nil
+                continuation?.resume(throwing: error)
+                let stoppedContinuation = self.stoppedTransitionContinuation
+                self.stoppedTransitionContinuation = nil
+                stoppedContinuation?.resume(throwing: error)
+            }
+            self.onRuntimeFailure?(failureContext)
         }
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
@@ -1,0 +1,269 @@
+import Foundation
+
+struct NativeHeartRatePreflightEngine {
+    static let timeoutSeconds: TimeInterval = 30
+
+    struct Intent: Equatable {
+        let id: UUID
+        let targetBPM: Int
+        let durationMinutes: Int
+        let requestedAt: Date
+    }
+
+    enum ObservationSource: Equatable {
+        case nativeHealthKit
+        case legacyWatch
+    }
+
+    struct Observation: Equatable {
+        let source: ObservationSource
+        let beatsPerMinute: Int
+        let measuredAt: Date?
+        let receivedAt: Date
+
+        func isQualifying(
+            collectionStartedAt: Date,
+            now: Date,
+            freshnessLimit: TimeInterval
+        ) -> Bool {
+            guard source == .nativeHealthKit,
+                  beatsPerMinute > 0,
+                  receivedAt >= collectionStartedAt else {
+                return false
+            }
+            let factualDate = measuredAt ?? receivedAt
+            return factualDate >= collectionStartedAt
+                && now.timeIntervalSince(factualDate) <= freshnessLimit
+        }
+    }
+
+    enum AppActivity: Equatable {
+        case active
+        case inactive
+        case background
+    }
+
+    enum TelemetryAvailability: Equatable {
+        case healthy
+        case degraded
+        case unavailable
+    }
+
+    struct SafetyFacts: Equatable {
+        let appActivity: AppActivity
+        let treadmillControlReady: Bool
+        let transportValid: Bool
+        let controllerUnitsAllowed: Bool
+        let hasConflictingWorkout: Bool
+        let stopInProgress: Bool
+        let telemetryAvailability: TelemetryAvailability
+
+        var permitsStartIntent: Bool {
+            appActivity == .active
+                && treadmillControlReady
+                && transportValid
+                && !hasConflictingWorkout
+                && !stopInProgress
+        }
+
+        var permitsCommit: Bool {
+            permitsStartIntent && controllerUnitsAllowed
+        }
+    }
+
+    enum CancellationReason: String, Equatable {
+        case user
+        case timeout
+        case treadmillControlLost
+        case appBackgrounded
+        case providerFailure
+        case hubLeft
+        case superseded
+    }
+
+    enum Effect: Equatable {
+        case prepare
+        case startCollection(intent: Intent, acquisitionStartedAt: Date)
+        case commit(
+            intent: Intent,
+            observation: Observation,
+            acquisitionStartedAt: Date
+        )
+        case discard(reason: CancellationReason)
+    }
+
+    private enum Phase: Equatable {
+        case idle
+        case warming
+        case prepared
+        case preparing(Intent)
+        case starting(Intent, acquisitionStartedAt: Date)
+        case waiting(
+            Intent,
+            acquisitionStartedAt: Date,
+            observation: Observation?
+        )
+    }
+
+    private var phase: Phase = .idle
+
+    var isWarmPrepared: Bool { phase == .prepared }
+
+    var hasStartIntent: Bool {
+        switch phase {
+        case .preparing, .starting, .waiting:
+            true
+        case .idle, .warming, .prepared:
+            false
+        }
+    }
+
+    var ownsUncommittedWorkout: Bool { phase != .idle }
+
+    mutating func requestWarmPreparation() -> [Effect] {
+        guard phase == .idle else { return [] }
+        phase = .warming
+        return [.prepare]
+    }
+
+    mutating func requestStart(intent: Intent, safety: SafetyFacts) -> [Effect] {
+        guard safety.permitsStartIntent else { return [] }
+        switch phase {
+        case .idle:
+            phase = .preparing(intent)
+            return [.prepare]
+        case .warming:
+            phase = .preparing(intent)
+            return []
+        case .prepared:
+            let acquisitionStartedAt = intent.requestedAt
+            phase = .starting(intent, acquisitionStartedAt: acquisitionStartedAt)
+            return [.startCollection(
+                intent: intent,
+                acquisitionStartedAt: acquisitionStartedAt
+            )]
+        case .preparing, .starting, .waiting:
+            return []
+        }
+    }
+
+    mutating func providerPrepared(at date: Date) -> [Effect] {
+        switch phase {
+        case .warming:
+            phase = .prepared
+            return []
+        case .preparing(let intent):
+            phase = .starting(intent, acquisitionStartedAt: date)
+            return [.startCollection(intent: intent, acquisitionStartedAt: date)]
+        case .idle, .prepared, .starting, .waiting:
+            return []
+        }
+    }
+
+    mutating func collectionStarted(
+        intentID: UUID,
+        acquisitionStartedAt: Date
+    ) {
+        guard case .starting(let intent, let expectedStart) = phase,
+              intent.id == intentID,
+              expectedStart == acquisitionStartedAt else {
+            return
+        }
+        phase = .waiting(
+            intent,
+            acquisitionStartedAt: acquisitionStartedAt,
+            observation: nil
+        )
+    }
+
+    mutating func receive(
+        _ observation: Observation,
+        safety: SafetyFacts,
+        now: Date,
+        freshnessLimit: TimeInterval
+    ) -> [Effect] {
+        guard case .waiting(let intent, let acquisitionStartedAt, _) = phase,
+              observation.isQualifying(
+                collectionStartedAt: acquisitionStartedAt,
+                now: now,
+                freshnessLimit: freshnessLimit
+              ) else {
+            return []
+        }
+        phase = .waiting(
+            intent,
+            acquisitionStartedAt: acquisitionStartedAt,
+            observation: observation
+        )
+        return commitIfAllowed(safety: safety, now: now, freshnessLimit: freshnessLimit)
+    }
+
+    mutating func safetyChanged(
+        _ safety: SafetyFacts,
+        now: Date,
+        freshnessLimit: TimeInterval
+    ) -> [Effect] {
+        guard ownsUncommittedWorkout else { return [] }
+        if safety.appActivity == .background {
+            return cancel(reason: .appBackgrounded)
+        }
+        if !safety.treadmillControlReady || !safety.transportValid {
+            return cancel(reason: .treadmillControlLost)
+        }
+        if safety.hasConflictingWorkout || safety.stopInProgress {
+            return cancel(reason: .superseded)
+        }
+        return commitIfAllowed(safety: safety, now: now, freshnessLimit: freshnessLimit)
+    }
+
+    mutating func tick(now: Date) -> [Effect] {
+        guard let intent = currentIntent,
+              now.timeIntervalSince(intent.requestedAt) >= Self.timeoutSeconds else {
+            return []
+        }
+        return cancel(reason: .timeout)
+    }
+
+    mutating func cancel(reason: CancellationReason) -> [Effect] {
+        guard phase != .idle else { return [] }
+        phase = .idle
+        return [.discard(reason: reason)]
+    }
+
+    private var currentIntent: Intent? {
+        switch phase {
+        case .preparing(let intent),
+             .starting(let intent, _),
+             .waiting(let intent, _, _):
+            intent
+        case .idle, .warming, .prepared:
+            nil
+        }
+    }
+
+    private mutating func commitIfAllowed(
+        safety: SafetyFacts,
+        now: Date,
+        freshnessLimit: TimeInterval
+    ) -> [Effect] {
+        guard safety.permitsCommit,
+              case .waiting(
+                let intent,
+                let acquisitionStartedAt,
+                let observation?
+              ) = phase,
+              observation.isQualifying(
+                collectionStartedAt: acquisitionStartedAt,
+                now: now,
+                freshnessLimit: freshnessLimit
+              ) else {
+            return []
+        }
+        phase = .idle
+        return [.commit(
+            intent: intent,
+            observation: observation,
+            acquisitionStartedAt: acquisitionStartedAt
+        )]
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
@@ -1,5 +1,18 @@
 import Foundation
 
+struct IPhoneHealthKitRuntimeFailureContext: Equatable {
+    let providerGeneration: UInt64
+    let attemptID: UUID?
+}
+
+struct DeferredNativeHealthKitLinkage: Codable, Equatable {
+    let acquisitionStartedAt: Date
+    let finishRequestedAt: Date
+    let profileID: UUID?
+    let telemetrySessionID: UUID?
+    let linksLegacyWorkout: Bool
+}
+
 struct NativeHeartRateProviderLifecycle: Equatable {
     private(set) var generation: UInt64 = 0
     private(set) var attemptID: UUID?

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
@@ -3,6 +3,65 @@ import Foundation
 struct NativeHeartRatePreflightEngine {
     static let timeoutSeconds: TimeInterval = 30
 
+    enum RuntimePolicy {
+        static func stopInProgress(
+            hasObservationLifecycle: Bool,
+            observationHasFinalResult: Bool,
+            hasUnavailableAttempt: Bool
+        ) -> Bool {
+            (hasObservationLifecycle && !observationHasFinalResult)
+                || hasUnavailableAttempt
+        }
+
+        static func hasConflictingWorkout(
+            isHrControlRunning: Bool,
+            treadmillTestRunIsActive: Bool,
+            nativeWorkoutCommitted: Bool,
+            nativeFlowOwnsController: Bool,
+            nativeWorkoutFinishInFlight: Bool
+        ) -> Bool {
+            isHrControlRunning
+                || treadmillTestRunIsActive
+                || nativeWorkoutFinishInFlight
+                || (nativeWorkoutCommitted && !nativeFlowOwnsController)
+        }
+
+        static func canWarmPrepare(
+            isTrainingHubVisible: Bool,
+            appActivity: AppActivity,
+            isHrControlRunning: Bool,
+            nativeWorkoutCommitted: Bool,
+            nativeWorkoutFinishInFlight: Bool,
+            providerIsIdle: Bool,
+            providerIsSupported: Bool
+        ) -> Bool {
+            isTrainingHubVisible
+                && appActivity == .active
+                && !isHrControlRunning
+                && !nativeWorkoutCommitted
+                && !nativeWorkoutFinishInFlight
+                && providerIsIdle
+                && providerIsSupported
+        }
+
+        static func permitsProductionCommit(
+            intent: Intent,
+            now: Date,
+            flowOwnsController: Bool,
+            nativeWorkoutAlreadyCommitted: Bool,
+            providerIsCollecting: Bool,
+            observationIsQualifying: Bool,
+            safety: SafetyFacts
+        ) -> Bool {
+            flowOwnsController
+                && !nativeWorkoutAlreadyCommitted
+                && providerIsCollecting
+                && observationIsQualifying
+                && now < intent.requestedAt.addingTimeInterval(timeoutSeconds)
+                && safety.permitsCommit
+        }
+    }
+
     struct Intent: Equatable {
         let id: UUID
         let targetBPM: Int
@@ -153,6 +212,9 @@ struct NativeHeartRatePreflightEngine {
             phase = .prepared
             return []
         case .preparing(let intent):
+            guard !deadlineReached(for: intent, now: date) else {
+                return cancel(reason: .timeout)
+            }
             phase = .starting(intent, acquisitionStartedAt: date)
             return [.startCollection(intent: intent, acquisitionStartedAt: date)]
         case .idle, .prepared, .starting, .waiting:
@@ -162,18 +224,23 @@ struct NativeHeartRatePreflightEngine {
 
     mutating func collectionStarted(
         intentID: UUID,
-        acquisitionStartedAt: Date
-    ) {
+        acquisitionStartedAt: Date,
+        now: Date
+    ) -> [Effect] {
         guard case .starting(let intent, let expectedStart) = phase,
               intent.id == intentID,
               expectedStart == acquisitionStartedAt else {
-            return
+            return []
+        }
+        guard !deadlineReached(for: intent, now: now) else {
+            return cancel(reason: .timeout)
         }
         phase = .waiting(
             intent,
             acquisitionStartedAt: acquisitionStartedAt,
             observation: nil
         )
+        return []
     }
 
     mutating func receive(
@@ -182,6 +249,10 @@ struct NativeHeartRatePreflightEngine {
         now: Date,
         freshnessLimit: TimeInterval
     ) -> [Effect] {
+        guard let intent = currentIntent else { return [] }
+        guard !deadlineReached(for: intent, now: now) else {
+            return cancel(reason: .timeout)
+        }
         guard case .waiting(let intent, let acquisitionStartedAt, _) = phase,
               observation.isQualifying(
                 collectionStartedAt: acquisitionStartedAt,
@@ -204,6 +275,9 @@ struct NativeHeartRatePreflightEngine {
         freshnessLimit: TimeInterval
     ) -> [Effect] {
         guard ownsUncommittedWorkout else { return [] }
+        if let intent = currentIntent, deadlineReached(for: intent, now: now) {
+            return cancel(reason: .timeout)
+        }
         if safety.appActivity == .background {
             return cancel(reason: .appBackgrounded)
         }
@@ -218,7 +292,7 @@ struct NativeHeartRatePreflightEngine {
 
     mutating func tick(now: Date) -> [Effect] {
         guard let intent = currentIntent,
-              now.timeIntervalSince(intent.requestedAt) >= Self.timeoutSeconds else {
+              deadlineReached(for: intent, now: now) else {
             return []
         }
         return cancel(reason: .timeout)
@@ -246,12 +320,17 @@ struct NativeHeartRatePreflightEngine {
         now: Date,
         freshnessLimit: TimeInterval
     ) -> [Effect] {
-        guard safety.permitsCommit,
-              case .waiting(
+        guard case .waiting(
                 let intent,
                 let acquisitionStartedAt,
                 let observation?
-              ) = phase,
+              ) = phase else {
+            return []
+        }
+        guard !deadlineReached(for: intent, now: now) else {
+            return cancel(reason: .timeout)
+        }
+        guard safety.permitsCommit,
               observation.isQualifying(
                 collectionStartedAt: acquisitionStartedAt,
                 now: now,
@@ -265,5 +344,9 @@ struct NativeHeartRatePreflightEngine {
             observation: observation,
             acquisitionStartedAt: acquisitionStartedAt
         )]
+    }
+
+    private func deadlineReached(for intent: Intent, now: Date) -> Bool {
+        now >= intent.requestedAt.addingTimeInterval(Self.timeoutSeconds)
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
@@ -1,5 +1,59 @@
 import Foundation
 
+struct NativeHeartRateProviderLifecycle: Equatable {
+    private(set) var generation: UInt64 = 0
+    private(set) var attemptID: UUID?
+    private(set) var cleanupGeneration: UInt64?
+
+    var cleanupInFlight: Bool { cleanupGeneration != nil }
+
+    mutating func bindAttempt(_ attemptID: UUID) {
+        guard !cleanupInFlight else { return }
+        self.attemptID = attemptID
+    }
+
+    mutating func beginProviderLifecycle() -> UInt64 {
+        precondition(!cleanupInFlight)
+        generation &+= 1
+        return generation
+    }
+
+    func acceptsProviderCompletion(
+        generation: UInt64,
+        attemptID expectedAttemptID: UUID? = nil
+    ) -> Bool {
+        guard !cleanupInFlight, generation == self.generation else { return false }
+        guard let expectedAttemptID else { return true }
+        return attemptID == expectedAttemptID
+    }
+
+    func acceptsObservation(providerIsCollecting: Bool) -> Bool {
+        !cleanupInFlight && attemptID != nil && providerIsCollecting
+    }
+
+    mutating func beginCleanup() -> UInt64 {
+        generation &+= 1
+        attemptID = nil
+        cleanupGeneration = generation
+        return generation
+    }
+
+    mutating func completeCleanup(
+        generation: UInt64,
+        providerIsIdle: Bool
+    ) -> Bool {
+        guard cleanupGeneration == generation, providerIsIdle else { return false }
+        cleanupGeneration = nil
+        return true
+    }
+
+    mutating func releaseCommittedProvider() {
+        generation &+= 1
+        attemptID = nil
+        cleanupGeneration = nil
+    }
+}
+
 struct NativeHeartRatePreflightEngine {
     static let timeoutSeconds: TimeInterval = 30
 
@@ -178,6 +232,11 @@ struct NativeHeartRatePreflightEngine {
     }
 
     var ownsUncommittedWorkout: Bool { phase != .idle }
+
+    var pendingObservation: Observation? {
+        guard case .waiting(_, _, let observation) = phase else { return nil }
+        return observation
+    }
 
     mutating func requestWarmPreparation() -> [Effect] {
         guard phase == .idle else { return [] }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
@@ -466,7 +466,7 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
         XCTAssertTrue(start.contains("guard isTreadmillControlReady"))
         XCTAssertTrue(slider.contains("guard isTreadmillControlReady"))
         XCTAssertTrue(adjust.contains("guard isTreadmillControlReady"))
-        XCTAssertTrue(hrStart.contains("treadmillConnected: isTreadmillControlReady"))
+        XCTAssertTrue(hrStart.contains("nativeHeartRateSafetyFacts(now: now)"))
         XCTAssertTrue(testRun.contains("isTreadmillControlReady"))
         XCTAssertTrue(speedWrite.contains("guard isTreadmillControlReady"))
         XCTAssertTrue(performWrite.contains("requiresControlReadiness && !isTreadmillControlReady"))

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/DeterministicSemanticControlReplayTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/DeterministicSemanticControlReplayTests.swift
@@ -104,18 +104,28 @@ final class DeterministicSemanticControlReplayTests: XCTestCase {
         XCTAssertTrue(tick.contains("HRDomainService.shouldStopForMissingHeartRateSignal("))
         XCTAssertTrue(tick.contains("CooldownRuntimeEngine.start("))
         XCTAssertTrue(tick.contains("CooldownRuntimeEngine.tick("))
-        XCTAssertTrue(
-            affordance.contains("HRDomainService.heartRateStartAffordanceAvailable(")
+        XCTAssertTrue(affordance.contains("isHrControlStartAllowed"))
+        let commit = try functionBody(
+            "private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)",
+            in: manager
         )
         assertOrdered(
             [
-                "HRDomainService",
-                ".heartRateRuntimePrerequisitesAllowStart(",
-                "guard existingGatesAllowStart",
+                "nativeHeartRatePreflightEngine.requestStart(",
+                "guard nativeHeartRatePreflightEngine.hasStartIntent",
+                "nativeHeartRateFlowOwnsController = true",
+                "applyNativeHeartRatePreflightEffects(effects)",
+            ],
+            in: start
+        )
+        assertOrdered(
+            [
+                "controllerUnitsGateDecision()",
+                "guard nativeHeartRateSafetyFacts().permitsCommit",
                 "isHrControlRunning = true",
                 "startWithSpeed",
             ],
-            in: start
+            in: commit
         )
         XCTAssertTrue(stop.contains("stopBeltWithToggle(reason: \"hr\")"))
         XCTAssertTrue(disconnect.contains("self.isHrControlRunning = false"))

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -179,11 +179,12 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
             "var isHrControlStartAffordanceAvailable: Bool",
             in: managerSource
         )
+        let commit = try functionBody(
+            "private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)",
+            in: managerSource
+        )
 
-        for body in [recompute, start] {
-            XCTAssertTrue(body.contains("HRDomainService"))
-            XCTAssertTrue(body.contains(".heartRateRuntimePrerequisitesAllowStart"))
-            XCTAssertTrue(body.contains("controllerUnits"))
+        for body in [recompute, start, commit] {
             XCTAssertFalse(body.contains("HeartRateControlStartEligibility"))
             XCTAssertFalse(body.contains("HeartRateLegacyControlSemantics"))
             XCTAssertFalse(body.contains("TelemetryRecorder"))
@@ -193,10 +194,13 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
             XCTAssertFalse(body.contains("telemetryPerformanceObservation"))
             XCTAssertFalse(body.contains("TelemetryPerformanceInstrumentation"))
         }
+        XCTAssertTrue(recompute.contains("nativeHeartRateSafetyFacts"))
+        XCTAssertTrue(recompute.contains("controllerUnitsGateDecision"))
+        XCTAssertTrue(start.contains("nativeHeartRatePreflightEngine.requestStart"))
+        XCTAssertTrue(commit.contains("controllerUnitsGateDecision"))
 
-        XCTAssertTrue(affordance.contains("HRDomainService.heartRateStartAffordanceAvailable"))
-        XCTAssertTrue(affordance.contains("treadmillConnected: isTreadmillControlReady"))
-        XCTAssertTrue(affordance.contains("currentHeartRateVisible: hrStreamingActive"))
+        XCTAssertTrue(affordance.contains("isHrControlStartAllowed"))
+        XCTAssertTrue(affordance.contains("!isNativeHeartRatePreflightActive"))
         XCTAssertFalse(affordance.contains("watchReachable"))
         XCTAssertFalse(affordance.contains("controllerUnits"))
         XCTAssertFalse(affordance.contains("telemetry"))
@@ -216,18 +220,23 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
 
         assertOrdered(
             [
-                ".heartRateRuntimePrerequisitesAllowStart",
-                "guard existingGatesAllowStart",
+                "nativeHeartRatePreflightEngine.requestStart(",
+                "guard nativeHeartRatePreflightEngine.hasStartIntent",
+                "nativeHeartRateFlowOwnsController = true",
+                "applyNativeHeartRatePreflightEffects(effects)",
+            ],
+            in: start
+        )
+        assertOrdered(
+            [
                 "let unitsDecision = controllerUnitsGateDecision()",
-                "guard unitsDecision.allowed",
-                "persistBlockedControllerUnitsStart(decision: unitsDecision)",
-                "retryControllerUnitsQueryAfterBlockedStart()",
+                "guard nativeHeartRateSafetyFacts().permitsCommit",
                 "let legacySessionID = startTrainingStructuredLog(trigger: \"start_hr\")",
                 "isHrControlRunning = true",
                 "beginTelemetryV2Session(legacySessionID: legacySessionID)",
                 "startWithSpeed",
             ],
-            in: start
+            in: commit
         )
     }
 
@@ -263,7 +272,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         XCTAssertFalse(mapping.contains("history"))
 
         XCTAssertTrue(production.contains("startEnabled: manager.isHrControlStartAffordanceAvailable"))
-        XCTAssertTrue(production.contains("heartRateSourceLabel: nil"))
+        XCTAssertTrue(production.contains("heartRateSourceLabel: manager.isNativeHeartRateCurrent ? \"HealthKit\" : nil"))
         XCTAssertFalse(production.contains("watchReachable"))
         XCTAssertFalse(production.contains("telemetry"))
 
@@ -810,7 +819,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
                 "stopTrainingStructuredLog(reason: \"manual_stop\")",
                 "isHrControlRunning = false",
                 "stopBeltWithToggle(reason: \"hr\")",
-                "sendWatchCommand(\"stop_hr\")",
+                "stopLegacyWatchHeartRateIfNeeded()",
                 "endTelemetryV2Session(reason: \"manual_stop\")",
             ],
             in: manual
@@ -823,7 +832,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         assertOrdered(
             [
                 "stopTrainingStructuredLog(reason: completionEffect.structuredLogReason)",
-                "sendWatchCommand(\"stop_hr\")",
+                "stopLegacyWatchHeartRateIfNeeded()",
                 "stopBeltWithToggle(reason: \"hr_cooldown_done\")",
                 "endTelemetryV2Session(reason: completionEffect.structuredLogReason)",
             ],
@@ -848,6 +857,10 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
 
     func testTelemetryV2LifecycleRaceCannotBranchProductOrLegacyOutputs() throws {
         let start = try functionBody("func startHrControl()", in: managerSource)
+        let commit = try functionBody(
+            "private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)",
+            in: managerSource
+        )
         let stop = try functionBody("func stopHrControl()", in: managerSource)
         let begin = try functionBody(
             "private func beginTelemetryV2Session(legacySessionID: UUID?)",
@@ -858,7 +871,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
             in: managerSource
         )
 
-        for productPath in [start, stop] {
+        for productPath in [start, commit, stop] {
             for forbiddenBranch in [
                 "if telemetryV2",
                 "guard telemetryV2",
@@ -875,14 +888,14 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
                 "beginTelemetryV2Session(legacySessionID: legacySessionID)",
                 "startWithSpeed",
             ],
-            in: start
+            in: commit
         )
         assertOrdered(
             [
                 "stopTrainingStructuredLog(reason: \"manual_stop\")",
                 "isHrControlRunning = false",
                 "stopBeltWithToggle(reason: \"hr\")",
-                "sendWatchCommand(\"stop_hr\")",
+                "stopLegacyWatchHeartRateIfNeeded()",
                 "endTelemetryV2Session(reason: \"manual_stop\")",
             ],
             in: stop

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/IPhoneHealthKitHeartRateProviderCoreTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/IPhoneHealthKitHeartRateProviderCoreTests.swift
@@ -144,6 +144,48 @@ final class IPhoneHealthKitHeartRateProviderCoreTests: XCTestCase {
         XCTAssertEqual(driver.finishCount, 1)
     }
 
+    func testRapidHubWarmDuringCommittedFinishLeavesProviderUntouched() async throws {
+        let (provider, driver) = makeProvider()
+        try await provider.prepare(configuration: "walking")
+        try await provider.start()
+        driver.calls.removeAll()
+        driver.suspendStoppedTransition = true
+
+        let finish = Task {
+            try await provider.finish(at: Date(timeIntervalSince1970: 5_010))
+        }
+        await driver.waitUntilStoppedTransitionIsPending()
+
+        let shouldWarm = NativeHeartRatePreflightEngine.RuntimePolicy.canWarmPrepare(
+            isTrainingHubVisible: true,
+            appActivity: .active,
+            isHrControlRunning: false,
+            nativeWorkoutCommitted: true,
+            nativeWorkoutFinishInFlight: true,
+            providerIsIdle: provider.state == .idle,
+            providerIsSupported: true
+        )
+        if shouldWarm {
+            try await provider.prepare(configuration: "unexpected-warm")
+        }
+
+        XCTAssertFalse(shouldWarm)
+        XCTAssertEqual(provider.state, .finishing)
+        XCTAssertEqual(driver.calls, ["stopActivity"])
+        XCTAssertEqual(driver.discardCount, 0)
+        XCTAssertEqual(driver.finishCount, 0)
+        XCTAssertEqual(driver.resetCount, 0)
+
+        driver.sendStoppedTransition(at: Date(timeIntervalSince1970: 5_011))
+        _ = try await finish.value
+
+        XCTAssertEqual(provider.state, .idle)
+        XCTAssertEqual(driver.finishCount, 1)
+        XCTAssertEqual(driver.discardCount, 0)
+        XCTAssertEqual(driver.resetCount, 1)
+        XCTAssertEqual(driver.createdConfigurations, ["walking"])
+    }
+
     func testUnavailableFinishedWorkoutEndsSessionWithoutDiscardOrRetry() async throws {
         let (provider, driver) = makeProvider()
         try await provider.prepare(configuration: "walking")

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/IPhoneHealthKitHeartRateProviderCoreTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/IPhoneHealthKitHeartRateProviderCoreTests.swift
@@ -271,7 +271,7 @@ final class IPhoneHealthKitHeartRateProviderCoreTests: XCTestCase {
             encoding: .utf8
         )
 
-        XCTAssertFalse(manager.contains("IPhoneHealthKitLiveHeartRateProvider"))
+        XCTAssertTrue(manager.contains("IPhoneHealthKitLiveHeartRateProvider"))
         for forbidden in [
             "sendTreadmill", "WCSession", "watchReachable", "start_hr", "CoreBluetooth",
         ] {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/IPhoneHealthKitHeartRateProviderCoreTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/IPhoneHealthKitHeartRateProviderCoreTests.swift
@@ -107,6 +107,44 @@ final class IPhoneHealthKitHeartRateProviderCoreTests: XCTestCase {
         XCTAssertEqual(driver.finishCount, 0)
     }
 
+    func testCollectionCleanupIgnoresLateSampleAndAllowsFreshAttempt() async throws {
+        let (provider, driver) = makeProvider()
+        var observations: [HeartRateProviderObservation] = []
+        provider.onObservation = { observations.append($0) }
+        try await provider.prepare(configuration: "attempt-a")
+        try await provider.start()
+
+        await provider.discard(at: Date(timeIntervalSince1970: 4_100))
+        provider.receive(IPhoneHealthKitHeartRateSample(
+            beatsPerMinute: 155,
+            measurementInterval: DateInterval(
+                start: Date(timeIntervalSince1970: 4_099),
+                duration: 1
+            ),
+            callbackObservedAt: Date(timeIntervalSince1970: 4_101),
+            receivedAt: Date(timeIntervalSince1970: 4_101)
+        ))
+
+        XCTAssertEqual(provider.state, .idle)
+        XCTAssertTrue(observations.isEmpty)
+
+        try await provider.prepare(configuration: "attempt-b")
+        try await provider.start()
+        provider.receive(IPhoneHealthKitHeartRateSample(
+            beatsPerMinute: 141,
+            measurementInterval: DateInterval(
+                start: Date(timeIntervalSince1970: 4_102),
+                duration: 1
+            ),
+            callbackObservedAt: Date(timeIntervalSince1970: 4_103),
+            receivedAt: Date(timeIntervalSince1970: 4_103)
+        ))
+
+        XCTAssertEqual(observations.map(\.beatsPerMinute), [141])
+        XCTAssertEqual(driver.createdConfigurations, ["attempt-a", "attempt-b"])
+        XCTAssertEqual(driver.discardCount, 1)
+    }
+
     func testCommittedFinishWaitsForStoppedTransitionAndUsesItsDate() async throws {
         let (provider, driver) = makeProvider()
         try await provider.prepare(configuration: "walking")

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
@@ -150,6 +150,216 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
         ])
     }
 
+    func testHeartRateAtDeadlineCannotCommitWithoutTimerTick() {
+        var engine = waitingEngine()
+
+        XCTAssertEqual(engine.receive(
+            nativeObservation(
+                measuredAt: now.addingTimeInterval(30),
+                receivedAt: now.addingTimeInterval(30)
+            ),
+            safety: safeFacts(),
+            now: now.addingTimeInterval(30),
+            freshnessLimit: 7
+        ), [.discard(reason: .timeout)])
+    }
+
+    func testHeartRateAfterDeadlineCannotCommitWithoutTimerTick() {
+        var engine = waitingEngine()
+
+        XCTAssertEqual(engine.receive(
+            nativeObservation(
+                measuredAt: now.addingTimeInterval(31),
+                receivedAt: now.addingTimeInterval(31)
+            ),
+            safety: safeFacts(),
+            now: now.addingTimeInterval(31),
+            freshnessLimit: 7
+        ), [.discard(reason: .timeout)])
+    }
+
+    func testDeferredInactiveToActiveAtDeadlineTimesOutInsteadOfCommitting() {
+        var engine = waitingEngine()
+        XCTAssertEqual(engine.receive(
+            nativeObservation(),
+            safety: safeFacts(appActivity: .inactive),
+            now: now.addingTimeInterval(2),
+            freshnessLimit: 40
+        ), [])
+
+        XCTAssertEqual(engine.safetyChanged(
+            safeFacts(),
+            now: now.addingTimeInterval(30),
+            freshnessLimit: 40
+        ), [.discard(reason: .timeout)])
+    }
+
+    func testPreparationCompletingAtDeadlineTimesOutBeforeCollection() {
+        var engine = NativeHeartRatePreflightEngine()
+        let intent = makeIntent()
+        XCTAssertEqual(engine.requestStart(intent: intent, safety: safeFacts()), [.prepare])
+
+        XCTAssertEqual(engine.providerPrepared(
+            at: now.addingTimeInterval(30)
+        ), [.discard(reason: .timeout)])
+    }
+
+    func testCollectionCompletingAtDeadlineTimesOutBeforeWaitingForHeartRate() {
+        var engine = preparedEngine()
+        let intent = makeIntent()
+        _ = engine.requestStart(intent: intent, safety: safeFacts())
+
+        XCTAssertEqual(engine.collectionStarted(
+            intentID: intent.id,
+            acquisitionStartedAt: intent.requestedAt,
+            now: now.addingTimeInterval(30)
+        ), [.discard(reason: .timeout)])
+    }
+
+    func testRuntimeStopPolicyAllowsCleanIdleAndBlocksUnresolvedStop() {
+        XCTAssertFalse(NativeHeartRatePreflightEngine.RuntimePolicy.stopInProgress(
+            hasObservationLifecycle: false,
+            observationHasFinalResult: false,
+            hasUnavailableAttempt: false
+        ))
+        XCTAssertTrue(NativeHeartRatePreflightEngine.RuntimePolicy.stopInProgress(
+            hasObservationLifecycle: true,
+            observationHasFinalResult: false,
+            hasUnavailableAttempt: false
+        ))
+
+        var engine = preparedEngine()
+        XCTAssertEqual(engine.requestStart(
+            intent: makeIntent(),
+            safety: safeFacts(stopInProgress: false)
+        ).count, 1)
+        var blockedEngine = preparedEngine()
+        XCTAssertEqual(blockedEngine.requestStart(
+            intent: makeIntent(),
+            safety: safeFacts(stopInProgress: true)
+        ), [])
+    }
+
+    func testFreshNativeHeartRateCrossesProductionCommitSeamExactlyOnce() {
+        var engine = waitingEngine()
+        let observation = nativeObservation()
+        let effects = engine.receive(
+            observation,
+            safety: safeFacts(),
+            now: now.addingTimeInterval(2),
+            freshnessLimit: 7
+        )
+        guard case .commit(let intent, let committedObservation, let startedAt) = effects.first else {
+            return XCTFail("Expected engine commit")
+        }
+
+        var nativeWorkoutCommitted = false
+        var productionStartCount = 0
+        for _ in 0..<2 {
+            let safety = safeFacts(hasConflictingWorkout:
+                NativeHeartRatePreflightEngine.RuntimePolicy.hasConflictingWorkout(
+                    isHrControlRunning: false,
+                    treadmillTestRunIsActive: false,
+                    nativeWorkoutCommitted: nativeWorkoutCommitted,
+                    nativeFlowOwnsController: true,
+                    nativeWorkoutFinishInFlight: false
+                )
+            )
+            let permitted = NativeHeartRatePreflightEngine.RuntimePolicy
+                .permitsProductionCommit(
+                    intent: intent,
+                    now: now.addingTimeInterval(2),
+                    flowOwnsController: true,
+                    nativeWorkoutAlreadyCommitted: nativeWorkoutCommitted,
+                    providerIsCollecting: true,
+                    observationIsQualifying: committedObservation.isQualifying(
+                        collectionStartedAt: startedAt,
+                        now: now.addingTimeInterval(2),
+                        freshnessLimit: 7
+                    ),
+                    safety: safety
+                )
+            if permitted {
+                nativeWorkoutCommitted = true
+                let postClaimSafety = safeFacts(hasConflictingWorkout:
+                    NativeHeartRatePreflightEngine.RuntimePolicy.hasConflictingWorkout(
+                        isHrControlRunning: false,
+                        treadmillTestRunIsActive: false,
+                        nativeWorkoutCommitted: nativeWorkoutCommitted,
+                        nativeFlowOwnsController: true,
+                        nativeWorkoutFinishInFlight: false
+                    )
+                )
+                if postClaimSafety.permitsCommit {
+                    productionStartCount += 1
+                }
+            }
+        }
+
+        XCTAssertEqual(productionStartCount, 1)
+    }
+
+    func testProductionCommitSeamRechecksDeadlineAfterEngineCommitEffect() {
+        var engine = waitingEngine()
+        let beforeDeadline = now.addingTimeInterval(29.9)
+        let effects = engine.receive(
+            nativeObservation(
+                measuredAt: beforeDeadline,
+                receivedAt: beforeDeadline
+            ),
+            safety: safeFacts(),
+            now: beforeDeadline,
+            freshnessLimit: 7
+        )
+        guard case .commit(let intent, let observation, let startedAt) = effects.first else {
+            return XCTFail("Expected engine commit before deadline")
+        }
+
+        XCTAssertFalse(NativeHeartRatePreflightEngine.RuntimePolicy.permitsProductionCommit(
+            intent: intent,
+            now: now.addingTimeInterval(30),
+            flowOwnsController: true,
+            nativeWorkoutAlreadyCommitted: false,
+            providerIsCollecting: true,
+            observationIsQualifying: observation.isQualifying(
+                collectionStartedAt: startedAt,
+                now: beforeDeadline,
+                freshnessLimit: 7
+            ),
+            safety: safeFacts()
+        ))
+    }
+
+    func testRapidStopToHubWarmCannotInterfereWithCommittedFinish() {
+        XCTAssertFalse(NativeHeartRatePreflightEngine.RuntimePolicy.canWarmPrepare(
+            isTrainingHubVisible: true,
+            appActivity: .active,
+            isHrControlRunning: false,
+            nativeWorkoutCommitted: true,
+            nativeWorkoutFinishInFlight: true,
+            providerIsIdle: false,
+            providerIsSupported: true
+        ))
+        XCTAssertFalse(NativeHeartRatePreflightEngine.RuntimePolicy.canWarmPrepare(
+            isTrainingHubVisible: true,
+            appActivity: .active,
+            isHrControlRunning: false,
+            nativeWorkoutCommitted: false,
+            nativeWorkoutFinishInFlight: false,
+            providerIsIdle: false,
+            providerIsSupported: true
+        ))
+        XCTAssertTrue(NativeHeartRatePreflightEngine.RuntimePolicy.canWarmPrepare(
+            isTrainingHubVisible: true,
+            appActivity: .active,
+            isHrControlRunning: false,
+            nativeWorkoutCommitted: false,
+            nativeWorkoutFinishInFlight: false,
+            providerIsIdle: true,
+            providerIsSupported: true
+        ))
+    }
+
     func testFrozenIntentIsReturnedAtCommit() {
         var engine = waitingEngine(targetBPM: 151, durationMinutes: 45)
 
@@ -220,9 +430,10 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
         var engine = preparedEngine()
         let intent = makeIntent(targetBPM: targetBPM, durationMinutes: durationMinutes)
         _ = engine.requestStart(intent: intent, safety: safeFacts())
-        engine.collectionStarted(
+        _ = engine.collectionStarted(
             intentID: intent.id,
-            acquisitionStartedAt: intent.requestedAt
+            acquisitionStartedAt: intent.requestedAt,
+            now: intent.requestedAt
         )
         return engine
     }
@@ -255,6 +466,8 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
     private func safeFacts(
         appActivity: NativeHeartRatePreflightEngine.AppActivity = .active,
         treadmillControlReady: Bool = true,
+        hasConflictingWorkout: Bool = false,
+        stopInProgress: Bool = false,
         telemetryAvailability: NativeHeartRatePreflightEngine.TelemetryAvailability = .healthy
     ) -> NativeHeartRatePreflightEngine.SafetyFacts {
         .init(
@@ -262,8 +475,8 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
             treadmillControlReady: treadmillControlReady,
             transportValid: true,
             controllerUnitsAllowed: true,
-            hasConflictingWorkout: false,
-            stopInProgress: false,
+            hasConflictingWorkout: hasConflictingWorkout,
+            stopInProgress: stopInProgress,
             telemetryAvailability: telemetryAvailability
         )
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
@@ -360,6 +360,87 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
         ))
     }
 
+    func testCancelDuringPrepareBlocksRetryUntilProviderCleanupIsIdle() {
+        var lifecycle = NativeHeartRateProviderLifecycle()
+        let attemptA = UUID()
+        lifecycle.bindAttempt(attemptA)
+        let prepareGeneration = lifecycle.beginProviderLifecycle()
+
+        let cleanupGeneration = lifecycle.beginCleanup()
+
+        XCTAssertTrue(lifecycle.cleanupInFlight)
+        XCTAssertFalse(lifecycle.acceptsProviderCompletion(
+            generation: prepareGeneration,
+            attemptID: attemptA
+        ))
+        XCTAssertFalse(lifecycle.completeCleanup(
+            generation: cleanupGeneration,
+            providerIsIdle: false
+        ))
+        XCTAssertTrue(lifecycle.cleanupInFlight)
+        XCTAssertTrue(lifecycle.completeCleanup(
+            generation: cleanupGeneration,
+            providerIsIdle: true
+        ))
+        XCTAssertFalse(lifecycle.cleanupInFlight)
+    }
+
+    func testTimeoutDuringCollectionRejectsLateObservationAndCompletion() {
+        var lifecycle = NativeHeartRateProviderLifecycle()
+        let attemptA = UUID()
+        lifecycle.bindAttempt(attemptA)
+        let collectionGeneration = lifecycle.beginProviderLifecycle()
+        XCTAssertTrue(lifecycle.acceptsObservation(providerIsCollecting: true))
+
+        let cleanupGeneration = lifecycle.beginCleanup()
+
+        XCTAssertFalse(lifecycle.acceptsObservation(providerIsCollecting: true))
+        XCTAssertFalse(lifecycle.acceptsProviderCompletion(
+            generation: collectionGeneration,
+            attemptID: attemptA
+        ))
+        XCTAssertTrue(lifecycle.completeCleanup(
+            generation: cleanupGeneration,
+            providerIsIdle: true
+        ))
+    }
+
+    func testStaleAttemptCompletionCannotAffectNewAttempt() {
+        var lifecycle = NativeHeartRateProviderLifecycle()
+        let attemptA = UUID()
+        lifecycle.bindAttempt(attemptA)
+        let generationA = lifecycle.beginProviderLifecycle()
+        let cleanupGeneration = lifecycle.beginCleanup()
+        XCTAssertTrue(lifecycle.completeCleanup(
+            generation: cleanupGeneration,
+            providerIsIdle: true
+        ))
+
+        let attemptB = UUID()
+        lifecycle.bindAttempt(attemptB)
+        let generationB = lifecycle.beginProviderLifecycle()
+
+        XCTAssertFalse(lifecycle.acceptsProviderCompletion(
+            generation: generationA,
+            attemptID: attemptA
+        ))
+        XCTAssertTrue(lifecycle.acceptsProviderCompletion(
+            generation: generationB,
+            attemptID: attemptB
+        ))
+        XCTAssertTrue(lifecycle.acceptsObservation(providerIsCollecting: true))
+    }
+
+    func testLateObservationAfterCancelCannotRegainOwnership() {
+        var lifecycle = NativeHeartRateProviderLifecycle()
+        lifecycle.bindAttempt(UUID())
+        _ = lifecycle.beginProviderLifecycle()
+        _ = lifecycle.beginCleanup()
+
+        XCTAssertNil(lifecycle.attemptID)
+        XCTAssertFalse(lifecycle.acceptsObservation(providerIsCollecting: true))
+    }
+
     func testFrozenIntentIsReturnedAtCommit() {
         var engine = waitingEngine(targetBPM: 151, durationMinutes: 45)
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
@@ -431,6 +431,67 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
         XCTAssertTrue(lifecycle.acceptsObservation(providerIsCollecting: true))
     }
 
+    func testDelayedRuntimeFailureFromAttemptACannotFailAttemptB() {
+        var lifecycle = NativeHeartRateProviderLifecycle()
+        let attemptA = UUID()
+        lifecycle.bindAttempt(attemptA)
+        let contextA = IPhoneHealthKitRuntimeFailureContext(
+            providerGeneration: lifecycle.beginProviderLifecycle(),
+            attemptID: attemptA
+        )
+        let cleanupGeneration = lifecycle.beginCleanup()
+        XCTAssertTrue(lifecycle.completeCleanup(
+            generation: cleanupGeneration,
+            providerIsIdle: true
+        ))
+
+        let attemptB = UUID()
+        lifecycle.bindAttempt(attemptB)
+        let contextB = IPhoneHealthKitRuntimeFailureContext(
+            providerGeneration: lifecycle.beginProviderLifecycle(),
+            attemptID: attemptB
+        )
+
+        XCTAssertFalse(lifecycle.acceptsProviderCompletion(
+            generation: contextA.providerGeneration,
+            attemptID: contextA.attemptID
+        ))
+        XCTAssertTrue(lifecycle.acceptsProviderCompletion(
+            generation: contextB.providerGeneration,
+            attemptID: contextB.attemptID
+        ))
+    }
+
+    func testResolvingDeferredLinkageAPreservesLinkageBIdentity() {
+        let profileA = UUID()
+        let telemetrySessionA = UUID()
+        let linkageA = DeferredNativeHealthKitLinkage(
+            acquisitionStartedAt: now,
+            finishRequestedAt: now.addingTimeInterval(30),
+            profileID: profileA,
+            telemetrySessionID: telemetrySessionA,
+            linksLegacyWorkout: true
+        )
+        let profileB = UUID()
+        let telemetrySessionB = UUID()
+        let linkageB = DeferredNativeHealthKitLinkage(
+            acquisitionStartedAt: now.addingTimeInterval(60),
+            finishRequestedAt: now.addingTimeInterval(90),
+            profileID: profileB,
+            telemetrySessionID: telemetrySessionB,
+            linksLegacyWorkout: true
+        )
+        var pending = [linkageA, linkageB]
+
+        pending.removeAll { $0 == linkageA }
+
+        XCTAssertEqual(pending, [linkageB])
+        XCTAssertEqual(pending[0].profileID, profileB)
+        XCTAssertEqual(pending[0].telemetrySessionID, telemetrySessionB)
+        XCTAssertNotEqual(pending[0].profileID, profileA)
+        XCTAssertNotEqual(pending[0].telemetrySessionID, telemetrySessionA)
+    }
+
     func testLateObservationAfterCancelCannotRegainOwnership() {
         var lifecycle = NativeHeartRateProviderLifecycle()
         lifecycle.bindAttempt(UUID())

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
@@ -1,0 +1,270 @@
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class NativeHeartRatePreflightEngineTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_000)
+
+    func testHubHoldsOnePreparedSessionWithoutPollingOrStartingCollection() {
+        var engine = NativeHeartRatePreflightEngine()
+
+        XCTAssertEqual(engine.requestWarmPreparation(), [.prepare])
+        XCTAssertEqual(engine.requestWarmPreparation(), [])
+        XCTAssertEqual(engine.providerPrepared(at: now), [])
+        XCTAssertTrue(engine.isWarmPrepared)
+        XCTAssertEqual(engine.requestWarmPreparation(), [])
+    }
+
+    func testStartWithoutHeartRateOnlyStartsNativeCollection() {
+        var engine = preparedEngine()
+        let intent = makeIntent()
+
+        let effects = engine.requestStart(intent: intent, safety: safeFacts())
+
+        XCTAssertEqual(effects, [
+            .startCollection(intent: intent, acquisitionStartedAt: intent.requestedAt),
+        ])
+        XCTAssertTrue(engine.hasStartIntent)
+    }
+
+    func testQualifyingNativeHeartRateCommitsExactlyOnce() {
+        var engine = waitingEngine()
+        let observation = nativeObservation()
+
+        let first = engine.receive(
+            observation,
+            safety: safeFacts(),
+            now: now.addingTimeInterval(2),
+            freshnessLimit: 7
+        )
+        let repeated = engine.receive(
+            observation,
+            safety: safeFacts(),
+            now: now.addingTimeInterval(3),
+            freshnessLimit: 7
+        )
+
+        XCTAssertEqual(first.count, 1)
+        guard case .commit = first.first else {
+            return XCTFail("Expected one commit")
+        }
+        XCTAssertEqual(repeated, [])
+    }
+
+    func testCachedPreSessionAndLegacyWatchHeartRateCannotCommit() {
+        var cachedEngine = waitingEngine()
+        var watchEngine = waitingEngine()
+
+        XCTAssertEqual(cachedEngine.receive(
+            nativeObservation(measuredAt: now.addingTimeInterval(-1)),
+            safety: safeFacts(),
+            now: now.addingTimeInterval(2),
+            freshnessLimit: 7
+        ), [])
+        XCTAssertEqual(watchEngine.receive(
+            nativeObservation(source: .legacyWatch),
+            safety: safeFacts(),
+            now: now.addingTimeInterval(2),
+            freshnessLimit: 7
+        ), [])
+    }
+
+    func testFirstNativeHeartRateCommitsImmediatelyWithoutTimerTick() {
+        var engine = waitingEngine()
+
+        let effects = engine.receive(
+            nativeObservation(),
+            safety: safeFacts(),
+            now: now.addingTimeInterval(2),
+            freshnessLimit: 7
+        )
+
+        XCTAssertEqual(effects.count, 1)
+        guard case .commit = effects[0] else {
+            return XCTFail("Expected immediate commit")
+        }
+    }
+
+    func testRawLinkWithoutControlReadinessBlocksStart() {
+        var engine = preparedEngine()
+        XCTAssertEqual(engine.requestStart(
+            intent: makeIntent(),
+            safety: safeFacts(treadmillControlReady: false)
+        ), [])
+        XCTAssertTrue(engine.isWarmPrepared)
+    }
+
+    func testControlReadinessLossBeforeHeartRateDiscards() {
+        var engine = waitingEngine()
+
+        XCTAssertEqual(engine.safetyChanged(
+            safeFacts(treadmillControlReady: false),
+            now: now.addingTimeInterval(2),
+            freshnessLimit: 7
+        ), [.discard(reason: .treadmillControlLost)])
+        XCTAssertFalse(engine.ownsUncommittedWorkout)
+    }
+
+    func testTransientInactiveKeepsPreflightAndDefersCommitUntilActive() {
+        var engine = waitingEngine()
+        let inactiveFacts = safeFacts(appActivity: .inactive)
+
+        XCTAssertEqual(engine.receive(
+            nativeObservation(),
+            safety: inactiveFacts,
+            now: now.addingTimeInterval(2),
+            freshnessLimit: 7
+        ), [])
+        XCTAssertTrue(engine.hasStartIntent)
+
+        let effects = engine.safetyChanged(
+            safeFacts(),
+            now: now.addingTimeInterval(3),
+            freshnessLimit: 7
+        )
+        XCTAssertEqual(effects.count, 1)
+        guard case .commit = effects[0] else {
+            return XCTFail("Expected deferred commit")
+        }
+    }
+
+    func testBackgroundBeforeCommitDiscards() {
+        var engine = waitingEngine()
+        XCTAssertEqual(engine.safetyChanged(
+            safeFacts(appActivity: .background),
+            now: now.addingTimeInterval(2),
+            freshnessLimit: 7
+        ), [.discard(reason: .appBackgrounded)])
+    }
+
+    func testUserCancelDiscards() {
+        var engine = waitingEngine()
+        XCTAssertEqual(engine.cancel(reason: .user), [.discard(reason: .user)])
+        XCTAssertEqual(engine.cancel(reason: .user), [])
+    }
+
+    func testThirtySecondTimeoutDiscards() {
+        var engine = waitingEngine()
+        XCTAssertEqual(engine.tick(now: now.addingTimeInterval(29.9)), [])
+        XCTAssertEqual(engine.tick(now: now.addingTimeInterval(30)), [
+            .discard(reason: .timeout),
+        ])
+    }
+
+    func testFrozenIntentIsReturnedAtCommit() {
+        var engine = waitingEngine(targetBPM: 151, durationMinutes: 45)
+
+        let effects = engine.receive(
+            nativeObservation(),
+            safety: safeFacts(),
+            now: now.addingTimeInterval(2),
+            freshnessLimit: 7
+        )
+
+        guard case .commit(let intent, _, let acquisitionStartedAt) = effects.first else {
+            return XCTFail("Expected commit")
+        }
+        XCTAssertEqual(intent.targetBPM, 151)
+        XCTAssertEqual(intent.durationMinutes, 45)
+        XCTAssertEqual(acquisitionStartedAt, now)
+    }
+
+    func testAcquisitionStartPrecedesCommitAndIsPreserved() {
+        var engine = waitingEngine()
+        let commitAt = now.addingTimeInterval(5)
+
+        let effects = engine.receive(
+            nativeObservation(receivedAt: commitAt),
+            safety: safeFacts(),
+            now: commitAt,
+            freshnessLimit: 7
+        )
+
+        guard case .commit(_, _, let acquisitionStartedAt) = effects.first else {
+            return XCTFail("Expected commit")
+        }
+        XCTAssertEqual(acquisitionStartedAt, now)
+        XCTAssertLessThan(acquisitionStartedAt, commitAt)
+    }
+
+    func testTelemetryAvailabilityDoesNotChangeCommitSafety() {
+        for availability in [
+            NativeHeartRatePreflightEngine.TelemetryAvailability.healthy,
+            .degraded,
+            .unavailable,
+        ] {
+            var engine = waitingEngine()
+            let effects = engine.receive(
+                nativeObservation(),
+                safety: safeFacts(telemetryAvailability: availability),
+                now: now.addingTimeInterval(2),
+                freshnessLimit: 7
+            )
+            XCTAssertEqual(effects.count, 1, "\(availability)")
+            guard case .commit = effects[0] else {
+                return XCTFail("Expected commit for \(availability)")
+            }
+        }
+    }
+
+    private func preparedEngine() -> NativeHeartRatePreflightEngine {
+        var engine = NativeHeartRatePreflightEngine()
+        _ = engine.requestWarmPreparation()
+        _ = engine.providerPrepared(at: now)
+        return engine
+    }
+
+    private func waitingEngine(
+        targetBPM: Int = 145,
+        durationMinutes: Int = 30
+    ) -> NativeHeartRatePreflightEngine {
+        var engine = preparedEngine()
+        let intent = makeIntent(targetBPM: targetBPM, durationMinutes: durationMinutes)
+        _ = engine.requestStart(intent: intent, safety: safeFacts())
+        engine.collectionStarted(
+            intentID: intent.id,
+            acquisitionStartedAt: intent.requestedAt
+        )
+        return engine
+    }
+
+    private func makeIntent(
+        targetBPM: Int = 145,
+        durationMinutes: Int = 30
+    ) -> NativeHeartRatePreflightEngine.Intent {
+        .init(
+            id: UUID(uuidString: "A7B3EAB7-C59A-453D-BC4E-9C030BAC8659")!,
+            targetBPM: targetBPM,
+            durationMinutes: durationMinutes,
+            requestedAt: now
+        )
+    }
+
+    private func nativeObservation(
+        source: NativeHeartRatePreflightEngine.ObservationSource = .nativeHealthKit,
+        measuredAt: Date? = nil,
+        receivedAt: Date? = nil
+    ) -> NativeHeartRatePreflightEngine.Observation {
+        .init(
+            source: source,
+            beatsPerMinute: 142,
+            measuredAt: measuredAt ?? now.addingTimeInterval(1),
+            receivedAt: receivedAt ?? now.addingTimeInterval(1)
+        )
+    }
+
+    private func safeFacts(
+        appActivity: NativeHeartRatePreflightEngine.AppActivity = .active,
+        treadmillControlReady: Bool = true,
+        telemetryAvailability: NativeHeartRatePreflightEngine.TelemetryAvailability = .healthy
+    ) -> NativeHeartRatePreflightEngine.SafetyFacts {
+        .init(
+            appActivity: appActivity,
+            treadmillControlReady: treadmillControlReady,
+            transportValid: true,
+            controllerUnitsAllowed: true,
+            hasConflictingWorkout: false,
+            stopInProgress: false,
+            telemetryAvailability: telemetryAvailability
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
@@ -59,7 +59,7 @@ final class NativeHeartRatePreflightIntegrationContractTests: XCTestCase {
 
         assertOrdered([
             "observation.isQualifying(",
-            "nativeHeartRateSafetyFacts(now: now).permitsCommit",
+            "RuntimePolicy.permitsProductionCommit(",
             "hrTargetBPM = intent.targetBPM",
             "hrDurationMinutes = intent.durationMinutes",
             "nativeHealthKitWorkoutCommitted = true",
@@ -72,6 +72,27 @@ final class NativeHeartRatePreflightIntegrationContractTests: XCTestCase {
             "startWithSpeed",
         ], in: productionStart)
         XCTAssertEqual(productionStart.components(separatedBy: "isHrControlRunning = true").count - 1, 1)
+    }
+
+    func testRuntimeSafetyFixesUseBehavioralPoliciesAtProductionBoundaries() throws {
+        let safety = try functionBody(
+            "private func nativeHeartRateSafetyFacts(",
+            in: managerSource
+        )
+        let warm = try functionBody(
+            "private func warmNativeHeartRateProviderIfPossible()",
+            in: managerSource
+        )
+        let collection = try functionBody(
+            "private func startNativeHeartRateCollection(",
+            in: managerSource
+        )
+        XCTAssertTrue(safety.contains("RuntimePolicy.stopInProgress("))
+        XCTAssertTrue(safety.contains("RuntimePolicy\n                .hasConflictingWorkout("))
+        XCTAssertTrue(warm.contains("RuntimePolicy.canWarmPrepare("))
+        XCTAssertTrue(warm.contains("providerIsIdle: iPhoneHealthKitHeartRateProvider.state == .idle"))
+        XCTAssertTrue(collection.contains("collectionStarted("))
+        XCTAssertTrue(collection.contains("now: Date()"))
     }
 
     func testNativeHeartRateMarksFreshImmediatelyAndLegacyWatchCannotRace() throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
@@ -118,6 +118,8 @@ final class NativeHeartRatePreflightIntegrationContractTests: XCTestCase {
         XCTAssertTrue(start.contains("bindAttempt(intent.id)"))
         XCTAssertTrue(prepare.contains("beginProviderLifecycle()"))
         XCTAssertTrue(prepare.contains("acceptsProviderCompletion("))
+        XCTAssertTrue(prepare.contains("failureContext: IPhoneHealthKitRuntimeFailureContext("))
+        XCTAssertTrue(collection.contains("bindRuntimeFailureContext("))
         XCTAssertTrue(collection.contains("attemptID: intent.id"))
         assertOrdered([
             "beginCleanup()",
@@ -159,6 +161,25 @@ final class NativeHeartRatePreflightIntegrationContractTests: XCTestCase {
             "inputs: [result.delivery.causalReference]",
         ], in: persist)
         XCTAssertFalse(persist.contains("heartRateObservationNormalizer.normalize"))
+    }
+
+    func testRuntimeFailureCallbackCarriesOriginatingProviderContext() throws {
+        let providerFactory = try functionBody(
+            "private lazy var iPhoneHealthKitHeartRateProvider:",
+            in: managerSource
+        )
+        let providerFailure = try functionBody(
+            "func workoutSession(_ workoutSession: HKWorkoutSession, didFailWithError error: Error)",
+            in: providerSource
+        )
+
+        XCTAssertTrue(providerFactory.contains("provider.onFailure = { [weak self] context"))
+        XCTAssertTrue(providerFactory.contains("generation: context.providerGeneration"))
+        XCTAssertTrue(providerFactory.contains("attemptID: context.attemptID"))
+        XCTAssertTrue(providerSource.contains("runtimeFailureContexts[identifier] = context"))
+        XCTAssertTrue(providerFailure.contains("ObjectIdentifier(workoutSession)"))
+        XCTAssertTrue(providerFailure.contains("self.onRuntimeFailure?(failureContext)"))
+        XCTAssertFalse(providerFactory.contains("nativeHeartRateProviderLifecycle.generation"))
     }
 
     func testNativeHeartRateMarksFreshImmediatelyAndLegacyWatchCannotRace() throws {
@@ -229,9 +250,28 @@ final class NativeHeartRatePreflightIntegrationContractTests: XCTestCase {
         XCTAssertTrue(finish.contains("case .savedWorkoutUnavailable"))
         XCTAssertTrue(finish.contains("retainDeferredNativeHealthKitLinkage"))
         XCTAssertTrue(resolver.contains("HKSampleQuery"))
-        XCTAssertTrue(resolver.contains("linkNativeHealthKitWorkout"))
+        XCTAssertTrue(resolver.contains("linkDeferredNativeHealthKitWorkout"))
         XCTAssertFalse(resolver.contains(".finish("))
         XCTAssertTrue(managerSource.contains("deferred_native_healthkit_linkage_v1"))
+    }
+
+    func testDeferredLinkageResolutionIsSelfContainedAndDoesNotClearCurrentAcquisition() throws {
+        let clear = try functionBody(
+            "private func clearDeferredNativeHealthKitLinkage(",
+            in: managerSource
+        )
+        let link = try functionBody(
+            "private func linkDeferredNativeHealthKitWorkout(",
+            in: managerSource
+        )
+
+        XCTAssertFalse(clear.contains("nativeHealthKitAcquisitionStartedAt"))
+        XCTAssertTrue(link.contains("linkage.profileID"))
+        XCTAssertTrue(link.contains("linkage.telemetrySessionID"))
+        XCTAssertTrue(link.contains("loadLegacyShadowWorkoutHistory(profileID: profileID)"))
+        XCTAssertTrue(link.contains("saveLegacyShadowWorkoutHistory(entries, profileID: profileID)"))
+        XCTAssertFalse(link.contains("pendingHealthkit"))
+        XCTAssertFalse(link.contains("nativeHealthKitAcquisitionStartedAt"))
     }
 
     func testTelemetryIdentityIsNativeAndCannotGateMotion() throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
@@ -1,0 +1,215 @@
+import XCTest
+
+final class NativeHeartRatePreflightIntegrationContractTests: XCTestCase {
+    private lazy var packageDirectory: URL = {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        return testsDirectory.deletingLastPathComponent()
+    }()
+    private lazy var managerSource: String = {
+        try! String(
+            contentsOf: packageDirectory.appendingPathComponent(
+                "WalkingPadRemote/BluetoothManager.swift"
+            ),
+            encoding: .utf8
+        )
+    }()
+    private lazy var contentSource: String = {
+        try! String(
+            contentsOf: packageDirectory.appendingPathComponent(
+                "WalkingPadRemote/ContentView.swift"
+            ),
+            encoding: .utf8
+        )
+    }()
+    private lazy var providerSource: String = {
+        try! String(
+            contentsOf: packageDirectory.appendingPathComponent(
+                "WalkingPadRemote/IPhoneHealthKitLiveHeartRateProvider.swift"
+            ),
+            encoding: .utf8
+        )
+    }()
+
+    func testStartAndCollectionPreflightContainNoProductionMotionTimingOrV2() throws {
+        let start = try functionBody("func startHrControl()", in: managerSource)
+        let collection = try functionBody(
+            "private func startNativeHeartRateCollection(",
+            in: managerSource
+        )
+        for body in [start, collection] {
+            XCTAssertFalse(body.contains("isHrControlRunning = true"))
+            XCTAssertFalse(body.contains("beginTelemetryV2Session"))
+            XCTAssertFalse(body.contains("startWithSpeed"))
+            XCTAssertFalse(body.contains("sendTreadmill"))
+            XCTAssertFalse(body.contains("hrRemainingSeconds"))
+        }
+        XCTAssertTrue(start.contains("nativeHeartRatePreflightEngine.requestStart"))
+        XCTAssertTrue(collection.contains("iPhoneHealthKitHeartRateProvider.start"))
+    }
+
+    func testCommitIsTheSingleProductionStartBoundaryWithFrozenIntent() throws {
+        let commit = try functionBody(
+            "private func commitNativeHeartRatePreflight(",
+            in: managerSource
+        )
+        let productionStart = try functionBody(
+            "private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)",
+            in: managerSource
+        )
+
+        assertOrdered([
+            "observation.isQualifying(",
+            "nativeHeartRateSafetyFacts(now: now).permitsCommit",
+            "hrTargetBPM = intent.targetBPM",
+            "hrDurationMinutes = intent.durationMinutes",
+            "nativeHealthKitWorkoutCommitted = true",
+            "commitExistingHrControl(preflightLatencySeconds: latency)",
+        ], in: commit)
+        assertOrdered([
+            "controllerUnitsGateDecision()",
+            "isHrControlRunning = true",
+            "beginTelemetryV2Session(legacySessionID: legacySessionID)",
+            "startWithSpeed",
+        ], in: productionStart)
+        XCTAssertEqual(productionStart.components(separatedBy: "isHrControlRunning = true").count - 1, 1)
+    }
+
+    func testNativeHeartRateMarksFreshImmediatelyAndLegacyWatchCannotRace() throws {
+        let nativeDelivery = try functionBody(
+            "private func handleNativeHeartRateObservation(",
+            in: managerSource
+        )
+        let watchPayload = try functionBody(
+            "private func handleWatchPayload(_ payload: [String: Any])",
+            in: managerSource
+        )
+
+        assertOrdered([
+            "hrStreamingActive = HRDomainService.heartRateStreamIsActive(",
+            "isNativeHeartRateCurrent = hrStreamingActive",
+            "nativeHeartRatePreflightEngine.receive(",
+        ], in: nativeDelivery)
+        XCTAssertTrue(watchPayload.contains("guard !self.nativeHeartRateFlowOwnsController"))
+        XCTAssertTrue(watchPayload.contains("Ignored legacy Watch HR"))
+        XCTAssertTrue(watchPayload.contains("Ignored legacy Watch workout UUID"))
+    }
+
+    func testLifecycleAndCancellationStayPrecommitOnly() throws {
+        let discard = try functionBody(
+            "private func discardNativeHeartRatePreflight(",
+            in: managerSource
+        )
+        XCTAssertTrue(managerSource.contains("nativeHeartRatePreflightEngine.cancel(reason: .user)"))
+        XCTAssertTrue(managerSource.contains("nativeHeartRateAppActivity = .inactive"))
+        XCTAssertTrue(managerSource.contains("nativeHeartRateAppActivity = .background"))
+        XCTAssertTrue(managerSource.contains("nativeHeartRatePreflightEngine.tick(now: Date())"))
+        XCTAssertTrue(discard.contains("iPhoneHealthKitHeartRateProvider.discard"))
+        XCTAssertFalse(discard.contains("stopBelt"))
+        XCTAssertFalse(discard.contains("sendTreadmill"))
+        XCTAssertTrue(discard.contains("Пульс не получен"))
+        XCTAssertFalse(discard.contains("Нет разрешения на пульс"))
+    }
+
+    func testFirstAuthorizationAutomaticallyContinuesAndWarmPrepareDoesNotPromptOrPoll() throws {
+        let warm = try functionBody(
+            "private func warmNativeHeartRateProviderIfPossible()",
+            in: managerSource
+        )
+        let prepare = try functionBody(
+            "private func prepareNativeHeartRateProvider()",
+            in: managerSource
+        )
+        XCTAssertTrue(warm.contains("canPrepareWithoutAuthorizationPrompt"))
+        XCTAssertTrue(warm.contains("requestWarmPreparation()"))
+        XCTAssertTrue(prepare.contains("providerPrepared(at: Date())"))
+        XCTAssertTrue(providerSource.contains("statusForAuthorizationRequest"))
+        XCTAssertTrue(providerSource.contains("status == .unnecessary"))
+        XCTAssertFalse(managerSource.contains("Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in\n            self?.warmNativeHeartRateProviderIfPossible"))
+    }
+
+    func testFinishUsesDirectUUIDAndPersistsUnavailableDeferredLinkageWithoutRetry() throws {
+        let finish = try functionBody(
+            "private func finishNativeHealthKitWorkoutIfNeeded()",
+            in: managerSource
+        )
+        let resolver = try functionBody(
+            "private func resolveDeferredNativeHealthKitLinkageIfPossible()",
+            in: managerSource
+        )
+        XCTAssertTrue(finish.contains("iPhoneHealthKitHeartRateProvider.finish"))
+        XCTAssertTrue(finish.contains("case .saved(let workout)"))
+        XCTAssertTrue(finish.contains("linkNativeHealthKitWorkout"))
+        XCTAssertTrue(finish.contains("case .savedWorkoutUnavailable"))
+        XCTAssertTrue(finish.contains("retainDeferredNativeHealthKitLinkage"))
+        XCTAssertTrue(resolver.contains("HKSampleQuery"))
+        XCTAssertTrue(resolver.contains("linkNativeHealthKitWorkout"))
+        XCTAssertFalse(resolver.contains(".finish("))
+        XCTAssertTrue(managerSource.contains("deferred_native_healthkit_linkage_v1"))
+    }
+
+    func testTelemetryIdentityIsNativeAndCannotGateMotion() throws {
+        let descriptor = try functionBody(
+            "private func beginTelemetryV2Session(legacySessionID: UUID?)",
+            in: managerSource
+        )
+        let safety = try functionBody(
+            "private func nativeHeartRateSafetyFacts(",
+            in: managerSource
+        )
+        let commit = try functionBody(
+            "private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)",
+            in: managerSource
+        )
+        XCTAssertTrue(descriptor.contains("heartRateProviderKind: \"healthKitSelected\""))
+        XCTAssertTrue(descriptor.contains("heartRateProviderStableLocalKey: \"iphone-healthkit-selected\""))
+        XCTAssertFalse(safety.contains("telemetryV2"))
+        XCTAssertFalse(commit.contains("telemetryV2Status"))
+        XCTAssertFalse(commit.contains("telemetryV2WriterHealthSnapshot"))
+    }
+
+    func testPreflightUIUsesBindingIndeterminateCopyAndCancel() {
+        XCTAssertTrue(contentSource.contains("Получаем пульс…"))
+        XCTAssertTrue(contentSource.contains("Дорожка запустится автоматически, когда появится пульс."))
+        XCTAssertTrue(contentSource.contains("Button(\"Отмена\", role: .cancel, action: onCancel)"))
+        XCTAssertTrue(contentSource.contains("manager.cancelNativeHeartRatePreflight()"))
+        XCTAssertFalse(contentSource.contains("30 секунд до старта"))
+    }
+
+    private func functionBody(_ signature: String, in source: String) throws -> String {
+        guard let signatureRange = source.range(of: signature),
+              let openingBrace = source[signatureRange.upperBound...].firstIndex(of: "{") else {
+            throw NSError(domain: "NativeHeartRatePreflightIntegrationContractTests", code: 1)
+        }
+        var depth = 0
+        var index = openingBrace
+        while index < source.endIndex {
+            switch source[index] {
+            case "{": depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 {
+                    return String(source[openingBrace...index])
+                }
+            default: break
+            }
+            index = source.index(after: index)
+        }
+        throw NSError(domain: "NativeHeartRatePreflightIntegrationContractTests", code: 2)
+    }
+
+    private func assertOrdered(
+        _ fragments: [String],
+        in text: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        var cursor = text.startIndex
+        for fragment in fragments {
+            guard let range = text[cursor...].range(of: fragment) else {
+                XCTFail("Missing or out-of-order fragment: \(fragment)", file: file, line: line)
+                return
+            }
+            cursor = range.upperBound
+        }
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
@@ -95,6 +95,72 @@ final class NativeHeartRatePreflightIntegrationContractTests: XCTestCase {
         XCTAssertTrue(collection.contains("now: Date()"))
     }
 
+    func testProviderAsyncWorkIsGenerationBoundAndRetryWaitsForCleanup() throws {
+        let start = try functionBody("func startHrControl()", in: managerSource)
+        let prepare = try functionBody(
+            "private func prepareNativeHeartRateProvider()",
+            in: managerSource
+        )
+        let collection = try functionBody(
+            "private func startNativeHeartRateCollection(",
+            in: managerSource
+        )
+        let discard = try functionBody(
+            "private func discardNativeHeartRatePreflight(",
+            in: managerSource
+        )
+        let delivery = try functionBody(
+            "private func handleNativeHeartRateObservation(",
+            in: managerSource
+        )
+
+        XCTAssertTrue(start.contains("!nativeHeartRateProviderLifecycle.cleanupInFlight"))
+        XCTAssertTrue(start.contains("bindAttempt(intent.id)"))
+        XCTAssertTrue(prepare.contains("beginProviderLifecycle()"))
+        XCTAssertTrue(prepare.contains("acceptsProviderCompletion("))
+        XCTAssertTrue(collection.contains("attemptID: intent.id"))
+        assertOrdered([
+            "beginCleanup()",
+            "iPhoneHealthKitHeartRateProvider.discard",
+            "completeCleanup(",
+            "recomputeHrStartAllowed()",
+        ], in: discard)
+        assertOrdered([
+            "acceptsObservation(",
+            "HRDomainService.applyHeartRateDelivery(",
+        ], in: delivery)
+    }
+
+    func testExactQualifyingNormalizationIsEnqueuedBeforeMotionAndThenReferenced() throws {
+        let delivery = try functionBody(
+            "private func handleNativeHeartRateObservation(",
+            in: managerSource
+        )
+        let productionStart = try functionBody(
+            "private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)",
+            in: managerSource
+        )
+        let persist = try functionBody(
+            "private func persistQualifyingNativeHeartRateBeforeMotion()",
+            in: managerSource
+        )
+
+        XCTAssertTrue(delivery.contains("let normalization = normalizeHeartRateDelivery("))
+        XCTAssertTrue(delivery.contains("pendingNativePreflightHeartRate = normalization"))
+        assertOrdered([
+            "beginTelemetryV2Session(legacySessionID: legacySessionID)",
+            "persistQualifyingNativeHeartRateBeforeMotion()",
+            "startWithSpeed",
+        ], in: productionStart)
+        assertOrdered([
+            "let result = pendingNativePreflightHeartRate",
+            "heartRateTelemetrySink?.observeHeartRate(result)",
+            "latestHeartRateDelivery = result.delivery",
+            "inputs: [result.delivery.causalReference]",
+        ], in: persist)
+        XCTAssertFalse(persist.contains("heartRateObservationNormalizer.normalize"))
+    }
+
     func testNativeHeartRateMarksFreshImmediatelyAndLegacyWatchCannotRace() throws {
         let nativeDelivery = try functionBody(
             "private func handleNativeHeartRateObservation(",

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/StopCommandBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/StopCommandBehaviorContractTests.swift
@@ -145,9 +145,12 @@ final class StopCommandBehaviorContractTests: XCTestCase {
         )
 
         let startBody = try functionBody("func startHrControl()")
-        XCTAssertTrue(startBody.contains("controllerUnitsGateDecision"))
-        XCTAssertTrue(startBody.contains("guard existingGatesAllowStart"))
-        XCTAssertTrue(startBody.contains("guard unitsDecision.allowed"))
+        let commitBody = try functionBody(
+            "private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)"
+        )
+        XCTAssertTrue(startBody.contains("nativeHeartRatePreflightEngine.requestStart"))
+        XCTAssertTrue(commitBody.contains("controllerUnitsGateDecision"))
+        XCTAssertTrue(commitBody.contains("guard nativeHeartRateSafetyFacts().permitsCommit"))
     }
 
     func testStopTruthAnchorsToActualInitialWriteAndPersistsUnavailableOutcome() throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TreadmillTelemetryBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TreadmillTelemetryBoundaryTests.swift
@@ -147,13 +147,18 @@ final class TreadmillTelemetryBoundaryTests: XCTestCase {
             in: managerSource
         )
         let start = try functionBody("func startHrControl()", in: managerSource)
+        let commit = try functionBody(
+            "private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)",
+            in: managerSource
+        )
         XCTAssertFalse(affordance.lowercased().contains("telemetry"))
         XCTAssertFalse(affordance.contains("factual"))
         XCTAssertFalse(affordance.contains("commandID"))
         XCTAssertFalse(affordance.contains("treadmillTelemetrySink"))
-        XCTAssertTrue(start.contains("heartRateRuntimePrerequisitesAllowStart"))
-        XCTAssertTrue(start.contains("controllerUnitsGateDecision"))
+        XCTAssertTrue(start.contains("nativeHeartRatePreflightEngine.requestStart"))
+        XCTAssertTrue(commit.contains("controllerUnitsGateDecision"))
         XCTAssertFalse(start.contains("treadmillTelemetrySink"))
+        XCTAssertFalse(commit.contains("treadmillTelemetrySink"))
     }
 
     func testFactualAndStopEvidenceOnlyUseDecodedObservationAndExistingPredicate() throws {


### PR DESCRIPTION
## Summary
- add a deterministic two-phase native HealthKit HR preflight that freezes the Start intent and commits existing HR control exactly once only after fresh current-session HR and all current motion gates pass
- keep pre-commit acquisition motionless and outside controlled timing/Telemetry V2, with bounded cancellation for user, timeout, background, provider failure, and control-readiness loss
- make iPhone HealthKit the production HR/workout owner, ignore legacy Watch HR/UUID/Stop interaction while native-owned, and link the saved workout directly or through persisted deferred lookup without retrying save
- show the binding indeterminate Training Hub copy and explicit Cancel action

## Safety boundaries
- no treadmill Start/speed command, production Stop, controlled timer, workout statistics, or Telemetry V2 session before commit
- commit rechecks foreground activity, fresh native measurement provenance, current control-ready transport/epoch, controller units, and conflicting workout/Stop state
- transient inactive defers commit; background discards the uncommitted HealthKit workout
- telemetry availability remains observational and cannot gate Start or motion

## Verification
- `swift test`
- `xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -configuration Debug -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
- fresh adversarial review of preflight, lifecycle, Watch-race, finish, and deferred-linkage paths

Closes #78