### PR TITLE
Recover native HealthKit workouts after relaunch

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -7356,13 +7356,21 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         return stored == deferredNativeHealthKitLinkages
     }
 
-    private func resolveDeferredNativeHealthKitLinkageIfPossible() {
+    private func resolveDeferredNativeHealthKitLinkageIfPossible(
+        excluding attempted: [DeferredNativeHealthKitLinkage] = []
+    ) {
         guard nativeHeartRateAppActivity == .active,
               !nativeHealthKitLinkageQueryInFlight else { return }
         loadDeferredNativeHealthKitLinkagesIfNeeded()
+        let candidates = deferredNativeHealthKitLinkages.filter {
+            !attempted.contains($0)
+        }
         guard let linkage = DeferredNativeHealthKitLinkageQueue.next(
-            in: deferredNativeHealthKitLinkages
+            in: candidates,
+            preferredRecoveryAppWorkoutID: activeNativeWorkoutRecoveryRecord?
+                .appWorkoutID
         ) else { return }
+        let attemptedIncludingCurrent = attempted + [linkage]
 
         if let workoutID = linkage.healthKitWorkoutID {
             nativeHealthKitLinkageQueryInFlight = true
@@ -7376,12 +7384,17 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 nativeHealthKitLinkageQueryInFlight = false
                 guard linkagePersisted else {
                     nativeHeartRateLogger.error("deferred_exact_link_failed")
+                    resolveDeferredNativeHealthKitLinkageIfPossible(
+                        excluding: attemptedIncludingCurrent
+                    )
                     return
                 }
                 appendLog("Deferred native HealthKit workout linked: \(workoutID.uuidString)")
                 nativeHeartRateLogger.info("deferred_exact_link_resolved")
                 clearDeferredNativeHealthKitLinkage(linkage)
-                resolveDeferredNativeHealthKitLinkageIfPossible()
+                resolveDeferredNativeHealthKitLinkageIfPossible(
+                    excluding: attempted
+                )
             }
             return
         }
@@ -7404,6 +7417,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 guard error == nil else {
                     nativeHealthKitLinkageQueryInFlight = false
                     nativeHeartRateLogger.error("deferred_link_query_failed")
+                    resolveDeferredNativeHealthKitLinkageIfPossible(
+                        excluding: attemptedIncludingCurrent
+                    )
                     return
                 }
                 let appBundleIdentifier = Bundle.main.bundleIdentifier
@@ -7437,6 +7453,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 }
                 guard let workout else {
                     nativeHealthKitLinkageQueryInFlight = false
+                    nativeHeartRateLogger.error("deferred_link_match_unproven")
+                    resolveDeferredNativeHealthKitLinkageIfPossible(
+                        excluding: attemptedIncludingCurrent
+                    )
                     return
                 }
                 let provenLinkage = retainSavedWorkoutProof(
@@ -7446,10 +7466,15 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 nativeHealthKitLinkageQueryInFlight = false
                 guard let provenLinkage else {
                     nativeHeartRateLogger.error("deferred_saved_proof_write_failed")
+                    resolveDeferredNativeHealthKitLinkageIfPossible(
+                        excluding: attemptedIncludingCurrent
+                    )
                     return
                 }
                 completeRecoveredFinishIfProven(linkage: provenLinkage)
-                resolveDeferredNativeHealthKitLinkageIfPossible()
+                resolveDeferredNativeHealthKitLinkageIfPossible(
+                    excluding: attempted
+                )
             }
         }
         healthStore.execute(query)

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -2288,11 +2288,16 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             pendingHealthkitTelemetryV2SessionID = record.telemetrySessionID.map {
                 SessionID(rawValue: $0)
             }
-            retainDeferredNativeHealthKitLinkage(
+            guard retainDeferredNativeHealthKitLinkage(
                 record: record,
                 finishRequestedAt: finishRequestedAt,
                 healthKitStoppedAt: healthKitStoppedAt
-            )
+            ) != nil else {
+                isNativeWorkoutRecoveryActive = true
+                nativeWorkoutRecoveryStatusText = "Не удалось сохранить проверку тренировки"
+                recomputeHrStartAllowed()
+                return
+            }
             isNativeWorkoutRecoveryActive = true
             nativeWorkoutRecoveryStatusText = "Проверяем сохранение восстановленной тренировки…"
             recomputeHrStartAllowed()
@@ -2415,21 +2420,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         hrStreamingActive = false
         hrLastValueAt = nil
         heartRateBPM = 0
-        switch nativeWorkoutRecoveryLoadResult {
-        case .missing:
-            isNativeWorkoutRecoveryActive = false
-            nativeWorkoutRecoveryStatusText = nil
-        case .record(let record) where record.phase == .preflight:
-            if clearNativeWorkoutRecoveryRecord() {
-                isNativeWorkoutRecoveryActive = false
-                isNativeHeartRatePreflightActive = false
-                nativeWorkoutRecoveryStatusText = nil
-            }
-        case .invalid, .record:
-            isNativeWorkoutRecoveryActive = true
-            nativeWorkoutRecoveryStatusText = "Не удалось восстановить тренировку"
-            infoToastMessage = "HealthKit не восстановил активную тренировку. Управление дорожкой не возобновлено."
-        }
+        isNativeWorkoutRecoveryActive = true
+        nativeWorkoutRecoveryStatusText = "Не удалось восстановить тренировку"
+        infoToastMessage = "HealthKit не восстановил активную тренировку. Управление дорожкой не возобновлено."
         if error != nil {
             nativeHeartRateLogger.error("active_workout_recovery_failed")
         }
@@ -7229,15 +7222,19 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                         throw IPhoneHealthKitHeartRateProviderError.operationCancelled
                     }
                     nativeHealthKitAcquisitionStartedAt = nil
-                    guard await linkNativeHealthKitWorkout(
-                        uuid: workout.uuid,
-                        record: completedRecord
-                    ) else {
+                    guard retainDeferredNativeHealthKitLinkage(
+                        record: completedRecord,
+                        finishRequestedAt: completedRecord.terminalRequestedAt
+                            ?? finishRequestedAt,
+                        healthKitStoppedAt: completedRecord.healthKitStopActivityAt,
+                        healthKitWorkoutID: workout.uuid
+                    ) != nil else {
                         throw IPhoneHealthKitHeartRateProviderError.operationCancelled
                     }
-                    appendLog("Native HealthKit workout linked: \(workout.uuid.uuidString)")
-                    nativeHeartRateLogger.info("workout_finished_direct_link")
                     terminalSaveProven = true
+                    resolveDeferredNativeHealthKitLinkageIfPossible()
+                    appendLog("Native HealthKit workout saved: \(workout.uuid.uuidString)")
+                    nativeHeartRateLogger.info("workout_finished_direct_proof")
                 case .savedWorkoutUnavailable:
                     guard let completedRecord = activeNativeWorkoutRecoveryRecord,
                           let terminalRequestedAt = completedRecord.terminalRequestedAt,
@@ -7245,11 +7242,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                         throw IPhoneHealthKitHeartRateProviderError.operationCancelled
                     }
                     appendLog("Native HealthKit finish returned no workout; exact saved proof pending")
-                    retainDeferredNativeHealthKitLinkage(
+                    guard retainDeferredNativeHealthKitLinkage(
                         record: completedRecord,
                         finishRequestedAt: terminalRequestedAt,
-                        healthKitStoppedAt: healthKitStoppedAt
-                    )
+                        healthKitStoppedAt: healthKitStoppedAt,
+                        healthKitWorkoutID: nil
+                    ) != nil else {
+                        throw IPhoneHealthKitHeartRateProviderError.operationCancelled
+                    }
                     resolveDeferredNativeHealthKitLinkageIfPossible()
                     nativeHeartRateLogger.info("workout_finish_proof_deferred")
                     terminalProofPending = true
@@ -7264,8 +7264,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private func retainDeferredNativeHealthKitLinkage(
         record: NativeWorkoutRecoveryRecord,
         finishRequestedAt: Date,
-        healthKitStoppedAt: Date
-    ) {
+        healthKitStoppedAt: Date?,
+        healthKitWorkoutID: UUID? = nil
+    ) -> DeferredNativeHealthKitLinkage? {
         let linkage = DeferredNativeHealthKitLinkage(
             acquisitionStartedAt: record.acquisitionStartedAt,
             finishRequestedAt: finishRequestedAt,
@@ -7274,14 +7275,32 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             telemetrySessionID: record.telemetrySessionID,
             linksLegacyWorkout: record.legacyWorkoutID != nil,
             legacyWorkoutID: record.legacyWorkoutID,
-            recoveryAppWorkoutID: record.appWorkoutID
+            recoveryAppWorkoutID: record.appWorkoutID,
+            healthKitWorkoutID: healthKitWorkoutID
         )
-        if !deferredNativeHealthKitLinkages.contains(linkage) {
+        guard retainDeferredNativeHealthKitLinkage(linkage) else { return nil }
+        return linkage
+    }
+
+    @discardableResult
+    private func retainDeferredNativeHealthKitLinkage(
+        _ linkage: DeferredNativeHealthKitLinkage
+    ) -> Bool {
+        loadDeferredNativeHealthKitLinkagesIfNeeded()
+        if let recoveryAppWorkoutID = linkage.recoveryAppWorkoutID,
+           let index = deferredNativeHealthKitLinkages.firstIndex(where: {
+               $0.recoveryAppWorkoutID == recoveryAppWorkoutID
+           }) {
+            let existing = deferredNativeHealthKitLinkages[index]
+            if existing.healthKitWorkoutID != nil,
+               linkage.healthKitWorkoutID == nil {
+                return true
+            }
+            deferredNativeHealthKitLinkages[index] = linkage
+        } else if !deferredNativeHealthKitLinkages.contains(linkage) {
             deferredNativeHealthKitLinkages.append(linkage)
         }
-        if let data = try? JSONEncoder().encode(deferredNativeHealthKitLinkages) {
-            UserDefaults.standard.set(data, forKey: deferredNativeHealthKitLinkageStoreKey)
-        }
+        return persistDeferredNativeHealthKitLinkages()
     }
 
     private func clearDeferredNativeHealthKitLinkage(
@@ -7290,22 +7309,65 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         deferredNativeHealthKitLinkages.removeAll { $0 == linkage }
         if deferredNativeHealthKitLinkages.isEmpty {
             UserDefaults.standard.removeObject(forKey: deferredNativeHealthKitLinkageStoreKey)
-        } else if let data = try? JSONEncoder().encode(deferredNativeHealthKitLinkages) {
-            UserDefaults.standard.set(data, forKey: deferredNativeHealthKitLinkageStoreKey)
+        } else {
+            _ = persistDeferredNativeHealthKitLinkages()
         }
+    }
+
+    private func loadDeferredNativeHealthKitLinkagesIfNeeded() {
+        guard deferredNativeHealthKitLinkages.isEmpty,
+              let data = UserDefaults.standard.data(
+                forKey: deferredNativeHealthKitLinkageStoreKey
+              ) else { return }
+        deferredNativeHealthKitLinkages = (try? JSONDecoder().decode(
+            [DeferredNativeHealthKitLinkage].self,
+            from: data
+        )) ?? []
+    }
+
+    private func persistDeferredNativeHealthKitLinkages() -> Bool {
+        guard let data = try? JSONEncoder().encode(deferredNativeHealthKitLinkages) else {
+            return false
+        }
+        UserDefaults.standard.set(data, forKey: deferredNativeHealthKitLinkageStoreKey)
+        guard let storedData = UserDefaults.standard.data(
+            forKey: deferredNativeHealthKitLinkageStoreKey
+        ), let stored = try? JSONDecoder().decode(
+            [DeferredNativeHealthKitLinkage].self,
+            from: storedData
+        ) else {
+            return false
+        }
+        return stored == deferredNativeHealthKitLinkages
     }
 
     private func resolveDeferredNativeHealthKitLinkageIfPossible() {
         guard nativeHeartRateAppActivity == .active,
               !nativeHealthKitLinkageQueryInFlight else { return }
-        if deferredNativeHealthKitLinkages.isEmpty,
-           let data = UserDefaults.standard.data(forKey: deferredNativeHealthKitLinkageStoreKey) {
-            deferredNativeHealthKitLinkages = (try? JSONDecoder().decode(
-                [DeferredNativeHealthKitLinkage].self,
-                from: data
-            )) ?? []
-        }
+        loadDeferredNativeHealthKitLinkagesIfNeeded()
         guard let linkage = deferredNativeHealthKitLinkages.first else { return }
+
+        if let workoutID = linkage.healthKitWorkoutID {
+            nativeHealthKitLinkageQueryInFlight = true
+            completeRecoveredFinishIfProven(linkage: linkage)
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let linkagePersisted = await linkDeferredNativeHealthKitWorkout(
+                    uuid: workoutID,
+                    linkage: linkage
+                )
+                nativeHealthKitLinkageQueryInFlight = false
+                guard linkagePersisted else {
+                    nativeHeartRateLogger.error("deferred_exact_link_failed")
+                    return
+                }
+                appendLog("Deferred native HealthKit workout linked: \(workoutID.uuidString)")
+                nativeHeartRateLogger.info("deferred_exact_link_resolved")
+                clearDeferredNativeHealthKitLinkage(linkage)
+                resolveDeferredNativeHealthKitLinkageIfPossible()
+            }
+            return
+        }
 
         nativeHealthKitLinkageQueryInFlight = true
         let expectedEndAt = linkage.healthKitStoppedAt ?? linkage.finishRequestedAt
@@ -7360,16 +7422,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     nativeHealthKitLinkageQueryInFlight = false
                     return
                 }
-                let linkagePersisted = await linkDeferredNativeHealthKitWorkout(
-                    uuid: workout.uuid,
-                    linkage: linkage
-                )
+                let provenLinkage = linkage.provingSavedWorkout(id: workout.uuid)
+                let proofPersisted = retainDeferredNativeHealthKitLinkage(provenLinkage)
                 nativeHealthKitLinkageQueryInFlight = false
-                guard linkagePersisted else { return }
-                appendLog("Deferred native HealthKit workout linked: \(workout.uuid.uuidString)")
-                nativeHeartRateLogger.info("deferred_link_resolved")
-                clearDeferredNativeHealthKitLinkage(linkage)
-                completeRecoveredFinishIfProven(linkage: linkage)
+                guard proofPersisted else {
+                    nativeHeartRateLogger.error("deferred_saved_proof_write_failed")
+                    return
+                }
+                completeRecoveredFinishIfProven(linkage: provenLinkage)
                 resolveDeferredNativeHealthKitLinkageIfPossible()
             }
         }
@@ -7438,26 +7498,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             legacyShadowWorkoutHistory = entries
         }
         return true
-    }
-
-    @discardableResult
-    private func linkNativeHealthKitWorkout(
-        uuid: UUID,
-        record: NativeWorkoutRecoveryRecord
-    ) async -> Bool {
-        await linkDeferredNativeHealthKitWorkout(
-            uuid: uuid,
-            linkage: DeferredNativeHealthKitLinkage(
-                acquisitionStartedAt: record.acquisitionStartedAt,
-                finishRequestedAt: record.terminalRequestedAt ?? Date.distantPast,
-                healthKitStoppedAt: record.healthKitStopActivityAt,
-                profileID: record.profileID,
-                telemetrySessionID: record.telemetrySessionID,
-                linksLegacyWorkout: record.legacyWorkoutID != nil,
-                legacyWorkoutID: record.legacyWorkoutID,
-                recoveryAppWorkoutID: record.appWorkoutID
-            )
-        )
     }
 
     private func completeRecoveredFinishIfProven(

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -626,24 +626,27 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         return list.map { legacyShadowWorkoutEntry(from: $0) }
     }
 
+    @discardableResult
     private func saveLegacyShadowWorkoutHistory(
         _ entries: [LegacyShadowWorkoutEntry],
         profileID: UUID
-    ) {
+    ) -> Bool {
         // Compatibility-only parity evidence through #37; #36 owns mandatory removal.
         let list = entries.prefix(50).map { workoutEntryDTO(from: $0) }
         guard let data = try? JSONEncoder().encode(list) else {
             legacyShadowWriterStatusText = "failed: encode"
             appendLog("Legacy shadow writer failed: encode")
-            return
+            return false
         }
         let key = profileScopedStoreKey(workoutHistoryStoreKey, profileID: profileID)
         UserDefaults.standard.set(data, forKey: key)
         if UserDefaults.standard.data(forKey: key) == data {
             legacyShadowWriterStatusText = "ok"
+            return true
         } else {
             legacyShadowWriterStatusText = "failed: persistence"
             appendLog("Legacy shadow writer failed: persistence")
+            return false
         }
     }
 
@@ -7226,7 +7229,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                         throw IPhoneHealthKitHeartRateProviderError.operationCancelled
                     }
                     nativeHealthKitAcquisitionStartedAt = nil
-                    guard linkNativeHealthKitWorkout(
+                    guard await linkNativeHealthKitWorkout(
                         uuid: workout.uuid,
                         record: completedRecord
                     ) else {
@@ -7317,10 +7320,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             limit: 10,
             sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)]
         ) { [weak self] _, samples, error in
-            DispatchQueue.main.async { [weak self] in
+            Task { @MainActor [weak self] in
                 guard let self else { return }
-                nativeHealthKitLinkageQueryInFlight = false
                 guard error == nil else {
+                    nativeHealthKitLinkageQueryInFlight = false
                     nativeHeartRateLogger.error("deferred_link_query_failed")
                     return
                 }
@@ -7353,11 +7356,16 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                         )) <= 5
                         && abs(workout.endDate.timeIntervalSince(expectedEndAt)) <= 15
                 }
-                guard let workout else { return }
-                guard linkDeferredNativeHealthKitWorkout(
+                guard let workout else {
+                    nativeHealthKitLinkageQueryInFlight = false
+                    return
+                }
+                let linkagePersisted = await linkDeferredNativeHealthKitWorkout(
                     uuid: workout.uuid,
                     linkage: linkage
-                ) else { return }
+                )
+                nativeHealthKitLinkageQueryInFlight = false
+                guard linkagePersisted else { return }
                 appendLog("Deferred native HealthKit workout linked: \(workout.uuid.uuidString)")
                 nativeHeartRateLogger.info("deferred_link_resolved")
                 clearDeferredNativeHealthKitLinkage(linkage)
