### PR TITLE
Reduce discovery UI publication churn

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -137,6 +137,7 @@ let package = Package(
                 "ControllerUnitsSafetyPolicy.swift",
                 "CooldownRuntimeEngine.swift",
                 "DeterministicControlReplay.swift",
+                "DiscoveryUIPublicationPolicy.swift",
                 "HRDomainService.swift",
                 "HRSettingsDefaults.swift",
                 "IPhoneHealthKitHeartRateProviderCore.swift",

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -144,7 +144,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         var label: String
         let createdAt: Date
     }
-    @Published var discoveredPeripherals: [DiscoveredPeripheral] = []
+    private(set) var discoveredPeripherals: [DiscoveredPeripheral] = []
+    @Published private(set) var discoveryUIPeripherals: [DiscoveredPeripheral] = []
     @Published var knownPeripherals: [KnownPeripheral] = []
     @Published private(set) var userProfiles: [UserProfile] = []
     @Published private(set) var activeUserProfileID: UUID? = nil
@@ -2513,6 +2514,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         appendLog("Discovery refresh requested")
         DispatchQueue.main.async {
             self.discoveredPeripherals = []
+            self.discoveryUIPeripherals = []
         }
         discoveredMap.removeAll()
         if shouldBeScanning, let central, central.state == .poweredOn {
@@ -2768,6 +2770,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 self.recomputeHrStartAllowed()
                 self.stopDiscoveryScan()
                 self.discoveredPeripherals = []
+                self.discoveryUIPeripherals = []
                 self.discoveredMap.removeAll()
             default:
                 break
@@ -2787,11 +2790,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         appendLog("Discovered: name=\(name.isEmpty ? "(no name)" : name) id=\(id.uuidString) rssi=\(rssi) isKnown=\(isKnown)")
         let item = DiscoveredPeripheral(id: id, name: name, rssi: rssi, isKnown: isKnown)
         DispatchQueue.main.async {
-            if let idx = self.discoveredPeripherals.firstIndex(where: { $0.id == id }) {
-                self.discoveredPeripherals[idx] = item
-            } else {
-                self.discoveredPeripherals.append(item)
-            }
+            self.recordDiscoveredPeripheral(item)
             // Auto-connect policy:
             // - Prefer the last successful known device during the bounded discovery grace
             // - After grace, fall back through the remaining known devices serially
@@ -2829,6 +2828,32 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 }
             }
         }
+    }
+
+    private func recordDiscoveredPeripheral(_ item: DiscoveredPeripheral) {
+        if let idx = self.discoveredPeripherals.firstIndex(where: { $0.id == item.id }) {
+            self.discoveredPeripherals[idx] = item
+        } else {
+            self.discoveredPeripherals.append(item)
+        }
+        self.publishDiscoveredPeripheralToUI(item)
+    }
+
+    private func publishDiscoveredPeripheralToUI(_ item: DiscoveredPeripheral) {
+        guard let idx = self.discoveryUIPeripherals.firstIndex(where: { $0.id == item.id }) else {
+            self.discoveryUIPeripherals.append(item)
+            return
+        }
+        let current = self.discoveryUIPeripherals[idx]
+        guard DiscoveryUIPublicationPolicy.shouldPublish(
+            currentName: current.name,
+            currentRSSI: current.rssi,
+            currentIsKnown: current.isKnown,
+            nextName: item.name,
+            nextRSSI: item.rssi,
+            nextIsKnown: item.isKnown
+        ) else { return }
+        self.discoveryUIPeripherals[idx] = item
     }
 
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
@@ -3198,6 +3223,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     isKnown: false
                 )
             }
+            self.discoveryUIPeripherals = self.discoveredPeripherals
             if self.connectedPeripheralId == id {
                 self.disconnect(userInitiated: true)
             } else if self.connectingPeripheralId == id,
@@ -4562,7 +4588,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         isNativeHeartRateCurrent = false
         hrStreamingActive = false
         heartRateBPM = 0
