### PR TITLE
Reduce heart rate Training UI publication churn

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -156,6 +156,7 @@ let package = Package(
                 "ZonePlanProgress.swift",
                 "CommandQueueService.swift",
                 "TreadmillSpeedBoundsService.swift",
+                "TrainingUIHeartRatePublicationPolicy.swift",
                 "TrainingUITreadmillPublicationPolicy.swift",
                 "TreadmillControlReadinessPolicy.swift",
                 "TreadmillCommandTelemetrySidecar.swift"

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -20,6 +20,15 @@ final class TreadmillFactualObservationPublisher: ObservableObject {
     }
 }
 
+final class HeartRateFactualState: ObservableObject {
+    @Published fileprivate(set) var heartRateBPM = 0
+    @Published fileprivate(set) var lastKnownHeartRateBPM = 0
+    @Published fileprivate(set) var isStreamActive = false
+    @Published fileprivate(set) var lastValueAt: Date?
+    @Published fileprivate(set) var staleSeconds = 0
+    @Published fileprivate(set) var isNativeCurrent = false
+}
+
 // Minimal stub to satisfy references in the UI. Replace with real implementation.
 final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeripheralDelegate {
     private let telemetryPerformanceObservation = TelemetryV2PerformanceObservation()
@@ -961,15 +970,46 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @Published var allowAutoConnectUnknown: Bool = false
 
     // Watch / HR
-    @Published var heartRateBPM: Int = 0
-    @Published var lastKnownHeartRateBPM: Int = 0
-    @Published var hrStreamingActive: Bool = false
+    let heartRateFactualState = HeartRateFactualState()
+    var heartRateBPM: Int {
+        get { heartRateFactualState.heartRateBPM }
+        set {
+            heartRateFactualState.heartRateBPM = newValue
+            publishTrainingUIHeartRateIfNeeded()
+        }
+    }
+    var lastKnownHeartRateBPM: Int {
+        get { heartRateFactualState.lastKnownHeartRateBPM }
+        set {
+            heartRateFactualState.lastKnownHeartRateBPM = newValue
+            publishTrainingUIHeartRateIfNeeded()
+        }
+    }
+    var hrStreamingActive: Bool {
+        get { heartRateFactualState.isStreamActive }
+        set {
+            heartRateFactualState.isStreamActive = newValue
+            publishTrainingUIHeartRateIfNeeded()
+        }
+    }
     @Published var watchReachable: Bool = false
     @Published var watchPaired: Bool = false
     @Published var watchAppInstalled: Bool = false
     @Published var hrPermissionGranted: Bool = false
-    @Published var hrLastValueAt: Date? = nil
-    @Published var hrDataStaleSeconds: Int = 0
+    var hrLastValueAt: Date? {
+        get { heartRateFactualState.lastValueAt }
+        set {
+            heartRateFactualState.lastValueAt = newValue
+            publishTrainingUIHeartRateIfNeeded()
+        }
+    }
+    var hrDataStaleSeconds: Int {
+        get { heartRateFactualState.staleSeconds }
+        set {
+            heartRateFactualState.staleSeconds = newValue
+            publishTrainingUIHeartRateIfNeeded()
+        }
+    }
     @Published var treadmillStatusText: String = "unknown"
     @Published private(set) var stopTruthStatusText: String = ""
     @Published var lastNotifyAgeSeconds: Int = 0
@@ -987,6 +1027,12 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     var deviceReportedChecksumOk: Bool = true
     var deviceReportedRawHex: String = ""
     @Published private(set) var trainingUITreadmillSpeedKmh: Double? = nil
+    @Published private(set) var trainingUIHeartRateSnapshot =
+        TrainingUIHeartRatePublicationPolicy.snapshot(
+            isNativeHeartRateCurrent: false,
+            isHeartRateStreamActive: false,
+            heartRateBPM: 0
+        )
     @Published private(set) var controllerUnitsTruth: ControllerUnitsTruth = .disconnected
     @Published private(set) var treadmillTestRunIsActive = false
     @Published private(set) var treadmillTestRunStatusText = "READY"
@@ -1000,7 +1046,13 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @Published var isHrControlStartAllowed: Bool = false
     @Published var hrControlStartBlockReasonText: String? = nil
     @Published private(set) var isNativeHeartRatePreflightActive: Bool = false
-    @Published private(set) var isNativeHeartRateCurrent: Bool = false
+    private(set) var isNativeHeartRateCurrent: Bool {
+        get { heartRateFactualState.isNativeCurrent }
+        set {
+            heartRateFactualState.isNativeCurrent = newValue
+            publishTrainingUIHeartRateIfNeeded()
+        }
+    }
     @Published private(set) var isNativeWorkoutRecoveryActive: Bool = false
     @Published private(set) var nativeWorkoutRecoveryStatusText: String? = nil
 
@@ -1263,6 +1315,16 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             appReportedSpeedKmh: deviceReportedAppSpeedKmh,
             rawReportedSpeedKmh: deviceReportedSpeedKmh
         )