@@ -7372,47 +7380,62 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private func linkDeferredNativeHealthKitWorkout(
         uuid: UUID,
         linkage: DeferredNativeHealthKitLinkage
-    ) -> Bool {
-        if linkage.linksLegacyWorkout {
-            guard let profileID = linkage.profileID,
-                  let legacyWorkoutID = linkage.legacyWorkoutID else {
-                return false
-            }
-            var entries = loadLegacyShadowWorkoutHistory(profileID: profileID)
-            guard let index = entries.firstIndex(where: { $0.id == legacyWorkoutID }) else {
-                return false
-            }
-            let entry = entries[index]
-            guard NativeWorkoutLegacyLinkPolicy.canLink(
-                existingWorkoutUUID: entry.healthkitWorkoutUUID,
-                expectedWorkoutUUID: uuid
-            ) else {
-                return false
-            }
-            if entry.healthkitWorkoutUUID == nil {
-                entries[index] = LegacyShadowWorkoutEntry(
-                    id: entry.id,
-                    date: entry.date,
-                    beatsPerMeter: entry.beatsPerMeter,
-                    targetBpm: entry.targetBpm,
-                    durationSeconds: entry.durationSeconds,
-                    avgBpm: entry.avgBpm,
-                    avgSpeedKmh: entry.avgSpeedKmh,
-                    healthkitWorkoutUUID: uuid.uuidString,
-                    zoneSeconds: entry.zoneSeconds
-                )
-                saveLegacyShadowWorkoutHistory(entries, profileID: profileID)
-                if activeUserProfileID == profileID {
-                    legacyShadowWorkoutHistory = entries
-                }
-            }
+    ) async -> Bool {
+        let telemetrySessionID = linkage.telemetrySessionID.map {
+            SessionID(rawValue: $0)
         }
+        return await NativeWorkoutRequiredLinkagePolicy.complete(
+            legacyRequired: linkage.linksLegacyWorkout,
+            persistLegacy: { [self] in
+                persistExactLegacyWorkoutLink(uuid: uuid, linkage: linkage)
+            },
+            telemetryRequired: telemetrySessionID != nil,
+            persistTelemetry: { [self] in
+                guard let telemetrySessionID else { return false }
+                return await persistHealthKitWorkoutAssociationWithTelemetryV2(
+                    sessionID: telemetrySessionID,
+                    workoutIdentifier: uuid
+                )
+            }
+        )
+    }
 
-        if let telemetrySessionID = linkage.telemetrySessionID {
-            associateHealthKitWorkoutWithTelemetryV2(
-                sessionID: SessionID(rawValue: telemetrySessionID),
-                workoutIdentifier: uuid
-            )
+    private func persistExactLegacyWorkoutLink(
+        uuid: UUID,
+        linkage: DeferredNativeHealthKitLinkage
+    ) -> Bool {
+        guard let profileID = linkage.profileID,
+              let legacyWorkoutID = linkage.legacyWorkoutID else {
+            return false
+        }
+        var entries = loadLegacyShadowWorkoutHistory(profileID: profileID)
+        guard let index = entries.firstIndex(where: { $0.id == legacyWorkoutID }) else {
+            return false
+        }
+        let entry = entries[index]
+        guard NativeWorkoutLegacyLinkPolicy.canLink(
+            existingWorkoutUUID: entry.healthkitWorkoutUUID,
+            expectedWorkoutUUID: uuid
+        ) else {
+            return false
+        }
+        guard entry.healthkitWorkoutUUID == nil else { return true }
+        entries[index] = LegacyShadowWorkoutEntry(
+            id: entry.id,
+            date: entry.date,
+            beatsPerMeter: entry.beatsPerMeter,
+            targetBpm: entry.targetBpm,
+            durationSeconds: entry.durationSeconds,
+            avgBpm: entry.avgBpm,
+            avgSpeedKmh: entry.avgSpeedKmh,
+            healthkitWorkoutUUID: uuid.uuidString,
+            zoneSeconds: entry.zoneSeconds
+        )
+        guard saveLegacyShadowWorkoutHistory(entries, profileID: profileID) else {
+            return false
+        }
+        if activeUserProfileID == profileID {
+            legacyShadowWorkoutHistory = entries
         }
         return true
     }
@@ -7421,8 +7444,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private func linkNativeHealthKitWorkout(
         uuid: UUID,
         record: NativeWorkoutRecoveryRecord
-    ) -> Bool {
-        linkDeferredNativeHealthKitWorkout(
+    ) async -> Bool {
+        await linkDeferredNativeHealthKitWorkout(
             uuid: uuid,
             linkage: DeferredNativeHealthKitLinkage(
                 acquisitionStartedAt: record.acquisitionStartedAt,
@@ -7924,21 +7947,31 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         sessionID: SessionID,
         workoutIdentifier: UUID
     ) {
-        Task { [weak self] in
+        Task { @MainActor [weak self] in
             guard let self else { return }
-            do {
-                try await self.telemetryV2Coordinator.associateHealthKitWorkout(
-                    sessionID: sessionID,
-                    workoutIdentifier: workoutIdentifier
-                )
-            } catch {
-                await MainActor.run {
-                    self.appendLog("Telemetry V2 HealthKit linkage failed: \(error)")
-                    self.telemetryV2WorkoutHistoryState = .failed(
-                        "HealthKit linkage failed: \(error.localizedDescription)"
-                    )
-                }
-            }
+            _ = await persistHealthKitWorkoutAssociationWithTelemetryV2(
+                sessionID: sessionID,
+                workoutIdentifier: workoutIdentifier
+            )
+        }
+    }
+
+    private func persistHealthKitWorkoutAssociationWithTelemetryV2(
+        sessionID: SessionID,
+        workoutIdentifier: UUID
+    ) async -> Bool {
+        do {
+            try await telemetryV2Coordinator.associateHealthKitWorkout(
+                sessionID: sessionID,
+                workoutIdentifier: workoutIdentifier
+            )
+            return true
+        } catch {
+            appendLog("Telemetry V2 HealthKit linkage failed: \(error)")
+            telemetryV2WorkoutHistoryState = .failed(
+                "HealthKit linkage failed: \(error.localizedDescription)"
+            )
+            return false
         }
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -7287,20 +7287,35 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         _ linkage: DeferredNativeHealthKitLinkage
     ) -> Bool {
         loadDeferredNativeHealthKitLinkagesIfNeeded()
-        if let recoveryAppWorkoutID = linkage.recoveryAppWorkoutID,
-           let index = deferredNativeHealthKitLinkages.firstIndex(where: {
-               $0.recoveryAppWorkoutID == recoveryAppWorkoutID
-           }) {
-            let existing = deferredNativeHealthKitLinkages[index]
-            if existing.healthKitWorkoutID != nil,
-               linkage.healthKitWorkoutID == nil {
-                return true
-            }
-            deferredNativeHealthKitLinkages[index] = linkage
-        } else if !deferredNativeHealthKitLinkages.contains(linkage) {
-            deferredNativeHealthKitLinkages.append(linkage)
+        guard let updated = DeferredNativeHealthKitLinkageQueue.retaining(
+            linkage,
+            in: deferredNativeHealthKitLinkages
+        ) else { return false }
+        let previous = deferredNativeHealthKitLinkages
+        deferredNativeHealthKitLinkages = updated
+        guard persistDeferredNativeHealthKitLinkages() else {
+            deferredNativeHealthKitLinkages = previous
+            return false
         }
-        return persistDeferredNativeHealthKitLinkages()
+        return true
+    }
+
+    private func retainSavedWorkoutProof(
+        id: UUID,
+        replacing source: DeferredNativeHealthKitLinkage
+    ) -> DeferredNativeHealthKitLinkage? {
+        guard let updated = DeferredNativeHealthKitLinkageQueue.provingSavedWorkout(
+            id: id,
+            replacing: source,
+            in: deferredNativeHealthKitLinkages
+        ) else { return nil }
+        let previous = deferredNativeHealthKitLinkages
+        deferredNativeHealthKitLinkages = updated
+        guard persistDeferredNativeHealthKitLinkages() else {
+            deferredNativeHealthKitLinkages = previous
+            return nil
+        }
+        return source.provingSavedWorkout(id: id)
     }
 
     private func clearDeferredNativeHealthKitLinkage(
@@ -7345,7 +7360,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         guard nativeHeartRateAppActivity == .active,
               !nativeHealthKitLinkageQueryInFlight else { return }
         loadDeferredNativeHealthKitLinkagesIfNeeded()
-        guard let linkage = deferredNativeHealthKitLinkages.first else { return }
+        guard let linkage = DeferredNativeHealthKitLinkageQueue.next(
+            in: deferredNativeHealthKitLinkages
+        ) else { return }
 
         if let workoutID = linkage.healthKitWorkoutID {
             nativeHealthKitLinkageQueryInFlight = true
@@ -7422,10 +7439,12 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     nativeHealthKitLinkageQueryInFlight = false
                     return
                 }
-                let provenLinkage = linkage.provingSavedWorkout(id: workout.uuid)
-                let proofPersisted = retainDeferredNativeHealthKitLinkage(provenLinkage)
+                let provenLinkage = retainSavedWorkoutProof(
+                    id: workout.uuid,
+                    replacing: linkage
+                )
                 nativeHealthKitLinkageQueryInFlight = false
-                guard proofPersisted else {
+                guard let provenLinkage else {
                     nativeHeartRateLogger.error("deferred_saved_proof_write_failed")
                     return
                 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -2262,26 +2262,45 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             .resolveWithoutActiveRecoveryRequest(
                 loadResult: nativeWorkoutRecoveryLoadResult
             )
-        guard case .reconcileFinished(let record) = resolution,
-              let finishRequestedAt = record.terminalRequestedAt else { return }
-
-        nativeHealthKitAcquisitionStartedAt = record.acquisitionStartedAt
-        pendingHealthkitWorkoutProfileID = record.profileID
-        pendingHealthkitTelemetryV2SessionID = record.telemetrySessionID.map {
-            SessionID(rawValue: $0)
-        }
-        retainDeferredNativeHealthKitLinkage(
-            finishRequestedAt: finishRequestedAt
-        )
-        guard clearNativeWorkoutRecoveryRecord() else {
-            isNativeWorkoutRecoveryActive = true
-            nativeWorkoutRecoveryStatusText = "Не удалось завершить восстановленную тренировку"
-            recomputeHrStartAllowed()
+        switch resolution {
+        case .retainFailClosed:
             return
+        case .discardPreflight:
+            guard clearNativeWorkoutRecoveryRecord() else {
+                isNativeWorkoutRecoveryActive = true
+                nativeWorkoutRecoveryStatusText = "Не удалось очистить незапущенную тренировку"
+                recomputeHrStartAllowed()
+                return
+            }
+            completeNativeWorkoutRecoveryToIdle()
+            warmNativeHeartRateProviderIfPossible()
+            nativeHeartRateLogger.info("stale_preflight_cleared_without_recovery_request")
+        case .reconcileFinished(let record):
+            guard let finishRequestedAt = record.terminalRequestedAt,
+                  let healthKitStoppedAt = record.healthKitStopActivityAt else {
+                return
+            }
+            nativeHealthKitAcquisitionStartedAt = record.acquisitionStartedAt
+            pendingHealthkitWorkoutProfileID = record.profileID
+            pendingHealthkitTelemetryV2SessionID = record.telemetrySessionID.map {
+                SessionID(rawValue: $0)
+            }
+            retainDeferredNativeHealthKitLinkage(
+                record: record,
+                finishRequestedAt: finishRequestedAt,
+                healthKitStoppedAt: healthKitStoppedAt
+            )
+            isNativeWorkoutRecoveryActive = true
+            nativeWorkoutRecoveryStatusText = "Проверяем сохранение восстановленной тренировки…"
+            recomputeHrStartAllowed()
+            resolveDeferredNativeHealthKitLinkageIfPossible()
         }
+    }
 
+    private func completeNativeWorkoutRecoveryToIdle() {
         nativeHealthKitWorkoutCommitted = false
         nativeHeartRateFlowOwnsController = false
+        isNativeHeartRatePreflightActive = false
         isNativeHeartRateCurrent = false
         hrStreamingActive = false
         hrLastValueAt = nil
@@ -2295,9 +2314,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         hrRemainingSeconds = 0
         hrProgress = 0
         recomputeHrStartAllowed()
-        resolveDeferredNativeHealthKitLinkageIfPossible()
-        warmNativeHeartRateProviderIfPossible()
-        nativeHeartRateLogger.info("finished_workout_reconciled_without_recovery_request")
     }
 
     private func discardRecoveredUncommittedWorkout() {
@@ -2370,9 +2386,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     ) {
         isRestoringNativeWorkoutRecoveryState = true
         hrTargetBPM = record.targetBPM
-        hrDurationMinutes = record.durationMinutes
+        hrDurationMinutes = max(1, (record.effectivePlannedDurationSeconds + 59) / 60)
         isRestoringNativeWorkoutRecoveryState = false
-        hrSessionTotalSeconds = max(60, record.durationMinutes * 60)
+        hrSessionTotalSeconds = record.effectivePlannedDurationSeconds
         hrControlStartedAt = record.controlledWorkoutStartedAt
         syncRecoveredWorkoutTiming()
     }
@@ -4477,6 +4493,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let newTotalSeconds = min(hrSessionTotalSeconds + addSeconds, maxTotalSeconds)
         let addedSeconds = max(0, newTotalSeconds - hrSessionTotalSeconds)
         guard addedSeconds > 0 else { return }
+        if nativeHealthKitWorkoutCommitted,
+           let recoveryRecord = activeNativeWorkoutRecoveryRecord,
+           !persistNativeWorkoutRecoveryRecord(
+                recoveryRecord.planningDuration(seconds: newTotalSeconds)
+           ) {
+            infoToastMessage = "Не удалось сохранить новое время тренировки."
+            return
+        }
         hrSessionTotalSeconds = newTotalSeconds
         hrRemainingSeconds += addedSeconds
         hrProgress = hrSessionTotalSeconds > 0 ? (1.0 - (Double(hrRemainingSeconds) / Double(hrSessionTotalSeconds))) : 0
@@ -7142,10 +7166,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             recomputeHrStartAllowed()
             return
         }
+        guard let finishingRecord = activeNativeWorkoutRecoveryRecord,
+              finishingRecord.phase == .finishing else { return }
         nativeHealthKitWorkoutFinishInFlight = true
         Task { @MainActor [weak self] in
             guard let self else { return }
-            var terminalCompletionSucceeded = false
+            var terminalSaveProven = false
+            var terminalProofPending = false
             defer {
                 nativeHealthKitWorkoutFinishInFlight = false
                 nativeHeartRateFlowOwnsController = false
@@ -7154,18 +7181,15 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 nativeHeartRateProviderLifecycle.releaseCommittedProvider()
                 nativeWorkoutRecoverySessionRecovered = false
                 nativeWorkoutRecoveryStopRequested = false
-                if terminalCompletionSucceeded,
+                if terminalSaveProven,
                    clearNativeWorkoutRecoveryRecord() {
-                    nativeHealthKitWorkoutCommitted = false
-                    isNativeWorkoutRecoveryActive = false
-                    nativeWorkoutRecoveryStatusText = nil
-                    hrControlStartedAt = nil
-                    hrRemainingSeconds = 0
-                    hrProgress = 0
+                    completeNativeWorkoutRecoveryToIdle()
                 } else {
                     nativeHealthKitWorkoutCommitted = true
                     isNativeWorkoutRecoveryActive = true
-                    nativeWorkoutRecoveryStatusText = "Не удалось завершить восстановленную тренировку"
+                    nativeWorkoutRecoveryStatusText = terminalProofPending
+                        ? "Проверяем сохранение восстановленной тренировки…"
+                        : "Не удалось завершить восстановленную тренировку"
                 }
                 recomputeHrStartAllowed()
                 if !hasOutstandingNativeWorkoutRecovery {
@@ -7173,28 +7197,60 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 }
             }
             do {
-                switch try await iPhoneHealthKitHeartRateProvider.finish(at: finishRequestedAt) {
+                switch try await iPhoneHealthKitHeartRateProvider.finish(
+                    at: finishRequestedAt,
+                    recoveredStoppedAt: finishingRecord.healthKitStopActivityAt,
+                    persistStoppedAt: { [weak self] stoppedAt in
+                        guard let self,
+                              let currentRecord = activeNativeWorkoutRecoveryRecord,
+                              currentRecord.appWorkoutID == finishingRecord.appWorkoutID,
+                              currentRecord.phase == .finishing else {
+                            return false
+                        }
+                        return persistNativeWorkoutRecoveryRecord(
+                            currentRecord.recordingHealthKitStopActivity(at: stoppedAt)
+                        )
+                    }
+                ) {
                 case .saved(let workout):
+                    guard let completedRecord = activeNativeWorkoutRecoveryRecord,
+                          completedRecord.appWorkoutID == finishingRecord.appWorkoutID,
+                          NativeWorkoutSavedProofPolicy.matches(
+                            record: completedRecord,
+                            workoutStartedAt: workout.startDate,
+                            workoutEndedAt: workout.endDate,
+                            isWalking: workout.workoutActivityType == .walking,
+                            sourceMatchesApp: workout.sourceRevision.source.bundleIdentifier
+                                == Bundle.main.bundleIdentifier
+                          ) else {
+                        throw IPhoneHealthKitHeartRateProviderError.operationCancelled
+                    }
                     nativeHealthKitAcquisitionStartedAt = nil
-                    linkNativeHealthKitWorkout(
+                    guard linkNativeHealthKitWorkout(
                         uuid: workout.uuid,
-                        endedAt: workout.endDate,
-                        profileID: pendingHealthkitWorkoutProfileID ?? activeUserProfileID,
-                        telemetrySessionID: pendingHealthkitTelemetryV2SessionID
-                            ?? activeTelemetryV2SessionID,
-                        linksLegacyWorkout: hrWorkoutRecorded
-                    )
+                        record: completedRecord
+                    ) else {
+                        throw IPhoneHealthKitHeartRateProviderError.operationCancelled
+                    }
                     appendLog("Native HealthKit workout linked: \(workout.uuid.uuidString)")
                     nativeHeartRateLogger.info("workout_finished_direct_link")
+                    terminalSaveProven = true
                 case .savedWorkoutUnavailable:
-                    appendLog("Native HealthKit workout saved; direct UUID unavailable, deferred linkage retained")
+                    guard let completedRecord = activeNativeWorkoutRecoveryRecord,
+                          let terminalRequestedAt = completedRecord.terminalRequestedAt,
+                          let healthKitStoppedAt = completedRecord.healthKitStopActivityAt else {
+                        throw IPhoneHealthKitHeartRateProviderError.operationCancelled
+                    }
+                    appendLog("Native HealthKit finish returned no workout; exact saved proof pending")
                     retainDeferredNativeHealthKitLinkage(
-                        finishRequestedAt: finishRequestedAt
+                        record: completedRecord,
+                        finishRequestedAt: terminalRequestedAt,
+                        healthKitStoppedAt: healthKitStoppedAt
                     )
                     resolveDeferredNativeHealthKitLinkageIfPossible()
-                    nativeHeartRateLogger.info("workout_finished_deferred_link")
+                    nativeHeartRateLogger.info("workout_finish_proof_deferred")
+                    terminalProofPending = true
                 }
-                terminalCompletionSucceeded = true
             } catch {
                 appendLog("Native HealthKit workout finish failed: \(error.localizedDescription)")
                 nativeHeartRateLogger.error("workout_finish_failed")
@@ -7202,14 +7258,20 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
     }
 
-    private func retainDeferredNativeHealthKitLinkage(finishRequestedAt: Date) {
-        guard let acquisitionStartedAt = nativeHealthKitAcquisitionStartedAt else { return }
+    private func retainDeferredNativeHealthKitLinkage(
+        record: NativeWorkoutRecoveryRecord,
+        finishRequestedAt: Date,
+        healthKitStoppedAt: Date
+    ) {
         let linkage = DeferredNativeHealthKitLinkage(
-            acquisitionStartedAt: acquisitionStartedAt,
+            acquisitionStartedAt: record.acquisitionStartedAt,
             finishRequestedAt: finishRequestedAt,
-            profileID: pendingHealthkitWorkoutProfileID ?? activeUserProfileID,
-            telemetrySessionID: (pendingHealthkitTelemetryV2SessionID ?? activeTelemetryV2SessionID)?.rawValue,
-            linksLegacyWorkout: hrWorkoutRecorded
+            healthKitStoppedAt: healthKitStoppedAt,
+            profileID: record.profileID,
+            telemetrySessionID: record.telemetrySessionID,
+            linksLegacyWorkout: record.legacyWorkoutID != nil,
+            legacyWorkoutID: record.legacyWorkoutID,
+            recoveryAppWorkoutID: record.appWorkoutID
         )
         if !deferredNativeHealthKitLinkages.contains(linkage) {
             deferredNativeHealthKitLinkages.append(linkage)
@@ -7243,9 +7305,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         guard let linkage = deferredNativeHealthKitLinkages.first else { return }
 
         nativeHealthKitLinkageQueryInFlight = true
+        let expectedEndAt = linkage.healthKitStoppedAt ?? linkage.finishRequestedAt
         let predicate = HKQuery.predicateForSamples(
             withStart: linkage.acquisitionStartedAt.addingTimeInterval(-2),
-            end: linkage.finishRequestedAt.addingTimeInterval(2),
+            end: expectedEndAt.addingTimeInterval(2),
             options: []
         )
         let query = HKSampleQuery(
@@ -7253,26 +7316,52 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             predicate: predicate,
             limit: 10,
             sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)]
-        ) { [weak self] _, samples, _ in
+        ) { [weak self] _, samples, error in
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 nativeHealthKitLinkageQueryInFlight = false
+                guard error == nil else {
+                    nativeHeartRateLogger.error("deferred_link_query_failed")
+                    return
+                }
                 let appBundleIdentifier = Bundle.main.bundleIdentifier
-                let workout = (samples as? [HKWorkout])?.first { workout in
-                    workout.workoutActivityType == .walking
+                let recoveryRecord: NativeWorkoutRecoveryRecord? = {
+                    guard let recoveryAppWorkoutID = linkage.recoveryAppWorkoutID,
+                          case .record(let record) = self.nativeWorkoutRecoveryLoadResult,
+                          record.appWorkoutID == recoveryAppWorkoutID else {
+                        return nil
+                    }
+                    return record
+                }()
+                let workout = NativeWorkoutSavedProofPolicy.uniqueMatch(
+                    in: samples as? [HKWorkout] ?? []
+                ) { workout in
+                    if let recoveryRecord {
+                        return NativeWorkoutSavedProofPolicy.matches(
+                            record: recoveryRecord,
+                            workoutStartedAt: workout.startDate,
+                            workoutEndedAt: workout.endDate,
+                            isWalking: workout.workoutActivityType == .walking,
+                            sourceMatchesApp: workout.sourceRevision.source.bundleIdentifier
+                                == appBundleIdentifier
+                        )
+                    }
+                    return workout.workoutActivityType == .walking
                         && workout.sourceRevision.source.bundleIdentifier == appBundleIdentifier
-                        && abs(workout.startDate.timeIntervalSince(linkage.acquisitionStartedAt)) <= 5
-                        && abs(workout.endDate.timeIntervalSince(linkage.finishRequestedAt)) <= 15
+                        && abs(workout.startDate.timeIntervalSince(
+                            linkage.acquisitionStartedAt
+                        )) <= 5
+                        && abs(workout.endDate.timeIntervalSince(expectedEndAt)) <= 15
                 }
                 guard let workout else { return }
                 guard linkDeferredNativeHealthKitWorkout(
                     uuid: workout.uuid,
-                    endedAt: workout.endDate,
                     linkage: linkage
                 ) else { return }
                 appendLog("Deferred native HealthKit workout linked: \(workout.uuid.uuidString)")
                 nativeHeartRateLogger.info("deferred_link_resolved")
                 clearDeferredNativeHealthKitLinkage(linkage)
+                completeRecoveredFinishIfProven(linkage: linkage)
                 resolveDeferredNativeHealthKitLinkageIfPossible()
             }
         }
@@ -7282,32 +7371,40 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @discardableResult
     private func linkDeferredNativeHealthKitWorkout(
         uuid: UUID,
-        endedAt: Date,
         linkage: DeferredNativeHealthKitLinkage
     ) -> Bool {
         if linkage.linksLegacyWorkout {
-            guard let profileID = linkage.profileID else { return false }
+            guard let profileID = linkage.profileID,
+                  let legacyWorkoutID = linkage.legacyWorkoutID else {
+                return false
+            }
             var entries = loadLegacyShadowWorkoutHistory(profileID: profileID)
-            let matchWindow: TimeInterval = 15 * 60
-            guard let index = entries.firstIndex(where: {
-                $0.healthkitWorkoutUUID == nil
-                    && abs($0.date.timeIntervalSince(endedAt)) <= matchWindow
-            }) else { return false }
+            guard let index = entries.firstIndex(where: { $0.id == legacyWorkoutID }) else {
+                return false
+            }
             let entry = entries[index]
-            entries[index] = LegacyShadowWorkoutEntry(
-                id: entry.id,
-                date: entry.date,
-                beatsPerMeter: entry.beatsPerMeter,
-                targetBpm: entry.targetBpm,
-                durationSeconds: entry.durationSeconds,
-                avgBpm: entry.avgBpm,
-                avgSpeedKmh: entry.avgSpeedKmh,
-                healthkitWorkoutUUID: uuid.uuidString,
-                zoneSeconds: entry.zoneSeconds
-            )
-            saveLegacyShadowWorkoutHistory(entries, profileID: profileID)
-            if activeUserProfileID == profileID {
-                legacyShadowWorkoutHistory = entries
+            guard NativeWorkoutLegacyLinkPolicy.canLink(
+                existingWorkoutUUID: entry.healthkitWorkoutUUID,
+                expectedWorkoutUUID: uuid
+            ) else {
+                return false
+            }
+            if entry.healthkitWorkoutUUID == nil {
+                entries[index] = LegacyShadowWorkoutEntry(
+                    id: entry.id,
+                    date: entry.date,
+                    beatsPerMeter: entry.beatsPerMeter,
+                    targetBpm: entry.targetBpm,
+                    durationSeconds: entry.durationSeconds,
+                    avgBpm: entry.avgBpm,
+                    avgSpeedKmh: entry.avgSpeedKmh,
+                    healthkitWorkoutUUID: uuid.uuidString,
+                    zoneSeconds: entry.zoneSeconds
+                )
+                saveLegacyShadowWorkoutHistory(entries, profileID: profileID)
+                if activeUserProfileID == profileID {
+                    legacyShadowWorkoutHistory = entries
+                }
             }
         }
 
@@ -7320,23 +7417,37 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         return true
     }
 
+    @discardableResult
     private func linkNativeHealthKitWorkout(
         uuid: UUID,
-        endedAt: Date,
-        profileID: UUID?,
-        telemetrySessionID: SessionID?,
-        linksLegacyWorkout: Bool
-    ) {
-        if linksLegacyWorkout {
-            pendingHealthkitWorkoutProfileID = profileID
-            pendingHealthkitTelemetryV2SessionID = telemetrySessionID
-            attachHealthkitWorkoutUUID(uuid.uuidString, endedAt: endedAt)
-        } else if let telemetrySessionID {
-            associateHealthKitWorkoutWithTelemetryV2(
-                sessionID: telemetrySessionID,
-                workoutIdentifier: uuid
+        record: NativeWorkoutRecoveryRecord
+    ) -> Bool {
+        linkDeferredNativeHealthKitWorkout(
+            uuid: uuid,
+            linkage: DeferredNativeHealthKitLinkage(
+                acquisitionStartedAt: record.acquisitionStartedAt,
+                finishRequestedAt: record.terminalRequestedAt ?? Date.distantPast,
+                healthKitStoppedAt: record.healthKitStopActivityAt,
+                profileID: record.profileID,
+                telemetrySessionID: record.telemetrySessionID,
+                linksLegacyWorkout: record.legacyWorkoutID != nil,
+                legacyWorkoutID: record.legacyWorkoutID,
+                recoveryAppWorkoutID: record.appWorkoutID
             )
-        }
+        )
+    }
+
+    private func completeRecoveredFinishIfProven(
+        linkage: DeferredNativeHealthKitLinkage
+    ) {
+        guard let recoveryAppWorkoutID = linkage.recoveryAppWorkoutID,
+              case .record(let record) = nativeWorkoutRecoveryLoadResult,
+              record.phase == .finishing,
+              record.appWorkoutID == recoveryAppWorkoutID,
+              clearNativeWorkoutRecoveryRecord() else { return }
+        completeNativeWorkoutRecoveryToIdle()
+        warmNativeHeartRateProviderIfPossible()
+        nativeHeartRateLogger.info("finished_workout_reconciled_after_saved_proof")
     }
 
     private var treadmillTelemetryConnectionEpoch: TreadmillConnectionEpoch? {
@@ -7720,6 +7831,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             healthkitWorkoutUUID: attachedHealthkitWorkoutUUID,
             zoneSeconds: hrZoneSeconds
         )
+        if nativeHealthKitWorkoutCommitted,
+           let recoveryRecord = activeNativeWorkoutRecoveryRecord,
+           !persistNativeWorkoutRecoveryRecord(
+                recoveryRecord.linkingLegacyWorkout(id: entry.id)
+           ) {
+            appendLog("Workout not saved: recovery linkage persistence failed")
+            return
+        }
         legacyShadowWorkoutHistory.insert(entry, at: 0)
         pendingHealthkitWorkoutUUID = nil
         pendingHealthkitWorkoutProfileID = attachedHealthkitWorkoutUUID == nil ? workoutProfileID : nil

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -230,6 +230,23 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var deferredNativeHealthKitLinkages: [DeferredNativeHealthKitLinkage] = []
     private var nativeHealthKitAcquisitionStartedAt: Date?
     private var nativeHealthKitLinkageQueryInFlight = false
+    private lazy var nativeWorkoutRecoveryStore: NativeWorkoutRecoveryStore? = try? .applicationSupport(
+        bundleIdentifier: Bundle.main.bundleIdentifier ?? "sw.WalkingPadRemote"
+    )
+    private var nativeWorkoutRecoveryLoadResult: NativeWorkoutRecoveryLoadResult = .missing
+    private var activeNativeWorkoutRecoveryRecord: NativeWorkoutRecoveryRecord?
+    private var pendingActiveWorkoutRecoveryResult: (HKWorkoutSession?, Error?)?
+    private var didStartApplicationRuntime = false
+    private var activeWorkoutRecoveryAvailability: Bool?
+    private var activeWorkoutRecoveryRequestPending = false
+    private var didHandleActiveWorkoutRecoveryCallback = false
+    private var nativeWorkoutRecoverySessionRecovered = false
+    private var nativeWorkoutRecoveryStopRequested = false
+    private var pendingNativeWorkoutStopTerminalRequest: (
+        record: NativeWorkoutRecoveryRecord,
+        requestedAt: Date
+    )?
+    private var isRestoringNativeWorkoutRecoveryState = false
     private var hrControlFailed: Bool = false
     private let legacyWatchHeartRateSource = HeartRateProviderIdentity(
         kind: .legacyWatchWorkoutStream,
@@ -645,7 +662,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     func selectUserProfile(id: UUID) {
         guard userProfiles.contains(where: { $0.id == id }) else { return }
-        guard !isHrControlRunning else {
+        guard !shouldPresentActiveWorkout else {
             infoToastMessage = "Во время активной тренировки профиль переключать нельзя."
             return
         }
@@ -665,7 +682,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     func createUserProfile(named rawLabel: String) {
-        guard !isHrControlRunning else {
+        guard !shouldPresentActiveWorkout else {
             infoToastMessage = "Во время активной тренировки профиль менять нельзя."
             return
         }
@@ -695,7 +712,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     func renameActiveUserProfile(to rawLabel: String) {
-        guard !isHrControlRunning else {
+        guard !shouldPresentActiveWorkout else {
             infoToastMessage = "Во время активной тренировки профиль менять нельзя."
             return
         }
@@ -715,7 +732,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     func deleteActiveUserProfile() {
-        guard !isHrControlRunning else {
+        guard !shouldPresentActiveWorkout else {
             infoToastMessage = "Во время активной тренировки профиль менять нельзя."
             return
         }
@@ -972,6 +989,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @Published var hrControlStartBlockReasonText: String? = nil
     @Published private(set) var isNativeHeartRatePreflightActive: Bool = false
     @Published private(set) var isNativeHeartRateCurrent: Bool = false
+    @Published private(set) var isNativeWorkoutRecoveryActive: Bool = false
+    @Published private(set) var nativeWorkoutRecoveryStatusText: String? = nil
 
     private var nativeHeartRatePreflightEngine = NativeHeartRatePreflightEngine()
     private var nativeHeartRateAppActivity: NativeHeartRatePreflightEngine.AppActivity = .inactive
@@ -998,11 +1017,17 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @Published var hrCooldownProgress: Double = 0
     @Published var hrTargetBPM: Int = 130 {
         didSet {
+            guard !isRestoringNativeWorkoutRecoveryState else { return }
             sendHrTargetBpm()
             saveHrSettingsIfNeeded()
         }
     }
-    @Published var hrDurationMinutes: Int = 10 { didSet { saveHrSettingsIfNeeded() } }
+    @Published var hrDurationMinutes: Int = 10 {
+        didSet {
+            guard !isRestoringNativeWorkoutRecoveryState else { return }
+            saveHrSettingsIfNeeded()
+        }
+    }
     @Published var hrAdaptiveStepEnabled: Bool = true { didSet { saveHrSettingsIfNeeded() } }
     @Published var hrDecisionIntervalSeconds: Int = 10 { didSet { saveHrSettingsIfNeeded() } }
     @Published var hrSpeedStepKmh: Double = 0.5 { didSet { saveHrSettingsIfNeeded() } }
@@ -1571,11 +1596,20 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     @discardableResult
-    private func startTrainingStructuredLog(trigger: String) -> UUID? {
+    private func startTrainingStructuredLog(
+        trigger: String,
+        sessionID: UUID? = nil
+    ) -> UUID? {
         stopTrainingStructuredLog(reason: "restart_before_new_session")
-        guard let dir = trainingLogsDirectoryURL() else { return nil }
-
-        let sessionId = UUID().uuidString
+        let resolvedSessionID = sessionID
+            ?? (trigger == "start_hr"
+                ? activeNativeWorkoutRecoveryRecord?.legacySessionID
+                : nil)
+            ?? UUID()
+        guard let dir = trainingLogsDirectoryURL() else {
+            return resolvedSessionID
+        }
+        let sessionId = resolvedSessionID.uuidString
         let fileName = "hr_session_\(trainingLogTimestampFormatter.string(from: Date()))_\(sessionId).jsonl"
         let fileURL = dir.appendingPathComponent(fileName, isDirectory: false)
         FileManager.default.createFile(atPath: fileURL.path, contents: nil)
@@ -1606,10 +1640,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 "zone_bounds": [hrZone1Max, hrZone2Max, hrZone3Max, hrZone4Max]
             ].merging(controllerUnitsTelemetryFields(action: "session_start")) { current, _ in current })
             scheduleTrainingLogsInventoryRefresh()
-            return UUID(uuidString: sessionId)
+            return resolvedSessionID
         } catch {
             appendLog("Training log file open error: \(error.localizedDescription)")
-            return nil
+            return resolvedSessionID
         }
     }
 
@@ -2051,6 +2085,338 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
     }
 
+    func handleActiveWorkoutRecoveryRequest() {
+        guard !didHandleActiveWorkoutRecoveryCallback else { return }
+        activeWorkoutRecoveryRequestPending = true
+        isNativeWorkoutRecoveryActive = true
+        nativeWorkoutRecoveryStatusText = "Восстанавливаем тренировку…"
+        recomputeHrStartAllowed()
+    }
+
+    func handleActiveWorkoutRecoveryAvailability(recoveryRequested: Bool) {
+        if recoveryRequested {
+            activeWorkoutRecoveryAvailability = true
+            return
+        }
+        guard activeWorkoutRecoveryAvailability != true else { return }
+        activeWorkoutRecoveryAvailability = false
+        processNoActiveWorkoutRecoveryIfPossible()
+    }
+
+    func handleActiveWorkoutRecovery(
+        session: HKWorkoutSession?,
+        error: Error?
+    ) {
+        guard !didHandleActiveWorkoutRecoveryCallback else { return }
+        didHandleActiveWorkoutRecoveryCallback = true
+        activeWorkoutRecoveryRequestPending = false
+        pendingActiveWorkoutRecoveryResult = (session, error)
+        processPendingActiveWorkoutRecoveryIfPossible()
+    }
+
+    private var hasOutstandingNativeWorkoutRecovery: Bool {
+        if activeWorkoutRecoveryRequestPending || isNativeWorkoutRecoveryActive {
+            return true
+        }
+        switch nativeWorkoutRecoveryLoadResult {
+        case .missing:
+            return false
+        case .invalid, .record:
+            return true
+        }
+    }
+
+    private var blocksNonStopTreadmillMotion: Bool {
+        activeWorkoutRecoveryRequestPending
+            || isNativeWorkoutRecoveryActive
+            || pendingNativeWorkoutStopTerminalRequest != nil
+            || activeNativeWorkoutRecoveryRecord?.phase == .stopping
+            || activeNativeWorkoutRecoveryRecord?.phase == .finishing
+    }
+
+    private func loadNativeWorkoutRecoveryState() {
+        guard let nativeWorkoutRecoveryStore else {
+            nativeWorkoutRecoveryLoadResult = .invalid
+            isNativeWorkoutRecoveryActive = true
+            nativeWorkoutRecoveryStatusText = "Не удалось прочитать состояние восстановления"
+            return
+        }
+        nativeWorkoutRecoveryLoadResult = nativeWorkoutRecoveryStore.load()
+        guard case .record(let record) = nativeWorkoutRecoveryLoadResult else {
+            if case .invalid = nativeWorkoutRecoveryLoadResult {
+                isNativeWorkoutRecoveryActive = true
+                nativeWorkoutRecoveryStatusText = "Восстанавливаем тренировку…"
+            }
+            return
+        }
+        activeNativeWorkoutRecoveryRecord = record
+        switch record.phase {
+        case .preflight:
+            isNativeWorkoutRecoveryActive = true
+            nativeWorkoutRecoveryStatusText = "Восстанавливаем тренировку…"
+            isNativeHeartRatePreflightActive = true
+        case .committed, .stopping, .finishing:
+            restoreNativeWorkoutRecoveryPresentation(record)
+            isNativeWorkoutRecoveryActive = true
+            nativeWorkoutRecoveryStopRequested = record.phase == .finishing
+            nativeWorkoutRecoveryStatusText = record.phase == .finishing
+                ? "Завершаем восстановленную тренировку…"
+                : "Восстанавливаем тренировку…"
+        }
+    }
+
+    @discardableResult
+    private func persistNativeWorkoutRecoveryRecord(
+        _ record: NativeWorkoutRecoveryRecord
+    ) -> Bool {
+        guard let nativeWorkoutRecoveryStore else { return false }
+        do {
+            try nativeWorkoutRecoveryStore.save(record)
+            nativeWorkoutRecoveryLoadResult = .record(record)
+            activeNativeWorkoutRecoveryRecord = record
+            return true
+        } catch {
+            nativeHeartRateLogger.error("recovery_marker_write_failed")
+            return false
+        }
+    }
+
+    @discardableResult
+    private func clearNativeWorkoutRecoveryRecord() -> Bool {
+        guard let nativeWorkoutRecoveryStore else { return false }
+        do {
+            try nativeWorkoutRecoveryStore.clear()
+            nativeWorkoutRecoveryLoadResult = .missing
+            activeNativeWorkoutRecoveryRecord = nil
+            return true
+        } catch {
+            nativeHeartRateLogger.error("recovery_marker_clear_failed")
+            return false
+        }
+    }
+
+    private func processPendingActiveWorkoutRecoveryIfPossible() {
+        guard didStartApplicationRuntime,
+              let result = pendingActiveWorkoutRecoveryResult else { return }
+        pendingActiveWorkoutRecoveryResult = nil
+        guard result.1 == nil, let recoveredSession = result.0 else {
+            handleUnavailableActiveWorkoutRecovery(error: result.1)
+            return
+        }
+
+        isNativeWorkoutRecoveryActive = true
+        isNativeHeartRatePreflightActive = false
+        nativeWorkoutRecoveryStatusText = "Восстанавливаем тренировку…"
+        let recoveryAttemptID: UUID = {
+            guard case .record(let record) = nativeWorkoutRecoveryLoadResult else {
+                return UUID()
+            }
+            return record.appWorkoutID
+        }()
+        nativeHeartRateProviderLifecycle.bindAttempt(recoveryAttemptID)
+        let providerGeneration = nativeHeartRateProviderLifecycle.beginProviderLifecycle()
+        do {
+            let lifecycle = try iPhoneHealthKitHeartRateProvider.recover(
+                recoveredSession,
+                failureContext: IPhoneHealthKitRuntimeFailureContext(
+                    providerGeneration: providerGeneration,
+                    attemptID: recoveryAttemptID
+                )
+            )
+            let configuration = recoveredSession.workoutConfiguration
+            let resolution = NativeWorkoutRecoveryPolicy.resolve(
+                loadResult: nativeWorkoutRecoveryLoadResult,
+                recoveredSessionStartedAt: lifecycle.startedAt,
+                recoveredCollectionStarted: lifecycle.collectionStarted,
+                configurationIsIndoorWalking: configuration.activityType == .walking
+                    && configuration.locationType == .indoor
+            )
+            switch resolution {
+            case .discard:
+                discardRecoveredUncommittedWorkout()
+            case .restore(let record):
+                restoreCommittedNativeWorkout(record)
+            case .finish(let record):
+                resumeFinishingNativeWorkout(record)
+            }
+        } catch {
+            nativeHeartRateLogger.error("active_workout_recovery_attach_failed")
+            let cleanupGeneration = nativeHeartRateProviderLifecycle.beginCleanup()
+            _ = nativeHeartRateProviderLifecycle.completeCleanup(
+                generation: cleanupGeneration,
+                providerIsIdle: iPhoneHealthKitHeartRateProvider.state == .idle
+            )
+            handleUnavailableActiveWorkoutRecovery(error: error)
+        }
+    }
+
+    private func processNoActiveWorkoutRecoveryIfPossible() {
+        guard didStartApplicationRuntime,
+              activeWorkoutRecoveryAvailability == false,
+              !activeWorkoutRecoveryRequestPending,
+              !didHandleActiveWorkoutRecoveryCallback,
+              !nativeHealthKitWorkoutCommitted,
+              !nativeHeartRateFlowOwnsController,
+              !nativeHealthKitWorkoutFinishInFlight else { return }
+        let resolution = NativeWorkoutRecoveryPolicy
+            .resolveWithoutActiveRecoveryRequest(
+                loadResult: nativeWorkoutRecoveryLoadResult
+            )
+        guard case .reconcileFinished(let record) = resolution,
+              let finishRequestedAt = record.terminalRequestedAt else { return }
+
+        nativeHealthKitAcquisitionStartedAt = record.acquisitionStartedAt
+        pendingHealthkitWorkoutProfileID = record.profileID
+        pendingHealthkitTelemetryV2SessionID = record.telemetrySessionID.map {
+            SessionID(rawValue: $0)
+        }
+        retainDeferredNativeHealthKitLinkage(
+            finishRequestedAt: finishRequestedAt
+        )
+        guard clearNativeWorkoutRecoveryRecord() else {
+            isNativeWorkoutRecoveryActive = true
+            nativeWorkoutRecoveryStatusText = "Не удалось завершить восстановленную тренировку"
+            recomputeHrStartAllowed()
+            return
+        }
+
+        nativeHealthKitWorkoutCommitted = false
+        nativeHeartRateFlowOwnsController = false
+        isNativeHeartRateCurrent = false
+        hrStreamingActive = false
+        hrLastValueAt = nil
+        heartRateBPM = 0
+        nativeHealthKitAcquisitionStartedAt = nil
+        nativeWorkoutRecoverySessionRecovered = false
+        nativeWorkoutRecoveryStopRequested = false
+        isNativeWorkoutRecoveryActive = false
+        nativeWorkoutRecoveryStatusText = nil
+        hrControlStartedAt = nil
+        hrRemainingSeconds = 0
+        hrProgress = 0
+        recomputeHrStartAllowed()
+        resolveDeferredNativeHealthKitLinkageIfPossible()
+        warmNativeHeartRateProviderIfPossible()
+        nativeHeartRateLogger.info("finished_workout_reconciled_without_recovery_request")
+    }
+
+    private func discardRecoveredUncommittedWorkout() {
+        nativeHeartRateFlowOwnsController = false
+        nativeHealthKitWorkoutCommitted = false
+        isNativeHeartRateCurrent = false
+        hrStreamingActive = false
+        hrLastValueAt = nil
+        heartRateBPM = 0
+        let cleanupGeneration = nativeHeartRateProviderLifecycle.beginCleanup()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await iPhoneHealthKitHeartRateProvider.discard(at: Date())
+            guard nativeHeartRateProviderLifecycle.completeCleanup(
+                generation: cleanupGeneration,
+                providerIsIdle: iPhoneHealthKitHeartRateProvider.state == .idle
+            ) else { return }
+            guard clearNativeWorkoutRecoveryRecord() else {
+                handleUnavailableActiveWorkoutRecovery(error: nil)
+                return
+            }
+            isNativeWorkoutRecoveryActive = false
+            isNativeHeartRatePreflightActive = false
+            nativeWorkoutRecoveryStatusText = nil
+            nativeWorkoutRecoverySessionRecovered = false
+            nativeWorkoutRecoveryStopRequested = false
+            recomputeHrStartAllowed()
+            warmNativeHeartRateProviderIfPossible()
+        }
+    }
+
+    private func restoreCommittedNativeWorkout(
+        _ record: NativeWorkoutRecoveryRecord
+    ) {
+        guard let controlledWorkoutStartedAt = record.controlledWorkoutStartedAt,
+              let profileID = record.profileID,
+              let telemetrySessionID = record.telemetrySessionID else {
+            discardRecoveredUncommittedWorkout()
+            return
+        }
+        activeNativeWorkoutRecoveryRecord = record
+        nativeWorkoutRecoveryLoadResult = .record(record)
+        nativeHealthKitWorkoutCommitted = true
+        nativeHeartRateFlowOwnsController = true
+        nativeWorkoutRecoverySessionRecovered = true
+        nativeWorkoutRecoveryStopRequested = false
+        nativeHealthKitAcquisitionStartedAt = record.acquisitionStartedAt
+        pendingHealthkitWorkoutProfileID = profileID
+        pendingHealthkitTelemetryV2SessionID = SessionID(rawValue: telemetrySessionID)
+        hrControlStartedAt = controlledWorkoutStartedAt
+        restoreNativeWorkoutRecoveryPresentation(record)
+        isNativeWorkoutRecoveryActive = true
+        nativeWorkoutRecoveryStatusText = "Тренировка восстановлена"
+        syncRecoveredWorkoutTiming()
+        recomputeHrStartAllowed()
+        nativeHeartRateLogger.info("active_workout_recovered_fail_closed")
+    }
+
+    private func resumeFinishingNativeWorkout(
+        _ record: NativeWorkoutRecoveryRecord
+    ) {
+        restoreCommittedNativeWorkout(record)
+        nativeWorkoutRecoveryStopRequested = true
+        nativeWorkoutRecoveryStatusText = "Завершаем восстановленную тренировку…"
+        finishNativeHealthKitWorkoutIfNeeded()
+    }
+
+    private func restoreNativeWorkoutRecoveryPresentation(
+        _ record: NativeWorkoutRecoveryRecord
+    ) {
+        isRestoringNativeWorkoutRecoveryState = true
+        hrTargetBPM = record.targetBPM
+        hrDurationMinutes = record.durationMinutes
+        isRestoringNativeWorkoutRecoveryState = false
+        hrSessionTotalSeconds = max(60, record.durationMinutes * 60)
+        hrControlStartedAt = record.controlledWorkoutStartedAt
+        syncRecoveredWorkoutTiming()
+    }
+
+    private func syncRecoveredWorkoutTiming(now: Date = Date()) {
+        guard let controlledWorkoutStartedAt = activeNativeWorkoutRecoveryRecord?
+                .controlledWorkoutStartedAt else { return }
+        let elapsed = max(0, Int(now.timeIntervalSince(controlledWorkoutStartedAt)))
+        hrRemainingSeconds = max(0, hrSessionTotalSeconds - elapsed)
+        hrProgress = hrSessionTotalSeconds > 0
+            ? min(1, Double(elapsed) / Double(hrSessionTotalSeconds))
+            : 0
+        hrNextDecisionSeconds = 0
+    }
+
+    private func handleUnavailableActiveWorkoutRecovery(error: Error?) {
+        nativeHeartRateFlowOwnsController = false
+        nativeWorkoutRecoverySessionRecovered = false
+        nativeWorkoutRecoveryStopRequested = false
+        isNativeHeartRateCurrent = false
+        hrStreamingActive = false
+        hrLastValueAt = nil
+        heartRateBPM = 0
+        switch nativeWorkoutRecoveryLoadResult {
+        case .missing:
+            isNativeWorkoutRecoveryActive = false
+            nativeWorkoutRecoveryStatusText = nil
+        case .record(let record) where record.phase == .preflight:
+            if clearNativeWorkoutRecoveryRecord() {
+                isNativeWorkoutRecoveryActive = false
+                isNativeHeartRatePreflightActive = false
+                nativeWorkoutRecoveryStatusText = nil
+            }
+        case .invalid, .record:
+            isNativeWorkoutRecoveryActive = true
+            nativeWorkoutRecoveryStatusText = "Не удалось восстановить тренировку"
+            infoToastMessage = "HealthKit не восстановил активную тренировку. Управление дорожкой не возобновлено."
+        }
+        if error != nil {
+            nativeHeartRateLogger.error("active_workout_recovery_failed")
+        }
+        recomputeHrStartAllowed()
+    }
+
     func start() {
         ensureCentral()
         autoConnectSuppressed = false
@@ -2065,12 +2431,16 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         loadHrSettings()
         loadZonePlan()
         loadLegacyShadowWorkoutHistory()
+        loadNativeWorkoutRecoveryState()
         refreshWorkoutHistoryFromV2(reset: true)
         refreshTrainingLogsInventory()
         setHeartRateTelemetrySink(telemetryV2Coordinator)
         setTreadmillTelemetrySink(telemetryV2Coordinator)
         telemetryV2Coordinator.prepareStoreAndRecover()
         scheduleLegacyTelemetryMigration()
+        didStartApplicationRuntime = true
+        processNoActiveWorkoutRecoveryIfPossible()
+        processPendingActiveWorkoutRecoveryIfPossible()
 #if canImport(WatchConnectivity)
         startWatchConnectivity()
 #endif
@@ -2858,6 +3228,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     func startStopTruthExperiment() {
         guard stopTruthExperimentController == nil,
               !stopTruthExperimentTerminalLatch,
+              !blocksNonStopTreadmillMotion,
               !isHrControlRunning,
               treadmillProtocol == .walkingPad,
               controllerUnitsQueryTransportReady,
@@ -3038,6 +3409,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         completion: @escaping (Result<StopTruthExperimentTransportReceipt, Error>) -> Void
     ) -> Bool {
         guard Thread.isMainThread,
+              !blocksNonStopTreadmillMotion,
               stopTruthExperimentController?.isActive == true,
               BLETransportCodec.validateStopTruthExperimentPacket(packet, role: role),
               treadmillProtocol == .walkingPad,
@@ -3073,6 +3445,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             requiresFreshMetricTruth: controllerUnitsTruthRequired
         )
         guard !treadmillTestRunService.isActive,
+              !blocksNonStopTreadmillMotion,
               !isHrControlRunning,
               isTreadmillControlReady,
               connectedPeripheralId != nil,
@@ -3255,7 +3628,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     func manualStop() {
         logUiAction("STOP pressed (speed=\(String(format: "%.1f", speedKmh)), deviceTarget=\(String(format: "%.1f", deviceTargetSpeedKmh)), status=\(treadmillStatusText))")
-        if isHrControlRunning {
+        if isHrControlRunning || isNativeWorkoutRecoveryActive {
             appendLog("Manual stop while HR control active → ending training")
             stopHrControl()
             return
@@ -3264,6 +3637,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
 
     func startWithSpeed(_ kmh: Double) {
+        guard !blocksNonStopTreadmillMotion else {
+            infoToastMessage = "Сначала завершите восстановленную тренировку"
+            return
+        }
         guard isTreadmillControlReady else {
             infoToastMessage = isConnected
                 ? "Дождитесь готовности управления дорожкой"
@@ -3489,7 +3866,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         return true
     }
 
-    private func stopBeltWithToggle(reason: String) {
+    @discardableResult
+    private func stopBeltWithToggle(reason: String) -> Bool {
+        beginNativeWorkoutStopTerminalRequestIfNeeded()
         let wasRunning = (deviceTargetSpeedKmh > 0.3) || (speedKmh > 0.3)
         let telemetryDecision = makeTreadmillDecision(
             source: .stop,
@@ -3505,6 +3884,11 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             telemetryDecision: telemetryDecision,
             telemetryRequest: telemetryRequest
         )
+        if !stopCommandWasEnqueued {
+            nativeWorkoutStopTransportInvocationFailedIfNeeded(
+                reason: "Stop не поставлен в очередь"
+            )
+        }
         let telemetryChain = telemetryDecision.map {
             TreadmillStopTelemetryChain(
                 decisionID: $0.decisionID,
@@ -3513,7 +3897,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
         guard wasRunning else {
             beginStopObservation(source: reason, telemetryChain: telemetryChain)
-            return
+            return stopCommandWasEnqueued
         }
         switch treadmillProtocol {
         case .walkingPad:
@@ -3562,6 +3946,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             }
         }
         beginStopObservation(source: reason, telemetryChain: telemetryChain)
+        return stopCommandWasEnqueued
     }
 
     private func currentStopObservationContext() -> StopObservationContext? {
@@ -3997,6 +4382,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         activeTreadmillStopTelemetryChain = nil
     }
     func setTargetSpeedFromSlider(_ kmh: Double) {
+        guard !blocksNonStopTreadmillMotion else { return }
         let v = clampRunningSpeedKmh(kmh)
         desiredSpeedKmh = v
         guard isTreadmillControlReady else { return }
@@ -4020,6 +4406,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     }
     func adjustSpeed(delta: Double) {
         guard isTreadmillControlReady else { return }
+        guard !blocksNonStopTreadmillMotion else { return }
         let base = (deviceTargetSpeedKmh > 0.1) ? deviceTargetSpeedKmh : (speedKmh > 0.1 ? speedKmh : desiredSpeedKmh)
         let v = clampAnySpeedKmh(base + delta)
         guard abs(v - base) >= 0.01 else { return }
@@ -4046,6 +4433,40 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         return hrSessionTotalSeconds < (hrMaxSessionMinutes * 60)
     }
 
+    var shouldPresentActiveWorkout: Bool {
+        if isHrControlRunning { return true }
+        guard isNativeWorkoutRecoveryActive,
+              case .record(let record) = nativeWorkoutRecoveryLoadResult else {
+            return false
+        }
+        return record.phase == .committed
+            || record.phase == .stopping
+            || record.phase == .finishing
+    }
+
+    var canStopPresentedWorkout: Bool {
+        guard isNativeWorkoutRecoveryActive else { return true }
+        guard case .record(let record) = nativeWorkoutRecoveryLoadResult,
+              record.phase == .committed || record.phase == .stopping else {
+            return false
+        }
+        return !nativeWorkoutRecoveryStopRequested
+            && isTreadmillControlReady
+    }
+
+    var presentedWorkoutElapsedSeconds: Int {
+        guard let hrControlStartedAt else { return timeSec }
+        return max(0, Int(Date().timeIntervalSince(hrControlStartedAt)))
+    }
+
+    var presentedWorkoutPhaseTitle: String? {
+        guard isNativeWorkoutRecoveryActive else { return nil }
+        if nativeWorkoutRecoveryStopRequested { return "ЗАВЕРШАЕМ" }
+        return nativeWorkoutRecoverySessionRecovered
+            ? "ВОССТАНОВЛЕНА"
+            : "ВОССТАНОВЛЕНИЕ"
+    }
+
     var hrSessionMaxMinutes: Int { hrMaxSessionMinutes }
 
     func extendHrSession(minutes: Int = 5) {
@@ -4064,6 +4485,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     func startHrControl() {
         guard !isHrControlRunning,
+              !hasOutstandingNativeWorkoutRecovery,
               !nativeHeartRatePreflightEngine.hasStartIntent,
               !nativeHeartRateProviderLifecycle.cleanupInFlight else { return }
         let now = Date()
@@ -4105,7 +4527,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     func trainingHubDidDisappear() {
         isTrainingHubVisible = false
-        guard !isHrControlRunning else { return }
+        guard !shouldPresentActiveWorkout else { return }
         applyNativeHeartRatePreflightEffects(
             nativeHeartRatePreflightEngine.cancel(reason: .hubLeft)
         )
@@ -4153,7 +4575,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let unitsDecision = controllerUnitsGateDecision()
         guard nativeHeartRateSafetyFacts().permitsCommit,
               unitsDecision.allowed,
-              nativeHealthKitWorkoutCommitted else {
+              nativeHealthKitWorkoutCommitted,
+              let controlledWorkoutStartedAt = activeNativeWorkoutRecoveryRecord?
+                .controlledWorkoutStartedAt,
+              activeNativeWorkoutRecoveryRecord?.legacySessionID != nil else {
             if !unitsDecision.allowed {
                 persistBlockedControllerUnitsStart(decision: unitsDecision)
                 retryControllerUnitsQueryAfterBlockedStart()
@@ -4175,7 +4600,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         hrRemainingSeconds = hrSessionTotalSeconds
         hrNextDecisionSeconds = hrDecisionIntervalSeconds
         hrProgress = 0
-        hrControlStartedAt = Date()
+        hrControlStartedAt = controlledWorkoutStartedAt
         hrDecisionDetails = ""
         hrPredictorStatusLine = ""
         hrWorkoutRecorded = false
@@ -4265,6 +4690,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     private func warmNativeHeartRateProviderIfPossible() {
         guard !nativeHeartRateProviderLifecycle.cleanupInFlight,
+              !hasOutstandingNativeWorkoutRecovery,
               NativeHeartRatePreflightEngine.RuntimePolicy.canWarmPrepare(
             isTrainingHubVisible: isTrainingHubVisible,
             appActivity: nativeHeartRateAppActivity,
@@ -4280,6 +4706,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 .canPrepareWithoutAuthorizationPrompt()
             guard canPrepare,
                   !nativeHeartRateProviderLifecycle.cleanupInFlight,
+                  !hasOutstandingNativeWorkoutRecovery,
                   NativeHeartRatePreflightEngine.RuntimePolicy.canWarmPrepare(
                     isTrainingHubVisible: isTrainingHubVisible,
                     appActivity: nativeHeartRateAppActivity,
@@ -4359,6 +4786,19 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         intent: NativeHeartRatePreflightEngine.Intent,
         acquisitionStartedAt: Date
     ) {
+        let recoveryRecord = NativeWorkoutRecoveryRecord.preflight(
+            appWorkoutID: intent.id,
+            targetBPM: intent.targetBPM,
+            durationMinutes: intent.durationMinutes,
+            acquisitionStartedAt: acquisitionStartedAt,
+            profileID: activeUserProfileID
+        )
+        guard persistNativeWorkoutRecoveryRecord(recoveryRecord) else {
+            applyNativeHeartRatePreflightEffects(
+                nativeHeartRatePreflightEngine.cancel(reason: .providerFailure)
+            )
+            return
+        }
         let providerGeneration = nativeHeartRateProviderLifecycle.generation
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -4479,6 +4919,30 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             return
         }
 
+        guard case .record(let preflightRecord) = nativeWorkoutRecoveryLoadResult,
+              preflightRecord.phase == .preflight,
+              preflightRecord.appWorkoutID == intent.id,
+              preflightRecord.acquisitionStartedAt == acquisitionStartedAt,
+              let profileID = activeUserProfileID else {
+            abortNativeHeartRateFlow(reason: .superseded)
+            return
+        }
+        let controlledWorkoutStartedAt = now
+        let legacySessionID = UUID()
+        let telemetrySessionID = TelemetryV2SessionDescriptor.sessionID(
+            deterministicallyLinkedTo: legacySessionID
+        ).rawValue
+        let committedRecoveryRecord = preflightRecord.committed(
+            controlledWorkoutStartedAt: controlledWorkoutStartedAt,
+            profileID: profileID,
+            legacySessionID: legacySessionID,
+            telemetrySessionID: telemetrySessionID
+        )
+        guard persistNativeWorkoutRecoveryRecord(committedRecoveryRecord) else {
+            abortNativeHeartRateFlow(reason: .providerFailure)
+            return
+        }
+
         hrTargetBPM = intent.targetBPM
         hrDurationMinutes = intent.durationMinutes
         nativeHealthKitWorkoutCommitted = true
@@ -4513,6 +4977,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 generation: cleanupGeneration,
                 providerIsIdle: iPhoneHealthKitHeartRateProvider.state == .idle
             ) else { return }
+            guard clearNativeWorkoutRecoveryRecord() else {
+                handleUnavailableActiveWorkoutRecovery(error: nil)
+                return
+            }
             recomputeHrStartAllowed()
             warmNativeHeartRateProviderIfPossible()
         }
@@ -4542,6 +5010,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 generation: cleanupGeneration,
                 providerIsIdle: iPhoneHealthKitHeartRateProvider.state == .idle
             ) else { return }
+            guard clearNativeWorkoutRecoveryRecord() else {
+                handleUnavailableActiveWorkoutRecovery(error: nil)
+                return
+            }
             recomputeHrStartAllowed()
             warmNativeHeartRateProviderIfPossible()
         }
@@ -4571,6 +5043,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
     }
     func stopHrControl() {
+        if isNativeWorkoutRecoveryActive {
+            stopRecoveredNativeWorkout()
+            return
+        }
         let elapsed = hrControlStartedAt.map { Int(Date().timeIntervalSince($0)) }
         appendLog("HR stop: elapsed=\(elapsed ?? 0)s")
         logTrainingEvent("hr_control_stop_requested", fields: [
@@ -4596,6 +5072,65 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         stopBeltWithToggle(reason: "hr")
         stopLegacyWatchHeartRateIfNeeded()
         endTelemetryV2Session(reason: "manual_stop")
+    }
+
+    private func stopRecoveredNativeWorkout() {
+        guard canStopPresentedWorkout else { return }
+        nativeWorkoutRecoveryStopRequested = true
+        nativeWorkoutRecoveryStatusText = "Завершаем восстановленную тренировку…"
+        appendLog("Recovered native workout stop requested")
+        stopBeltWithToggle(reason: "recovered_hr_manual_stop")
+    }
+
+    private func beginNativeWorkoutStopTerminalRequestIfNeeded() {
+        guard pendingNativeWorkoutStopTerminalRequest == nil,
+              let record = activeNativeWorkoutRecoveryRecord,
+              record.phase == .committed || record.phase == .stopping else {
+            return
+        }
+        let requestedAt = record.terminalRequestedAt ?? Date()
+        if record.phase == .committed,
+           !persistNativeWorkoutRecoveryRecord(
+                record.stopping(requestedAt: requestedAt)
+           ) {
+            nativeHeartRateLogger.error("stopping_marker_write_failed")
+        }
+        pendingNativeWorkoutStopTerminalRequest = (
+            record: record,
+            requestedAt: requestedAt
+        )
+    }
+
+    private func nativeWorkoutStopTransportInvokedIfNeeded() {
+        guard let pending = pendingNativeWorkoutStopTerminalRequest else { return }
+        pendingNativeWorkoutStopTerminalRequest = nil
+        guard nativeHealthKitWorkoutCommitted else {
+            nativeWorkoutRecoveryStopRequested = false
+            nativeWorkoutRecoveryStatusText = "Stop отправлен • HealthKit не восстановлен"
+            recomputeHrStartAllowed()
+            return
+        }
+        guard persistNativeWorkoutRecoveryRecord(
+            pending.record.finishing(requestedAt: pending.requestedAt)
+        ) else {
+            isNativeWorkoutRecoveryActive = true
+            nativeWorkoutRecoveryStopRequested = false
+            nativeWorkoutRecoveryStatusText = "Не удалось сохранить завершение тренировки"
+            infoToastMessage = "Stop отправлен, но завершение не сохранено. Проверьте дорожку и повторите Stop."
+            recomputeHrStartAllowed()
+            return
+        }
+        finishNativeHealthKitWorkoutIfNeeded()
+    }
+
+    private func nativeWorkoutStopTransportInvocationFailedIfNeeded(reason: String) {
+        guard pendingNativeWorkoutStopTerminalRequest != nil else { return }
+        pendingNativeWorkoutStopTerminalRequest = nil
+        isNativeWorkoutRecoveryActive = true
+        nativeWorkoutRecoveryStopRequested = false
+        nativeWorkoutRecoveryStatusText = "Stop не отправлен"
+        infoToastMessage = "\(reason). Проверьте подключение и повторите Stop."
+        recomputeHrStartAllowed()
     }
 
     private func stopLegacyWatchHeartRateIfNeeded() {
@@ -4652,6 +5187,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let safety = nativeHeartRateSafetyFacts(now: now)
         let preflightGatesAllowStart = safety.permitsStartIntent
             && IPhoneHealthKitLiveHeartRateProvider.isSupported
+            && !hasOutstandingNativeWorkoutRecovery
             && !nativeHeartRatePreflightEngine.hasStartIntent
             && !nativeHeartRateProviderLifecycle.cleanupInFlight
         let unitsDecision = controllerUnitsGateDecision(now: now)
@@ -4755,6 +5291,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         applyNativeHeartRatePreflightEffects(
             nativeHeartRatePreflightEngine.tick(now: Date())
         )
+        if isNativeWorkoutRecoveryActive {
+            syncRecoveredWorkoutTiming()
+        }
         defer {
             if isHrControlRunning {
                 _ = telemetryV2Coordinator.observeCurrentElapsedSecond()
@@ -5373,10 +5912,16 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             guard let self else { return }
             guard self.commandQueueEpoch == epoch else {
                 self.isCommandQueueProcessing = false
+                self.nativeWorkoutStopTransportInvocationFailedIfNeeded(
+                    reason: "Очередь Stop была сброшена"
+                )
                 return
             }
             guard !self.commandQueue.isEmpty else {
                 self.isCommandQueueProcessing = false
+                self.nativeWorkoutStopTransportInvocationFailedIfNeeded(
+                    reason: "Команда Stop отсутствует в очереди"
+                )
                 return
             }
             let next = self.commandQueue.removeFirst()
@@ -5446,6 +5991,11 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     ) -> [TreadmillTelemetryEvidence] {
         if requiresControlReadiness && !isTreadmillControlReady {
             appendLog("WRITE SKIPPED (control not ready): \(label)")
+            if label == "STOP" {
+                nativeWorkoutStopTransportInvocationFailedIfNeeded(
+                    reason: "Управление дорожкой потеряло готовность"
+                )
+            }
             return [
                 .commandFailed(
                     TreadmillCommandFailureObservation(
@@ -5463,6 +6013,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             appendLog("WRITE SKIPPED (not connected): \(label)")
             if label == "STOP" {
                 markInitialStopCommandNotSent(reason: "not_connected")
+                nativeWorkoutStopTransportInvocationFailedIfNeeded(
+                    reason: "Дорожка отключилась до отправки Stop"
+                )
             }
             return [
                 .commandFailed(
@@ -5481,6 +6034,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             appendLog("WRITE SKIPPED (no characteristic): \(label)")
             if label == "STOP" {
                 markInitialStopCommandNotSent(reason: "characteristic_unavailable")
+                nativeWorkoutStopTransportInvocationFailedIfNeeded(
+                    reason: "Канал управления недоступен для Stop"
+                )
             }
             return [
                 .commandFailed(
@@ -5513,6 +6069,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         ])
         trackExpectedSpeedIfNeeded(label: label)
         p.writeValue(data, for: ch, type: type)
+        if label == "STOP" {
+            nativeWorkoutStopTransportInvokedIfNeeded()
+        }
         let sentAt = lastCommandSentAt ?? Date()
         let telemetryWriteType: TreadmillCommandWriteType = type == .withoutResponse
             ? .withoutResponse
@@ -6098,6 +6657,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         label: String,
         decision: TreadmillControlDecisionEvidence? = nil
     ) {
+        guard !blocksNonStopTreadmillMotion else {
+            appendLog("Set speed skipped: native workout recovery is fail-closed")
+            return
+        }
         guard isTreadmillControlReady else {
             appendLog("Set speed skipped: treadmill control not ready")
             return
@@ -6547,19 +7110,67 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private func finishNativeHealthKitWorkoutIfNeeded() {
         guard nativeHealthKitWorkoutCommitted,
               !nativeHealthKitWorkoutFinishInFlight else { return }
-        nativeHealthKitWorkoutFinishInFlight = true
+        guard pendingNativeWorkoutStopTerminalRequest == nil else { return }
         let finishRequestedAt = Date()
+        guard let record = activeNativeWorkoutRecoveryRecord else {
+            isNativeWorkoutRecoveryActive = true
+            nativeWorkoutRecoveryStatusText = "Не удалось сохранить завершение тренировки"
+            recomputeHrStartAllowed()
+            return
+        }
+        if record.phase == .stopping {
+            return
+        }
+        if record.phase == .committed {
+            guard !isConnected else {
+                isNativeWorkoutRecoveryActive = true
+                nativeWorkoutRecoveryStatusText = "Stop не отправлен"
+                recomputeHrStartAllowed()
+                return
+            }
+            guard persistNativeWorkoutRecoveryRecord(
+                record.finishing(requestedAt: finishRequestedAt)
+            ) else {
+                isNativeWorkoutRecoveryActive = true
+                nativeWorkoutRecoveryStatusText = "Не удалось сохранить завершение тренировки"
+                recomputeHrStartAllowed()
+                return
+            }
+        } else if record.phase != .finishing {
+            isNativeWorkoutRecoveryActive = true
+            nativeWorkoutRecoveryStatusText = "Некорректное состояние завершения"
+            recomputeHrStartAllowed()
+            return
+        }
+        nativeHealthKitWorkoutFinishInFlight = true
         Task { @MainActor [weak self] in
             guard let self else { return }
+            var terminalCompletionSucceeded = false
             defer {
-                nativeHealthKitWorkoutCommitted = false
                 nativeHealthKitWorkoutFinishInFlight = false
                 nativeHeartRateFlowOwnsController = false
                 isNativeHeartRateCurrent = false
                 nativeHealthKitAcquisitionStartedAt = nil
                 nativeHeartRateProviderLifecycle.releaseCommittedProvider()
+                nativeWorkoutRecoverySessionRecovered = false
+                nativeWorkoutRecoveryStopRequested = false
+                if terminalCompletionSucceeded,
+                   clearNativeWorkoutRecoveryRecord() {
+                    nativeHealthKitWorkoutCommitted = false
+                    isNativeWorkoutRecoveryActive = false
+                    nativeWorkoutRecoveryStatusText = nil
+                    hrControlStartedAt = nil
+                    hrRemainingSeconds = 0
+                    hrProgress = 0
+                } else {
+                    nativeHealthKitWorkoutCommitted = true
+                    isNativeWorkoutRecoveryActive = true
+                    nativeWorkoutRecoveryStatusText = "Не удалось завершить восстановленную тренировку"
+                }
                 recomputeHrStartAllowed()
-                warmNativeHeartRateProviderIfPossible()
+                if !hasOutstandingNativeWorkoutRecovery {
+                    warmNativeHeartRateProviderIfPossible()
+                }
             }
             do {
                 switch try await iPhoneHealthKitHeartRateProvider.finish(at: finishRequestedAt) {
@@ -6583,6 +7194,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     resolveDeferredNativeHealthKitLinkageIfPossible()
                     nativeHeartRateLogger.info("workout_finished_deferred_link")
                 }
+                terminalCompletionSucceeded = true
             } catch {
                 appendLog("Native HealthKit workout finish failed: \(error.localizedDescription)")
                 nativeHeartRateLogger.error("workout_finish_failed")

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -402,6 +402,7 @@ private func makeHRControlActivePresentation(
     isCooldown: Bool,
     cooldownTargetBPM: Int,
     canExtend: Bool,
+    phaseTitleOverride: String? = nil,
     isPreview: Bool = false
 ) -> TrainingHubPresentation {
     let fallbackRange = 60...220
@@ -478,7 +479,7 @@ private func makeHRControlActivePresentation(
         startBlocker: nil,
         isPreparing: false,
         isPreview: isPreview,
-        phaseTitle: isCooldown ? "ЗАМИНКА" : "ТРЕНИРОВКА",
+        phaseTitle: phaseTitleOverride ?? (isCooldown ? "ЗАМИНКА" : "ТРЕНИРОВКА"),
         primaryValue: factualHeartRate.map(String.init) ?? "—",
         primaryUnit: factualHeartRate == nil ? nil : "bpm",
         statusTitle: status.title,
@@ -1301,6 +1302,7 @@ private struct ActiveWorkoutShell: View {
     let presentation: TrainingHubPresentation
     let onExtend: () -> Void
     let onStop: () -> Void
+    var stopEnabled = true
 
     @ScaledMetric(relativeTo: .largeTitle) private var primaryValueSize: CGFloat = 86
     @State private var showExtendConfirm = false
@@ -1492,8 +1494,13 @@ private struct ActiveWorkoutShell: View {
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
             .tint(.red)
+            .disabled(!stopEnabled)
             .accessibilityLabel("Остановить HR-контроль")
-            .accessibilityHint("Запускает существующий процесс остановки тренировки")
+            .accessibilityHint(
+                stopEnabled
+                    ? "Запускает существующий процесс остановки тренировки"
+                    : "Доступно после восстановления управления дорожкой"
+            )
         }
         .padding(.horizontal, 16)
         .padding(.top, 8)
@@ -1944,10 +1951,11 @@ private struct ControlSwipeView: View {
             targetZoneIndex: hrZoneIndex(for: manager.hrTargetBPM, manager: manager),
             zoneRanges: hrZoneRanges(for: manager),
             factualSpeedKmh: factualSpeedKmh,
-            elapsedSeconds: manager.timeSec,
-            isCooldown: manager.hrRemainingSeconds <= 0,
+            elapsedSeconds: manager.presentedWorkoutElapsedSeconds,
+            isCooldown: manager.isHrControlRunning && manager.hrRemainingSeconds <= 0,
             cooldownTargetBPM: manager.hrCooldownTargetBpm,
-            canExtend: manager.canExtendHrSession
+            canExtend: manager.canExtendHrSession,
+            phaseTitleOverride: manager.presentedWorkoutPhaseTitle
         )
     }
 
@@ -1962,7 +1970,7 @@ private struct ControlSwipeView: View {
             }
         }
         #endif
-        guard manager.isHrControlRunning else { return nil }
+        guard manager.shouldPresentActiveWorkout else { return nil }
         return productionActiveWorkoutPresentation
     }
 
@@ -2040,7 +2048,8 @@ private struct ControlSwipeView: View {
             ActiveWorkoutShell(
                 presentation: activePresentation,
                 onExtend: { manager.extendHrSession(minutes: 5) },
-                onStop: { manager.stopHrControl() }
+                onStop: { manager.stopHrControl() },
+                stopEnabled: manager.canStopPresentedWorkout
             )
         } else {
             trainingHub

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/IPhoneHealthKitHeartRateProviderCore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/IPhoneHealthKitHeartRateProviderCore.swift
@@ -41,6 +41,8 @@ enum IPhoneHealthKitHeartRateProviderError: Error, Equatable {
         actual: IPhoneHealthKitHeartRateProviderState
     )
     case operationCancelled
+    case missingRecoveredStopDate
+    case stopDatePersistenceFailed
 }
 
 enum IPhoneHealthKitWorkoutFinishOutcome<Workout> {
@@ -73,6 +75,7 @@ final class IPhoneHealthKitHeartRateProviderCore<Driver: IPhoneHealthKitWorkoutL
     private var ownsWorkout = false
     private var activityStarted = false
     private var collectionStarted = false
+    private var stoppedAtForFinish: Date?
 
     private(set) var state: IPhoneHealthKitHeartRateProviderState = .idle
     var onObservation: ObservationHandler?
@@ -192,7 +195,9 @@ final class IPhoneHealthKitHeartRateProviderCore<Driver: IPhoneHealthKitWorkoutL
     }
 
     func finish(
-        at date: Date
+        at date: Date,
+        recoveredStoppedAt: Date? = nil,
+        persistStoppedAt: (Date) -> Bool = { _ in true }
     ) async throws -> IPhoneHealthKitWorkoutFinishOutcome<Driver.Workout> {
         guard state == .collecting else {
             throw IPhoneHealthKitHeartRateProviderError.invalidTransition(
@@ -201,13 +206,29 @@ final class IPhoneHealthKitHeartRateProviderCore<Driver: IPhoneHealthKitWorkoutL
             )
         }
 
+        if !activityStarted,
+           stoppedAtForFinish == nil,
+           recoveredStoppedAt == nil {
+            throw IPhoneHealthKitHeartRateProviderError.missingRecoveredStopDate
+        }
+
         let operationGeneration = generation
         state = .finishing
-        driver.stopActivity(at: date)
-
         do {
-            let stoppedAt = try await driver.waitForStoppedTransition()
+            let stoppedAt: Date
+            if let exactStoppedAt = stoppedAtForFinish ?? recoveredStoppedAt {
+                stoppedAt = exactStoppedAt
+            } else {
+                driver.stopActivity(at: date)
+                stoppedAt = try await driver.waitForStoppedTransition()
+                stoppedAtForFinish = stoppedAt
+            }
             try requireCurrent(operationGeneration, state: .finishing)
+            guard persistStoppedAt(stoppedAt) else {
+                state = .collecting
+                activityStarted = false
+                throw IPhoneHealthKitHeartRateProviderError.stopDatePersistenceFailed
+            }
             activityStarted = false
             try await driver.endCollection(at: stoppedAt)
             try requireCurrent(operationGeneration, state: .finishing)
@@ -221,6 +242,10 @@ final class IPhoneHealthKitHeartRateProviderCore<Driver: IPhoneHealthKitWorkoutL
             }
             return .savedWorkoutUnavailable
         } catch {
+            if error as? IPhoneHealthKitHeartRateProviderError
+                == .stopDatePersistenceFailed {
+                throw error
+            }
             if operationGeneration == generation {
                 await discardOwnedWorkout(at: date)
             }
@@ -265,6 +290,7 @@ final class IPhoneHealthKitHeartRateProviderCore<Driver: IPhoneHealthKitWorkoutL
         ownsWorkout = false
         activityStarted = false
         collectionStarted = false
+        stoppedAtForFinish = nil
         state = .idle
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/IPhoneHealthKitHeartRateProviderCore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/IPhoneHealthKitHeartRateProviderCore.swift
@@ -4,9 +4,13 @@ import TelemetryDomain
 protocol IPhoneHealthKitWorkoutLifecycleDriving: AnyObject {
     associatedtype Configuration
     associatedtype Workout
+    associatedtype RecoveredWorkout
 
     func requestAuthorization() async throws
     func createWorkout(configuration: Configuration) throws
+    func recoverWorkout(
+        _ recoveredWorkout: RecoveredWorkout
+    ) throws -> IPhoneHealthKitRecoveredWorkoutLifecycle
     func prepare() async throws
     func startActivity(at date: Date)
     func beginCollection(at date: Date) async throws
@@ -24,6 +28,7 @@ enum IPhoneHealthKitHeartRateProviderState: String, Equatable {
     case authorizing
     case preparing
     case prepared
+    case recovering
     case starting
     case collecting
     case resetting
@@ -50,6 +55,12 @@ struct IPhoneHealthKitHeartRateSample: Equatable {
     let measurementInterval: DateInterval?
     let callbackObservedAt: Date
     let receivedAt: Date
+}
+
+struct IPhoneHealthKitRecoveredWorkoutLifecycle: Equatable {
+    let activityStarted: Bool
+    let collectionStarted: Bool
+    let startedAt: Date?
 }
 
 @MainActor
@@ -103,6 +114,31 @@ final class IPhoneHealthKitHeartRateProviderCore<Driver: IPhoneHealthKitWorkoutL
             if operationGeneration == generation {
                 await discardOwnedWorkout()
             }
+            throw error
+        }
+    }
+
+    func recover(
+        _ recoveredWorkout: Driver.RecoveredWorkout
+    ) throws -> IPhoneHealthKitRecoveredWorkoutLifecycle {
+        guard state == .idle else {
+            throw IPhoneHealthKitHeartRateProviderError.invalidTransition(
+                expected: .idle,
+                actual: state
+            )
+        }
+
+        generation &+= 1
+        state = .recovering
+        do {
+            let lifecycle = try driver.recoverWorkout(recoveredWorkout)
+            ownsWorkout = true
+            activityStarted = lifecycle.activityStarted
+            collectionStarted = lifecycle.collectionStarted
+            state = lifecycle.collectionStarted ? .collecting : .prepared
+            return lifecycle
+        } catch {
+            resetOwnership()
             throw error
         }
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/IPhoneHealthKitLiveHeartRateProvider.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/IPhoneHealthKitLiveHeartRateProvider.swift
@@ -109,7 +109,9 @@ final class IPhoneHealthKitLiveHeartRateProvider {
     }
 
     func finish(
-        at date: Date = Date()
+        at date: Date = Date(),
+        recoveredStoppedAt: Date? = nil,
+        persistStoppedAt: (Date) -> Bool = { _ in true }
     ) async throws -> IPhoneHealthKitWorkoutFinishOutcome<HKWorkout> {
         let finishedContext = runtimeFailureContext
         defer {
@@ -117,7 +119,11 @@ final class IPhoneHealthKitLiveHeartRateProvider {
                 runtimeFailureContext = nil
             }
         }
-        return try await core.finish(at: date)
+        return try await core.finish(
+            at: date,
+            recoveredStoppedAt: recoveredStoppedAt,
+            persistStoppedAt: persistStoppedAt
+        )
     }
 }
 
@@ -245,7 +251,6 @@ private final class HealthKitLiveWorkoutDriver: NSObject, IPhoneHealthKitWorkout
         case .stopped:
             activityStarted = false
             collectionStarted = true
-            stoppedAt = recoveredSession.endDate ?? Date()
         case .notStarted, .prepared:
             activityStarted = false
             collectionStarted = false
@@ -295,9 +300,7 @@ private final class HealthKitLiveWorkoutDriver: NSObject, IPhoneHealthKitWorkout
 
     func stopActivity(at date: Date) {
         guard let session else { return }
-        if session.state == .stopped {
-            stoppedAt = session.endDate ?? date
-        } else if session.state == .running || session.state == .paused {
+        if session.state == .running || session.state == .paused {
             session.stopActivity(with: date)
         }
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/IPhoneHealthKitLiveHeartRateProvider.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/IPhoneHealthKitLiveHeartRateProvider.swift
@@ -80,6 +80,22 @@ final class IPhoneHealthKitLiveHeartRateProvider {
         driver.updateCurrentRuntimeFailureContext(context)
     }
 
+    func recover(
+        _ recoveredSession: HKWorkoutSession,
+        failureContext: IPhoneHealthKitRuntimeFailureContext
+    ) throws -> IPhoneHealthKitRecoveredWorkoutLifecycle {
+        runtimeFailureContext = failureContext
+        driver.setNextRuntimeFailureContext(failureContext)
+        do {
+            return try core.recover(recoveredSession)
+        } catch {
+            if runtimeFailureContext == failureContext {
+                runtimeFailureContext = nil
+            }
+            throw error
+        }
+    }
+
     func start(at date: Date = Date()) async throws {
         try await core.start(at: date)
     }
@@ -109,6 +125,7 @@ final class IPhoneHealthKitLiveHeartRateProvider {
 private final class HealthKitLiveWorkoutDriver: NSObject, IPhoneHealthKitWorkoutLifecycleDriving {
     typealias Configuration = HKWorkoutConfiguration
     typealias Workout = HKWorkout
+    typealias RecoveredWorkout = HKWorkoutSession
 
     var onHeartRateSample: ((IPhoneHealthKitHeartRateSample) -> Void)?
     var onRuntimeFailure: ((IPhoneHealthKitRuntimeFailureContext) -> Void)?
@@ -184,17 +201,7 @@ private final class HealthKitLiveWorkoutDriver: NSObject, IPhoneHealthKitWorkout
             configuration: configuration
         )
         let builder = session.associatedWorkoutBuilder()
-        let dataSource = HKLiveWorkoutDataSource(
-            healthStore: healthStore,
-            workoutConfiguration: configuration
-        )
-        if let heartRateType = HKQuantityType.quantityType(forIdentifier: .heartRate) {
-            for quantityType in dataSource.typesToCollect where quantityType != heartRateType {
-                dataSource.disableCollection(for: quantityType)
-            }
-            dataSource.enableCollection(for: heartRateType, predicate: nil)
-        }
-        builder.dataSource = dataSource
+        configureDataSource(for: configuration, builder: builder)
         session.delegate = self
         builder.delegate = self
         self.session = session
@@ -203,6 +210,55 @@ private final class HealthKitLiveWorkoutDriver: NSObject, IPhoneHealthKitWorkout
             retainRuntimeFailureContext(nextRuntimeFailureContext, for: session)
             self.nextRuntimeFailureContext = nil
         }
+    }
+
+    func recoverWorkout(
+        _ recoveredSession: HKWorkoutSession
+    ) throws -> IPhoneHealthKitRecoveredWorkoutLifecycle {
+        guard session == nil, builder == nil else {
+            throw HealthKitLiveWorkoutDriverError.workoutAlreadyOwned
+        }
+        guard recoveredSession.state != .ended else {
+            throw HealthKitLiveWorkoutDriverError.invalidRecoveredWorkoutState
+        }
+
+        let builder = recoveredSession.associatedWorkoutBuilder()
+        configureDataSource(
+            for: recoveredSession.workoutConfiguration,
+            builder: builder
+        )
+        recoveredSession.delegate = self
+        builder.delegate = self
+        session = recoveredSession
+        self.builder = builder
+        if let nextRuntimeFailureContext {
+            retainRuntimeFailureContext(nextRuntimeFailureContext, for: recoveredSession)
+            self.nextRuntimeFailureContext = nil
+        }
+
+        let activityStarted: Bool
+        let collectionStarted: Bool
+        switch recoveredSession.state {
+        case .running, .paused:
+            activityStarted = true
+            collectionStarted = true
+        case .stopped:
+            activityStarted = false
+            collectionStarted = true
+            stoppedAt = recoveredSession.endDate ?? Date()
+        case .notStarted, .prepared:
+            activityStarted = false
+            collectionStarted = false
+        case .ended:
+            throw HealthKitLiveWorkoutDriverError.invalidRecoveredWorkoutState
+        @unknown default:
+            throw HealthKitLiveWorkoutDriverError.invalidRecoveredWorkoutState
+        }
+        return IPhoneHealthKitRecoveredWorkoutLifecycle(
+            activityStarted: activityStarted,
+            collectionStarted: collectionStarted,
+            startedAt: recoveredSession.startDate
+        )
     }
 
     func prepare() async throws {
@@ -238,7 +294,12 @@ private final class HealthKitLiveWorkoutDriver: NSObject, IPhoneHealthKitWorkout
     }
 
     func stopActivity(at date: Date) {
-        session?.stopActivity(with: date)
+        guard let session else { return }
+        if session.state == .stopped {
+            stoppedAt = session.endDate ?? date
+        } else if session.state == .running || session.state == .paused {
+            session.stopActivity(with: date)
+        }
     }
 
     func waitForStoppedTransition() async throws -> Date {
@@ -337,6 +398,23 @@ private final class HealthKitLiveWorkoutDriver: NSObject, IPhoneHealthKitWorkout
                 throwing: error ?? HealthKitLiveWorkoutDriverError.operationFailed
             )
         }
+    }
+
+    private func configureDataSource(
+        for configuration: HKWorkoutConfiguration,
+        builder: HKLiveWorkoutBuilder
+    ) {
+        let dataSource = HKLiveWorkoutDataSource(
+            healthStore: healthStore,
+            workoutConfiguration: configuration
+        )
+        if let heartRateType = HKQuantityType.quantityType(forIdentifier: .heartRate) {
+            for quantityType in dataSource.typesToCollect where quantityType != heartRateType {
+                dataSource.disableCollection(for: quantityType)
+            }
+            dataSource.enableCollection(for: heartRateType, predicate: nil)
+        }
+        builder.dataSource = dataSource
     }
 
     private func retainRuntimeFailureContext(
@@ -439,6 +517,7 @@ extension HealthKitLiveWorkoutDriver: HKWorkoutSessionDelegate, HKLiveWorkoutBui
 private enum HealthKitLiveWorkoutDriverError: LocalizedError {
     case authorizationNotGranted
     case healthDataUnavailable
+    case invalidRecoveredWorkoutState
     case missingWorkout
     case operationCancelled
     case operationFailed
@@ -450,6 +529,8 @@ private enum HealthKitLiveWorkoutDriverError: LocalizedError {
             "HealthKit workout access was not granted."
         case .healthDataUnavailable:
             "HealthKit data is unavailable on this device."
+        case .invalidRecoveredWorkoutState:
+            "The recovered HealthKit workout is no longer active."
         case .missingWorkout:
             "The HealthKit workout lifecycle is not initialized."
         case .operationCancelled:

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
@@ -8,9 +8,12 @@ struct IPhoneHealthKitRuntimeFailureContext: Equatable {
 struct DeferredNativeHealthKitLinkage: Codable, Equatable {
     let acquisitionStartedAt: Date
     let finishRequestedAt: Date
+    let healthKitStoppedAt: Date?
     let profileID: UUID?
     let telemetrySessionID: UUID?
     let linksLegacyWorkout: Bool
+    let legacyWorkoutID: UUID?
+    let recoveryAppWorkoutID: UUID?
 }
 
 struct NativeWorkoutRecoveryRecord: Codable, Equatable {
@@ -28,12 +31,15 @@ struct NativeWorkoutRecoveryRecord: Codable, Equatable {
     let phase: Phase
     let targetBPM: Int
     let durationMinutes: Int
+    let plannedDurationSeconds: Int?
     let acquisitionStartedAt: Date
     let controlledWorkoutStartedAt: Date?
     let terminalRequestedAt: Date?
+    let healthKitStopActivityAt: Date?
     let profileID: UUID?
     let legacySessionID: UUID?
     let telemetrySessionID: UUID?
+    let legacyWorkoutID: UUID?
 
     static func preflight(
         appWorkoutID: UUID,
@@ -48,12 +54,15 @@ struct NativeWorkoutRecoveryRecord: Codable, Equatable {
             phase: .preflight,
             targetBPM: targetBPM,
             durationMinutes: durationMinutes,
+            plannedDurationSeconds: durationMinutes * 60,
             acquisitionStartedAt: acquisitionStartedAt,
             controlledWorkoutStartedAt: nil,
             terminalRequestedAt: nil,
+            healthKitStopActivityAt: nil,
             profileID: profileID,
             legacySessionID: nil,
-            telemetrySessionID: nil
+            telemetrySessionID: nil,
+            legacyWorkoutID: nil
         )
     }
 
@@ -69,12 +78,15 @@ struct NativeWorkoutRecoveryRecord: Codable, Equatable {
             phase: .committed,
             targetBPM: targetBPM,
             durationMinutes: durationMinutes,
+            plannedDurationSeconds: plannedDurationSeconds,
             acquisitionStartedAt: acquisitionStartedAt,
             controlledWorkoutStartedAt: controlledWorkoutStartedAt,
             terminalRequestedAt: nil,
+            healthKitStopActivityAt: nil,
             profileID: profileID,
             legacySessionID: legacySessionID,
-            telemetrySessionID: telemetrySessionID
+            telemetrySessionID: telemetrySessionID,
+            legacyWorkoutID: nil
         )
     }
 
@@ -85,12 +97,15 @@ struct NativeWorkoutRecoveryRecord: Codable, Equatable {
             phase: .finishing,
             targetBPM: targetBPM,
             durationMinutes: durationMinutes,
+            plannedDurationSeconds: plannedDurationSeconds,
             acquisitionStartedAt: acquisitionStartedAt,
             controlledWorkoutStartedAt: controlledWorkoutStartedAt,
             terminalRequestedAt: requestedAt,
+            healthKitStopActivityAt: healthKitStopActivityAt,
             profileID: profileID,
             legacySessionID: legacySessionID,
-            telemetrySessionID: telemetrySessionID
+            telemetrySessionID: telemetrySessionID,
+            legacyWorkoutID: legacyWorkoutID
         )
     }
 
@@ -101,27 +116,94 @@ struct NativeWorkoutRecoveryRecord: Codable, Equatable {
             phase: .stopping,
             targetBPM: targetBPM,
             durationMinutes: durationMinutes,
+            plannedDurationSeconds: plannedDurationSeconds,
             acquisitionStartedAt: acquisitionStartedAt,
             controlledWorkoutStartedAt: controlledWorkoutStartedAt,
             terminalRequestedAt: requestedAt,
+            healthKitStopActivityAt: nil,
             profileID: profileID,
             legacySessionID: legacySessionID,
-            telemetrySessionID: telemetrySessionID
+            telemetrySessionID: telemetrySessionID,
+            legacyWorkoutID: legacyWorkoutID
         )
+    }
+
+    func planningDuration(seconds: Int) -> Self {
+        Self(
+            schemaVersion: schemaVersion,
+            appWorkoutID: appWorkoutID,
+            phase: phase,
+            targetBPM: targetBPM,
+            durationMinutes: max(1, (seconds + 59) / 60),
+            plannedDurationSeconds: seconds,
+            acquisitionStartedAt: acquisitionStartedAt,
+            controlledWorkoutStartedAt: controlledWorkoutStartedAt,
+            terminalRequestedAt: terminalRequestedAt,
+            healthKitStopActivityAt: healthKitStopActivityAt,
+            profileID: profileID,
+            legacySessionID: legacySessionID,
+            telemetrySessionID: telemetrySessionID,
+            legacyWorkoutID: legacyWorkoutID
+        )
+    }
+
+    func linkingLegacyWorkout(id: UUID) -> Self {
+        Self(
+            schemaVersion: schemaVersion,
+            appWorkoutID: appWorkoutID,
+            phase: phase,
+            targetBPM: targetBPM,
+            durationMinutes: durationMinutes,
+            plannedDurationSeconds: plannedDurationSeconds,
+            acquisitionStartedAt: acquisitionStartedAt,
+            controlledWorkoutStartedAt: controlledWorkoutStartedAt,
+            terminalRequestedAt: terminalRequestedAt,
+            healthKitStopActivityAt: healthKitStopActivityAt,
+            profileID: profileID,
+            legacySessionID: legacySessionID,
+            telemetrySessionID: telemetrySessionID,
+            legacyWorkoutID: id
+        )
+    }
+
+    func recordingHealthKitStopActivity(at date: Date) -> Self {
+        Self(
+            schemaVersion: schemaVersion,
+            appWorkoutID: appWorkoutID,
+            phase: phase,
+            targetBPM: targetBPM,
+            durationMinutes: durationMinutes,
+            plannedDurationSeconds: plannedDurationSeconds,
+            acquisitionStartedAt: acquisitionStartedAt,
+            controlledWorkoutStartedAt: controlledWorkoutStartedAt,
+            terminalRequestedAt: terminalRequestedAt,
+            healthKitStopActivityAt: date,
+            profileID: profileID,
+            legacySessionID: legacySessionID,
+            telemetrySessionID: telemetrySessionID,
+            legacyWorkoutID: legacyWorkoutID
+        )
+    }
+
+    var effectivePlannedDurationSeconds: Int {
+        plannedDurationSeconds ?? durationMinutes * 60
     }
 
     var isStructurallyValid: Bool {
         guard schemaVersion == Self.currentSchemaVersion,
               (40...240).contains(targetBPM),
-              (1...120).contains(durationMinutes) else {
+              (1...120).contains(durationMinutes),
+              (60...(120 * 60)).contains(effectivePlannedDurationSeconds) else {
             return false
         }
         switch phase {
         case .preflight:
             return controlledWorkoutStartedAt == nil
                 && terminalRequestedAt == nil
+                && healthKitStopActivityAt == nil
                 && legacySessionID == nil
                 && telemetrySessionID == nil
+                && legacyWorkoutID == nil
         case .committed, .stopping, .finishing:
             guard let controlledWorkoutStartedAt,
                   let legacySessionID,
@@ -138,10 +220,20 @@ struct NativeWorkoutRecoveryRecord: Codable, Equatable {
                 terminalIsValid = false
             case .committed:
                 terminalIsValid = terminalRequestedAt == nil
-            case .stopping, .finishing:
-                terminalIsValid = terminalRequestedAt.map {
+                    && healthKitStopActivityAt == nil
+            case .stopping:
+                terminalIsValid = (terminalRequestedAt.map {
                     $0 >= controlledWorkoutStartedAt
-                } ?? false
+                } ?? false) && healthKitStopActivityAt == nil
+            case .finishing:
+                guard let terminalRequestedAt else {
+                    terminalIsValid = false
+                    break
+                }
+                terminalIsValid = terminalRequestedAt >= controlledWorkoutStartedAt
+                    && (healthKitStopActivityAt.map {
+                        $0 >= terminalRequestedAt
+                    } ?? true)
             }
             return preflightLatency >= 0
                 && preflightLatency <= NativeHeartRatePreflightEngine.timeoutSeconds
@@ -221,6 +313,7 @@ enum NativeWorkoutRecoveryResolution: Equatable {
 
 enum NativeWorkoutNoActiveRecoveryResolution: Equatable {
     case retainFailClosed
+    case discardPreflight(NativeWorkoutRecoveryRecord)
     case reconcileFinished(NativeWorkoutRecoveryRecord)
 }
 
@@ -253,11 +346,59 @@ enum NativeWorkoutRecoveryPolicy {
         loadResult: NativeWorkoutRecoveryLoadResult
     ) -> NativeWorkoutNoActiveRecoveryResolution {
         guard case .record(let record) = loadResult,
-              record.phase == .finishing,
               record.isStructurallyValid else {
             return .retainFailClosed
         }
+        if record.phase == .preflight {
+            return .discardPreflight(record)
+        }
+        guard record.phase == .finishing,
+              record.healthKitStopActivityAt != nil else {
+            return .retainFailClosed
+        }
         return .reconcileFinished(record)
+    }
+}
+
+enum NativeWorkoutSavedProofPolicy {
+    static func matches(
+        record: NativeWorkoutRecoveryRecord,
+        workoutStartedAt: Date,
+        workoutEndedAt: Date,
+        isWalking: Bool,
+        sourceMatchesApp: Bool
+    ) -> Bool {
+        guard record.phase == .finishing,
+              record.isStructurallyValid,
+              let stoppedAt = record.healthKitStopActivityAt,
+              isWalking,
+              sourceMatchesApp else {
+            return false
+        }
+        return abs(workoutStartedAt.timeIntervalSince(record.acquisitionStartedAt)) <= 5
+            && abs(workoutEndedAt.timeIntervalSince(stoppedAt)) <= 15
+    }
+
+    static func uniqueMatch<Candidate>(
+        in candidates: [Candidate],
+        matching matches: (Candidate) -> Bool
+    ) -> Candidate? {
+        var uniqueMatch: Candidate?
+        for candidate in candidates where matches(candidate) {
+            guard uniqueMatch == nil else { return nil }
+            uniqueMatch = candidate
+        }
+        return uniqueMatch
+    }
+}
+
+enum NativeWorkoutLegacyLinkPolicy {
+    static func canLink(
+        existingWorkoutUUID: String?,
+        expectedWorkoutUUID: UUID
+    ) -> Bool {
+        existingWorkoutUUID == nil
+            || existingWorkoutUUID == expectedWorkoutUUID.uuidString
     }
 }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
@@ -73,9 +73,21 @@ enum DeferredNativeHealthKitLinkageQueue {
     }
 
     static func next(
-        in pending: [DeferredNativeHealthKitLinkage]
+        in pending: [DeferredNativeHealthKitLinkage],
+        preferredRecoveryAppWorkoutID: UUID? = nil
     ) -> DeferredNativeHealthKitLinkage? {
-        pending.first(where: { $0.healthKitWorkoutID != nil }) ?? pending.first
+        if let preferredRecoveryAppWorkoutID,
+           let preferred = pending.last(where: {
+               $0.recoveryAppWorkoutID == preferredRecoveryAppWorkoutID
+           }) {
+            return preferred
+        }
+        return pending.last(where: {
+            $0.healthKitWorkoutID != nil
+                && (!$0.linksLegacyWorkout || $0.legacyWorkoutID != nil)
+        })
+            ?? pending.last(where: { $0.healthKitWorkoutID != nil })
+            ?? pending.last
     }
 }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
@@ -14,6 +14,21 @@ struct DeferredNativeHealthKitLinkage: Codable, Equatable {
     let linksLegacyWorkout: Bool
     let legacyWorkoutID: UUID?
     let recoveryAppWorkoutID: UUID?
+    let healthKitWorkoutID: UUID?
+
+    func provingSavedWorkout(id: UUID) -> Self {
+        Self(
+            acquisitionStartedAt: acquisitionStartedAt,
+            finishRequestedAt: finishRequestedAt,
+            healthKitStoppedAt: healthKitStoppedAt,
+            profileID: profileID,
+            telemetrySessionID: telemetrySessionID,
+            linksLegacyWorkout: linksLegacyWorkout,
+            legacyWorkoutID: legacyWorkoutID,
+            recoveryAppWorkoutID: recoveryAppWorkoutID,
+            healthKitWorkoutID: id
+        )
+    }
 }
 
 struct NativeWorkoutRecoveryRecord: Codable, Equatable {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
@@ -13,6 +13,266 @@ struct DeferredNativeHealthKitLinkage: Codable, Equatable {
     let linksLegacyWorkout: Bool
 }
 
+struct NativeWorkoutRecoveryRecord: Codable, Equatable {
+    enum Phase: String, Codable, Equatable {
+        case preflight
+        case committed
+        case stopping
+        case finishing
+    }
+
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+    let appWorkoutID: UUID
+    let phase: Phase
+    let targetBPM: Int
+    let durationMinutes: Int
+    let acquisitionStartedAt: Date
+    let controlledWorkoutStartedAt: Date?
+    let terminalRequestedAt: Date?
+    let profileID: UUID?
+    let legacySessionID: UUID?
+    let telemetrySessionID: UUID?
+
+    static func preflight(
+        appWorkoutID: UUID,
+        targetBPM: Int,
+        durationMinutes: Int,
+        acquisitionStartedAt: Date,
+        profileID: UUID?
+    ) -> Self {
+        Self(
+            schemaVersion: currentSchemaVersion,
+            appWorkoutID: appWorkoutID,
+            phase: .preflight,
+            targetBPM: targetBPM,
+            durationMinutes: durationMinutes,
+            acquisitionStartedAt: acquisitionStartedAt,
+            controlledWorkoutStartedAt: nil,
+            terminalRequestedAt: nil,
+            profileID: profileID,
+            legacySessionID: nil,
+            telemetrySessionID: nil
+        )
+    }
+
+    func committed(
+        controlledWorkoutStartedAt: Date,
+        profileID: UUID,
+        legacySessionID: UUID,
+        telemetrySessionID: UUID
+    ) -> Self {
+        Self(
+            schemaVersion: schemaVersion,
+            appWorkoutID: appWorkoutID,
+            phase: .committed,
+            targetBPM: targetBPM,
+            durationMinutes: durationMinutes,
+            acquisitionStartedAt: acquisitionStartedAt,
+            controlledWorkoutStartedAt: controlledWorkoutStartedAt,
+            terminalRequestedAt: nil,
+            profileID: profileID,
+            legacySessionID: legacySessionID,
+            telemetrySessionID: telemetrySessionID
+        )
+    }
+
+    func finishing(requestedAt: Date) -> Self {
+        Self(
+            schemaVersion: schemaVersion,
+            appWorkoutID: appWorkoutID,
+            phase: .finishing,
+            targetBPM: targetBPM,
+            durationMinutes: durationMinutes,
+            acquisitionStartedAt: acquisitionStartedAt,
+            controlledWorkoutStartedAt: controlledWorkoutStartedAt,
+            terminalRequestedAt: requestedAt,
+            profileID: profileID,
+            legacySessionID: legacySessionID,
+            telemetrySessionID: telemetrySessionID
+        )
+    }
+
+    func stopping(requestedAt: Date) -> Self {
+        Self(
+            schemaVersion: schemaVersion,
+            appWorkoutID: appWorkoutID,
+            phase: .stopping,
+            targetBPM: targetBPM,
+            durationMinutes: durationMinutes,
+            acquisitionStartedAt: acquisitionStartedAt,
+            controlledWorkoutStartedAt: controlledWorkoutStartedAt,
+            terminalRequestedAt: requestedAt,
+            profileID: profileID,
+            legacySessionID: legacySessionID,
+            telemetrySessionID: telemetrySessionID
+        )
+    }
+
+    var isStructurallyValid: Bool {
+        guard schemaVersion == Self.currentSchemaVersion,
+              (40...240).contains(targetBPM),
+              (1...120).contains(durationMinutes) else {
+            return false
+        }
+        switch phase {
+        case .preflight:
+            return controlledWorkoutStartedAt == nil
+                && terminalRequestedAt == nil
+                && legacySessionID == nil
+                && telemetrySessionID == nil
+        case .committed, .stopping, .finishing:
+            guard let controlledWorkoutStartedAt,
+                  let legacySessionID,
+                  let telemetrySessionID,
+                  profileID != nil else {
+                return false
+            }
+            let preflightLatency = controlledWorkoutStartedAt.timeIntervalSince(
+                acquisitionStartedAt
+            )
+            let terminalIsValid: Bool
+            switch phase {
+            case .preflight:
+                terminalIsValid = false
+            case .committed:
+                terminalIsValid = terminalRequestedAt == nil
+            case .stopping, .finishing:
+                terminalIsValid = terminalRequestedAt.map {
+                    $0 >= controlledWorkoutStartedAt
+                } ?? false
+            }
+            return preflightLatency >= 0
+                && preflightLatency <= NativeHeartRatePreflightEngine.timeoutSeconds
+                && terminalIsValid
+                && telemetrySessionID == legacySessionID
+        }
+    }
+}
+
+enum NativeWorkoutRecoveryLoadResult: Equatable {
+    case missing
+    case invalid
+    case record(NativeWorkoutRecoveryRecord)
+}
+
+struct NativeWorkoutRecoveryStore {
+    let fileURL: URL
+
+    static func applicationSupport(
+        bundleIdentifier: String,
+        fileManager: FileManager = .default
+    ) throws -> Self {
+        let root = try fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        return Self(fileURL: root
+            .appendingPathComponent(bundleIdentifier, isDirectory: true)
+            .appendingPathComponent("native_workout_recovery_v1.json"))
+    }
+
+    func load(fileManager: FileManager = .default) -> NativeWorkoutRecoveryLoadResult {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return .missing }
+        guard let data = try? Data(contentsOf: fileURL),
+              let record = try? JSONDecoder().decode(
+                NativeWorkoutRecoveryRecord.self,
+                from: data
+              ),
+              record.isStructurallyValid else {
+            return .invalid
+        }
+        return .record(record)
+    }
+
+    func save(
+        _ record: NativeWorkoutRecoveryRecord,
+        fileManager: FileManager = .default
+    ) throws {
+        guard record.isStructurallyValid else {
+            throw NativeWorkoutRecoveryStoreError.invalidRecord
+        }
+        try fileManager.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try JSONEncoder().encode(record)
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    func clear(fileManager: FileManager = .default) throws {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return }
+        try fileManager.removeItem(at: fileURL)
+    }
+}
+
+enum NativeWorkoutRecoveryStoreError: Error, Equatable {
+    case invalidRecord
+}
+
+enum NativeWorkoutRecoveryResolution: Equatable {
+    case discard
+    case restore(NativeWorkoutRecoveryRecord)
+    case finish(NativeWorkoutRecoveryRecord)
+}
+
+enum NativeWorkoutNoActiveRecoveryResolution: Equatable {
+    case retainFailClosed
+    case reconcileFinished(NativeWorkoutRecoveryRecord)
+}
+
+enum NativeWorkoutRecoveryPolicy {
+    static let sessionStartTolerance: TimeInterval = 5
+
+    static func resolve(
+        loadResult: NativeWorkoutRecoveryLoadResult,
+        recoveredSessionStartedAt: Date?,
+        recoveredCollectionStarted: Bool,
+        configurationIsIndoorWalking: Bool
+    ) -> NativeWorkoutRecoveryResolution {
+        guard case .record(let record) = loadResult,
+              record.phase == .committed
+                || record.phase == .stopping
+                || record.phase == .finishing,
+              record.isStructurallyValid,
+              recoveredCollectionStarted,
+              configurationIsIndoorWalking,
+              let recoveredSessionStartedAt,
+              abs(recoveredSessionStartedAt.timeIntervalSince(
+                record.acquisitionStartedAt
+              )) <= sessionStartTolerance else {
+            return .discard
+        }
+        return record.phase == .finishing ? .finish(record) : .restore(record)
+    }
+
+    static func resolveWithoutActiveRecoveryRequest(
+        loadResult: NativeWorkoutRecoveryLoadResult
+    ) -> NativeWorkoutNoActiveRecoveryResolution {
+        guard case .record(let record) = loadResult,
+              record.phase == .finishing,
+              record.isStructurallyValid else {
+            return .retainFailClosed
+        }
+        return .reconcileFinished(record)
+    }
+}
+
+struct ActiveWorkoutRecoveryRequestGate {
+    private var requestedSceneSessionIDs: Set<String> = []
+
+    mutating func shouldRequestRecovery(
+        sceneSessionID: String,
+        recoveryRequested: Bool
+    ) -> Bool {
+        guard recoveryRequested else { return false }
+        return requestedSceneSessionIDs.insert(sceneSessionID).inserted
+    }
+}
+
 struct NativeHeartRateProviderLifecycle: Equatable {
     private(set) var generation: UInt64 = 0
     private(set) var attemptID: UUID?

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
@@ -31,6 +31,54 @@ struct DeferredNativeHealthKitLinkage: Codable, Equatable {
     }
 }
 
+enum DeferredNativeHealthKitLinkageQueue {
+    static func retaining(
+        _ linkage: DeferredNativeHealthKitLinkage,
+        in pending: [DeferredNativeHealthKitLinkage]
+    ) -> [DeferredNativeHealthKitLinkage]? {
+        var updated = pending
+        guard let recoveryAppWorkoutID = linkage.recoveryAppWorkoutID,
+              let index = updated.firstIndex(where: {
+                  $0.recoveryAppWorkoutID == recoveryAppWorkoutID
+              }) else {
+            if !updated.contains(linkage) {
+                updated.append(linkage)
+            }
+            return updated
+        }
+        let existing = updated[index]
+        if let existingWorkoutID = existing.healthKitWorkoutID {
+            guard linkage.healthKitWorkoutID == nil
+                    || linkage.healthKitWorkoutID == existingWorkoutID else {
+                return nil
+            }
+            return updated
+        }
+        updated[index] = linkage
+        return updated
+    }
+
+    static func provingSavedWorkout(
+        id: UUID,
+        replacing source: DeferredNativeHealthKitLinkage,
+        in pending: [DeferredNativeHealthKitLinkage]
+    ) -> [DeferredNativeHealthKitLinkage]? {
+        guard let index = pending.firstIndex(of: source) else { return nil }
+        if let existingWorkoutID = source.healthKitWorkoutID {
+            return existingWorkoutID == id ? pending : nil
+        }
+        var updated = pending
+        updated[index] = source.provingSavedWorkout(id: id)
+        return updated
+    }
+
+    static func next(
+        in pending: [DeferredNativeHealthKitLinkage]
+    ) -> DeferredNativeHealthKitLinkage? {
+        pending.first(where: { $0.healthKitWorkoutID != nil }) ?? pending.first
+    }
+}
+
 struct NativeWorkoutRecoveryRecord: Codable, Equatable {
     enum Phase: String, Codable, Equatable {
         case preflight

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
@@ -402,6 +402,19 @@ enum NativeWorkoutLegacyLinkPolicy {
     }
 }
 
+enum NativeWorkoutRequiredLinkagePolicy {
+    static func complete(
+        legacyRequired: Bool,
+        persistLegacy: () -> Bool,
+        telemetryRequired: Bool,
+        persistTelemetry: () async -> Bool
+    ) async -> Bool {
+        if legacyRequired, !persistLegacy() { return false }
+        if telemetryRequired, !(await persistTelemetry()) { return false }
+        return true
+    }
+}
+
 struct ActiveWorkoutRecoveryRequestGate {
     private var requestedSceneSessionIDs: Set<String> = []
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteApp.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteApp.swift
@@ -1,8 +1,124 @@
 import SwiftUI
+import HealthKit
+import HealthKitUI
+import UIKit
+
+@available(iOS 26.0, *)
+final class WalkingPadRemoteSceneDelegate: UIResponder, UIWindowSceneDelegate {}
+
+@available(iOS 26.0, *)
+@MainActor
+final class WalkingPadRemoteAppDelegate: NSObject, UIApplicationDelegate {
+    typealias RecoveryHandler = (HKWorkoutSession?, Error?) -> Void
+
+    var recoveryAvailabilityHandler: ((Bool) -> Void)? {
+        didSet { deliverPendingRecoveryAvailabilityIfPossible() }
+    }
+    var recoveryRequestHandler: (() -> Void)? {
+        didSet { deliverPendingRecoveryRequestIfPossible() }
+    }
+    var recoveryHandler: RecoveryHandler? {
+        didSet { deliverPendingRecoveryIfPossible() }
+    }
+
+    private let healthStore = HKHealthStore()
+    private var recoveryRequestGate = ActiveWorkoutRecoveryRequestGate()
+    private var pendingRecoveryAvailability: Bool?
+    private var recoveryRequestPendingDelivery = false
+    private var pendingRecoveryResult: (HKWorkoutSession?, Error?)?
+
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        deliverRecoveryAvailability(options.shouldHandleActiveWorkoutRecovery)
+        if recoveryRequestGate.shouldRequestRecovery(
+            sceneSessionID: connectingSceneSession.persistentIdentifier,
+            recoveryRequested: options.shouldHandleActiveWorkoutRecovery
+        ) {
+            deliverRecoveryRequest()
+            healthStore.recoverActiveWorkoutSession { [weak self] session, error in
+                DispatchQueue.main.async {
+                    self?.deliverRecovery(session: session, error: error)
+                }
+            }
+        }
+
+        let configuration = UISceneConfiguration(
+            name: "Default Configuration",
+            sessionRole: connectingSceneSession.role
+        )
+        configuration.delegateClass = WalkingPadRemoteSceneDelegate.self
+        return configuration
+    }
+
+    private func deliverRecoveryAvailability(_ recoveryRequested: Bool) {
+        guard let recoveryAvailabilityHandler else {
+            pendingRecoveryAvailability = pendingRecoveryAvailability == true
+                || recoveryRequested
+            return
+        }
+        recoveryAvailabilityHandler(recoveryRequested)
+    }
+
+    private func deliverPendingRecoveryAvailabilityIfPossible() {
+        guard let recoveryAvailabilityHandler,
+              let pendingRecoveryAvailability else { return }
+        self.pendingRecoveryAvailability = nil
+        recoveryAvailabilityHandler(pendingRecoveryAvailability)
+    }
+
+    private func deliverRecoveryRequest() {
+        guard let recoveryRequestHandler else {
+            recoveryRequestPendingDelivery = true
+            return
+        }
+        recoveryRequestHandler()
+    }
+
+    private func deliverPendingRecoveryRequestIfPossible() {
+        guard recoveryRequestPendingDelivery, let recoveryRequestHandler else { return }
+        recoveryRequestPendingDelivery = false
+        recoveryRequestHandler()
+    }
+
+    private func deliverRecovery(session: HKWorkoutSession?, error: Error?) {
+        guard let recoveryHandler else {
+            pendingRecoveryResult = (session, error)
+            return
+        }
+        recoveryHandler(session, error)
+    }
+
+    private func deliverPendingRecoveryIfPossible() {
+        guard let recoveryHandler, let pendingRecoveryResult else { return }
+        self.pendingRecoveryResult = nil
+        recoveryHandler(pendingRecoveryResult.0, pendingRecoveryResult.1)
+    }
+}
 
 @main
 struct WalkingPadRemoteApp: App {
-    @StateObject private var manager = BluetoothManager()
+    @UIApplicationDelegateAdaptor(WalkingPadRemoteAppDelegate.self)
+    private var appDelegate
+    @StateObject private var manager: BluetoothManager
+
+    init() {
+        let manager = BluetoothManager()
+        _manager = StateObject(wrappedValue: manager)
+        appDelegate.recoveryAvailabilityHandler = { [weak manager] recoveryRequested in
+            manager?.handleActiveWorkoutRecoveryAvailability(
+                recoveryRequested: recoveryRequested
+            )
+        }
+        appDelegate.recoveryRequestHandler = { [weak manager] in
+            manager?.handleActiveWorkoutRecoveryRequest()
+        }
+        appDelegate.recoveryHandler = { [weak manager] session, error in
+            manager?.handleActiveWorkoutRecovery(session: session, error: error)
+        }
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/IPhoneHealthKitHeartRateProviderCoreTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/IPhoneHealthKitHeartRateProviderCoreTests.swift
@@ -32,6 +32,51 @@ final class IPhoneHealthKitHeartRateProviderCoreTests: XCTestCase {
         XCTAssertEqual(driver.beginCollectionCount, 1)
     }
 
+    func testRecoveryReusesExistingWorkoutWithoutCreatingReplacement() throws {
+        let (provider, driver) = makeProvider()
+        let recoveredID = UUID()
+        let startedAt = Date(timeIntervalSince1970: 1_500)
+        driver.recoveredLifecycle = IPhoneHealthKitRecoveredWorkoutLifecycle(
+            activityStarted: true,
+            collectionStarted: true,
+            startedAt: startedAt
+        )
+
+        let lifecycle = try provider.recover(recoveredID)
+        XCTAssertThrowsError(try provider.recover(recoveredID)) { error in
+            XCTAssertEqual(
+                error as? IPhoneHealthKitHeartRateProviderError,
+                .invalidTransition(expected: .idle, actual: .collecting)
+            )
+        }
+
+        XCTAssertEqual(lifecycle.startedAt, startedAt)
+        XCTAssertEqual(provider.state, .collecting)
+        XCTAssertEqual(driver.recoveredWorkouts, [recoveredID])
+        XCTAssertEqual(driver.calls, ["recover"])
+        XCTAssertTrue(driver.createdConfigurations.isEmpty)
+    }
+
+    func testRecoveredUncommittedWorkoutDiscardsWithoutFinishing() async throws {
+        let (provider, driver) = makeProvider()
+        driver.recoveredLifecycle = IPhoneHealthKitRecoveredWorkoutLifecycle(
+            activityStarted: false,
+            collectionStarted: false,
+            startedAt: nil
+        )
+        _ = try provider.recover(UUID())
+        XCTAssertEqual(provider.state, .prepared)
+        driver.calls.removeAll()
+
+        await provider.discard(at: Date(timeIntervalSince1970: 1_600))
+
+        XCTAssertEqual(provider.state, .idle)
+        XCTAssertEqual(driver.calls, ["discard", "endSession", "reset"])
+        XCTAssertEqual(driver.stopActivityCount, 0)
+        XCTAssertEqual(driver.endCollectionCount, 0)
+        XCTAssertEqual(driver.finishCount, 0)
+    }
+
     func testHeartRateCallbackEmitsOneTruthfulProviderObservation() async throws {
         let (provider, _) = makeProvider()
         try await provider.prepare(configuration: "walking")
@@ -372,11 +417,18 @@ final class IPhoneHealthKitHeartRateProviderCoreTests: XCTestCase {
 private final class FakeHealthKitWorkoutDriver: IPhoneHealthKitWorkoutLifecycleDriving {
     typealias Configuration = String
     typealias Workout = UUID
+    typealias RecoveredWorkout = UUID
 
     let workoutID = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
     var finishedWorkout: UUID?
     var calls: [String] = []
     var createdConfigurations: [String] = []
+    var recoveredWorkouts: [UUID] = []
+    var recoveredLifecycle = IPhoneHealthKitRecoveredWorkoutLifecycle(
+        activityStarted: true,
+        collectionStarted: true,
+        startedAt: Date(timeIntervalSince1970: 1_000)
+    )
     var beginCollectionError: Error?
     var finishWorkoutError: Error?
     var suspendPrepare = false
@@ -404,6 +456,14 @@ private final class FakeHealthKitWorkoutDriver: IPhoneHealthKitWorkoutLifecycleD
     func createWorkout(configuration: String) throws {
         calls.append("create:\(configuration)")
         createdConfigurations.append(configuration)
+    }
+
+    func recoverWorkout(
+        _ recoveredWorkout: UUID
+    ) throws -> IPhoneHealthKitRecoveredWorkoutLifecycle {
+        calls.append("recover")
+        recoveredWorkouts.append(recoveredWorkout)
+        return recoveredLifecycle
     }
 
     func prepare() async throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/IPhoneHealthKitHeartRateProviderCoreTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/IPhoneHealthKitHeartRateProviderCoreTests.swift
@@ -227,6 +227,91 @@ final class IPhoneHealthKitHeartRateProviderCoreTests: XCTestCase {
         XCTAssertEqual(driver.finishCount, 1)
     }
 
+    func testRecoveredStoppedWorkoutUsesDurableStopDateInsteadOfRelaunchTime() async throws {
+        let (provider, driver) = makeProvider()
+        driver.recoveredLifecycle = IPhoneHealthKitRecoveredWorkoutLifecycle(
+            activityStarted: false,
+            collectionStarted: true,
+            startedAt: Date(timeIntervalSince1970: 6_000)
+        )
+        _ = try provider.recover(UUID())
+        driver.calls.removeAll()
+        let originalStoppedAt = Date(timeIntervalSince1970: 6_900)
+        let relaunchedAt = originalStoppedAt.addingTimeInterval(3_600)
+        var persistedDates: [Date] = []
+
+        _ = try await provider.finish(
+            at: relaunchedAt,
+            recoveredStoppedAt: originalStoppedAt,
+            persistStoppedAt: {
+                persistedDates.append($0)
+                return true
+            }
+        )
+
+        XCTAssertEqual(persistedDates, [originalStoppedAt])
+        XCTAssertEqual(driver.endCollectionDates, [originalStoppedAt])
+        XCTAssertEqual(driver.stopActivityCount, 0)
+        XCTAssertFalse(driver.endCollectionDates.contains(relaunchedAt))
+    }
+
+    func testRecoveredStoppedWorkoutWithoutDurableStopDateRemainsOwnedFailClosed() async throws {
+        let (provider, driver) = makeProvider()
+        driver.recoveredLifecycle = IPhoneHealthKitRecoveredWorkoutLifecycle(
+            activityStarted: false,
+            collectionStarted: true,
+            startedAt: Date(timeIntervalSince1970: 7_000)
+        )
+        _ = try provider.recover(UUID())
+        driver.calls.removeAll()
+
+        await XCTAssertThrowsErrorAsync(
+            try await provider.finish(at: Date(timeIntervalSince1970: 10_600))
+        ) { error in
+            XCTAssertEqual(
+                error as? IPhoneHealthKitHeartRateProviderError,
+                .missingRecoveredStopDate
+            )
+        }
+
+        XCTAssertEqual(provider.state, .collecting)
+        XCTAssertTrue(driver.calls.isEmpty)
+        XCTAssertEqual(driver.endCollectionCount, 0)
+        XCTAssertEqual(driver.finishCount, 0)
+        XCTAssertEqual(driver.discardCount, 0)
+    }
+
+    func testStopDateMustPersistBeforeEndCollection() async throws {
+        let (provider, driver) = makeProvider()
+        try await provider.prepare(configuration: "walking")
+        try await provider.start()
+        driver.calls.removeAll()
+
+        await XCTAssertThrowsErrorAsync(
+            try await provider.finish(
+                at: Date(timeIntervalSince1970: 7_100),
+                persistStoppedAt: { _ in
+                    driver.calls.append("persistStoppedAt")
+                    return false
+                }
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? IPhoneHealthKitHeartRateProviderError,
+                .stopDatePersistenceFailed
+            )
+        }
+
+        XCTAssertEqual(
+            driver.calls,
+            ["stopActivity", "stoppedTransition", "persistStoppedAt"]
+        )
+        XCTAssertEqual(provider.state, .collecting)
+        XCTAssertEqual(driver.endCollectionCount, 0)
+        XCTAssertEqual(driver.finishCount, 0)
+        XCTAssertEqual(driver.discardCount, 0)
+    }
+
     func testRapidHubWarmDuringCommittedFinishLeavesProviderUntouched() async throws {
         let (provider, driver) = makeProvider()
         try await provider.prepare(configuration: "walking")

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
@@ -468,18 +468,24 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
         let linkageA = DeferredNativeHealthKitLinkage(
             acquisitionStartedAt: now,
             finishRequestedAt: now.addingTimeInterval(30),
+            healthKitStoppedAt: nil,
             profileID: profileA,
             telemetrySessionID: telemetrySessionA,
-            linksLegacyWorkout: true
+            linksLegacyWorkout: true,
+            legacyWorkoutID: nil,
+            recoveryAppWorkoutID: nil
         )
         let profileB = UUID()
         let telemetrySessionB = UUID()
         let linkageB = DeferredNativeHealthKitLinkage(
             acquisitionStartedAt: now.addingTimeInterval(60),
             finishRequestedAt: now.addingTimeInterval(90),
+            healthKitStoppedAt: nil,
             profileID: profileB,
             telemetrySessionID: telemetrySessionB,
-            linksLegacyWorkout: true
+            linksLegacyWorkout: true,
+            legacyWorkoutID: nil,
+            recoveryAppWorkoutID: nil
         )
         var pending = [linkageA, linkageB]
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
@@ -668,6 +668,72 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
         )
     }
 
+    func testActionableExactLinkageIsSelectedAheadOfBaseExactLegacyDebt() {
+        let baseExact = DeferredNativeHealthKitLinkage(
+            acquisitionStartedAt: now,
+            finishRequestedAt: now.addingTimeInterval(30),
+            healthKitStoppedAt: nil,
+            profileID: UUID(),
+            telemetrySessionID: UUID(),
+            linksLegacyWorkout: true,
+            legacyWorkoutID: nil,
+            recoveryAppWorkoutID: nil,
+            healthKitWorkoutID: UUID()
+        )
+        let actionableExact = DeferredNativeHealthKitLinkage(
+            acquisitionStartedAt: now.addingTimeInterval(60),
+            finishRequestedAt: now.addingTimeInterval(90),
+            healthKitStoppedAt: now.addingTimeInterval(91),
+            profileID: UUID(),
+            telemetrySessionID: UUID(),
+            linksLegacyWorkout: true,
+            legacyWorkoutID: UUID(),
+            recoveryAppWorkoutID: UUID(),
+            healthKitWorkoutID: UUID()
+        )
+
+        XCTAssertEqual(
+            DeferredNativeHealthKitLinkageQueue.next(
+                in: [baseExact, actionableExact]
+            ),
+            actionableExact
+        )
+    }
+
+    func testCurrentPendingProofIsSelectedAheadOfOlderBaseDebt() {
+        let oldBase = DeferredNativeHealthKitLinkage(
+            acquisitionStartedAt: now,
+            finishRequestedAt: now.addingTimeInterval(30),
+            healthKitStoppedAt: nil,
+            profileID: nil,
+            telemetrySessionID: nil,
+            linksLegacyWorkout: true,
+            legacyWorkoutID: nil,
+            recoveryAppWorkoutID: nil,
+            healthKitWorkoutID: nil
+        )
+        let currentWorkoutID = UUID()
+        let currentPending = DeferredNativeHealthKitLinkage(
+            acquisitionStartedAt: now.addingTimeInterval(60),
+            finishRequestedAt: now.addingTimeInterval(90),
+            healthKitStoppedAt: now.addingTimeInterval(91),
+            profileID: UUID(),
+            telemetrySessionID: UUID(),
+            linksLegacyWorkout: true,
+            legacyWorkoutID: UUID(),
+            recoveryAppWorkoutID: currentWorkoutID,
+            healthKitWorkoutID: nil
+        )
+
+        XCTAssertEqual(
+            DeferredNativeHealthKitLinkageQueue.next(
+                in: [oldBase, currentPending],
+                preferredRecoveryAppWorkoutID: currentWorkoutID
+            ),
+            currentPending
+        )
+    }
+
     func testLateObservationAfterCancelCannotRegainOwnership() {
         var lifecycle = NativeHeartRateProviderLifecycle()
         lifecycle.bindAttempt(UUID())

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
@@ -473,7 +473,8 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
             telemetrySessionID: telemetrySessionA,
             linksLegacyWorkout: true,
             legacyWorkoutID: nil,
-            recoveryAppWorkoutID: nil
+            recoveryAppWorkoutID: nil,
+            healthKitWorkoutID: nil
         )
         let profileB = UUID()
         let telemetrySessionB = UUID()
@@ -485,7 +486,8 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
             telemetrySessionID: telemetrySessionB,
             linksLegacyWorkout: true,
             legacyWorkoutID: nil,
-            recoveryAppWorkoutID: nil
+            recoveryAppWorkoutID: nil,
+            healthKitWorkoutID: nil
         )
         var pending = [linkageA, linkageB]
 
@@ -496,6 +498,63 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
         XCTAssertEqual(pending[0].telemetrySessionID, telemetrySessionB)
         XCTAssertNotEqual(pending[0].profileID, profileA)
         XCTAssertNotEqual(pending[0].telemetrySessionID, telemetrySessionA)
+    }
+
+    func testSavedWorkoutProofFreezesExactUUIDWithoutLosingDeferredIdentity() {
+        let recoveryAppWorkoutID = UUID()
+        let legacyWorkoutID = UUID()
+        let telemetrySessionID = UUID()
+        let pending = DeferredNativeHealthKitLinkage(
+            acquisitionStartedAt: now,
+            finishRequestedAt: now.addingTimeInterval(30),
+            healthKitStoppedAt: now.addingTimeInterval(31),
+            profileID: UUID(),
+            telemetrySessionID: telemetrySessionID,
+            linksLegacyWorkout: true,
+            legacyWorkoutID: legacyWorkoutID,
+            recoveryAppWorkoutID: recoveryAppWorkoutID,
+            healthKitWorkoutID: nil
+        )
+        let healthKitWorkoutID = UUID()
+
+        let proven = pending.provingSavedWorkout(id: healthKitWorkoutID)
+
+        XCTAssertEqual(proven.healthKitWorkoutID, healthKitWorkoutID)
+        XCTAssertEqual(proven.recoveryAppWorkoutID, recoveryAppWorkoutID)
+        XCTAssertEqual(proven.legacyWorkoutID, legacyWorkoutID)
+        XCTAssertEqual(proven.telemetrySessionID, telemetrySessionID)
+        XCTAssertEqual(proven.acquisitionStartedAt, pending.acquisitionStartedAt)
+        XCTAssertEqual(proven.finishRequestedAt, pending.finishRequestedAt)
+        XCTAssertEqual(proven.healthKitStoppedAt, pending.healthKitStoppedAt)
+    }
+
+    func testDeferredLinkageWithoutExactWorkoutIDStillDecodesForProofQuery() throws {
+        let linkage = DeferredNativeHealthKitLinkage(
+            acquisitionStartedAt: now,
+            finishRequestedAt: now.addingTimeInterval(30),
+            healthKitStoppedAt: now.addingTimeInterval(31),
+            profileID: UUID(),
+            telemetrySessionID: UUID(),
+            linksLegacyWorkout: false,
+            legacyWorkoutID: nil,
+            recoveryAppWorkoutID: UUID(),
+            healthKitWorkoutID: UUID()
+        )
+        let encoded = try JSONEncoder().encode(linkage)
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        object.removeValue(forKey: "healthKitWorkoutID")
+
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder().decode(
+            DeferredNativeHealthKitLinkage.self,
+            from: legacyData
+        )
+
+        XCTAssertNil(decoded.healthKitWorkoutID)
+        XCTAssertEqual(decoded.recoveryAppWorkoutID, linkage.recoveryAppWorkoutID)
+        XCTAssertEqual(decoded.telemetrySessionID, linkage.telemetrySessionID)
     }
 
     func testLateObservationAfterCancelCannotRegainOwnership() {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
@@ -557,6 +557,117 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
         XCTAssertEqual(decoded.telemetrySessionID, linkage.telemetrySessionID)
     }
 
+    func testBaseShapeDeferredLinkageUpgradesInPlaceWithoutRepeatedQuery() throws {
+        let current = DeferredNativeHealthKitLinkage(
+            acquisitionStartedAt: now,
+            finishRequestedAt: now.addingTimeInterval(30),
+            healthKitStoppedAt: now.addingTimeInterval(31),
+            profileID: UUID(),
+            telemetrySessionID: UUID(),
+            linksLegacyWorkout: true,
+            legacyWorkoutID: UUID(),
+            recoveryAppWorkoutID: UUID(),
+            healthKitWorkoutID: nil
+        )
+        let encoded = try JSONEncoder().encode(current)
+        var baseObject = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        for key in [
+            "healthKitStoppedAt", "legacyWorkoutID",
+            "recoveryAppWorkoutID", "healthKitWorkoutID",
+        ] {
+            baseObject.removeValue(forKey: key)
+        }
+        let baseData = try JSONSerialization.data(withJSONObject: baseObject)
+        let baseShape = try JSONDecoder().decode(
+            DeferredNativeHealthKitLinkage.self,
+            from: baseData
+        )
+        let workoutID = UUID()
+
+        let updated = try XCTUnwrap(
+            DeferredNativeHealthKitLinkageQueue.provingSavedWorkout(
+                id: workoutID,
+                replacing: baseShape,
+                in: [baseShape]
+            )
+        )
+
+        XCTAssertEqual(updated.count, 1)
+        XCTAssertEqual(updated[0].healthKitWorkoutID, workoutID)
+        XCTAssertNil(updated[0].recoveryAppWorkoutID)
+        XCTAssertEqual(
+            DeferredNativeHealthKitLinkageQueue.next(in: updated),
+            updated[0]
+        )
+    }
+
+    func testExactDeferredProofCannotDowngradeOrChangeUUID() throws {
+        let recoveryAppWorkoutID = UUID()
+        let pending = DeferredNativeHealthKitLinkage(
+            acquisitionStartedAt: now,
+            finishRequestedAt: now.addingTimeInterval(30),
+            healthKitStoppedAt: now.addingTimeInterval(31),
+            profileID: UUID(),
+            telemetrySessionID: UUID(),
+            linksLegacyWorkout: false,
+            legacyWorkoutID: nil,
+            recoveryAppWorkoutID: recoveryAppWorkoutID,
+            healthKitWorkoutID: nil
+        )
+        let workoutA = UUID()
+        let exactA = pending.provingSavedWorkout(id: workoutA)
+        let workoutB = UUID()
+
+        XCTAssertEqual(
+            DeferredNativeHealthKitLinkageQueue.retaining(
+                pending,
+                in: [exactA]
+            ),
+            [exactA]
+        )
+        XCTAssertNil(DeferredNativeHealthKitLinkageQueue.retaining(
+            pending.provingSavedWorkout(id: workoutB),
+            in: [exactA]
+        ))
+        XCTAssertNil(DeferredNativeHealthKitLinkageQueue.provingSavedWorkout(
+            id: workoutB,
+            replacing: exactA,
+            in: [exactA]
+        ))
+    }
+
+    func testExactDeferredLinkageIsSelectedAheadOfUnresolvedLegacyRow() {
+        let legacy = DeferredNativeHealthKitLinkage(
+            acquisitionStartedAt: now,
+            finishRequestedAt: now.addingTimeInterval(30),
+            healthKitStoppedAt: nil,
+            profileID: nil,
+            telemetrySessionID: nil,
+            linksLegacyWorkout: false,
+            legacyWorkoutID: nil,
+            recoveryAppWorkoutID: nil,
+            healthKitWorkoutID: nil
+        )
+        let exact = DeferredNativeHealthKitLinkage(
+            acquisitionStartedAt: now.addingTimeInterval(60),
+            finishRequestedAt: now.addingTimeInterval(90),
+            healthKitStoppedAt: now.addingTimeInterval(91),
+            profileID: UUID(),
+            telemetrySessionID: UUID(),
+            linksLegacyWorkout: false,
+            legacyWorkoutID: nil,
+            recoveryAppWorkoutID: UUID(),
+            healthKitWorkoutID: UUID()
+        )
+
+        XCTAssertEqual(
+            DeferredNativeHealthKitLinkageQueue.next(in: [legacy, exact]),
+            exact
+        )
+    }
+
     func testLateObservationAfterCancelCannotRegainOwnership() {
         var lifecycle = NativeHeartRateProviderLifecycle()
         lifecycle.bindAttempt(UUID())

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
@@ -235,7 +235,7 @@ final class NativeHeartRatePreflightIntegrationContractTests: XCTestCase {
         XCTAssertFalse(managerSource.contains("Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in\n            self?.warmNativeHeartRateProviderIfPossible"))
     }
 
-    func testFinishUsesDirectUUIDAndPersistsUnavailableDeferredLinkageWithoutRetry() throws {
+    func testFinishPersistsExactUUIDBeforeRetryableDeferredLinkage() throws {
         let finish = try functionBody(
             "private func finishNativeHealthKitWorkoutIfNeeded()",
             in: managerSource
@@ -246,11 +246,14 @@ final class NativeHeartRatePreflightIntegrationContractTests: XCTestCase {
         )
         XCTAssertTrue(finish.contains("iPhoneHealthKitHeartRateProvider.finish"))
         XCTAssertTrue(finish.contains("case .saved(let workout)"))
-        XCTAssertTrue(finish.contains("linkNativeHealthKitWorkout"))
+        XCTAssertTrue(finish.contains("healthKitWorkoutID: workout.uuid"))
+        XCTAssertTrue(finish.contains("terminalSaveProven = true"))
         XCTAssertTrue(finish.contains("case .savedWorkoutUnavailable"))
         XCTAssertTrue(finish.contains("retainDeferredNativeHealthKitLinkage"))
         XCTAssertTrue(resolver.contains("HKSampleQuery"))
         XCTAssertTrue(resolver.contains("linkDeferredNativeHealthKitWorkout"))
+        XCTAssertTrue(resolver.contains("linkage.healthKitWorkoutID"))
+        XCTAssertTrue(resolver.contains("completeRecoveredFinishIfProven"))
         XCTAssertFalse(resolver.contains(".finish("))
         XCTAssertTrue(managerSource.contains("deferred_native_healthkit_linkage_v1"))
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
@@ -241,7 +241,7 @@ final class NativeHeartRatePreflightIntegrationContractTests: XCTestCase {
             in: managerSource
         )
         let resolver = try functionBody(
-            "private func resolveDeferredNativeHealthKitLinkageIfPossible()",
+            "private func resolveDeferredNativeHealthKitLinkageIfPossible(",
             in: managerSource
         )
         XCTAssertTrue(finish.contains("iPhoneHealthKitHeartRateProvider.finish"))

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
@@ -264,14 +264,25 @@ final class NativeHeartRatePreflightIntegrationContractTests: XCTestCase {
             "private func linkDeferredNativeHealthKitWorkout(",
             in: managerSource
         )
+        let exactLegacy = try functionBody(
+            "private func persistExactLegacyWorkoutLink(",
+            in: managerSource
+        )
 
         XCTAssertFalse(clear.contains("nativeHealthKitAcquisitionStartedAt"))
-        XCTAssertTrue(link.contains("linkage.profileID"))
         XCTAssertTrue(link.contains("linkage.telemetrySessionID"))
-        XCTAssertTrue(link.contains("loadLegacyShadowWorkoutHistory(profileID: profileID)"))
-        XCTAssertTrue(link.contains("saveLegacyShadowWorkoutHistory(entries, profileID: profileID)"))
+        XCTAssertTrue(link.contains("NativeWorkoutRequiredLinkagePolicy.complete("))
+        XCTAssertTrue(exactLegacy.contains("linkage.profileID"))
+        XCTAssertTrue(exactLegacy.contains(
+            "loadLegacyShadowWorkoutHistory(profileID: profileID)"
+        ))
+        XCTAssertTrue(exactLegacy.contains(
+            "saveLegacyShadowWorkoutHistory(entries, profileID: profileID)"
+        ))
         XCTAssertFalse(link.contains("pendingHealthkit"))
         XCTAssertFalse(link.contains("nativeHealthKitAcquisitionStartedAt"))
+        XCTAssertFalse(exactLegacy.contains("pendingHealthkit"))
+        XCTAssertFalse(exactLegacy.contains("nativeHealthKitAcquisitionStartedAt"))
     }
 
     func testTelemetryIdentityIsNativeAndCannotGateMotion() throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryIntegrationContractTests.swift
@@ -16,7 +16,7 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
         XCTAssertTrue(app.contains("handleActiveWorkoutRecovery(session: session, error: error)"))
     }
 
-    func testMissingAppleRecoveryFlagReconcilesOnlyDurableFinishingMarker() throws {
+    func testMissingAppleRecoveryFlagClearsPreflightButRetainsFinishUntilSavedProof() throws {
         let app = try source("WalkingPadRemote/WalkingPadRemoteApp.swift")
         let manager = try source("WalkingPadRemote/BluetoothManager.swift")
         let configuration = try functionBody(
@@ -38,15 +38,27 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
         XCTAssertTrue(reconcile.contains("!nativeHeartRateFlowOwnsController"))
         XCTAssertTrue(reconcile.contains("!nativeHealthKitWorkoutFinishInFlight"))
         XCTAssertTrue(reconcile.contains("resolveWithoutActiveRecoveryRequest"))
+        XCTAssertTrue(reconcile.contains("case .discardPreflight"))
         XCTAssertTrue(reconcile.contains("case .reconcileFinished(let record)"))
-        assertOrdered([
-            "retainDeferredNativeHealthKitLinkage(",
-            "clearNativeWorkoutRecoveryRecord()",
-            "resolveDeferredNativeHealthKitLinkageIfPossible()",
-        ], in: reconcile)
+        XCTAssertTrue(reconcile.contains("healthKitStopActivityAt"))
+        let finishedBranch = try XCTUnwrap(
+            reconcile.components(
+                separatedBy: "case .reconcileFinished(let record):"
+            ).last
+        )
+        XCTAssertTrue(finishedBranch.contains("retainDeferredNativeHealthKitLinkage("))
+        XCTAssertTrue(finishedBranch.contains("resolveDeferredNativeHealthKitLinkageIfPossible()"))
+        XCTAssertFalse(finishedBranch.contains("clearNativeWorkoutRecoveryRecord()"))
         for token in ["stopBelt", "sendTreadmill", "writeCommand", "enqueue"] {
             XCTAssertFalse(reconcile.contains(token), token)
         }
+
+        let idle = try functionBody(
+            "private func completeNativeWorkoutRecoveryToIdle()",
+            in: manager
+        )
+        XCTAssertTrue(idle.contains("isNativeHeartRatePreflightActive = false"))
+        XCTAssertTrue(idle.contains("recomputeHrStartAllowed()"))
     }
 
     func testRecoveredProviderReusesAssociatedBuilderAndOnlyRecreatesDataSource() throws {
@@ -275,7 +287,7 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
         XCTAssertTrue(callback.contains(
             "guard !didHandleActiveWorkoutRecoveryCallback else { return }"
         ))
-        XCTAssertTrue(finish.contains("if terminalCompletionSucceeded"))
+        XCTAssertTrue(finish.contains("if terminalSaveProven"))
         XCTAssertTrue(finish.contains(
             "guard pendingNativeWorkoutStopTerminalRequest == nil else { return }"
         ))
@@ -285,6 +297,99 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
             finish.components(separatedBy: "clearNativeWorkoutRecoveryRecord()").count - 1,
             1
         )
+    }
+
+    func testStoppedRecoveryPersistsTruthBeforeCollectionEndAndNeverUsesRelaunchFallback() throws {
+        let provider = try source(
+            "WalkingPadRemote/IPhoneHealthKitLiveHeartRateProvider.swift"
+        )
+        let core = try source("WalkingPadRemote/IPhoneHealthKitHeartRateProviderCore.swift")
+        let recovery = try functionBody("func recoverWorkout(", in: provider)
+        let stop = try functionBody("func stopActivity(at date: Date)", in: provider)
+
+        XCTAssertFalse(recovery.contains("endDate ?? Date()"))
+        XCTAssertFalse(stop.contains("endDate ?? date"))
+        assertOrdered([
+            "persistStoppedAt(stoppedAt)",
+            "driver.endCollection(at: stoppedAt)",
+            "driver.finishWorkout()",
+        ], in: core)
+        XCTAssertTrue(core.contains("missingRecoveredStopDate"))
+    }
+
+    func testDurationExtensionAndLegacyIdentityPersistBeforeRuntimeExposure() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let extend = try functionBody("func extendHrSession(", in: manager)
+        let legacy = try functionBody(
+            "private func recordHrWorkoutIfNeeded(durationOverride: Int?, failed: Bool?)",
+            in: manager
+        )
+
+        assertOrdered([
+            "recoveryRecord.planningDuration(seconds: newTotalSeconds)",
+            "hrSessionTotalSeconds = newTotalSeconds",
+        ], in: extend)
+        assertOrdered([
+            "recoveryRecord.linkingLegacyWorkout(id: entry.id)",
+            "legacyShadowWorkoutHistory.insert(entry, at: 0)",
+            "hrWorkoutRecorded = true",
+        ], in: legacy)
+    }
+
+    func testDeferredSavedProofClearsOnlyAfterExactWorkoutMatch() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let resolve = try functionBody(
+            "private func resolveDeferredNativeHealthKitLinkageIfPossible()",
+            in: manager
+        )
+        let complete = try functionBody(
+            "private func completeRecoveredFinishIfProven(",
+            in: manager
+        )
+
+        assertOrdered([
+            "guard error == nil else",
+            "NativeWorkoutSavedProofPolicy.uniqueMatch(",
+            "guard let workout else { return }",
+            "completeRecoveredFinishIfProven(linkage: linkage)",
+        ], in: resolve)
+        XCTAssertFalse(resolve.contains("clearNativeWorkoutRecoveryRecord()"))
+        XCTAssertTrue(complete.contains("record.phase == .finishing"))
+        XCTAssertTrue(complete.contains("record.appWorkoutID == recoveryAppWorkoutID"))
+        XCTAssertTrue(complete.contains("clearNativeWorkoutRecoveryRecord()"))
+
+        let becameActive = try functionBody(
+            "func nativeHeartRateAppBecameActive()",
+            in: manager
+        )
+        XCTAssertTrue(becameActive.contains(
+            "resolveDeferredNativeHealthKitLinkageIfPossible()"
+        ))
+
+        let link = try functionBody(
+            "private func linkDeferredNativeHealthKitWorkout(",
+            in: manager
+        )
+        assertOrdered([
+            "guard let index = entries.firstIndex",
+            "NativeWorkoutLegacyLinkPolicy.canLink(",
+            "return false",
+        ], in: link)
+
+        let directLink = try functionBody(
+            "private func linkNativeHealthKitWorkout(",
+            in: manager
+        )
+        XCTAssertTrue(directLink.contains("linkDeferredNativeHealthKitWorkout("))
+
+        let finish = try functionBody(
+            "private func finishNativeHealthKitWorkoutIfNeeded()",
+            in: manager
+        )
+        assertOrdered([
+            "guard linkNativeHealthKitWorkout(",
+            "terminalSaveProven = true",
+        ], in: finish)
     }
 
     private func source(_ relativePath: String) throws -> String {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryIntegrationContractTests.swift
@@ -350,7 +350,10 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
         assertOrdered([
             "guard error == nil else",
             "NativeWorkoutSavedProofPolicy.uniqueMatch(",
-            "guard let workout else { return }",
+            "guard let workout else {",
+            "let linkagePersisted = await linkDeferredNativeHealthKitWorkout(",
+            "guard linkagePersisted else { return }",
+            "clearDeferredNativeHealthKitLinkage(linkage)",
             "completeRecoveredFinishIfProven(linkage: linkage)",
         ], in: resolve)
         XCTAssertFalse(resolve.contains("clearNativeWorkoutRecoveryRecord()"))
@@ -370,24 +373,32 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
             "private func linkDeferredNativeHealthKitWorkout(",
             in: manager
         )
+        XCTAssertTrue(link.contains("NativeWorkoutRequiredLinkagePolicy.complete("))
+        XCTAssertTrue(link.contains("persistHealthKitWorkoutAssociationWithTelemetryV2("))
+
+        let exactLegacy = try functionBody(
+            "private func persistExactLegacyWorkoutLink(",
+            in: manager
+        )
         assertOrdered([
             "guard let index = entries.firstIndex",
             "NativeWorkoutLegacyLinkPolicy.canLink(",
+            "guard saveLegacyShadowWorkoutHistory",
             "return false",
-        ], in: link)
+        ], in: exactLegacy)
 
         let directLink = try functionBody(
             "private func linkNativeHealthKitWorkout(",
             in: manager
         )
-        XCTAssertTrue(directLink.contains("linkDeferredNativeHealthKitWorkout("))
+        XCTAssertTrue(directLink.contains("await linkDeferredNativeHealthKitWorkout("))
 
         let finish = try functionBody(
             "private func finishNativeHealthKitWorkoutIfNeeded()",
             in: manager
         )
         assertOrdered([
-            "guard linkNativeHealthKitWorkout(",
+            "guard await linkNativeHealthKitWorkout(",
             "terminalSaveProven = true",
         ], in: finish)
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryIntegrationContractTests.swift
@@ -195,6 +195,27 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
         }
     }
 
+    func testDeferredResolutionPrioritizesCurrentFinishAndBoundsEachRetryPass() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let resolve = try functionBody(
+            "private func resolveDeferredNativeHealthKitLinkageIfPossible(",
+            in: manager
+        )
+
+        assertOrdered([
+            "let candidates = deferredNativeHealthKitLinkages.filter",
+            "!attempted.contains($0)",
+            "preferredRecoveryAppWorkoutID: activeNativeWorkoutRecoveryRecord?",
+            "let attemptedIncludingCurrent = attempted + [linkage]",
+        ], in: resolve)
+        XCTAssertGreaterThanOrEqual(
+            resolve.components(
+                separatedBy: "excluding: attemptedIncludingCurrent"
+            ).count - 1,
+            4
+        )
+    }
+
     func testEveryNonStopMotionEntryPointIsRecoveryGated() throws {
         let manager = try source("WalkingPadRemote/BluetoothManager.swift")
         let sharedGate = try functionBody(
@@ -407,7 +428,7 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
     func testSavedProofIsDurableBeforeRecoveryClearsAndLinkageCannotGateStart() throws {
         let manager = try source("WalkingPadRemote/BluetoothManager.swift")
         let resolve = try functionBody(
-            "private func resolveDeferredNativeHealthKitLinkageIfPossible()",
+            "private func resolveDeferredNativeHealthKitLinkageIfPossible(",
             in: manager
         )
         let complete = try functionBody(
@@ -422,7 +443,7 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
             "let provenLinkage = retainSavedWorkoutProof(",
             "guard let provenLinkage else",
             "completeRecoveredFinishIfProven(linkage: provenLinkage)",
-            "resolveDeferredNativeHealthKitLinkageIfPossible()",
+            "resolveDeferredNativeHealthKitLinkageIfPossible(",
         ], in: resolve)
         XCTAssertTrue(resolve.contains("DeferredNativeHealthKitLinkageQueue.next("))
         assertOrdered([

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryIntegrationContractTests.swift
@@ -1,0 +1,335 @@
+import Foundation
+import XCTest
+
+final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
+    func testSceneFlagRequestsExactlyOneAppleRecoveryCall() throws {
+        let app = try source("WalkingPadRemote/WalkingPadRemoteApp.swift")
+
+        XCTAssertTrue(app.contains("options.shouldHandleActiveWorkoutRecovery"))
+        XCTAssertEqual(app.components(separatedBy: "recoverActiveWorkoutSession").count - 1, 1)
+        XCTAssertTrue(app.contains("ActiveWorkoutRecoveryRequestGate"))
+        assertOrdered([
+            "deliverRecoveryRequest()",
+            "healthStore.recoverActiveWorkoutSession",
+        ], in: app)
+        XCTAssertTrue(app.contains("handleActiveWorkoutRecoveryRequest()"))
+        XCTAssertTrue(app.contains("handleActiveWorkoutRecovery(session: session, error: error)"))
+    }
+
+    func testMissingAppleRecoveryFlagReconcilesOnlyDurableFinishingMarker() throws {
+        let app = try source("WalkingPadRemote/WalkingPadRemoteApp.swift")
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let configuration = try functionBody(
+            "func application(",
+            in: app
+        )
+        let reconcile = try functionBody(
+            "private func processNoActiveWorkoutRecoveryIfPossible()",
+            in: manager
+        )
+
+        assertOrdered([
+            "deliverRecoveryAvailability(options.shouldHandleActiveWorkoutRecovery)",
+            "deliverRecoveryRequest()",
+            "healthStore.recoverActiveWorkoutSession",
+        ], in: configuration)
+        XCTAssertTrue(app.contains("handleActiveWorkoutRecoveryAvailability("))
+        XCTAssertTrue(reconcile.contains("!nativeHealthKitWorkoutCommitted"))
+        XCTAssertTrue(reconcile.contains("!nativeHeartRateFlowOwnsController"))
+        XCTAssertTrue(reconcile.contains("!nativeHealthKitWorkoutFinishInFlight"))
+        XCTAssertTrue(reconcile.contains("resolveWithoutActiveRecoveryRequest"))
+        XCTAssertTrue(reconcile.contains("case .reconcileFinished(let record)"))
+        assertOrdered([
+            "retainDeferredNativeHealthKitLinkage(",
+            "clearNativeWorkoutRecoveryRecord()",
+            "resolveDeferredNativeHealthKitLinkageIfPossible()",
+        ], in: reconcile)
+        for token in ["stopBelt", "sendTreadmill", "writeCommand", "enqueue"] {
+            XCTAssertFalse(reconcile.contains(token), token)
+        }
+    }
+
+    func testRecoveredProviderReusesAssociatedBuilderAndOnlyRecreatesDataSource() throws {
+        let provider = try source(
+            "WalkingPadRemote/IPhoneHealthKitLiveHeartRateProvider.swift"
+        )
+        let recovery = try functionBody("func recoverWorkout(", in: provider)
+
+        XCTAssertTrue(recovery.contains("recoveredSession.associatedWorkoutBuilder()"))
+        XCTAssertTrue(recovery.contains("configureDataSource("))
+        XCTAssertTrue(recovery.contains("recoveredSession.delegate = self"))
+        XCTAssertTrue(recovery.contains("builder.delegate = self"))
+        XCTAssertFalse(recovery.contains("HKWorkoutSession("))
+        XCTAssertFalse(recovery.contains("createWorkout"))
+    }
+
+    func testPreflightMarkerPrecedesCollectionAndCommitMarkerPrecedesMotionBoundary() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let collection = try functionBody(
+            "private func startNativeHeartRateCollection(",
+            in: manager
+        )
+        assertOrdered([
+            "persistNativeWorkoutRecoveryRecord(recoveryRecord)",
+            "iPhoneHealthKitHeartRateProvider.start(at: acquisitionStartedAt)",
+        ], in: collection)
+
+        let commit = try functionBody(
+            "private func commitNativeHeartRatePreflight(",
+            in: manager
+        )
+        assertOrdered([
+            "persistNativeWorkoutRecoveryRecord(committedRecoveryRecord)",
+            "nativeHealthKitWorkoutCommitted = true",
+            "commitExistingHrControl(preflightLatencySeconds: latency)",
+        ], in: commit)
+    }
+
+    func testRecoveryCannotAuthorizeMotionOrCreateSecondTelemetrySession() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let process = try functionBody(
+            "private func processPendingActiveWorkoutRecoveryIfPossible()",
+            in: manager
+        )
+        let restore = try functionBody(
+            "private func restoreCommittedNativeWorkout(",
+            in: manager
+        )
+        let unavailable = try functionBody(
+            "private func handleUnavailableActiveWorkoutRecovery(error: Error?)",
+            in: manager
+        )
+        let forbidden = [
+            "startWithSpeed", "sendTreadmill", "writeCommand", "enqueue",
+            "beginTelemetryV2Session", "isHrControlRunning = true",
+        ]
+        for body in [process, restore, unavailable] {
+            for token in forbidden {
+                XCTAssertFalse(body.contains(token), token)
+            }
+        }
+        XCTAssertTrue(process.contains(
+            "recoveredCollectionStarted: lifecycle.collectionStarted"
+        ))
+        XCTAssertTrue(restore.contains("pendingHealthkitTelemetryV2SessionID"))
+        XCTAssertTrue(restore.contains("nativeWorkoutRecoverySessionRecovered = true"))
+    }
+
+    func testEveryNonStopMotionEntryPointIsRecoveryGated() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let sharedGate = try functionBody(
+            "private var blocksNonStopTreadmillMotion: Bool",
+            in: manager
+        )
+        XCTAssertTrue(sharedGate.contains("pendingNativeWorkoutStopTerminalRequest != nil"))
+        for signature in [
+            "func startWithSpeed(",
+            "func setTargetSpeedFromSlider(",
+            "func adjustSpeed(",
+            "private func sendTreadmillSetSpeed(",
+            "func startStopTruthExperiment()",
+            "private func invokeStopTruthExperimentTransport(",
+        ] {
+            XCTAssertTrue(
+                try functionBody(signature, in: manager).contains(
+                    "blocksNonStopTreadmillMotion"
+                ),
+                signature
+            )
+        }
+        XCTAssertTrue(
+            try functionBody("var canStartTreadmillTestRun: Bool", in: manager)
+                .contains("blocksNonStopTreadmillMotion")
+        )
+    }
+
+    func testCommittedIdentityDrivesStructuredLogAndTelemetryV2Session() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let structuredLog = try functionBody(
+            "private func startTrainingStructuredLog(",
+            in: manager
+        )
+        let commit = try functionBody(
+            "private func commitExistingHrControl(",
+            in: manager
+        )
+
+        XCTAssertTrue(structuredLog.contains("return resolvedSessionID"))
+        XCTAssertEqual(
+            structuredLog.components(separatedBy: "return resolvedSessionID").count - 1,
+            3
+        )
+        assertOrdered([
+            "let legacySessionID = startTrainingStructuredLog(trigger: \"start_hr\")",
+            "beginTelemetryV2Session(legacySessionID: legacySessionID)",
+        ], in: commit)
+    }
+
+    func testPendingRequestBlocksProviderWarmAndUnprovenMarkerCannotPresentElapsedTime() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let outstanding = try functionBody(
+            "private var hasOutstandingNativeWorkoutRecovery: Bool",
+            in: manager
+        )
+        let presentation = try functionBody(
+            "var shouldPresentActiveWorkout: Bool",
+            in: manager
+        )
+
+        XCTAssertTrue(outstanding.contains("activeWorkoutRecoveryRequestPending"))
+        XCTAssertTrue(presentation.contains("case .record(let record)"))
+        XCTAssertTrue(presentation.contains("record.phase == .committed"))
+    }
+
+    func testRecoveredPreflightDiscardHasZeroTreadmillWrites() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let discard = try functionBody(
+            "private func discardRecoveredUncommittedWorkout()",
+            in: manager
+        )
+
+        XCTAssertTrue(discard.contains("iPhoneHealthKitHeartRateProvider.discard"))
+        XCTAssertTrue(discard.contains("clearNativeWorkoutRecoveryRecord()"))
+        for token in ["stopBelt", "startWithSpeed", "sendTreadmill", "writeCommand", "enqueue"] {
+            XCTAssertFalse(discard.contains(token), token)
+        }
+    }
+
+    func testRecoveredStopRequiresFreshControlReadinessAndExplicitUserAction() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let readiness = try functionBody(
+            "var canStopPresentedWorkout: Bool",
+            in: manager
+        )
+        let stop = try functionBody(
+            "private func stopRecoveredNativeWorkout()",
+            in: manager
+        )
+        let performWrite = try functionBody(
+            "private func performWrite(",
+            in: manager
+        )
+        let stopBelt = try functionBody(
+            "private func stopBeltWithToggle(",
+            in: manager
+        )
+        let beginTerminal = try functionBody(
+            "private func beginNativeWorkoutStopTerminalRequestIfNeeded()",
+            in: manager
+        )
+        let invoked = try functionBody(
+            "private func nativeWorkoutStopTransportInvokedIfNeeded()",
+            in: manager
+        )
+
+        XCTAssertTrue(readiness.contains("record.phase == .committed"))
+        XCTAssertTrue(readiness.contains("record.phase == .stopping"))
+        XCTAssertTrue(readiness.contains("&& isTreadmillControlReady"))
+        assertOrdered([
+            "guard canStopPresentedWorkout else { return }",
+            "stopBeltWithToggle(reason: \"recovered_hr_manual_stop\")",
+        ], in: stop)
+        XCTAssertFalse(stop.contains("record.finishing"))
+        XCTAssertFalse(stop.contains("finishNativeHealthKitWorkoutIfNeeded"))
+        assertOrdered([
+            "beginNativeWorkoutStopTerminalRequestIfNeeded()",
+            "stopBeltOnce(",
+        ], in: stopBelt)
+        XCTAssertTrue(beginTerminal.contains("record.stopping(requestedAt: requestedAt)"))
+        XCTAssertFalse(beginTerminal.contains("nativeHealthKitWorkoutCommitted"))
+        assertOrdered([
+            "p.writeValue(data, for: ch, type: type)",
+            "nativeWorkoutStopTransportInvokedIfNeeded()",
+        ], in: performWrite)
+        assertOrdered([
+            "guard nativeHealthKitWorkoutCommitted else",
+            "pending.record.finishing(requestedAt: pending.requestedAt)",
+            "finishNativeHealthKitWorkoutIfNeeded()",
+        ], in: invoked)
+    }
+
+    func testFinishingRecoveryResumesHealthKitTerminalWorkWithoutSecondTreadmillStop() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let resume = try functionBody(
+            "private func resumeFinishingNativeWorkout(",
+            in: manager
+        )
+
+        XCTAssertTrue(resume.contains("finishNativeHealthKitWorkoutIfNeeded()"))
+        XCTAssertFalse(resume.contains("stopBelt"))
+        XCTAssertFalse(resume.contains("sendTreadmill"))
+        XCTAssertFalse(resume.contains("writeCommand"))
+    }
+
+    func testRecoveryCallbackAndTerminalClearAreIdempotent() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let callback = try functionBody(
+            "func handleActiveWorkoutRecovery(",
+            in: manager
+        )
+        let finish = try functionBody(
+            "private func finishNativeHealthKitWorkoutIfNeeded()",
+            in: manager
+        )
+
+        XCTAssertTrue(callback.contains(
+            "guard !didHandleActiveWorkoutRecoveryCallback else { return }"
+        ))
+        XCTAssertTrue(finish.contains("if terminalCompletionSucceeded"))
+        XCTAssertTrue(finish.contains(
+            "guard pendingNativeWorkoutStopTerminalRequest == nil else { return }"
+        ))
+        XCTAssertTrue(finish.contains("guard !isConnected else"))
+        XCTAssertTrue(finish.contains("record.finishing(requestedAt: finishRequestedAt)"))
+        XCTAssertEqual(
+            finish.components(separatedBy: "clearNativeWorkoutRecoveryRecord()").count - 1,
+            1
+        )
+    }
+
+    private func source(_ relativePath: String) throws -> String {
+        let packageDirectory = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(
+            contentsOf: packageDirectory.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+
+    private func functionBody(_ signature: String, in source: String) throws -> String {
+        guard let signatureRange = source.range(of: signature),
+              let openingBrace = source[signatureRange.lowerBound...].firstIndex(of: "{") else {
+            throw NSError(domain: "NativeWorkoutRecoveryIntegrationContractTests", code: 1)
+        }
+        var depth = 0
+        var cursor = openingBrace
+        while cursor < source.endIndex {
+            if source[cursor] == "{" { depth += 1 }
+            if source[cursor] == "}" {
+                depth -= 1
+                if depth == 0 {
+                    return String(source[openingBrace...cursor])
+                }
+            }
+            cursor = source.index(after: cursor)
+        }
+        throw NSError(domain: "NativeWorkoutRecoveryIntegrationContractTests", code: 2)
+    }
+
+    private func assertOrdered(
+        _ tokens: [String],
+        in source: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        var lowerBound = source.startIndex
+        for token in tokens {
+            guard let range = source.range(of: token, range: lowerBound..<source.endIndex) else {
+                XCTFail("Missing ordered token: \(token)", file: file, line: line)
+                return
+            }
+            lowerBound = range.upperBound
+        }
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryIntegrationContractTests.swift
@@ -127,6 +127,53 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
         XCTAssertTrue(restore.contains("nativeWorkoutRecoverySessionRecovered = true"))
     }
 
+    func testRequestedRecoveryFailureRetainsBlockerForMissingAndPreflightState() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let callback = try functionBody(
+            "func handleActiveWorkoutRecovery(",
+            in: manager
+        )
+        let process = try functionBody(
+            "private func processPendingActiveWorkoutRecoveryIfPossible()",
+            in: manager
+        )
+        let unavailable = try functionBody(
+            "private func handleUnavailableActiveWorkoutRecovery(error: Error?)",
+            in: manager
+        )
+        let noRequest = try functionBody(
+            "private func processNoActiveWorkoutRecoveryIfPossible()",
+            in: manager
+        )
+        let start = try functionBody("func startHrControl()", in: manager)
+        let warm = try functionBody(
+            "private func warmNativeHeartRateProviderIfPossible()",
+            in: manager
+        )
+
+        assertOrdered([
+            "activeWorkoutRecoveryRequestPending = false",
+            "pendingActiveWorkoutRecoveryResult = (session, error)",
+            "processPendingActiveWorkoutRecoveryIfPossible()",
+        ], in: callback)
+        XCTAssertTrue(process.contains(
+            "handleUnavailableActiveWorkoutRecovery(error: result.1)"
+        ))
+        XCTAssertTrue(unavailable.contains("isNativeWorkoutRecoveryActive = true"))
+        XCTAssertFalse(unavailable.contains("case .missing"))
+        XCTAssertFalse(unavailable.contains("record.phase == .preflight"))
+        XCTAssertFalse(unavailable.contains("clearNativeWorkoutRecoveryRecord()"))
+        XCTAssertFalse(unavailable.contains("completeNativeWorkoutRecoveryToIdle()"))
+        XCTAssertFalse(unavailable.contains("warmNativeHeartRateProviderIfPossible()"))
+        XCTAssertTrue(noRequest.contains("case .discardPreflight"))
+        XCTAssertTrue(noRequest.contains("clearNativeWorkoutRecoveryRecord()"))
+        XCTAssertTrue(start.contains("!hasOutstandingNativeWorkoutRecovery"))
+        XCTAssertTrue(warm.contains("!hasOutstandingNativeWorkoutRecovery"))
+        for token in ["stopBelt", "startWithSpeed", "sendTreadmill", "writeCommand", "enqueue"] {
+            XCTAssertFalse(unavailable.contains(token), token)
+        }
+    }
+
     func testEveryNonStopMotionEntryPointIsRecoveryGated() throws {
         let manager = try source("WalkingPadRemote/BluetoothManager.swift")
         let sharedGate = try functionBody(
@@ -336,7 +383,7 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
         ], in: legacy)
     }
 
-    func testDeferredSavedProofClearsOnlyAfterExactWorkoutMatch() throws {
+    func testSavedProofIsDurableBeforeRecoveryClearsAndLinkageCannotGateStart() throws {
         let manager = try source("WalkingPadRemote/BluetoothManager.swift")
         let resolve = try functionBody(
             "private func resolveDeferredNativeHealthKitLinkageIfPossible()",
@@ -351,10 +398,18 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
             "guard error == nil else",
             "NativeWorkoutSavedProofPolicy.uniqueMatch(",
             "guard let workout else {",
-            "let linkagePersisted = await linkDeferredNativeHealthKitWorkout(",
-            "guard linkagePersisted else { return }",
-            "clearDeferredNativeHealthKitLinkage(linkage)",
+            "let provenLinkage = linkage.provingSavedWorkout(id: workout.uuid)",
+            "let proofPersisted = retainDeferredNativeHealthKitLinkage(provenLinkage)",
+            "guard proofPersisted else",
+            "completeRecoveredFinishIfProven(linkage: provenLinkage)",
+            "resolveDeferredNativeHealthKitLinkageIfPossible()",
+        ], in: resolve)
+        assertOrdered([
+            "if let workoutID = linkage.healthKitWorkoutID",
             "completeRecoveredFinishIfProven(linkage: linkage)",
+            "let linkagePersisted = await linkDeferredNativeHealthKitWorkout(",
+            "guard linkagePersisted else",
+            "clearDeferredNativeHealthKitLinkage(linkage)",
         ], in: resolve)
         XCTAssertFalse(resolve.contains("clearNativeWorkoutRecoveryRecord()"))
         XCTAssertTrue(complete.contains("record.phase == .finishing"))
@@ -387,20 +442,26 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
             "return false",
         ], in: exactLegacy)
 
-        let directLink = try functionBody(
-            "private func linkNativeHealthKitWorkout(",
+        let durableWrite = try functionBody(
+            "private func persistDeferredNativeHealthKitLinkages()",
             in: manager
         )
-        XCTAssertTrue(directLink.contains("await linkDeferredNativeHealthKitWorkout("))
+        assertOrdered([
+            "UserDefaults.standard.set(data",
+            "UserDefaults.standard.data(",
+            "return stored == deferredNativeHealthKitLinkages",
+        ], in: durableWrite)
 
         let finish = try functionBody(
             "private func finishNativeHealthKitWorkoutIfNeeded()",
             in: manager
         )
         assertOrdered([
-            "guard await linkNativeHealthKitWorkout(",
+            "healthKitWorkoutID: workout.uuid",
             "terminalSaveProven = true",
+            "resolveDeferredNativeHealthKitLinkageIfPossible()",
         ], in: finish)
+        XCTAssertFalse(finish.contains("guard await linkNativeHealthKitWorkout("))
     }
 
     private func source(_ relativePath: String) throws -> String {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryIntegrationContractTests.swift
@@ -174,6 +174,27 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
         }
     }
 
+    func testDeferredProofPublicationRollsBackWhenDurableWriteFails() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let retain = try functionBody(
+            "private func retainDeferredNativeHealthKitLinkage(\n        _ linkage:",
+            in: manager
+        )
+        let prove = try functionBody(
+            "private func retainSavedWorkoutProof(",
+            in: manager
+        )
+
+        for body in [retain, prove] {
+            assertOrdered([
+                "let previous = deferredNativeHealthKitLinkages",
+                "deferredNativeHealthKitLinkages = updated",
+                "guard persistDeferredNativeHealthKitLinkages() else",
+                "deferredNativeHealthKitLinkages = previous",
+            ], in: body)
+        }
+    }
+
     func testEveryNonStopMotionEntryPointIsRecoveryGated() throws {
         let manager = try source("WalkingPadRemote/BluetoothManager.swift")
         let sharedGate = try functionBody(
@@ -398,12 +419,12 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
             "guard error == nil else",
             "NativeWorkoutSavedProofPolicy.uniqueMatch(",
             "guard let workout else {",
-            "let provenLinkage = linkage.provingSavedWorkout(id: workout.uuid)",
-            "let proofPersisted = retainDeferredNativeHealthKitLinkage(provenLinkage)",
-            "guard proofPersisted else",
+            "let provenLinkage = retainSavedWorkoutProof(",
+            "guard let provenLinkage else",
             "completeRecoveredFinishIfProven(linkage: provenLinkage)",
             "resolveDeferredNativeHealthKitLinkageIfPossible()",
         ], in: resolve)
+        XCTAssertTrue(resolve.contains("DeferredNativeHealthKitLinkageQueue.next("))
         assertOrdered([
             "if let workoutID = linkage.healthKitWorkoutID",
             "completeRecoveredFinishIfProven(linkage: linkage)",
@@ -446,11 +467,20 @@ final class NativeWorkoutRecoveryIntegrationContractTests: XCTestCase {
             "private func persistDeferredNativeHealthKitLinkages()",
             in: manager
         )
+        let retainProof = try functionBody(
+            "private func retainSavedWorkoutProof(",
+            in: manager
+        )
         assertOrdered([
             "UserDefaults.standard.set(data",
             "UserDefaults.standard.data(",
             "return stored == deferredNativeHealthKitLinkages",
         ], in: durableWrite)
+        assertOrdered([
+            "DeferredNativeHealthKitLinkageQueue.provingSavedWorkout(",
+            "deferredNativeHealthKitLinkages = updated",
+            "persistDeferredNativeHealthKitLinkages()",
+        ], in: retainProof)
 
         let finish = try functionBody(
             "private func finishNativeHealthKitWorkoutIfNeeded()",

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryTests.swift
@@ -74,6 +74,29 @@ final class NativeWorkoutRecoveryTests: XCTestCase {
         XCTAssertEqual(store.load(), .invalid)
     }
 
+    func testExistingSchemaV1RecordWithoutNewOptionalFieldsStillDecodes() throws {
+        let committed = makeCommitted(makePreflight(), latency: 2)
+        let encoded = try JSONEncoder().encode(committed)
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        object.removeValue(forKey: "plannedDurationSeconds")
+        object.removeValue(forKey: "healthKitStopActivityAt")
+        object.removeValue(forKey: "legacyWorkoutID")
+
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder().decode(
+            NativeWorkoutRecoveryRecord.self,
+            from: legacyData
+        )
+
+        XCTAssertNil(decoded.plannedDurationSeconds)
+        XCTAssertNil(decoded.healthKitStopActivityAt)
+        XCTAssertNil(decoded.legacyWorkoutID)
+        XCTAssertEqual(decoded.effectivePlannedDurationSeconds, 1_800)
+        XCTAssertTrue(decoded.isStructurallyValid)
+    }
+
     func testOnlyExactlyLinkedCommittedIndoorWalkingSessionRestores() {
         let preflight = makePreflight()
         let committed = makeCommitted(preflight, latency: 3)
@@ -172,11 +195,42 @@ final class NativeWorkoutRecoveryTests: XCTestCase {
 
         XCTAssertEqual(committed.targetBPM, 145)
         XCTAssertEqual(committed.durationMinutes, 30)
+        XCTAssertEqual(committed.effectivePlannedDurationSeconds, 1_800)
         XCTAssertEqual(committed.controlledWorkoutStartedAt, controlledStart)
         XCTAssertEqual(committed.profileID, profileID)
         XCTAssertEqual(committed.legacySessionID, legacySessionID)
         XCTAssertEqual(committed.telemetrySessionID, telemetrySessionID)
         XCTAssertTrue(committed.isStructurallyValid)
+    }
+
+    func testExtendedDurationIsDurableAtExactSecondPrecision() throws {
+        let preflight = makePreflight()
+        let committed = makeCommitted(preflight, latency: 2)
+        let extended = committed.planningDuration(seconds: 35 * 60)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = NativeWorkoutRecoveryStore(
+            fileURL: directory.appendingPathComponent("recovery.json")
+        )
+
+        try store.save(extended)
+
+        XCTAssertEqual(extended.durationMinutes, 35)
+        XCTAssertEqual(extended.effectivePlannedDurationSeconds, 2_100)
+        XCTAssertEqual(store.load(), .record(extended))
+    }
+
+    func testLegacyWorkoutIdentitySurvivesTerminalRecoveryWithoutGuessing() {
+        let committed = makeCommitted(makePreflight(), latency: 2)
+        let legacyWorkoutID = UUID()
+        let linked = committed.linkingLegacyWorkout(id: legacyWorkoutID)
+        let finishing = linked.finishing(
+            requestedAt: linked.acquisitionStartedAt.addingTimeInterval(60)
+        )
+
+        XCTAssertEqual(finishing.legacyWorkoutID, legacyWorkoutID)
+        XCTAssertTrue(finishing.isStructurallyValid)
     }
 
     func testCommittedRecordRejectsContradictoryPreflightTiming() {
@@ -215,15 +269,17 @@ final class NativeWorkoutRecoveryTests: XCTestCase {
         XCTAssertFalse(invalid.isStructurallyValid)
     }
 
-    func testNoActiveRecoveryRequestReconcilesOnlyDurableFinishingPhase() {
+    func testNoActiveRecoveryRequestClearsPreflightAndReconcilesOnlyProvenFinishBoundary() {
         let preflight = makePreflight()
         let committed = makeCommitted(preflight, latency: 2)
         let stopping = committed.stopping(
             requestedAt: preflight.acquisitionStartedAt.addingTimeInterval(60)
         )
-        let finishing = stopping.finishing(
+        let unfinished = stopping.finishing(
             requestedAt: preflight.acquisitionStartedAt.addingTimeInterval(60)
         )
+        let stoppedAt = preflight.acquisitionStartedAt.addingTimeInterval(61)
+        let finishing = unfinished.recordingHealthKitStopActivity(at: stoppedAt)
 
         XCTAssertEqual(
             NativeWorkoutRecoveryPolicy.resolveWithoutActiveRecoveryRequest(
@@ -231,12 +287,18 @@ final class NativeWorkoutRecoveryTests: XCTestCase {
             ),
             .reconcileFinished(finishing)
         )
+        XCTAssertEqual(
+            NativeWorkoutRecoveryPolicy.resolveWithoutActiveRecoveryRequest(
+                loadResult: .record(preflight)
+            ),
+            .discardPreflight(preflight)
+        )
         for loadResult in [
             NativeWorkoutRecoveryLoadResult.missing,
             .invalid,
-            .record(preflight),
             .record(committed),
             .record(stopping),
+            .record(unfinished),
         ] {
             XCTAssertEqual(
                 NativeWorkoutRecoveryPolicy.resolveWithoutActiveRecoveryRequest(
@@ -245,6 +307,68 @@ final class NativeWorkoutRecoveryTests: XCTestCase {
                 .retainFailClosed
             )
         }
+    }
+
+    func testSavedWorkoutProofRequiresExactAppOwnedStartAndDurableStopTimes() {
+        let preflight = makePreflight()
+        let stoppedAt = preflight.acquisitionStartedAt.addingTimeInterval(600)
+        let finishing = makeCommitted(preflight, latency: 2)
+            .finishing(requestedAt: stoppedAt)
+            .recordingHealthKitStopActivity(at: stoppedAt)
+
+        XCTAssertTrue(NativeWorkoutSavedProofPolicy.matches(
+            record: finishing,
+            workoutStartedAt: preflight.acquisitionStartedAt,
+            workoutEndedAt: stoppedAt,
+            isWalking: true,
+            sourceMatchesApp: true
+        ))
+        XCTAssertFalse(NativeWorkoutSavedProofPolicy.matches(
+            record: finishing,
+            workoutStartedAt: preflight.acquisitionStartedAt,
+            workoutEndedAt: stoppedAt.addingTimeInterval(3_600),
+            isWalking: true,
+            sourceMatchesApp: true
+        ))
+        XCTAssertFalse(NativeWorkoutSavedProofPolicy.matches(
+            record: finishing,
+            workoutStartedAt: preflight.acquisitionStartedAt,
+            workoutEndedAt: stoppedAt,
+            isWalking: true,
+            sourceMatchesApp: false
+        ))
+    }
+
+    func testSavedWorkoutProofRequiresExactlyOneMatchingCandidate() {
+        XCTAssertNil(NativeWorkoutSavedProofPolicy.uniqueMatch(
+            in: [1, 2, 3],
+            matching: { _ in false }
+        ))
+        XCTAssertEqual(NativeWorkoutSavedProofPolicy.uniqueMatch(
+            in: [1, 2, 3],
+            matching: { $0 == 2 }
+        ), 2)
+        XCTAssertNil(NativeWorkoutSavedProofPolicy.uniqueMatch(
+            in: [1, 2, 3],
+            matching: { $0 >= 2 }
+        ))
+    }
+
+    func testLegacyWorkoutLinkRequiresExactMissingOrSameUUIDState() {
+        let expected = UUID()
+
+        XCTAssertTrue(NativeWorkoutLegacyLinkPolicy.canLink(
+            existingWorkoutUUID: nil,
+            expectedWorkoutUUID: expected
+        ))
+        XCTAssertTrue(NativeWorkoutLegacyLinkPolicy.canLink(
+            existingWorkoutUUID: expected.uuidString,
+            expectedWorkoutUUID: expected
+        ))
+        XCTAssertFalse(NativeWorkoutLegacyLinkPolicy.canLink(
+            existingWorkoutUUID: UUID().uuidString,
+            expectedWorkoutUUID: expected
+        ))
     }
 
     private func makePreflight() -> NativeWorkoutRecoveryRecord {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryTests.swift
@@ -371,6 +371,45 @@ final class NativeWorkoutRecoveryTests: XCTestCase {
         ))
     }
 
+    func testRequiredLinkageFailsClosedUntilEveryApplicableWriteSucceeds() async {
+        var telemetryAttempts = 0
+        let legacyFailure = await NativeWorkoutRequiredLinkagePolicy.complete(
+            legacyRequired: true,
+            persistLegacy: { false },
+            telemetryRequired: true,
+            persistTelemetry: {
+                telemetryAttempts += 1
+                return true
+            }
+        )
+        XCTAssertFalse(legacyFailure)
+        XCTAssertEqual(telemetryAttempts, 0)
+
+        let telemetryFailure = await NativeWorkoutRequiredLinkagePolicy.complete(
+            legacyRequired: true,
+            persistLegacy: { true },
+            telemetryRequired: true,
+            persistTelemetry: {
+                telemetryAttempts += 1
+                return false
+            }
+        )
+        XCTAssertFalse(telemetryFailure)
+        XCTAssertEqual(telemetryAttempts, 1)
+
+        let success = await NativeWorkoutRequiredLinkagePolicy.complete(
+            legacyRequired: true,
+            persistLegacy: { true },
+            telemetryRequired: true,
+            persistTelemetry: {
+                telemetryAttempts += 1
+                return true
+            }
+        )
+        XCTAssertTrue(success)
+        XCTAssertEqual(telemetryAttempts, 2)
+    }
+
     private func makePreflight() -> NativeWorkoutRecoveryRecord {
         NativeWorkoutRecoveryRecord.preflight(
             appWorkoutID: UUID(),

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeWorkoutRecoveryTests.swift
@@ -1,0 +1,274 @@
+import Foundation
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class NativeWorkoutRecoveryTests: XCTestCase {
+    func testRecoveryRequestGateAcceptsFlagExactlyOncePerSceneSession() {
+        var gate = ActiveWorkoutRecoveryRequestGate()
+
+        XCTAssertFalse(gate.shouldRequestRecovery(
+            sceneSessionID: "scene-a",
+            recoveryRequested: false
+        ))
+        XCTAssertTrue(gate.shouldRequestRecovery(
+            sceneSessionID: "scene-a",
+            recoveryRequested: true
+        ))
+        XCTAssertFalse(gate.shouldRequestRecovery(
+            sceneSessionID: "scene-a",
+            recoveryRequested: true
+        ))
+        XCTAssertTrue(gate.shouldRequestRecovery(
+            sceneSessionID: "scene-b",
+            recoveryRequested: true
+        ))
+    }
+
+    func testRecoveryStoreAtomicallyTransitionsPreflightToCommittedAndClears() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = NativeWorkoutRecoveryStore(
+            fileURL: directory.appendingPathComponent("recovery.json")
+        )
+        let preflight = makePreflight()
+
+        try store.save(preflight)
+        XCTAssertEqual(store.load(), .record(preflight))
+
+        let committed = makeCommitted(preflight, latency: 4)
+        try store.save(committed)
+        XCTAssertEqual(store.load(), .record(committed))
+
+        let stopping = committed.stopping(
+            requestedAt: preflight.acquisitionStartedAt.addingTimeInterval(60)
+        )
+        try store.save(stopping)
+        XCTAssertEqual(store.load(), .record(stopping))
+
+        let finishing = stopping.finishing(
+            requestedAt: preflight.acquisitionStartedAt.addingTimeInterval(60)
+        )
+        try store.save(finishing)
+        XCTAssertEqual(store.load(), .record(finishing))
+
+        try store.clear()
+        XCTAssertEqual(store.load(), .missing)
+        try store.clear()
+        XCTAssertEqual(store.load(), .missing)
+    }
+
+    func testCorruptRecoveryMarkerRemainsInvalidRatherThanInventingIdentity() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        let store = NativeWorkoutRecoveryStore(
+            fileURL: directory.appendingPathComponent("recovery.json")
+        )
+        try Data("not-json".utf8).write(to: store.fileURL, options: .atomic)
+
+        XCTAssertEqual(store.load(), .invalid)
+    }
+
+    func testOnlyExactlyLinkedCommittedIndoorWalkingSessionRestores() {
+        let preflight = makePreflight()
+        let committed = makeCommitted(preflight, latency: 3)
+
+        XCTAssertEqual(
+            NativeWorkoutRecoveryPolicy.resolve(
+                loadResult: .record(committed),
+                recoveredSessionStartedAt: preflight.acquisitionStartedAt,
+                recoveredCollectionStarted: true,
+                configurationIsIndoorWalking: true
+            ),
+            .restore(committed)
+        )
+        let finishing = committed.finishing(
+            requestedAt: preflight.acquisitionStartedAt.addingTimeInterval(60)
+        )
+        XCTAssertEqual(
+            NativeWorkoutRecoveryPolicy.resolve(
+                loadResult: .record(finishing),
+                recoveredSessionStartedAt: preflight.acquisitionStartedAt,
+                recoveredCollectionStarted: true,
+                configurationIsIndoorWalking: true
+            ),
+            .finish(finishing)
+        )
+        let stopping = committed.stopping(
+            requestedAt: preflight.acquisitionStartedAt.addingTimeInterval(60)
+        )
+        XCTAssertEqual(
+            NativeWorkoutRecoveryPolicy.resolve(
+                loadResult: .record(stopping),
+                recoveredSessionStartedAt: preflight.acquisitionStartedAt,
+                recoveredCollectionStarted: true,
+                configurationIsIndoorWalking: true
+            ),
+            .restore(stopping)
+        )
+        for loadResult in [
+            NativeWorkoutRecoveryLoadResult.missing,
+            .invalid,
+            .record(preflight),
+        ] {
+            XCTAssertEqual(
+                NativeWorkoutRecoveryPolicy.resolve(
+                    loadResult: loadResult,
+                    recoveredSessionStartedAt: preflight.acquisitionStartedAt,
+                    recoveredCollectionStarted: true,
+                    configurationIsIndoorWalking: true
+                ),
+                .discard
+            )
+        }
+        XCTAssertEqual(
+            NativeWorkoutRecoveryPolicy.resolve(
+                loadResult: .record(committed),
+                recoveredSessionStartedAt: preflight.acquisitionStartedAt
+                    .addingTimeInterval(10),
+                recoveredCollectionStarted: true,
+                configurationIsIndoorWalking: true
+            ),
+            .discard
+        )
+        XCTAssertEqual(
+            NativeWorkoutRecoveryPolicy.resolve(
+                loadResult: .record(committed),
+                recoveredSessionStartedAt: preflight.acquisitionStartedAt,
+                recoveredCollectionStarted: true,
+                configurationIsIndoorWalking: false
+            ),
+            .discard
+        )
+        XCTAssertEqual(
+            NativeWorkoutRecoveryPolicy.resolve(
+                loadResult: .record(committed),
+                recoveredSessionStartedAt: preflight.acquisitionStartedAt,
+                recoveredCollectionStarted: false,
+                configurationIsIndoorWalking: true
+            ),
+            .discard
+        )
+    }
+
+    func testCommittedRecordPreservesFrozenTimingAndSessionIdentities() {
+        let preflight = makePreflight()
+        let controlledStart = preflight.acquisitionStartedAt.addingTimeInterval(2)
+        let profileID = UUID()
+        let legacySessionID = UUID()
+        let telemetrySessionID = legacySessionID
+
+        let committed = preflight.committed(
+            controlledWorkoutStartedAt: controlledStart,
+            profileID: profileID,
+            legacySessionID: legacySessionID,
+            telemetrySessionID: telemetrySessionID
+        )
+
+        XCTAssertEqual(committed.targetBPM, 145)
+        XCTAssertEqual(committed.durationMinutes, 30)
+        XCTAssertEqual(committed.controlledWorkoutStartedAt, controlledStart)
+        XCTAssertEqual(committed.profileID, profileID)
+        XCTAssertEqual(committed.legacySessionID, legacySessionID)
+        XCTAssertEqual(committed.telemetrySessionID, telemetrySessionID)
+        XCTAssertTrue(committed.isStructurallyValid)
+    }
+
+    func testCommittedRecordRejectsContradictoryPreflightTiming() {
+        let preflight = makePreflight()
+        let legacySessionID = UUID()
+        let invalid = preflight.committed(
+            controlledWorkoutStartedAt: preflight.acquisitionStartedAt.addingTimeInterval(
+                NativeHeartRatePreflightEngine.timeoutSeconds + 1
+            ),
+            profileID: UUID(),
+            legacySessionID: legacySessionID,
+            telemetrySessionID: legacySessionID
+        )
+
+        XCTAssertFalse(invalid.isStructurallyValid)
+        XCTAssertEqual(
+            NativeWorkoutRecoveryPolicy.resolve(
+                loadResult: .record(invalid),
+                recoveredSessionStartedAt: preflight.acquisitionStartedAt,
+                recoveredCollectionStarted: true,
+                configurationIsIndoorWalking: true
+            ),
+            .discard
+        )
+    }
+
+    func testCommittedRecordRejectsInventedTelemetryLinkage() {
+        let preflight = makePreflight()
+        let invalid = preflight.committed(
+            controlledWorkoutStartedAt: preflight.acquisitionStartedAt.addingTimeInterval(2),
+            profileID: UUID(),
+            legacySessionID: UUID(),
+            telemetrySessionID: UUID()
+        )
+
+        XCTAssertFalse(invalid.isStructurallyValid)
+    }
+
+    func testNoActiveRecoveryRequestReconcilesOnlyDurableFinishingPhase() {
+        let preflight = makePreflight()
+        let committed = makeCommitted(preflight, latency: 2)
+        let stopping = committed.stopping(
+            requestedAt: preflight.acquisitionStartedAt.addingTimeInterval(60)
+        )
+        let finishing = stopping.finishing(
+            requestedAt: preflight.acquisitionStartedAt.addingTimeInterval(60)
+        )
+
+        XCTAssertEqual(
+            NativeWorkoutRecoveryPolicy.resolveWithoutActiveRecoveryRequest(
+                loadResult: .record(finishing)
+            ),
+            .reconcileFinished(finishing)
+        )
+        for loadResult in [
+            NativeWorkoutRecoveryLoadResult.missing,
+            .invalid,
+            .record(preflight),
+            .record(committed),
+            .record(stopping),
+        ] {
+            XCTAssertEqual(
+                NativeWorkoutRecoveryPolicy.resolveWithoutActiveRecoveryRequest(
+                    loadResult: loadResult
+                ),
+                .retainFailClosed
+            )
+        }
+    }
+
+    private func makePreflight() -> NativeWorkoutRecoveryRecord {
+        NativeWorkoutRecoveryRecord.preflight(
+            appWorkoutID: UUID(),
+            targetBPM: 145,
+            durationMinutes: 30,
+            acquisitionStartedAt: Date(timeIntervalSince1970: 10_000),
+            profileID: UUID()
+        )
+    }
+
+    private func makeCommitted(
+        _ preflight: NativeWorkoutRecoveryRecord,
+        latency: TimeInterval
+    ) -> NativeWorkoutRecoveryRecord {
+        let legacySessionID = UUID()
+        return preflight.committed(
+            controlledWorkoutStartedAt: preflight.acquisitionStartedAt.addingTimeInterval(
+                latency
+            ),
+            profileID: UUID(),
+            legacySessionID: legacySessionID,
+            telemetrySessionID: legacySessionID
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- recover the exact iPhone-native HealthKit workout handed back by the scene recovery API without creating a replacement session or builder
- persist an atomic recovery marker across preflight, committed, stopping, and finishing phases while preserving original workout, profile, timing, legacy, and Telemetry V2 identities
- keep explicit Apple recovery requests fail-closed on nil/error, while safely discarding stale preflight state only when no recovery request exists
- persist and read back exact saved-workout proof before clearing a finishing recovery marker; retry legacy and Telemetry V2 associations separately without gating Start or motion
- upgrade base-schema deferred rows in place, preserve exact UUID identity, reject conflicting proof, and prioritize the active finishing workout over unrelated backlog
- bound each deferred-resolution pass so failed, ambiguous, or unresolvable entries cannot loop or starve later actionable entries
- preserve existing Stop, cooldown, control-readiness, adaptive-control, treadmill transport, and Telemetry V2 factual semantics
- add focused behavioral and integration-contract coverage for crash gaps, compatibility, exact proof durability, queue fairness, motion gates, and terminal ordering

Closes #80

## Verification

- `swift test --filter 'NativeWorkoutRecovery|NativeHeartRatePreflightIntegrationContractTests|NativeHeartRatePreflightEngineTests|IPhoneHealthKitHeartRateProviderCoreTests'` — 100 tests passed
- `swift test` — passed locally; the opt-in 1000-hour telemetry profile was not enabled
- `xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` — BUILD SUCCEEDED
- `xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -sdk iphoneos CODE_SIGNING_ALLOWED=NO build` — failed in the current Xcode beta SDK 27 environment at the watch AppIcon asset step; the repository-documented generic iOS destination command above passed
- `python3 -m compileall -q scripts tools` — passed
- `git diff --check` — clean
- exact-head GitHub CI run `32716221337`, attempt 1 — 4/4 passed on `f3bc6c989fa64fdebc2de2be7e4aec40e503d64a`
- independent high-scope safety challenge — GO with no P1/P2 findings
- fresh final full-PR safety review — GO with no P1/P2 findings

## Risks / Notes

- No physical crash injection, device install, BLE exercise, deployment, Ready-for-review transition, or merge was performed; physical-device recovery remains a later evidence gate.
- Query errors, zero/multiple matches, failed durable proof writes, and legacy/Telemetry V2 association failures remain fail-closed. Each deferred item is attempted at most once per resolution pass, and the active finishing workout is prioritized over old backlog.
- Added deferred-linkage fields are optional and existing records remain decodable; no migration, configuration change, or deployment step is required.
- The local unsigned build retains only existing project warnings, including AppIntents metadata output.
- Rollback is a revert of the full Issue #80 PR. Partial rollback while recovery records exist could reintroduce the reviewed crash-gap and queue-ordering risks.
- Verified Draft head: `f3bc6c989fa64fdebc2de2be7e4aec40e503d64a`; base: `7f8afea7b7649b4c2c5a68ef4d2aa032d78e1955`.

