### PR TITLE
Reduce treadmill status UI publication churn

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -156,6 +156,7 @@ let package = Package(
                 "ZonePlanProgress.swift",
                 "CommandQueueService.swift",
                 "TreadmillSpeedBoundsService.swift",
+                "TrainingUITreadmillPublicationPolicy.swift",
                 "TreadmillControlReadinessPolicy.swift",
                 "TreadmillCommandTelemetrySidecar.swift"
             ]

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -14,6 +14,12 @@ import UIKit
 import WatchConnectivity
 #endif
 
+final class TreadmillFactualObservationPublisher: ObservableObject {
+    func publish() {
+        objectWillChange.send()
+    }
+}
+
 // Minimal stub to satisfy references in the UI. Replace with real implementation.
 final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeripheralDelegate {
     private let telemetryPerformanceObservation = TelemetryV2PerformanceObservation()
@@ -969,16 +975,18 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @Published var lastNotifyAgeSeconds: Int = 0
     @Published var lastCommandAckStatusText: String = ""
     @Published var lastCommandTimeoutsCount: Int = 0
-    @Published var deviceReportedSpeedKmh: Double = 0
-    @Published var deviceReportedAppSpeedKmh: Double = 0
-    @Published var deviceReportedState: Int = 0
-    @Published var deviceReportedManualMode: Int = 0
-    @Published var deviceReportedTimeSeconds: Int = 0
-    @Published var deviceReportedDistance10m: Int = 0
-    @Published var deviceReportedSteps: Int = 0
-    @Published var deviceReportedButton: Int = 0
-    @Published var deviceReportedChecksumOk: Bool = true
-    @Published var deviceReportedRawHex: String = ""
+    let treadmillFactualObservationPublisher = TreadmillFactualObservationPublisher()
+    var deviceReportedSpeedKmh: Double = 0
+    var deviceReportedAppSpeedKmh: Double = 0
+    var deviceReportedState: Int = 0
+    var deviceReportedManualMode: Int = 0
+    var deviceReportedTimeSeconds: Int = 0
+    var deviceReportedDistance10m: Int = 0
+    var deviceReportedSteps: Int = 0
+    var deviceReportedButton: Int = 0
+    var deviceReportedChecksumOk: Bool = true
+    var deviceReportedRawHex: String = ""
+    @Published private(set) var trainingUITreadmillSpeedKmh: Double? = nil
     @Published private(set) var controllerUnitsTruth: ControllerUnitsTruth = .disconnected
     @Published private(set) var treadmillTestRunIsActive = false
     @Published private(set) var treadmillTestRunStatusText = "READY"
@@ -1241,6 +1249,19 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             appReportedSpeedKmh: deviceReportedAppSpeedKmh,
             rawReportedSpeedKmh: deviceReportedSpeedKmh,
             currentActualSpeedKmh: speedKmh
+        )
+    }
+
+    private func publishTrainingUITreadmillSpeedIfNeeded() {
+        treadmillFactualObservationPublisher.publish()
+        guard TrainingUITreadmillPublicationPolicy.shouldPublish(
+            currentVisibleSpeedKmh: trainingUITreadmillSpeedKmh,
+            appReportedSpeedKmh: deviceReportedAppSpeedKmh,
+            rawReportedSpeedKmh: deviceReportedSpeedKmh
+        ) else { return }
+        trainingUITreadmillSpeedKmh = TrainingUITreadmillPublicationPolicy.visibleSpeedKmh(
+            appReportedSpeedKmh: deviceReportedAppSpeedKmh,
+            rawReportedSpeedKmh: deviceReportedSpeedKmh
         )
     }
 
@@ -4633,6 +4654,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         deviceReportedButton = 0
         deviceReportedChecksumOk = true
         deviceReportedRawHex = "F8A2"
+        publishTrainingUITreadmillSpeedIfNeeded()
         speedKmh = 5.0
         timeSec = 0
         distKm = 0
@@ -4671,6 +4693,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         deviceReportedButton = 0
         deviceReportedChecksumOk = true
         deviceReportedRawHex = String(format: "F8A2%04X", second)