-        discoveredPeripherals = (0..<4).map { index in
+        let initialPeripherals = (0..<4).map { index in
             DiscoveredPeripheral(
                 id: UUID(uuidString: "00000000-0000-0000-0000-00000000000\(index)")!,
                 name: "Mock WalkingPad \(index + 1)",
@@ -4570,19 +4596,20 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 isKnown: false
             )
         }
+        discoveredPeripherals = initialPeripherals
+        discoveryUIPeripherals = initialPeripherals
     }
 
     func applyTrainingUIDiscoveryPressureEvent(_ eventIndex: Int) {
         let deviceIndex = eventIndex % discoveredPeripherals.count
-        var updated = discoveredPeripherals
-        let existing = updated[deviceIndex]
-        updated[deviceIndex] = DiscoveredPeripheral(
+        let existing = discoveredPeripherals[deviceIndex]
+        let updated = DiscoveredPeripheral(
             id: existing.id,
             name: existing.name,
             rssi: -50 - ((eventIndex / discoveredPeripherals.count) % 4),
             isKnown: existing.isKnown
         )
-        discoveredPeripherals = updated
+        recordDiscoveredPeripheral(updated)
     }
 
     func prepareTrainingUIActivePressureBaseline() {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DevicePickerView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DevicePickerView.swift
@@ -64,7 +64,7 @@ struct DevicePickerView: View {
         scanSessionId = currentId
         DispatchQueue.main.asyncAfter(deadline: .now() + 8) { [weak manager] in
             guard let manager = manager else { return }
-            if scanSessionId == currentId && isScanning && manager.discoveredPeripherals.isEmpty {
+            if scanSessionId == currentId && isScanning && manager.discoveryUIPeripherals.isEmpty {
                 isScanning = false
                 manager.stopDiscoveryScan()
                 lastUpdate = Date()
@@ -196,7 +196,7 @@ struct DevicePickerView: View {
     @ViewBuilder
     private func DiscoveryHeader() -> some View {
         HStack(spacing: 8) {
-            Text("Устройств: \(manager.discoveredPeripherals.count)")
+            Text("Устройств: \(manager.discoveryUIPeripherals.count)")
                 .font(.caption)
                 .foregroundStyle(.secondary)
             Spacer()
@@ -219,7 +219,7 @@ struct DevicePickerView: View {
             } else if manager.isConnected {
                 Text("Сканирование отключено — уже подключены к дорожке")
                     .foregroundStyle(.secondary)
-            } else if manager.discoveredPeripherals.isEmpty {
+            } else if manager.discoveryUIPeripherals.isEmpty {
                 if isScanning {
                     HStack {
                         ProgressView()
@@ -239,7 +239,7 @@ struct DevicePickerView: View {
                     Label("Повторить поиск", systemImage: "arrow.clockwise")
                 }
             } else {
-                ForEach(manager.discoveredPeripherals) { d in
+                ForEach(manager.discoveryUIPeripherals) { d in
                     Button {
                         manager.connectToDiscovered(id: d.id)
                         dismiss()
@@ -366,7 +366,7 @@ struct DevicePickerView: View {
                     startScanIfPossible()
                 }
             }
-            .onChange(of: manager.discoveredPeripherals.count) { _, _ in
+            .onChange(of: manager.discoveryUIPeripherals.count) { _, _ in
                 markUpdated()
             }
             .onChange(of: scenePhase) { oldValue, newValue in

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DiscoveryUIPublicationPolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DiscoveryUIPublicationPolicy.swift
@@ -1,0 +1,17 @@
+enum DiscoveryUIPublicationPolicy {
+    // Suppress normal 1–2 dBm jitter while keeping the UI snapshot within 2 dBm of factual RSSI.
+    static let minimumRSSIDelta = 3
+
+    static func shouldPublish(
+        currentName: String,
+        currentRSSI: Int,
+        currentIsKnown: Bool,
+        nextName: String,
+        nextRSSI: Int,
+        nextIsKnown: Bool
+    ) -> Bool {
+        currentName != nextName
+            || currentIsKnown != nextIsKnown
+            || abs(nextRSSI - currentRSSI) >= minimumRSSIDelta
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
@@ -110,6 +110,52 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
         XCTAssertFalse(discovery.contains("central.connect("))
     }
 
+    func testDiscoveryUIPublicationDedupeCannotBecomeAutoConnectTruth() throws {
+        let discovery = try functionBody(
+            "func centralManager(_ central: CBCentralManager,\n                        didDiscover peripheral: CBPeripheral,",
+            in: managerSource
+        )
+        let record = try functionBody(
+            "private func recordDiscoveredPeripheral(_ item: DiscoveredPeripheral)",
+            in: managerSource
+        )
+        let publish = try functionBody(
+            "private func publishDiscoveredPeripheralToUI(_ item: DiscoveredPeripheral)",
+            in: managerSource
+        )
+        let preferredKnown = try functionBody(
+            "private func preferredKnownDiscoveredPeripheral()",
+            in: managerSource
+        )
+        let autoConnect = try functionBody(
+            "private func attemptAutoConnectIfNeeded()",
+            in: managerSource
+        )
+
+        XCTAssertEqual(
+            discovery.components(separatedBy: "recordDiscoveredPeripheral(item)").count - 1,
+            1
+        )
+        assertOrdered(
+            ["recordDiscoveredPeripheral(item)", "rearmAutoConnectCandidateAfterFreshDiscovery("],
+            in: discovery
+        )
+        assertOrdered(
+            ["self.discoveredPeripherals[idx] = item", "self.publishDiscoveredPeripheralToUI(item)"],
+            in: record
+        )
+        assertOrdered(
+            ["self.discoveredPeripherals.append(item)", "self.publishDiscoveredPeripheralToUI(item)"],
+            in: record
+        )
+        XCTAssertTrue(publish.contains("DiscoveryUIPublicationPolicy.shouldPublish"))
+        XCTAssertTrue(publish.contains("self.discoveryUIPeripherals[idx] = item"))
+        XCTAssertTrue(preferredKnown.contains("discoveredPeripherals.filter"))
+        XCTAssertTrue(autoConnect.contains("discoveredPeripherals.max"))
+        XCTAssertFalse(preferredKnown.contains("discoveryUIPeripherals"))
+        XCTAssertFalse(autoConnect.contains("discoveryUIPeripherals"))
+    }
+
     func testAutomaticFailuresStaySilentAndFallBackSerially() throws {
         let failure = try functionBody(
             "func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?)",

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/DiscoveryUIPublicationPolicyTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/DiscoveryUIPublicationPolicyTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class DiscoveryUIPublicationPolicyTests: XCTestCase {
+    func testSuppressesDuplicateAndSmallRSSIOnlyChanges() {
+        XCTAssertFalse(DiscoveryUIPublicationPolicy.shouldPublish(
+            currentName: "WalkingPad",
+            currentRSSI: -50,
+            currentIsKnown: false,
+            nextName: "WalkingPad",
+            nextRSSI: -50,
+            nextIsKnown: false
+        ))
+        XCTAssertFalse(DiscoveryUIPublicationPolicy.shouldPublish(
+            currentName: "WalkingPad",
+            currentRSSI: -50,
+            currentIsKnown: false,
+            nextName: "WalkingPad",
+            nextRSSI: -52,
+            nextIsKnown: false
+        ))
+    }
+
+    func testPublishesAccumulatedRSSIAndIdentityFactChanges() {
+        XCTAssertTrue(DiscoveryUIPublicationPolicy.shouldPublish(
+            currentName: "WalkingPad",
+            currentRSSI: -50,
+            currentIsKnown: false,
+            nextName: "WalkingPad",
+            nextRSSI: -53,
+            nextIsKnown: false
+        ))
+        XCTAssertTrue(DiscoveryUIPublicationPolicy.shouldPublish(
+            currentName: "",
+            currentRSSI: -50,
+            currentIsKnown: false,
+            nextName: "WalkingPad",
+            nextRSSI: -50,
+            nextIsKnown: false
+        ))
+        XCTAssertTrue(DiscoveryUIPublicationPolicy.shouldPublish(
+            currentName: "WalkingPad",
+            currentRSSI: -50,
+            currentIsKnown: false,
+            nextName: "WalkingPad",
+            nextRSSI: -50,
+            nextIsKnown: true
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

- Separate factual discovery state from the UI-published snapshot so every BLE discovery callback remains immediately available to auto-connect/control while Device Picker is the only consumer of coalesced rows.
- Publish new devices and name/known-state changes immediately; suppress 1–2 dBm RSSI jitter until the accumulated delta reaches 3 dBm.
- Preserve scan duplicate semantics, filters, auto-connect/retry/connection behavior, treadmill-status handling, readiness, commands, and telemetry.
- On the accepted #85 workload, reduce idle discovery manager-published boundaries from 120 to 29 (-75.8%); the active workload remains exactly unchanged.

Closes #87

## Verification

- Exact-base before measurement, fresh iPhone 17 / iOS 27.0 Simulator: 120 technical discovery callbacks, 120 manager publications, 0 visible changes, 120 potentially avoidable publications.
- Expected-failing source contract test before implementation.
- `swift test --filter DiscoveryUIPublicationPolicyTests` (2/2 passed).
- `swift test --filter BluetoothAutoConnectBehaviorContractTests` (17/17 passed).
- `swift test` (passed).
- Debug unsigned Simulator build (passed).
- Two fresh after launches: 120 technical discovery callbacks, 29 manager publications, 0 visible changes, 29 potentially avoidable publications; active source counters remained 180/180/73/107 and raw publications 1692.
- `xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -configuration Release -destination 'generic/platform=iOS' -derivedDataPath /private/tmp/walkingpad-issue87-generic CODE_SIGNING_ALLOWED=NO build` (passed).
- `python3 scripts/check_codex_governance.py` (passed).
- `git diff --check` (passed).
- Exact-head GitHub Actions on `6e52947479d4b0f8491d46fd37211033b797d5b7`: 4/4 successful (Python checks, Swift package tests, Xcode metadata, unsigned iOS/watchOS build).

## Risks / Notes

- Device Picker RSSI can lag the factual discovery state by at most 2 dBm; new devices and name/known-state changes publish immediately.
- The factual array remains the auto-connect/control source; the UI snapshot is never used as control truth.
- The deterministic publication count is a UI-boundary proxy, not an FPS or jank measurement.
- Production Swift delta is +60/-16 (net +44), with one focused policy file and no new dependency.
- No migration, configuration, deployment, or backward-compatibility change is required. Rollback is the single commit on this PR.
- No physical-device or BLE activity was performed.
