### PR TITLE
Measure Training UI update pressure

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -4553,6 +4553,119 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         )
     }
 
+#if DEBUG
+    func prepareTrainingUIIdlePressureBaseline() {
+        isConnected = false
+        isTreadmillControlReady = false
+        isHrControlRunning = false
+        isNativeHeartRatePreflightActive = false
+        isNativeHeartRateCurrent = false
+        hrStreamingActive = false
+        heartRateBPM = 0
+        discoveredPeripherals = (0..<4).map { index in
+            DiscoveredPeripheral(
+                id: UUID(uuidString: "00000000-0000-0000-0000-00000000000\(index)")!,
+                name: "Mock WalkingPad \(index + 1)",
+                rssi: -50 - index,
+                isKnown: false
+            )
+        }
+    }
+
+    func applyTrainingUIDiscoveryPressureEvent(_ eventIndex: Int) {
+        let deviceIndex = eventIndex % discoveredPeripherals.count
+        var updated = discoveredPeripherals
+        let existing = updated[deviceIndex]
+        updated[deviceIndex] = DiscoveredPeripheral(
+            id: existing.id,
+            name: existing.name,
+            rssi: -50 - ((eventIndex / discoveredPeripherals.count) % 4),
+            isKnown: existing.isKnown
+        )
+        discoveredPeripherals = updated
+    }
+
+    func prepareTrainingUIActivePressureBaseline() {
+        isConnected = true
+        isTreadmillControlReady = true
+        isHrControlRunning = true
+        isNativeHeartRatePreflightActive = false
+        isNativeHeartRateCurrent = true
+        hrStreamingActive = true
+        heartRateBPM = 130
+        lastKnownHeartRateBPM = 130
+        hrLastValueAt = Date(timeIntervalSince1970: 1_800_000_000)
+        hrDataStaleSeconds = 0
+        deviceReportedSpeedKmh = 5.0
+        deviceReportedAppSpeedKmh = 5.0
+        deviceReportedState = 1
+        deviceReportedManualMode = 1
+        deviceReportedTimeSeconds = 0
+        deviceReportedDistance10m = 0
+        deviceReportedSteps = 0
+        deviceReportedButton = 0
+        deviceReportedChecksumOk = true
+        deviceReportedRawHex = "F8A2"
+        speedKmh = 5.0
+        timeSec = 0
+        distKm = 0
+        stepsCount = 0
+        avgSpeedActive = true
+        avgSpeedKmh = 5.0
+        hrAverageBPM = 130
+        beatsPerMeter = 1.56
+        hrTargetBPM = 130
+        hrSessionTotalSeconds = 600
+        hrRemainingSeconds = 600
+        hrNextDecisionSeconds = 10
+        hrProgress = 0
+        hrCooldownRemainingSeconds = 0
+        hrControlStartedAt = nil
+    }
+
+    func applyTrainingUIHeartRatePressureEvent(second: Int) {
+        let bpm = 128 + ((second / 5) % 5)
+        heartRateBPM = bpm
+        lastKnownHeartRateBPM = bpm
+        hrLastValueAt = Date(timeIntervalSince1970: 1_800_000_000 + Double(second))
+        hrDataStaleSeconds = 0
+        hrStreamingActive = true
+        isNativeHeartRateCurrent = true
+    }
+
+    func applyTrainingUITreadmillPressureEvent(second: Int) {
+        deviceReportedSpeedKmh = 5.0
+        deviceReportedAppSpeedKmh = 5.0
+        deviceReportedState = 1
+        deviceReportedManualMode = 1
+        deviceReportedTimeSeconds = second
+        deviceReportedDistance10m = second / 2
+        deviceReportedSteps = second * 2
+        deviceReportedButton = 0
+        deviceReportedChecksumOk = true
+        deviceReportedRawHex = String(format: "F8A2%04X", second)
+    }
+
+    func applyTrainingUITimerPressureEvent(second: Int) {
+        speedKmh = 5.0
+        distKm = Double(second) * 5.0 / 3_600.0
+        timeSec = second
+        stepsCount = second * 2
+        avgSpeedActive = true
+        avgSpeedKmh = 5.0
+        hrAverageBPM = 130
+        beatsPerMeter = 1.56
+        hrPredictorStatusLine = "HR \(heartRateBPM) / цель \(hrTargetBPM) · тренд —"
+        hrRemainingSeconds = 600 - second
+        hrProgress = Double(second) / 600.0
+        hrNextDecisionSeconds = 10 - (second % 10)
+        if second.isMultiple(of: 10) {
+            hrStatusLine = "HR‑контроль: цель удерживается"
+            hrDecisionDetails = "Deterministic HOLD sample \(second / 10)"
+        }
+    }
+#endif
+
     func nativeHeartRateAppBecameActive() {
         nativeHeartRateAppActivity = .active
         applyNativeHeartRatePreflightEffects(

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -561,20 +561,22 @@ private enum TrainingUIUpdatePressureHarness {
     private struct Measurement: Codable {
         let source: String
         var technicalEvents = 0
-        var managerPublications = 0
+        var managerPublishedEvents = 0
         var visibleSnapshotChanges = 0
+        var potentialAvoidableManagerDrivenInvalidations = 0
+        var rawManagerPublications = 0
         var synchronousMainThreadNanoseconds: UInt64 = 0
-        var publicationsWithoutVisibleChangeLowerBound = 0
     }
 
     private struct Workload: Codable {
         let workload: String
         let measurements: [Measurement]
         let technicalEvents: Int
-        let managerPublications: Int
+        let managerPublishedEvents: Int
         let visibleSnapshotChanges: Int
-        let publicationsWithoutVisibleChangeLowerBound: Int
-        let publicationToVisibleChangeRatio: Double?
+        let potentialAvoidableManagerDrivenInvalidations: Int
+        let rawManagerPublications: Int
+        let eventToVisibleChangeRatio: Double?
         let synchronousMainThreadNanoseconds: UInt64
     }
 
@@ -611,7 +613,7 @@ private enum TrainingUIUpdatePressureHarness {
             events: activeEvents
         )
         let report = Report(
-            schema: "training-ui-update-pressure-v1",
+            schema: "training-ui-update-pressure-v2",
             workloads: [idle, active]
         )
         let encoder = JSONEncoder()
@@ -644,16 +646,20 @@ private enum TrainingUIUpdatePressureHarness {
 
             var measurement = measurements[event.source]
                 ?? Measurement(source: event.source)
+            let managerPublished = publicationCount > publicationsBefore
+            let snapshotChanged = nextSnapshot != snapshot
             measurement.technicalEvents += 1
-            measurement.managerPublications += publicationCount - publicationsBefore
+            measurement.rawManagerPublications += publicationCount - publicationsBefore
             measurement.synchronousMainThreadNanoseconds += elapsed
-            if nextSnapshot != snapshot {
+            if managerPublished {
+                measurement.managerPublishedEvents += 1
+            }
+            if snapshotChanged {
                 measurement.visibleSnapshotChanges += 1
             }
-            measurement.publicationsWithoutVisibleChangeLowerBound = max(
-                0,
-                measurement.managerPublications - measurement.visibleSnapshotChanges
-            )
+            if managerPublished && !snapshotChanged {
+                measurement.potentialAvoidableManagerDrivenInvalidations += 1
+            }
             measurements[event.source] = measurement
             snapshot = nextSnapshot
         }
@@ -661,20 +667,20 @@ private enum TrainingUIUpdatePressureHarness {
 
         let ordered = measurements.values.sorted { $0.source < $1.source }
         let technicalEvents = ordered.reduce(0) { $0 + $1.technicalEvents }
-        let managerPublications = ordered.reduce(0) { $0 + $1.managerPublications }
+        let managerPublishedEvents = ordered.reduce(0) { $0 + $1.managerPublishedEvents }
         let visibleSnapshotChanges = ordered.reduce(0) { $0 + $1.visibleSnapshotChanges }
         return Workload(
             workload: workload,
             measurements: ordered,
             technicalEvents: technicalEvents,
-            managerPublications: managerPublications,
+            managerPublishedEvents: managerPublishedEvents,
             visibleSnapshotChanges: visibleSnapshotChanges,
-            publicationsWithoutVisibleChangeLowerBound: max(
-                0,
-                managerPublications - visibleSnapshotChanges
-            ),
-            publicationToVisibleChangeRatio: visibleSnapshotChanges > 0
-                ? Double(managerPublications) / Double(visibleSnapshotChanges)
+            potentialAvoidableManagerDrivenInvalidations: ordered.reduce(0) {
+                $0 + $1.potentialAvoidableManagerDrivenInvalidations
+            },
+            rawManagerPublications: ordered.reduce(0) { $0 + $1.rawManagerPublications },
+            eventToVisibleChangeRatio: visibleSnapshotChanges > 0
+                ? Double(managerPublishedEvents) / Double(visibleSnapshotChanges)
                 : nil,
             synchronousMainThreadNanoseconds: ordered.reduce(0) {
                 $0 + $1.synchronousMainThreadNanoseconds

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if DEBUG
+import Combine
+#endif
 #if canImport(TelemetryRuntime)
 import TelemetryRuntime
 #endif
@@ -45,6 +48,7 @@ struct ContentView: View {
             $0.hasPrefix("--training-hub-preview=")
                 || $0.hasPrefix("--active-workout-preview=")
                 || $0.hasPrefix("--training-result-preview=")
+                || $0 == "--training-ui-pressure-baseline"
         }
     }
     #endif
@@ -82,6 +86,10 @@ struct ContentView: View {
         }
         .onAppear {
             #if DEBUG
+            if ProcessInfo.processInfo.arguments.contains("--training-ui-pressure-baseline") {
+                TrainingUIUpdatePressureHarness.run(manager: manager)
+                return
+            }
             guard !isTrainingPreviewLaunch else { return }
             #endif
             manager.start()
@@ -491,7 +499,215 @@ private func makeHRControlActivePresentation(
     )
 }
 
+private func makeProductionTrainingHubPresentation(
+    manager: BluetoothManager
+) -> TrainingHubPresentation {
+    makeHRControlTrainingHubPresentation(
+        treadmillConnected: manager.isTreadmillControlReady,
+        hrFresh: manager.isNativeHeartRateCurrent && manager.hrStreamingActive,
+        currentHeartRateBPM: manager.isNativeHeartRateCurrent
+            && manager.hrStreamingActive
+            && manager.heartRateBPM > 0
+            ? manager.heartRateBPM
+            : nil,
+        heartRateSourceLabel: manager.isNativeHeartRateCurrent ? "HealthKit" : nil,
+        targetZoneIndex: hrZoneIndex(for: manager.hrTargetBPM, manager: manager),
+        zoneRanges: hrZoneRanges(for: manager),
+        durationMinutes: manager.hrDurationMinutes,
+        startEnabled: manager.isHrControlStartAffordanceAvailable,
+        runtimeBlockReason: manager.hrControlStartBlockReasonText,
+        isPreparing: manager.isNativeHeartRatePreflightActive
+    )
+}
+
+private func makeProductionActiveWorkoutPresentation(
+    manager: BluetoothManager
+) -> TrainingHubPresentation {
+    let factualSpeedKmh: Double? = {
+        guard manager.isConnected else { return nil }
+        if manager.deviceReportedAppSpeedKmh > 0.05 {
+            return manager.deviceReportedAppSpeedKmh
+        }
+        if manager.deviceReportedSpeedKmh > 0.05 {
+            return manager.deviceReportedSpeedKmh
+        }
+        return nil
+    }()
+
+    return makeHRControlActivePresentation(
+        treadmillConnected: manager.isTreadmillControlReady,
+        hrFresh: manager.isNativeHeartRateCurrent && manager.hrStreamingActive,
+        currentHeartRateBPM: manager.isNativeHeartRateCurrent
+            && manager.hrStreamingActive
+            && manager.heartRateBPM > 0
+            ? manager.heartRateBPM
+            : nil,
+        heartRateSourceLabel: manager.isNativeHeartRateCurrent ? "HealthKit" : nil,
+        targetZoneIndex: hrZoneIndex(for: manager.hrTargetBPM, manager: manager),
+        zoneRanges: hrZoneRanges(for: manager),
+        factualSpeedKmh: factualSpeedKmh,
+        elapsedSeconds: manager.presentedWorkoutElapsedSeconds,
+        isCooldown: manager.isHrControlRunning && manager.hrRemainingSeconds <= 0,
+        cooldownTargetBPM: manager.hrCooldownTargetBpm,
+        canExtend: manager.canExtendHrSession,
+        phaseTitleOverride: manager.presentedWorkoutPhaseTitle
+    )
+}
+
 #if DEBUG
+@MainActor
+private enum TrainingUIUpdatePressureHarness {
+    private typealias Event = (source: String, apply: (BluetoothManager) -> Void)
+    private struct Measurement: Codable {
+        let source: String
+        var technicalEvents = 0
+        var managerPublications = 0
+        var visibleSnapshotChanges = 0
+        var synchronousMainThreadNanoseconds: UInt64 = 0
+        var publicationsWithoutVisibleChangeLowerBound = 0
+    }
+
+    private struct Workload: Codable {
+        let workload: String
+        let measurements: [Measurement]
+        let technicalEvents: Int
+        let managerPublications: Int
+        let visibleSnapshotChanges: Int
+        let publicationsWithoutVisibleChangeLowerBound: Int
+        let publicationToVisibleChangeRatio: Double?
+        let synchronousMainThreadNanoseconds: UInt64
+    }
+
+    private struct Report: Codable {
+        let schema: String
+        let workloads: [Workload]
+    }
+
+    private static var didRun = false
+
+    static func run(manager: BluetoothManager) {
+        guard !didRun else { return }
+        didRun = true
+
+        let idle = measure(
+            workload: "idle_hub_duplicate_discovery",
+            manager: manager,
+            configure: { $0.prepareTrainingUIIdlePressureBaseline() },
+            events: (0..<120).map { index -> Event in
+                ("ble_discovery", { $0.applyTrainingUIDiscoveryPressureEvent(index) })
+            }
+        )
+        let activeEvents = (1...60).flatMap { second -> [Event] in
+            [
+                ("heart_rate", { $0.applyTrainingUIHeartRatePressureEvent(second: second) }),
+                ("treadmill_status", { $0.applyTrainingUITreadmillPressureEvent(second: second) }),
+                ("timer", { $0.applyTrainingUITimerPressureEvent(second: second) }),
+            ]
+        }
+        let active = measure(
+            workload: "active_workout_60s",
+            manager: manager,
+            configure: { $0.prepareTrainingUIActivePressureBaseline() },
+            events: activeEvents
+        )
+        let report = Report(
+            schema: "training-ui-update-pressure-v1",
+            workloads: [idle, active]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(report),
+              let json = String(data: data, encoding: .utf8) else { return }
+        print("TRAINING_UI_PRESSURE \(json)")
+    }
+
+    private static func measure(
+        workload: String,
+        manager: BluetoothManager,
+        configure: (BluetoothManager) -> Void,
+        events: [Event]
+    ) -> Workload {
+        configure(manager)
+        var publicationCount = 0
+        let cancellable = manager.objectWillChange.sink {
+            publicationCount += 1
+        }
+        var measurements: [String: Measurement] = [:]
+        var snapshot = visibleSnapshot(manager: manager)
+
+        for event in events {
+            let publicationsBefore = publicationCount
+            let startedAt = DispatchTime.now().uptimeNanoseconds
+            event.apply(manager)
+            let nextSnapshot = visibleSnapshot(manager: manager)
+            let elapsed = DispatchTime.now().uptimeNanoseconds - startedAt
+
+            var measurement = measurements[event.source]
+                ?? Measurement(source: event.source)
+            measurement.technicalEvents += 1
+            measurement.managerPublications += publicationCount - publicationsBefore
+            measurement.synchronousMainThreadNanoseconds += elapsed
+            if nextSnapshot != snapshot {
+                measurement.visibleSnapshotChanges += 1
+            }
+            measurement.publicationsWithoutVisibleChangeLowerBound = max(
+                0,
+                measurement.managerPublications - measurement.visibleSnapshotChanges
+            )
+            measurements[event.source] = measurement
+            snapshot = nextSnapshot
+        }
+        withExtendedLifetime(cancellable) {}
+
+        let ordered = measurements.values.sorted { $0.source < $1.source }
+        let technicalEvents = ordered.reduce(0) { $0 + $1.technicalEvents }
+        let managerPublications = ordered.reduce(0) { $0 + $1.managerPublications }
+        let visibleSnapshotChanges = ordered.reduce(0) { $0 + $1.visibleSnapshotChanges }
+        return Workload(
+            workload: workload,
+            measurements: ordered,
+            technicalEvents: technicalEvents,
+            managerPublications: managerPublications,
+            visibleSnapshotChanges: visibleSnapshotChanges,
+            publicationsWithoutVisibleChangeLowerBound: max(
+                0,
+                managerPublications - visibleSnapshotChanges
+            ),
+            publicationToVisibleChangeRatio: visibleSnapshotChanges > 0
+                ? Double(managerPublications) / Double(visibleSnapshotChanges)
+                : nil,
+            synchronousMainThreadNanoseconds: ordered.reduce(0) {
+                $0 + $1.synchronousMainThreadNanoseconds
+            }
+        )
+    }
+
+    private static func visibleSnapshot(manager: BluetoothManager) -> [String] {
+        let presentation = manager.shouldPresentActiveWorkout
+            ? makeProductionActiveWorkoutPresentation(manager: manager)
+            : makeProductionTrainingHubPresentation(manager: manager)
+        return [
+            presentation.modeTitle,
+            presentation.targetTitle,
+            presentation.targetValue,
+            presentation.metrics.map { "\($0.id)=\($0.value)" }.joined(separator: "|"),
+            presentation.readiness.map {
+                "\($0.id)=\($0.value)|\($0.sourceLabel ?? "")|\($0.isReady)"
+            }.joined(separator: ";"),
+            String(presentation.startEnabled),
+            presentation.startBlocker ?? "",
+            String(presentation.isPreparing),
+            presentation.phaseTitle ?? "",
+            presentation.primaryValue ?? "",
+            presentation.primaryUnit ?? "",
+            presentation.statusTitle ?? "",
+            presentation.liveMarkerBPM.map(String.init) ?? "",
+            presentation.targetThresholdBPM.map(String.init) ?? "",
+            String(presentation.showsExtendAction),
+        ]
+    }
+}
+
 private func trainingHubPreviewPresentation(named name: String) -> TrainingHubPresentation? {
     let ranges = [60...134, 135...146, 147...158, 159...170, 171...220]
     func hrControl(
@@ -1899,20 +2115,7 @@ private struct ControlSwipeView: View {
     }
 
     private var productionTrainingHubPresentation: TrainingHubPresentation {
-        makeHRControlTrainingHubPresentation(
-            treadmillConnected: manager.isTreadmillControlReady,
-            hrFresh: manager.isNativeHeartRateCurrent && manager.hrStreamingActive,
-            currentHeartRateBPM: manager.isNativeHeartRateCurrent && manager.hrStreamingActive && manager.heartRateBPM > 0
-                ? manager.heartRateBPM
-                : nil,
-            heartRateSourceLabel: manager.isNativeHeartRateCurrent ? "HealthKit" : nil,
-            targetZoneIndex: hrZoneIndex(for: manager.hrTargetBPM, manager: manager),
-            zoneRanges: hrZoneRanges(for: manager),
-            durationMinutes: manager.hrDurationMinutes,
-            startEnabled: manager.isHrControlStartAffordanceAvailable,
-            runtimeBlockReason: manager.hrControlStartBlockReasonText,
-            isPreparing: manager.isNativeHeartRatePreflightActive
-        )
+        makeProductionTrainingHubPresentation(manager: manager)
     }
 
     private var trainingHubPresentation: TrainingHubPresentation {
@@ -1930,33 +2133,7 @@ private struct ControlSwipeView: View {
     }
 
     private var productionActiveWorkoutPresentation: TrainingHubPresentation {
-        let factualSpeedKmh: Double? = {
-            guard manager.isConnected else { return nil }
-            if manager.deviceReportedAppSpeedKmh > 0.05 {
-                return manager.deviceReportedAppSpeedKmh
-            }
-            if manager.deviceReportedSpeedKmh > 0.05 {
-                return manager.deviceReportedSpeedKmh
-            }
-            return nil
-        }()
-
-        return makeHRControlActivePresentation(
-            treadmillConnected: manager.isTreadmillControlReady,
-            hrFresh: manager.isNativeHeartRateCurrent && manager.hrStreamingActive,
-            currentHeartRateBPM: manager.isNativeHeartRateCurrent && manager.hrStreamingActive && manager.heartRateBPM > 0
-                ? manager.heartRateBPM
-                : nil,
-            heartRateSourceLabel: manager.isNativeHeartRateCurrent ? "HealthKit" : nil,
-            targetZoneIndex: hrZoneIndex(for: manager.hrTargetBPM, manager: manager),
-            zoneRanges: hrZoneRanges(for: manager),
-            factualSpeedKmh: factualSpeedKmh,
-            elapsedSeconds: manager.presentedWorkoutElapsedSeconds,
-            isCooldown: manager.isHrControlRunning && manager.hrRemainingSeconds <= 0,
-            cooldownTargetBPM: manager.hrCooldownTargetBpm,
-            canExtend: manager.canExtendHrSession,
-            phaseTitleOverride: manager.presentedWorkoutPhaseTitle
-        )
+        makeProductionActiveWorkoutPresentation(manager: manager)
     }
 
     private var activeWorkoutPresentation: TrainingHubPresentation? {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -246,7 +246,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
             in: contentViewSource
         )
         let production = try functionBody(
-            "private var productionTrainingHubPresentation: TrainingHubPresentation",
+            "private func makeProductionTrainingHubPresentation(",
             in: contentViewSource
         )
         let previewFixtures = try functionBody(
@@ -331,12 +331,14 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         XCTAssertTrue(contentBody.contains("--training-hub-preview="))
         XCTAssertTrue(contentBody.contains("--active-workout-preview="))
         XCTAssertTrue(contentBody.contains("--training-result-preview="))
+        XCTAssertTrue(contentBody.contains("--training-ui-pressure-baseline"))
         XCTAssertEqual(
             contentBody.components(separatedBy: "guard !isTrainingPreviewLaunch else { return }").count - 1,
             2
         )
         assertOrdered(
             [
+                "TrainingUIUpdatePressureHarness.run(manager: manager)",
                 "guard !isTrainingPreviewLaunch else { return }",
                 "manager.start()",
                 "guard !isTrainingPreviewLaunch else { return }",
@@ -415,6 +417,10 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
             "private struct ControlSwipeView: View",
             in: contentViewSource
         )
+        let production = try functionBody(
+            "private func makeProductionActiveWorkoutPresentation(",
+            in: contentViewSource
+        )
         let fixtures = try functionBody(
             "private func activeWorkoutPreviewPresentation(named name: String)",
             in: contentViewSource
@@ -459,7 +465,8 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         XCTAssertFalse(scale.contains("manager."))
         XCTAssertFalse(scale.contains("sendTreadmill"))
 
-        XCTAssertTrue(controlView.contains("makeHRControlActivePresentation("))
+        XCTAssertTrue(controlView.contains("makeProductionActiveWorkoutPresentation("))
+        XCTAssertTrue(production.contains("makeHRControlActivePresentation("))
         assertOrdered(
             [
                 "guard manager.isConnected else { return nil }",
@@ -469,7 +476,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
                 "return manager.deviceReportedSpeedKmh",
                 "factualSpeedKmh: factualSpeedKmh",
             ],
-            in: controlView
+            in: production
         )
         for forbiddenSpeedFallback in [
             "HRDomainService.cooldownSpeedSnapshot(",
@@ -479,7 +486,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
             "manager.deviceTargetSpeedKmh",
         ] {
             XCTAssertFalse(
-                controlView.contains(forbiddenSpeedFallback),
+                production.contains(forbiddenSpeedFallback),
                 "Active presentation contains \(forbiddenSpeedFallback)"
             )
         }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -332,6 +332,11 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         XCTAssertTrue(contentBody.contains("--active-workout-preview="))
         XCTAssertTrue(contentBody.contains("--training-result-preview="))
         XCTAssertTrue(contentBody.contains("--training-ui-pressure-baseline"))
+        XCTAssertTrue(contentViewSource.contains("managerPublishedEvents"))
+        XCTAssertTrue(contentViewSource.contains("potentialAvoidableManagerDrivenInvalidations"))
+        XCTAssertTrue(contentViewSource.contains("eventToVisibleChangeRatio"))
+        XCTAssertTrue(contentViewSource.contains("rawManagerPublications"))
+        XCTAssertFalse(contentViewSource.contains("publicationToVisibleChangeRatio"))
         XCTAssertEqual(
             contentBody.components(separatedBy: "guard !isTrainingPreviewLaunch else { return }").count - 1,
             2


### PR DESCRIPTION
## Summary

- Add one DEBUG-only deterministic launch harness, `--training-ui-pressure-baseline`, which observes the real `BluetoothManager.objectWillChange` stream and the same Training presentation assembly used by the production UI.
- Measure coalesced pressure at technical-event boundaries: whether each event caused at least one manager publication, whether the resulting Training presentation changed, and whether the event therefore represents a potential avoidable manager-driven invalidation.
- Retain the count of individual `@Published` sends as diagnostic output only; it does not drive the recommendation.
- Exercise the two required workloads without Bluetooth, HealthKit, treadmill commands, persistence, or a physical device.
- Keep Release behavior unchanged apart from extracting the existing Training presentation assembly into two shared pure helpers; add no files or dependencies.
- Rebase the accepted #85 implementation onto live `main` `1912667f00acd8f416ba6bdefc8aed21d1b617ae`, integrating merged CI reliability fix #91 through base ancestry without adding its test file to this PR diff.

### Before baseline

| Workload / source | Technical events | Events with publication | Visible Training snapshot changes | Potential avoidable event-boundary invalidations | Raw publications (diagnostic) |
| --- | ---: | ---: | ---: | ---: | ---: |
| Idle Hub duplicate discovery | 120 | 120 | 0 | 120 | 120 |
| Active workout total | 180 | 180 | 73 | 107 | 1,692 |
| Active: treadmill status | 60 | 60 | 0 | 60 | 600 |
| Active: heart rate | 60 | 60 | 13 | 47 | 360 |
| Active: timer | 60 | 60 | 60 | 0 | 732 |

The active workload produced 2.47 manager-published events per visible Training snapshot change. The idle ratio is undefined because no Training presentation snapshot changed.

Across both workloads, the event-boundary ranking is:

1. duplicate BLE discovery: 120 of 227 potential avoidable boundaries (52.9%)
2. treadmill status: 60 of 227 (26.4%)
3. heart rate: 47 of 227 (20.7%)
4. timer: 0 of 227 (0%)

The two BLE subpaths account for 180 of 227 potential avoidable event boundaries (79.3%). They also dominate each representative workload independently: duplicate discovery is 120 of 120 idle boundaries, and treadmill status is 60 of 107 active boundaries (56.1%).

**Decision: SELECT #87.** BLE discovery/treadmill publication churn is the dominant measured event-boundary cost. Raw publication totals are diagnostic only and no longer support or select #86. No optimization from #86, #87, or #88 is implemented here.

Closes #85

## Verification

- Base-to-head stable patch-id remained `d130e0e8d41d3f15f5266450519cf89dfe7d1240` before and after the rebase; changed files remain the same three accepted #85 files.
- `swift test --filter HeartRateLegacyBehaviorContractTests` — 19 tests passed.
- `swift test --skip-build --filter TelemetryV2RuntimeCoordinatorTests.testDecisionTelemetryDispositionCannotChangeAlreadySelectedControlOutput` — 20/20 consecutive runs passed.
- Full `swift test` — passed.
- Debug iOS Simulator unsigned build — passed.
- Two fresh temporary iPhone 17 / iOS 27.0 simulator launches with `--training-ui-pressure-baseline` reproduced all technical-event, published-event, visible-change, potential-avoidable, and raw-publication counts.
- Release generic iOS unsigned build — passed.
- `python3 scripts/check_codex_governance.py` — passed.
- `git diff --check` — passed.
- Exact-head GitHub CI for `f73a4e1b2e49e03943c19484eda4a13066460563` — 4/4 passed: Python, Swift Package Tests, project metadata, and unsigned iOS/watchOS app build.

## Risks / Notes

- The event-boundary metric is a deterministic upper-bound proxy for potential manager-driven invalidations. It does not measure actual SwiftUI render passes, frame rate, device jank, BLE timing, HealthKit activity, telemetry I/O, or asynchronous main-thread work.
- Multiple synchronous `@Published` sends inside one technical event are deliberately coalesced into one published-event boundary for the decision metric.
- Synchronous timing remains diagnostic only and is not used to select #88.
- Base-to-head source delta is +353/-45 across three existing files; the review correction itself is +31/-20 across two existing files. There are no new files or dependencies, and the measurement harness remains DEBUG-only.
- No production optimization, safety/control/readiness change, migration, configuration change, deployment step, or physical-device action is included. Rollback is the two commits in this Draft PR.