+        publishTrainingUITreadmillSpeedIfNeeded()
     }
 
     func applyTrainingUITimerPressureEvent(second: Int) {
@@ -6973,6 +6996,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         DispatchQueue.main.async {
             self.deviceReportedRawHex = frame.rawHex
             self.deviceReportedChecksumOk = frame.checksumOk
+            self.treadmillFactualObservationPublisher.publish()
         }
 
         if frame.cmd == 0x53, frame.subcmd == 0x02 {
@@ -6985,6 +7009,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     self.deviceReportedSpeedKmh = speedKmh
                     self.deviceReportedAppSpeedKmh = speedKmh
                     self.deviceReportedManualMode = incline
+                    self.publishTrainingUITreadmillSpeedIfNeeded()
                     if peripheral.identifier == self.connectedPeripheralId,
                        characteristic.uuid == self.fitShowCharRx,
                        let connectionEpoch = self.treadmillTelemetryConnectionEpoch {
@@ -7048,6 +7073,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     self.deviceReportedSpeedKmh = speedKmh
                     self.deviceReportedAppSpeedKmh = speedKmh
                 }
+                self.publishTrainingUITreadmillSpeedIfNeeded()
                 if peripheral.identifier == self.connectedPeripheralId,
                    characteristic.uuid == self.fitShowCharRx,
                    let connectionEpoch = self.treadmillTelemetryConnectionEpoch {
@@ -8645,6 +8671,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     self.deviceReportedButton = status.lastButton
                     self.deviceReportedChecksumOk = status.checksumOk
                     self.deviceReportedRawHex = hexStr
+                    self.publishTrainingUITreadmillSpeedIfNeeded()
 #if STOP_TRUTH_EXPERIMENT_CAPABILITY
                     if let experimentContext = self.stopTruthExperimentObservationContext(
                         peripheral: peripheral,
@@ -8747,6 +8774,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     self.deviceReportedAppSpeedKmh = parsed.instantaneousSpeedKmh
                     self.deviceReportedState = parsed.isMoving ? 1 : 0
                     self.deviceReportedRawHex = ""
+                    self.publishTrainingUITreadmillSpeedIfNeeded()
                     if peripheral.identifier == self.connectedPeripheralId,
                        characteristic.uuid == self.ftmsCharTreadmillData,
                        let connectionEpoch = self.treadmillTelemetryConnectionEpoch {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -525,13 +525,7 @@ private func makeProductionActiveWorkoutPresentation(
 ) -> TrainingHubPresentation {
     let factualSpeedKmh: Double? = {
         guard manager.isConnected else { return nil }
-        if manager.deviceReportedAppSpeedKmh > 0.05 {
-            return manager.deviceReportedAppSpeedKmh
-        }
-        if manager.deviceReportedSpeedKmh > 0.05 {
-            return manager.deviceReportedSpeedKmh
-        }
-        return nil
+        return manager.trainingUITreadmillSpeedKmh
     }()
 
     return makeHRControlActivePresentation(
@@ -4094,6 +4088,33 @@ private enum HrControlPreviewMode: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 }
 
+private struct DebugTreadmillFactualObservationRows: View {
+    @ObservedObject var publisher: TreadmillFactualObservationPublisher
+    let manager: BluetoothManager
+
+    var body: some View {
+        Group {
+            Text(
+                "Reported speed: \(String(format: "%.1f", manager.deviceReportedSpeedKmh))  "
+                    + "AppSpeed: \(String(format: "%.1f", manager.deviceReportedAppSpeedKmh))"
+            )
+            Text(
+                "State \(manager.deviceReportedState)  Mode \(manager.deviceReportedManualMode)  "
+                    + "Button \(manager.deviceReportedButton)  Checksum \(manager.deviceReportedChecksumOk ? "ok" : "bad")"
+            )
+            Text(
+                "Time \(manager.deviceReportedTimeSeconds)s  "
+                    + "Dist \(manager.deviceReportedDistance10m * 10)m  Steps \(manager.deviceReportedSteps)"
+            )
+            if !manager.deviceReportedRawHex.isEmpty {
+                Text("FE01 raw: \(manager.deviceReportedRawHex)")
+            }
+        }
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+}
+
 private struct DebugView: View {
     @EnvironmentObject private var manager: BluetoothManager
     @State private var showHrControlPreview = false
@@ -4395,20 +4416,10 @@ private struct DebugView: View {
                             Text("Speed \(actualStr)  Target \(targetStr)  AppSet \(deviceStr)  HR \(manager.heartRateBPM) (last \(manager.lastKnownHeartRateBPM))")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
-                            Text("Reported speed: \(String(format: "%.1f", manager.deviceReportedSpeedKmh))  AppSpeed: \(String(format: "%.1f", manager.deviceReportedAppSpeedKmh))")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                            Text("State \(manager.deviceReportedState)  Mode \(manager.deviceReportedManualMode)  Button \(manager.deviceReportedButton)  Checksum \(manager.deviceReportedChecksumOk ? "ok" : "bad")")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                            Text("Time \(manager.deviceReportedTimeSeconds)s  Dist \(manager.deviceReportedDistance10m * 10)m  Steps \(manager.deviceReportedSteps)")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                            if !manager.deviceReportedRawHex.isEmpty {
-                                Text("FE01 raw: \(manager.deviceReportedRawHex)")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            }
+                            DebugTreadmillFactualObservationRows(
+                                publisher: manager.treadmillFactualObservationPublisher,
+                                manager: manager
+                            )
 
                             let wcState = "WCSession: paired=\(manager.watchPaired ? "yes" : "no") installed=\(manager.watchAppInstalled ? "yes" : "no") reachable=\(manager.watchReachable ? "yes" : "no")"
                             Text(wcState)

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TrainingUITreadmillPublicationPolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TrainingUITreadmillPublicationPolicy.swift
@@ -1,0 +1,25 @@
+enum TrainingUITreadmillPublicationPolicy {
+    static func visibleSpeedKmh(
+        appReportedSpeedKmh: Double,
+        rawReportedSpeedKmh: Double
+    ) -> Double? {
+        if appReportedSpeedKmh > 0.05 {
+            return appReportedSpeedKmh
+        }
+        if rawReportedSpeedKmh > 0.05 {
+            return rawReportedSpeedKmh
+        }
+        return nil
+    }
+
+    static func shouldPublish(
+        currentVisibleSpeedKmh: Double?,
+        appReportedSpeedKmh: Double,
+        rawReportedSpeedKmh: Double
+    ) -> Bool {
+        currentVisibleSpeedKmh != visibleSpeedKmh(
+            appReportedSpeedKmh: appReportedSpeedKmh,
+            rawReportedSpeedKmh: rawReportedSpeedKmh
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -353,6 +353,56 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         )
     }
 
+    func testTrainingTreadmillUIPublicationCannotBecomeFactualTruth() throws {
+        let activePresentation = try functionBody(
+            "private func makeProductionActiveWorkoutPresentation(",
+            in: contentViewSource
+        )
+        let cooldownSnapshot = try functionBody(
+            "private func currentCooldownSpeedSnapshot()",
+            in: managerSource
+        )
+        let telemetryPayload = try functionBody(
+            "private func makeTrainingLogPayload(event: String, fields: [String: Any])",
+            in: managerSource
+        )
+        let uiPublisher = try functionBody(
+            "private func publishTrainingUITreadmillSpeedIfNeeded()",
+            in: managerSource
+        )
+
+        XCTAssertTrue(activePresentation.contains("manager.trainingUITreadmillSpeedKmh"))
+        XCTAssertFalse(activePresentation.contains("manager.deviceReportedAppSpeedKmh"))
+        XCTAssertFalse(activePresentation.contains("manager.deviceReportedSpeedKmh"))
+
+        for factualConsumer in [cooldownSnapshot, telemetryPayload] {
+            XCTAssertTrue(factualConsumer.contains("deviceReportedAppSpeedKmh"))
+            XCTAssertTrue(factualConsumer.contains("deviceReportedSpeedKmh"))
+            XCTAssertFalse(factualConsumer.contains("trainingUITreadmillSpeedKmh"))
+        }
+
+        XCTAssertTrue(managerSource.contains("let treadmillFactualObservationPublisher"))
+        XCTAssertTrue(managerSource.contains("publishTrainingUITreadmillSpeedIfNeeded()"))
+        XCTAssertFalse(managerSource.contains("@Published var deviceReportedSpeedKmh"))
+        XCTAssertFalse(managerSource.contains("@Published var deviceReportedAppSpeedKmh"))
+        XCTAssertEqual(
+            managerSource.components(
+                separatedBy: "self.publishTrainingUITreadmillSpeedIfNeeded()"
+            ).count - 1,
+            4
+        )
+        XCTAssertTrue(uiPublisher.contains("treadmillFactualObservationPublisher.publish()"))
+        XCTAssertTrue(uiPublisher.contains("trainingUITreadmillSpeedKmh ="))
+        XCTAssertFalse(uiPublisher.contains("DispatchQueue"))
+        XCTAssertFalse(uiPublisher.contains("Task"))
+        XCTAssertFalse(uiPublisher.contains("debounce"))
+        XCTAssertTrue(
+            contentViewSource.contains(
+                "@ObservedObject var publisher: TreadmillFactualObservationPublisher"
+            )
+        )
+    }
+
     func testTrainingHubDurationPresetsAreDirectTruthfulAndCooldownFree() throws {
         let mapping = try functionBody(
             "private func makeHRControlTrainingHubPresentation(",
@@ -475,10 +525,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         assertOrdered(
             [
                 "guard manager.isConnected else { return nil }",
-                "if manager.deviceReportedAppSpeedKmh > 0.05",
-                "return manager.deviceReportedAppSpeedKmh",
-                "if manager.deviceReportedSpeedKmh > 0.05",
-                "return manager.deviceReportedSpeedKmh",
+                "return manager.trainingUITreadmillSpeedKmh",
                 "factualSpeedKmh: factualSpeedKmh",
             ],
             in: production

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TrainingUITreadmillPublicationPolicyTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TrainingUITreadmillPublicationPolicyTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class TrainingUITreadmillPublicationPolicyTests: XCTestCase {
+    func testUnchangedVisibleSpeedDoesNotPublishNonRenderedTreadmillFacts() {
+        XCTAssertFalse(
+            TrainingUITreadmillPublicationPolicy.shouldPublish(
+                currentVisibleSpeedKmh: 5.0,
+                appReportedSpeedKmh: 5.0,
+                rawReportedSpeedKmh: 5.0
+            )
+        )
+    }
+
+    func testActualVisibleSpeedChangePublishesImmediately() {
+        XCTAssertTrue(
+            TrainingUITreadmillPublicationPolicy.shouldPublish(
+                currentVisibleSpeedKmh: 5.0,
+                appReportedSpeedKmh: 5.1,
+                rawReportedSpeedKmh: 5.1
+            )
+        )
+        XCTAssertEqual(
+            TrainingUITreadmillPublicationPolicy.visibleSpeedKmh(
+                appReportedSpeedKmh: 5.1,
+                rawReportedSpeedKmh: 5.1
+            ),
+            5.1
+        )
+    }
+
+    func testAppReportedSpeedKeepsExistingFactualPriority() {
+        XCTAssertEqual(
+            TrainingUITreadmillPublicationPolicy.visibleSpeedKmh(
+                appReportedSpeedKmh: 4.8,
+                rawReportedSpeedKmh: 5.0
+            ),
+            4.8
+        )
+        XCTAssertEqual(
+            TrainingUITreadmillPublicationPolicy.visibleSpeedKmh(
+                appReportedSpeedKmh: 0,
+                rawReportedSpeedKmh: 5.0
+            ),
+            5.0
+        )
+        XCTAssertNil(
+            TrainingUITreadmillPublicationPolicy.visibleSpeedKmh(
+                appReportedSpeedKmh: 0,
+                rawReportedSpeedKmh: 0
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Keep every decoded treadmill observation as immediate factual state for control, safety, readiness, and Telemetry V2 while moving its Debug invalidation off `BluetoothManager.objectWillChange`.
- Publish only the Training-visible resolved factual speed on `BluetoothManager`, and only when that value actually changes; real speed changes remain synchronous with the factual callback and have no debounce or artificial delay.
- Preserve WalkingPad, FTMS, and FitShow parsing and observation order, plus the accepted #92 discovery UI policy.
- On the accepted #85 active workload, reduce treadmill-status manager boundaries from 60 to 0 and avoidable invalidations from 60 to 0 (-100%); total active boundaries fall from 180 to 120 while visible changes remain 73.

Closes #93

## Verification

- Exact-base before measurement on a fresh iPhone 17 / iOS 27.0 Simulator: treadmill status 60 technical events, 60 manager boundaries, 0 visible changes, 60 avoidable invalidations; active totals 180/180/73/107 with 1692 raw publications.
- Expected-failing focused policy test before implementation: missing `TrainingUITreadmillPublicationPolicy`; passed after implementation (3/3).
- Focused factual-truth/source contract passed.
- Initial full `swift test` exposed the predecessor active-presentation source assertion; updated it to the dedicated Training snapshot, then the full suite passed twice.
- Initial Debug build exposed malformed string interpolation in the new Debug row; corrected it and reran successfully.
- Final fresh-Simulator after measurement: treadmill status 60 technical events, 0 manager boundaries, 0 visible changes, 0 avoidable invalidations; active totals 180/120/73/47 with 1092 raw publications. Heart-rate, timer, and discovery counters were unchanged.
- Debug unsigned iOS Simulator build passed.
- `python3 scripts/check_codex_governance.py` passed.
- `git diff --check` passed.
- Release unsigned generic iOS/watchOS build passed.
- Exact-head GitHub Actions on `b94f384e33cd667490d8da598d524c26d1fbffc8`: 4/4 successful (Python checks, Swift package tests, Xcode metadata, unsigned iOS/watchOS build).

## Risks / Notes

- The Debug treadmill rows now observe a dedicated invalidation publisher; factual values themselves remain the single manager-owned truth used by control and telemetry.
- Training speed keeps the existing priority: app-reported factual speed, then raw-reported factual speed, otherwise unavailable.
- The deterministic publication count is a UI-boundary proxy, not a physical-device FPS or jank measurement.
- Production delta is +96/-31 (net +65), with one focused policy file and no new dependency.
- No migration, configuration, deployment, or backward-compatibility change is required. Rollback is the single commit on this PR.
- No physical-device, BLE, deploy, or hardware activity was performed.
