### PR TITLE
Stabilize telemetry finalization test wait

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
@@ -893,7 +893,10 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
         enabled.endSession(reason: "enabled-complete")
         try await eventually { await enabledPersistence.finalizations.count == 1 }
 
-        let backpressuredPersistence = RuntimePersistence()
+        let backpressuredFinalized = expectation(description: "Backpressured session finalized")
+        let backpressuredPersistence = RuntimePersistence {
+            backpressuredFinalized.fulfill()
+        }
         let factoryGate = DispatchSemaphore(value: 0)
         let backpressured = TelemetryV2RuntimeCoordinator {
             factoryGate.wait()
@@ -936,7 +939,9 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
         XCTAssertEqual(backpressuredOutput, expectedOutput)
 
         factoryGate.signal()
-        try await eventually { await backpressuredPersistence.finalizations.count == 1 }
+        await fulfillment(of: [backpressuredFinalized], timeout: 5)
+        let backpressuredFinalizationCount = await backpressuredPersistence.finalizations.count
+        XCTAssertEqual(backpressuredFinalizationCount, 1)
         if case .incomplete = backpressured.status {
             // Recorder loss is visible only in telemetry state.
         } else {
@@ -1403,6 +1408,7 @@ private actor RuntimePersistence:
     private let suspendAnalysis: Bool
     private let suspendMigration: Bool
     private let finalizeFailure: Bool
+    private let finalizationDidPersist: @Sendable () -> Void
     private let migrationReport: LegacyTelemetryMigrationReport
     private var beginContinuation: CheckedContinuation<Void, Never>?
     private var finalizeContinuation: CheckedContinuation<Void, Never>?
@@ -1419,6 +1425,7 @@ private actor RuntimePersistence:
         suspendAnalysis: Bool = false,
         suspendMigration: Bool = false,
         finalizeFailure: Bool = false,
+        finalizationDidPersist: @escaping @Sendable () -> Void = {},
         migrationReport: LegacyTelemetryMigrationReport = LegacyTelemetryMigrationReport(
             completion: .completed,
             completedSourceCount: 0,
@@ -1433,6 +1440,7 @@ private actor RuntimePersistence:
         self.suspendAnalysis = suspendAnalysis
         self.suspendMigration = suspendMigration
         self.finalizeFailure = finalizeFailure
+        self.finalizationDidPersist = finalizationDidPersist
         self.migrationReport = migrationReport
     }
 
@@ -1458,6 +1466,7 @@ private actor RuntimePersistence:
             throw TelemetryPersistenceOperationError.terminal(code: "test-finalize")
         }
         finalizations.append(finalization)
+        finalizationDidPersist()
     }
 
     func fetchWorkoutHistoryPage(


### PR DESCRIPTION
## Summary

- Replace the backpressured-session finalization poll based on a fixed number of `Task.yield()` calls with an event-driven XCTest expectation.
- Fulfill the condition only after the file-local test persistence has appended the finalization, then retain the exact `finalizations.count == 1` assertion.
- Keep the change entirely inside `TelemetryV2RuntimeCoordinatorTests.swift`; production TelemetryRuntime and telemetry/control behavior are unchanged.

### Failure explanation

The shared `eventually` helper limits waits to 10,000 scheduler yields rather than a deterministic condition or elapsed-time contract. The coordinator performs store setup and finalization in detached utility-priority tasks, so the test task can exhaust those yields before the utility task records the backpressured finalization.

The unchanged test reproduced locally on iteration 4. Temporary phase markers reproduced it again on iteration 6 and confirmed that the failing phase was specifically the final `backpressuredPersistence.finalizations.count == 1` poll; all preceding status and enabled-session waits had completed.

Closes #90

## Verification

- Before change: focused repetition failed on iteration 4 with `EventuallyFailure.timedOut`.
- Diagnostic reproduction: focused repetition failed on iteration 6 at the backpressured finalization wait.
- After change: 20/20 consecutive focused repetitions passed.
- Final `swift test` — passed.
- `python3 scripts/check_codex_governance.py` — passed.
- `git diff --check` — passed.

## Risks / Notes

- The five-second XCTest timeout is only a failure guard around the event-driven condition; readiness is no longer determined by elapsed time or polling attempts.
- The persisted-finalization count assertion remains exact, so the test still proves one finalization and the original control-output invariance.
- Production LOC delta is zero. Test delta is +11/-2 in one existing file, with no new files or dependencies.
- No production telemetry/control semantics, migration, configuration, deployment, device, or BLE behavior changes are included. Rollback is the single commit.