+    }
+
+    private func publishTrainingUIHeartRateIfNeeded() {
+        let nextSnapshot = TrainingUIHeartRatePublicationPolicy.snapshot(
+            isNativeHeartRateCurrent: isNativeHeartRateCurrent,
+            isHeartRateStreamActive: hrStreamingActive,
+            heartRateBPM: heartRateBPM
+        )
+        guard nextSnapshot != trainingUIHeartRateSnapshot else { return }
+        trainingUIHeartRateSnapshot = nextSnapshot
     }
 
     private func applyCooldownOutput(

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -502,15 +502,12 @@ private func makeHRControlActivePresentation(
 private func makeProductionTrainingHubPresentation(
     manager: BluetoothManager
 ) -> TrainingHubPresentation {
-    makeHRControlTrainingHubPresentation(
+    let heartRate = manager.trainingUIHeartRateSnapshot
+    return makeHRControlTrainingHubPresentation(
         treadmillConnected: manager.isTreadmillControlReady,
-        hrFresh: manager.isNativeHeartRateCurrent && manager.hrStreamingActive,
-        currentHeartRateBPM: manager.isNativeHeartRateCurrent
-            && manager.hrStreamingActive
-            && manager.heartRateBPM > 0
-            ? manager.heartRateBPM
-            : nil,
-        heartRateSourceLabel: manager.isNativeHeartRateCurrent ? "HealthKit" : nil,
+        hrFresh: heartRate.isFresh,
+        currentHeartRateBPM: heartRate.currentHeartRateBPM,
+        heartRateSourceLabel: heartRate.sourceLabel,
         targetZoneIndex: hrZoneIndex(for: manager.hrTargetBPM, manager: manager),
         zoneRanges: hrZoneRanges(for: manager),
         durationMinutes: manager.hrDurationMinutes,
@@ -523,6 +520,7 @@ private func makeProductionTrainingHubPresentation(
 private func makeProductionActiveWorkoutPresentation(
     manager: BluetoothManager
 ) -> TrainingHubPresentation {
+    let heartRate = manager.trainingUIHeartRateSnapshot
     let factualSpeedKmh: Double? = {
         guard manager.isConnected else { return nil }
         return manager.trainingUITreadmillSpeedKmh
@@ -530,13 +528,9 @@ private func makeProductionActiveWorkoutPresentation(
 
     return makeHRControlActivePresentation(
         treadmillConnected: manager.isTreadmillControlReady,
-        hrFresh: manager.isNativeHeartRateCurrent && manager.hrStreamingActive,
-        currentHeartRateBPM: manager.isNativeHeartRateCurrent
-            && manager.hrStreamingActive
-            && manager.heartRateBPM > 0
-            ? manager.heartRateBPM
-            : nil,
-        heartRateSourceLabel: manager.isNativeHeartRateCurrent ? "HealthKit" : nil,
+        hrFresh: heartRate.isFresh,
+        currentHeartRateBPM: heartRate.currentHeartRateBPM,
+        heartRateSourceLabel: heartRate.sourceLabel,
         targetZoneIndex: hrZoneIndex(for: manager.hrTargetBPM, manager: manager),
         zoneRanges: hrZoneRanges(for: manager),
         factualSpeedKmh: factualSpeedKmh,
@@ -4115,6 +4109,18 @@ private struct DebugTreadmillFactualObservationRows: View {
     }
 }
 
+private struct DebugHeartRateFactualObservationRow: View {
+    @ObservedObject var state: HeartRateFactualState
+
+    var body: some View {
+        Text(
+            "HR \(state.heartRateBPM) (last \(state.lastKnownHeartRateBPM))"
+        )
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+}
+
 private struct DebugView: View {
     @EnvironmentObject private var manager: BluetoothManager
     @State private var showHrControlPreview = false
@@ -4413,9 +4419,12 @@ private struct DebugView: View {
                             let actualStr = String(format: "%.1f", manager.speedKmh)
                             let targetStr = String(format: "%.1f", manager.desiredSpeedKmh)
                             let deviceStr = String(format: "%.1f", manager.deviceTargetSpeedKmh)
-                            Text("Speed \(actualStr)  Target \(targetStr)  AppSet \(deviceStr)  HR \(manager.heartRateBPM) (last \(manager.lastKnownHeartRateBPM))")
+                            Text("Speed \(actualStr)  Target \(targetStr)  AppSet \(deviceStr)")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
+                            DebugHeartRateFactualObservationRow(
+                                state: manager.heartRateFactualState
+                            )
                             DebugTreadmillFactualObservationRows(
                                 publisher: manager.treadmillFactualObservationPublisher,
                                 manager: manager

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TrainingUIHeartRatePublicationPolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TrainingUIHeartRatePublicationPolicy.swift
@@ -1,0 +1,23 @@
+struct TrainingUIHeartRateSnapshot: Equatable {
+    let isFresh: Bool
+    let currentHeartRateBPM: Int?
+    let sourceLabel: String?
+}
+
+enum TrainingUIHeartRatePublicationPolicy {
+    static func snapshot(
+        isNativeHeartRateCurrent: Bool,
+        isHeartRateStreamActive: Bool,
+        heartRateBPM: Int
+    ) -> TrainingUIHeartRateSnapshot {
+        let isFresh = isNativeHeartRateCurrent && isHeartRateStreamActive
+        let currentHeartRateBPM = isFresh && heartRateBPM > 0
+            ? heartRateBPM
+            : nil
+        return TrainingUIHeartRateSnapshot(
+            isFresh: isFresh,
+            currentHeartRateBPM: currentHeartRateBPM,
+            sourceLabel: currentHeartRateBPM == nil ? nil : "HealthKit"
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -272,7 +272,8 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         XCTAssertFalse(mapping.contains("history"))
 
         XCTAssertTrue(production.contains("startEnabled: manager.isHrControlStartAffordanceAvailable"))
-        XCTAssertTrue(production.contains("heartRateSourceLabel: manager.isNativeHeartRateCurrent ? \"HealthKit\" : nil"))
+        XCTAssertTrue(production.contains("let heartRate = manager.trainingUIHeartRateSnapshot"))
+        XCTAssertTrue(production.contains("heartRateSourceLabel: heartRate.sourceLabel"))
         XCTAssertFalse(production.contains("watchReachable"))
         XCTAssertFalse(production.contains("telemetry"))
 
@@ -399,6 +400,77 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         XCTAssertTrue(
             contentViewSource.contains(
                 "@ObservedObject var publisher: TreadmillFactualObservationPublisher"
+            )
+        )
+    }
+
+    func testTrainingHeartRateUIPublicationCannotBecomeFactualTruth() throws {
+        let activePresentation = try functionBody(
+            "private func makeProductionActiveWorkoutPresentation(",
+            in: contentViewSource
+        )
+        let controlDecision = try functionBody(
+            "private func tickTelemetry()",
+            in: managerSource
+        )
+        let telemetryPayload = try functionBody(
+            "private func makeTrainingLogPayload(event: String, fields: [String: Any])",
+            in: managerSource
+        )
+        let uiPublisher = try functionBody(
+            "private func publishTrainingUIHeartRateIfNeeded()",
+            in: managerSource
+        )
+        let nativeDelivery = try functionBody(
+            "private func handleNativeHeartRateObservation(",
+            in: managerSource
+        )
+        let staleTimer = try functionBody(
+            "private func startHrStaleTimer()",
+            in: managerSource
+        )
+
+        XCTAssertTrue(activePresentation.contains("manager.trainingUIHeartRateSnapshot"))
+        XCTAssertFalse(activePresentation.contains("manager.heartRateBPM"))
+        XCTAssertFalse(activePresentation.contains("manager.hrLastValueAt"))
+
+        for factualConsumer in [controlDecision, telemetryPayload] {
+            XCTAssertTrue(factualConsumer.contains("heartRateBPM"))
+            XCTAssertFalse(factualConsumer.contains("trainingUIHeartRateSnapshot"))
+        }
+        XCTAssertTrue(telemetryPayload.contains("lastKnownHeartRateBPM"))
+
+        XCTAssertTrue(managerSource.contains("let heartRateFactualState"))
+        XCTAssertTrue(managerSource.contains("@Published fileprivate(set) var heartRateBPM"))
+        XCTAssertTrue(managerSource.contains("var heartRateBPM: Int {"))
+        XCTAssertTrue(managerSource.contains("var lastKnownHeartRateBPM: Int {"))
+        XCTAssertFalse(managerSource.contains("@Published var hrLastValueAt"))
+        XCTAssertEqual(
+            contentViewSource.components(separatedBy: "manager.trainingUIHeartRateSnapshot")
+                .count - 1,
+            2
+        )
+        XCTAssertFalse(nativeDelivery.contains("trainingUIHeartRateSnapshot"))
+        XCTAssertFalse(staleTimer.contains("trainingUIHeartRateSnapshot"))
+        assertOrdered(
+            [
+                "HRDomainService.applyHeartRateDelivery(",
+                "hrDataStaleSeconds = ageSeconds",
+                "hrStreamingActive = HRDomainService.heartRateStreamIsActive(",
+                "isNativeHeartRateCurrent = hrStreamingActive",
+                "let normalization = normalizeHeartRateDelivery",
+                "logTrainingEvent(\"hr_sample\"",
+            ],
+            in: nativeDelivery
+        )
+        XCTAssertTrue(uiPublisher.contains("guard nextSnapshot != trainingUIHeartRateSnapshot"))
+        XCTAssertTrue(uiPublisher.contains("trainingUIHeartRateSnapshot = nextSnapshot"))
+        XCTAssertFalse(uiPublisher.contains("DispatchQueue"))
+        XCTAssertFalse(uiPublisher.contains("Task"))
+        XCTAssertFalse(uiPublisher.contains("debounce"))
+        XCTAssertTrue(
+            contentViewSource.contains(
+                "@ObservedObject var state: HeartRateFactualState"
             )
         )
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TrainingUIHeartRatePublicationPolicyTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TrainingUIHeartRatePublicationPolicyTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class TrainingUIHeartRatePublicationPolicyTests: XCTestCase {
+    func testUnchangedVisibleHeartRateKeepsSameTrainingSnapshot() {
+        let current = TrainingUIHeartRatePublicationPolicy.snapshot(
+            isNativeHeartRateCurrent: true,
+            isHeartRateStreamActive: true,
+            heartRateBPM: 130
+        )
+
+        XCTAssertEqual(
+            current,
+            TrainingUIHeartRatePublicationPolicy.snapshot(
+                isNativeHeartRateCurrent: true,
+                isHeartRateStreamActive: true,
+                heartRateBPM: 130
+            )
+        )
+    }
+
+    func testVisibleHeartRateChangeIsAvailableImmediately() {
+        let updated = TrainingUIHeartRatePublicationPolicy.snapshot(
+            isNativeHeartRateCurrent: true,
+            isHeartRateStreamActive: true,
+            heartRateBPM: 131
+        )
+
+        XCTAssertEqual(updated.currentHeartRateBPM, 131)
+        XCTAssertTrue(updated.isFresh)
+        XCTAssertEqual(updated.sourceLabel, "HealthKit")
+    }
+
+    func testFreshnessLossAndRestorationAreImmediateAndFailSafe() {
+        let stale = TrainingUIHeartRatePublicationPolicy.snapshot(
+            isNativeHeartRateCurrent: false,
+            isHeartRateStreamActive: false,
+            heartRateBPM: 130
+        )
+        XCTAssertFalse(stale.isFresh)
+        XCTAssertNil(stale.currentHeartRateBPM)
+        XCTAssertNil(stale.sourceLabel)
+
+        let restored = TrainingUIHeartRatePublicationPolicy.snapshot(
+            isNativeHeartRateCurrent: true,
+            isHeartRateStreamActive: true,
+            heartRateBPM: 130
+        )
+        XCTAssertTrue(restored.isFresh)
+        XCTAssertEqual(restored.currentHeartRateBPM, 130)
+        XCTAssertEqual(restored.sourceLabel, "HealthKit")
+    }
+
+    func testInvalidHeartRateNeverBecomesCurrentTrainingState() {
+        let snapshot = TrainingUIHeartRatePublicationPolicy.snapshot(
+            isNativeHeartRateCurrent: true,
+            isHeartRateStreamActive: true,
+            heartRateBPM: 0
+        )
+
+        XCTAssertTrue(snapshot.isFresh)
+        XCTAssertNil(snapshot.currentHeartRateBPM)
+        XCTAssertNil(snapshot.sourceLabel)
+    }
+}


### PR DESCRIPTION
## Summary

- isolate factual heart-rate state from broad `BluetoothManager` publication while keeping the existing synchronous factual accessors for HR control, safety, freshness, and Telemetry V2
- publish an Equatable Training UI heart-rate snapshot only when rendered freshness/current BPM changes; Debug continues observing factual values directly
- add focused regressions for immediate visible/freshness transitions and for keeping the UI projection out of factual control and telemetry paths
- deterministic active-workout HR pressure improved from `60 technical / 60 manager boundaries / 13 visible / 47 avoidable / 360 raw publications` to `60 / 13 / 13 / 0 / 13`; timer stayed `60 / 60 / 60 / 0`, treadmill stayed `60 / 0 / 0 / 0`, and discovery stayed `120 / 29 / 0 / 29`

Closes #95

## Verification

- `--training-ui-pressure-baseline` on an isolated iOS 27.0 simulator, exact-base before build and exact-head after build
- `cd ios/WalkingPadRemote/WalkingPadRemote && swift test` (all suites green)
- `swift test --filter HeartRateLegacyBehaviorContractTests` (21 passed)
- `swift test --filter TrainingUIHeartRatePublicationPolicyTests` (4 passed)
- `python3 scripts/check_codex_governance.py`
- `python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py`
- `git diff --check`
- `xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -configuration Debug -destination 'generic/platform=iOS Simulator' ... CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' ... CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project WalkingPadRemote.xcodeproj -scheme 'WalkingPadRemoteWatch Watch App' -destination 'generic/platform=watchOS' ... CODE_SIGNING_ALLOWED=NO build`
- during iteration, the first app build failed for a missing explicit `Combine` import in an out-of-scope compatibility change; that change was removed after scope review. A second build exposed a missing explicit `return`; it was fixed. The first focused legacy contract run then failed three stale source-shape assertions; the assertions were updated for the approved presentation boundary. All affected commands and the full gates passed afterward.

## Risks / Notes

- HR values, measured/received timing, source selection, freshness policy, ordering, control decisions, safety gates, HealthKit lifecycle, telemetry semantics, and persistence are unchanged; the UI snapshot is presentation-only and is never read by factual consumers
- independent safety scope challenge found no P0/P1 issue; its setter-access, scope, and wiring-test findings were addressed before final verification
- no dependencies, migrations, configuration changes, deployment steps, or backward-compatibility changes
- no physical device, BLE, treadmill, workout, install, or deploy activity was performed; simulator counters are not a physical-device FPS claim
- rollback is a normal revert of this single commit
