### PR TITLE
Isolate Training UI from unrelated manager publications

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -157,6 +157,7 @@ let package = Package(
                 "CommandQueueService.swift",
                 "TreadmillSpeedBoundsService.swift",
                 "TrainingUIHeartRatePublicationPolicy.swift",
+                "TrainingUIObservationBoundary.swift",
                 "TrainingUITreadmillPublicationPolicy.swift",
                 "TreadmillControlReadinessPolicy.swift",
                 "TreadmillCommandTelemetrySidecar.swift"

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -1,7 +1,5 @@
 import SwiftUI
-#if DEBUG
 import Combine
-#endif
 #if canImport(TelemetryRuntime)
 import TelemetryRuntime
 #endif
@@ -55,10 +53,10 @@ struct ContentView: View {
 
     var body: some View {
         TabView(selection: rootTabSelection) {
-            ControlSwipeView {
+            ControlSwipeView(manager: manager) {
                 selectedRootTabRaw = RootTab.stats.rawValue
             }
-                .environmentObject(manager)
+                .equatable()
                 .tabItem {
                     Label("Тренировка", systemImage: "figure.run.circle")
                 }
@@ -542,6 +540,40 @@ private func makeProductionActiveWorkoutPresentation(
     )
 }
 
+private extension TrainingUIObservationBoundary {
+    convenience init(manager: BluetoothManager) {
+        self.init(signals: [
+            manager.$isConnected.map { _ in () }.eraseToAnyPublisher(),
+            manager.$isTreadmillControlReady.map { _ in () }.eraseToAnyPublisher(),
+            manager.$trainingUIHeartRateSnapshot.map { _ in () }.eraseToAnyPublisher(),
+            manager.$trainingUITreadmillSpeedKmh.map { _ in () }.eraseToAnyPublisher(),
+            manager.$hrTargetBPM.map { _ in () }.eraseToAnyPublisher(),
+            manager.$hrZone1Max.map { _ in () }.eraseToAnyPublisher(),
+            manager.$hrZone2Max.map { _ in () }.eraseToAnyPublisher(),
+            manager.$hrZone3Max.map { _ in () }.eraseToAnyPublisher(),
+            manager.$hrZone4Max.map { _ in () }.eraseToAnyPublisher(),
+            manager.$hrDurationMinutes.map { _ in () }.eraseToAnyPublisher(),
+            manager.$isHrControlStartAllowed.map { _ in () }.eraseToAnyPublisher(),
+            manager.$hrControlStartBlockReasonText.map { _ in () }.eraseToAnyPublisher(),
+            manager.$isNativeHeartRatePreflightActive.map { _ in () }.eraseToAnyPublisher(),
+            manager.$isHrControlRunning.map { _ in () }.eraseToAnyPublisher(),
+            manager.$hrRemainingSeconds.map { _ in () }.eraseToAnyPublisher(),
+            manager.$hrCooldownTargetBpm.map { _ in () }.eraseToAnyPublisher(),
+            manager.$timeSec.map { _ in () }.eraseToAnyPublisher(),
+            manager.$isNativeWorkoutRecoveryActive.map { _ in () }.eraseToAnyPublisher(),
+            manager.$nativeWorkoutRecoveryStatusText.map { _ in () }.eraseToAnyPublisher(),
+            manager.$stopTruthStatusText.map { _ in () }.eraseToAnyPublisher(),
+            manager.$telemetryV2ProjectionGeneration.map { _ in () }.eraseToAnyPublisher(),
+            manager.$telemetryV2WorkoutHistoryState.map { _ in () }.eraseToAnyPublisher(),
+            manager.$telemetryV2WorkoutHistory.map { _ in () }.eraseToAnyPublisher(),
+            manager.$telemetryV2StatusText.map { _ in () }.eraseToAnyPublisher(),
+            manager.$connectErrorMessage.map { _ in () }.eraseToAnyPublisher(),
+            manager.$suggestDevicePicker.map { _ in () }.eraseToAnyPublisher(),
+            manager.$infoToastMessage.map { _ in () }.eraseToAnyPublisher(),
+        ])
+    }
+}
+
 #if DEBUG
 @MainActor
 private enum TrainingUIUpdatePressureHarness {
@@ -550,9 +582,12 @@ private enum TrainingUIUpdatePressureHarness {
         let source: String
         var technicalEvents = 0
         var managerPublishedEvents = 0
+        var trainingBoundaryPublishedEvents = 0
         var visibleSnapshotChanges = 0
         var potentialAvoidableManagerDrivenInvalidations = 0
+        var potentialAvoidableTrainingBoundaryInvalidations = 0
         var rawManagerPublications = 0
+        var rawTrainingBoundaryPublications = 0
         var synchronousMainThreadNanoseconds: UInt64 = 0
     }
 
@@ -561,10 +596,14 @@ private enum TrainingUIUpdatePressureHarness {
         let measurements: [Measurement]
         let technicalEvents: Int
         let managerPublishedEvents: Int
+        let trainingBoundaryPublishedEvents: Int
         let visibleSnapshotChanges: Int
         let potentialAvoidableManagerDrivenInvalidations: Int
+        let potentialAvoidableTrainingBoundaryInvalidations: Int
         let rawManagerPublications: Int
+        let rawTrainingBoundaryPublications: Int
         let eventToVisibleChangeRatio: Double?
+        let boundaryEventToVisibleChangeRatio: Double?
         let synchronousMainThreadNanoseconds: UInt64
     }
 
@@ -601,7 +640,7 @@ private enum TrainingUIUpdatePressureHarness {
             events: activeEvents
         )
         let report = Report(
-            schema: "training-ui-update-pressure-v2",
+            schema: "training-ui-update-pressure-v3",
             workloads: [idle, active]
         )
         let encoder = JSONEncoder()
@@ -618,15 +657,21 @@ private enum TrainingUIUpdatePressureHarness {
         events: [Event]
     ) -> Workload {
         configure(manager)
+        let boundary = TrainingUIObservationBoundary(manager: manager)
         var publicationCount = 0
-        let cancellable = manager.objectWillChange.sink {
+        var boundaryPublicationCount = 0
+        let managerCancellable = manager.objectWillChange.sink {
             publicationCount += 1
+        }
+        let boundaryCancellable = boundary.objectWillChange.sink {
+            boundaryPublicationCount += 1
         }
         var measurements: [String: Measurement] = [:]
         var snapshot = visibleSnapshot(manager: manager)
 
         for event in events {
             let publicationsBefore = publicationCount
+            let boundaryPublicationsBefore = boundaryPublicationCount
             let startedAt = DispatchTime.now().uptimeNanoseconds
             event.apply(manager)
             let nextSnapshot = visibleSnapshot(manager: manager)
@@ -635,12 +680,18 @@ private enum TrainingUIUpdatePressureHarness {
             var measurement = measurements[event.source]
                 ?? Measurement(source: event.source)
             let managerPublished = publicationCount > publicationsBefore
+            let boundaryPublished = boundaryPublicationCount > boundaryPublicationsBefore
             let snapshotChanged = nextSnapshot != snapshot
             measurement.technicalEvents += 1
             measurement.rawManagerPublications += publicationCount - publicationsBefore
+            measurement.rawTrainingBoundaryPublications +=
+                boundaryPublicationCount - boundaryPublicationsBefore
             measurement.synchronousMainThreadNanoseconds += elapsed
             if managerPublished {
                 measurement.managerPublishedEvents += 1
+            }
+            if boundaryPublished {
+                measurement.trainingBoundaryPublishedEvents += 1
             }
             if snapshotChanged {
                 measurement.visibleSnapshotChanges += 1
@@ -648,27 +699,43 @@ private enum TrainingUIUpdatePressureHarness {
             if managerPublished && !snapshotChanged {
                 measurement.potentialAvoidableManagerDrivenInvalidations += 1
             }
+            if boundaryPublished && !snapshotChanged {
+                measurement.potentialAvoidableTrainingBoundaryInvalidations += 1
+            }
             measurements[event.source] = measurement
             snapshot = nextSnapshot
         }
-        withExtendedLifetime(cancellable) {}
+        withExtendedLifetime((managerCancellable, boundaryCancellable, boundary)) {}
 
         let ordered = measurements.values.sorted { $0.source < $1.source }
         let technicalEvents = ordered.reduce(0) { $0 + $1.technicalEvents }
         let managerPublishedEvents = ordered.reduce(0) { $0 + $1.managerPublishedEvents }
+        let trainingBoundaryPublishedEvents = ordered.reduce(0) {
+            $0 + $1.trainingBoundaryPublishedEvents
+        }
         let visibleSnapshotChanges = ordered.reduce(0) { $0 + $1.visibleSnapshotChanges }
         return Workload(
             workload: workload,
             measurements: ordered,
             technicalEvents: technicalEvents,
             managerPublishedEvents: managerPublishedEvents,
+            trainingBoundaryPublishedEvents: trainingBoundaryPublishedEvents,
             visibleSnapshotChanges: visibleSnapshotChanges,
             potentialAvoidableManagerDrivenInvalidations: ordered.reduce(0) {
                 $0 + $1.potentialAvoidableManagerDrivenInvalidations
             },
+            potentialAvoidableTrainingBoundaryInvalidations: ordered.reduce(0) {
+                $0 + $1.potentialAvoidableTrainingBoundaryInvalidations
+            },
             rawManagerPublications: ordered.reduce(0) { $0 + $1.rawManagerPublications },
+            rawTrainingBoundaryPublications: ordered.reduce(0) {
+                $0 + $1.rawTrainingBoundaryPublications
+            },
             eventToVisibleChangeRatio: visibleSnapshotChanges > 0
                 ? Double(managerPublishedEvents) / Double(visibleSnapshotChanges)
+                : nil,
+            boundaryEventToVisibleChangeRatio: visibleSnapshotChanges > 0
+                ? Double(trainingBoundaryPublishedEvents) / Double(visibleSnapshotChanges)
                 : nil,
             synchronousMainThreadNanoseconds: ordered.reduce(0) {
                 $0 + $1.synchronousMainThreadNanoseconds
@@ -2089,9 +2156,10 @@ private struct TrainingWorkoutUnavailableView: View {
     }
 }
 
-private struct ControlSwipeView: View {
-    @EnvironmentObject private var manager: BluetoothManager
+private struct ControlSwipeView: View, Equatable {
+    let manager: BluetoothManager
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @StateObject private var trainingObservation: TrainingUIObservationBoundary
     @State private var showDevicePicker = false
     @State private var showConnectError = false
     @State private var presentSuggestedPicker = false
@@ -2104,8 +2172,16 @@ private struct ControlSwipeView: View {
     let onOpenStatistics: () -> Void
     private let heroAccent: Color = .orange
 
-    init(onOpenStatistics: @escaping () -> Void) {
+    init(manager: BluetoothManager, onOpenStatistics: @escaping () -> Void) {
+        self.manager = manager
         self.onOpenStatistics = onOpenStatistics
+        _trainingObservation = StateObject(
+            wrappedValue: TrainingUIObservationBoundary(manager: manager)
+        )
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.manager === rhs.manager
     }
 
     private var productionTrainingHubPresentation: TrainingHubPresentation {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TrainingUIObservationBoundary.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TrainingUIObservationBoundary.swift
@@ -1,0 +1,13 @@
+import Combine
+
+final class TrainingUIObservationBoundary: ObservableObject {
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(signals: [AnyPublisher<Void, Never>]) {
+        Publishers.MergeMany(signals)
+            .sink { [weak self] in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TrainingUIObservationBoundaryTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TrainingUIObservationBoundaryTests.swift
@@ -1,0 +1,118 @@
+import Combine
+import Foundation
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class TrainingUIObservationBoundaryTests: XCTestCase {
+    func testBoundaryForwardsConfiguredTrainingSignalsSynchronously() {
+        let readiness = PassthroughSubject<Void, Never>()
+        let heartRate = PassthroughSubject<Void, Never>()
+        let treadmill = PassthroughSubject<Void, Never>()
+        let timing = PassthroughSubject<Void, Never>()
+        let phaseAndStop = PassthroughSubject<Void, Never>()
+        let result = PassthroughSubject<Void, Never>()
+        let feedback = PassthroughSubject<Void, Never>()
+        let boundary = TrainingUIObservationBoundary(
+            signals: [
+                readiness.eraseToAnyPublisher(),
+                heartRate.eraseToAnyPublisher(),
+                treadmill.eraseToAnyPublisher(),
+                timing.eraseToAnyPublisher(),
+                phaseAndStop.eraseToAnyPublisher(),
+                result.eraseToAnyPublisher(),
+                feedback.eraseToAnyPublisher(),
+            ]
+        )
+        var publications = 0
+        let cancellable = boundary.objectWillChange.sink { publications += 1 }
+
+        for signal in [
+            readiness,
+            heartRate,
+            treadmill,
+            timing,
+            phaseAndStop,
+            result,
+            feedback,
+        ] {
+            signal.send()
+        }
+
+        XCTAssertEqual(publications, 7)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    func testUnconfiguredDiscoverySignalCannotInvalidateBoundary() {
+        let training = PassthroughSubject<Void, Never>()
+        let discovery = PassthroughSubject<Void, Never>()
+        let boundary = TrainingUIObservationBoundary(
+            signals: [training.eraseToAnyPublisher()]
+        )
+        var publications = 0
+        let cancellable = boundary.objectWillChange.sink { publications += 1 }
+
+        discovery.send()
+        XCTAssertEqual(publications, 0)
+
+        training.send()
+        XCTAssertEqual(publications, 1)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    func testProductionWiringIncludesTrainingStateAndExcludesBroadManagerObservation() throws {
+        let source = try String(
+            contentsOf: packageRoot
+                .appendingPathComponent("WalkingPadRemote/ContentView.swift"),
+            encoding: .utf8
+        )
+        let boundaryStart = try XCTUnwrap(
+            source.range(of: "private extension TrainingUIObservationBoundary")
+        )
+        let harnessStart = try XCTUnwrap(
+            source.range(of: "#if DEBUG", range: boundaryStart.upperBound..<source.endIndex)
+        )
+        let wiring = String(source[boundaryStart.lowerBound..<harnessStart.lowerBound])
+
+        for requiredPublisher in [
+            "$isConnected",
+            "$isTreadmillControlReady",
+            "$trainingUIHeartRateSnapshot",
+            "$trainingUITreadmillSpeedKmh",
+            "$hrTargetBPM",
+            "$hrZone1Max",
+            "$hrZone2Max",
+            "$hrZone3Max",
+            "$hrZone4Max",
+            "$hrDurationMinutes",
+            "$isHrControlStartAllowed",
+            "$hrControlStartBlockReasonText",
+            "$isNativeHeartRatePreflightActive",
+            "$isHrControlRunning",
+            "$hrRemainingSeconds",
+            "$hrCooldownTargetBpm",
+            "$timeSec",
+            "$isNativeWorkoutRecoveryActive",
+            "$nativeWorkoutRecoveryStatusText",
+            "$stopTruthStatusText",
+            "$telemetryV2ProjectionGeneration",
+            "$telemetryV2WorkoutHistoryState",
+            "$telemetryV2WorkoutHistory",
+            "$telemetryV2StatusText",
+            "$connectErrorMessage",
+            "$suggestDevicePicker",
+            "$infoToastMessage",
+        ] {
+            XCTAssertTrue(wiring.contains(requiredPublisher), requiredPublisher)
+        }
+        XCTAssertFalse(wiring.contains("$discoveryUIPeripherals"))
+        XCTAssertFalse(wiring.contains("manager.objectWillChange"))
+        XCTAssertTrue(source.contains("ControlSwipeView(manager: manager)"))
+        XCTAssertTrue(source.contains(".equatable()"))
+    }
+
+    private var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+}


### PR DESCRIPTION
## Summary

- isolate the Training tab behind a synchronous observation boundary that forwards only Training-facing state changes
- keep the Training subtree stable when discovery and other unrelated `BluetoothManager` publications occur
- extend the existing pressure harness and focused contracts to prove discovery isolation while preserving immediate active-workout updates

Closes #86

## Verification

- `swift test` — passed; 338 core tests plus all telemetry suites passed, with the existing opt-in 1000-hour profile skipped
- `swift test --filter TrainingUIObservationBoundaryTests` — 3 passed
- `python3 scripts/check_codex_governance.py` — passed
- `git diff --check` / `git show --check` — passed
- unsigned generic iOS build — passed
- unsigned generic watchOS build — passed
- concrete iOS Simulator Debug build — passed
- pressure harness, two fresh launches before and two after:
  - discovery: 120 callbacks and 29 manager publication events preserved; Training boundary invalidations changed from the broad-path equivalent 29 to 0
  - active minute: 73 visible changes preserved as 73 immediate Training boundary publication events; 0 avoidable boundary invalidations
- initial baseline build against `generic/platform=iOS Simulator` failed in the embedded watch target because that generic destination had no applicable watch AppIcon; the required concrete-simulator build and generic device builds passed

## Risks / Notes

- This is presentation observation only. It does not change BLE discovery policy, HR/treadmill factual state, control decisions, Stop/cooldown/recovery behavior, persistence, or telemetry truth.
- No debounce, batching, resampling, delay, migration, configuration change, deployment step, or backward-compatibility change.
- Physical-device and BLE testing were not run, as excluded by the issue. Rollback is a single commit revert.
