### PR TITLE
Separate visible HR freshness from preflight readiness

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -157,6 +157,7 @@ let package = Package(
                 "CommandQueueService.swift",
                 "TreadmillSpeedBoundsService.swift",
                 "TrainingUIHeartRatePublicationPolicy.swift",
+                "TrainingUIHeartRateReadinessPresentationPolicy.swift",
                 "TrainingUIObservationBoundary.swift",
                 "TrainingUITreadmillPublicationPolicy.swift",
                 "TreadmillControlReadinessPolicy.swift",

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -334,6 +334,13 @@ private func makeHRControlTrainingHubPresentation(
 ) -> TrainingHubPresentation {
     let safeZoneIndex = max(0, min(zoneRanges.count - 1, targetZoneIndex))
     let targetRange = zoneRanges[safeZoneIndex]
+    let heartRateReadiness =
+        TrainingUIHeartRateReadinessPresentationPolicy.presentation(
+            isFresh: hrFresh,
+            currentHeartRateBPM: currentHeartRateBPM,
+            sourceLabel: heartRateSourceLabel,
+            isPreparing: isPreparing
+        )
     let startBlocker: String? = {
         guard !startEnabled, !isPreparing else { return nil }
         if !treadmillConnected { return "Подключите дорожку" }
@@ -369,13 +376,11 @@ private func makeHRControlTrainingHubPresentation(
             .init(
                 id: "heartRate",
                 title: "Пульс",
-                value: hrFresh
-                    ? currentHeartRateBPM.map { "\($0) bpm" } ?? "Доступен"
-                    : (isPreparing ? "Ожидание" : "При старте"),
-                sourceLabel: hrFresh ? heartRateSourceLabel : nil,
+                value: heartRateReadiness.value,
+                sourceLabel: heartRateReadiness.sourceLabel,
                 systemImage: "heart.fill",
-                tint: hrFresh ? .green : .orange,
-                isReady: hrFresh
+                tint: heartRateReadiness.isReady ? .green : .orange,
+                isReady: heartRateReadiness.isReady
             )
         ],
         startEnabled: startEnabled,

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TrainingUIHeartRateReadinessPresentationPolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TrainingUIHeartRateReadinessPresentationPolicy.swift
@@ -1,0 +1,37 @@
+struct TrainingUIHeartRateReadinessPresentation: Equatable {
+    let value: String
+    let sourceLabel: String?
+    let isReady: Bool
+}
+
+enum TrainingUIHeartRateReadinessPresentationPolicy {
+    /// Maps display freshness to the Training chip without authorizing workout start.
+    static func presentation(
+        isFresh: Bool,
+        currentHeartRateBPM: Int?,
+        sourceLabel: String?,
+        isPreparing: Bool
+    ) -> TrainingUIHeartRateReadinessPresentation {
+        if isPreparing {
+            return TrainingUIHeartRateReadinessPresentation(
+                value: "Ожидание",
+                sourceLabel: nil,
+                isReady: false
+            )
+        }
+
+        guard isFresh else {
+            return TrainingUIHeartRateReadinessPresentation(
+                value: "При старте",
+                sourceLabel: nil,
+                isReady: false
+            )
+        }
+
+        return TrainingUIHeartRateReadinessPresentation(
+            value: currentHeartRateBPM.map { "\($0) bpm" } ?? "Доступен",
+            sourceLabel: sourceLabel,
+            isReady: true
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -265,7 +265,12 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         XCTAssertTrue(mapping.contains("targetTitle: \"Зона "))
         XCTAssertTrue(mapping.contains("targetValue: \"\\(targetRange.lowerBound)–\\(targetRange.upperBound) bpm\""))
         XCTAssertTrue(mapping.contains("title: \"Пульс\""))
-        XCTAssertTrue(mapping.contains("heartRateSourceLabel"))
+        XCTAssertTrue(
+            mapping.contains("TrainingUIHeartRateReadinessPresentationPolicy.presentation(")
+        )
+        XCTAssertTrue(mapping.contains("sourceLabel: heartRateSourceLabel"))
+        XCTAssertTrue(mapping.contains("startEnabled: startEnabled"))
+        XCTAssertFalse(mapping.contains("startEnabled: heartRateReadiness.isReady"))
         XCTAssertFalse(mapping.contains("watchReachable"))
         XCTAssertFalse(mapping.contains("Apple Watch"))
         XCTAssertFalse(mapping.contains("Telemetry"))
@@ -472,6 +477,20 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
             contentViewSource.contains(
                 "@ObservedObject var state: HeartRateFactualState"
             )
+        )
+        XCTAssertEqual(
+            contentViewSource.components(
+                separatedBy: "TrainingUIHeartRateReadinessPresentationPolicy.presentation("
+            ).count - 1,
+            1
+        )
+        XCTAssertFalse(
+            managerSource.contains("TrainingUIHeartRateReadinessPresentationPolicy")
+        )
+        XCTAssertFalse(
+            source(
+                relativePath: "WalkingPadRemote/NativeHeartRatePreflightEngine.swift"
+            ).contains("TrainingUIHeartRateReadinessPresentationPolicy")
         )
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TrainingUIHeartRateReadinessPresentationPolicyTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TrainingUIHeartRateReadinessPresentationPolicyTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class TrainingUIHeartRateReadinessPresentationPolicyTests: XCTestCase {
+    func testFreshHeartRateIsReadyBeforePreflight() {
+        let presentation = TrainingUIHeartRateReadinessPresentationPolicy.presentation(
+            isFresh: true,
+            currentHeartRateBPM: 77,
+            sourceLabel: "HealthKit",
+            isPreparing: false
+        )
+
+        XCTAssertEqual(presentation.value, "77 bpm")
+        XCTAssertEqual(presentation.sourceLabel, "HealthKit")
+        XCTAssertTrue(presentation.isReady)
+    }
+
+    func testFreshHeartRateWaitsDuringPreflightWithoutSourceClaim() {
+        let presentation = TrainingUIHeartRateReadinessPresentationPolicy.presentation(
+            isFresh: true,
+            currentHeartRateBPM: 77,
+            sourceLabel: "HealthKit",
+            isPreparing: true
+        )
+
+        XCTAssertEqual(presentation.value, "Ожидание")
+        XCTAssertNil(presentation.sourceLabel)
+        XCTAssertFalse(presentation.isReady)
+    }
+
+    func testUnavailableHeartRateUsesSameWaitingPresentationDuringPreflight() {
+        let presentation = TrainingUIHeartRateReadinessPresentationPolicy.presentation(
+            isFresh: false,
+            currentHeartRateBPM: nil,
+            sourceLabel: nil,
+            isPreparing: true
+        )
+
+        XCTAssertEqual(
+            presentation,
+            TrainingUIHeartRateReadinessPresentation(
+                value: "Ожидание",
+                sourceLabel: nil,
+                isReady: false
+            )
+        )
+    }
+
+    func testUnavailableHeartRateBeforePreflightKeepsExistingPresentation() {
+        let presentation = TrainingUIHeartRateReadinessPresentationPolicy.presentation(
+            isFresh: false,
+            currentHeartRateBPM: nil,
+            sourceLabel: nil,
+            isPreparing: false
+        )
+
+        XCTAssertEqual(presentation.value, "При старте")
+        XCTAssertNil(presentation.sourceLabel)
+        XCTAssertFalse(presentation.isReady)
+    }
+}


### PR DESCRIPTION
## Summary

- Show the Training heart-rate chip as `Ожидание`, orange, and not ready during native preflight, even when a previous fresh BPM remains visible in the display snapshot.
- Preserve the accepted pre-Start affordance and factual active-workout heart-rate presentation.
- Add deterministic presentation-policy and boundary contract coverage.

Closes #99

## Verification

- `swift test --filter TrainingUIHeartRateReadinessPresentationPolicyTests`
- `swift test --filter HeartRateLegacyBehaviorContractTests.testTrainingHubPresentationStaysGenericAndPreviewOnlyModesCannotStart`
- `swift test --filter HeartRateLegacyBehaviorContractTests.testTrainingHeartRateUIPublicationCannotBecomeFactualTruth`
- `cd ios/WalkingPadRemote/WalkingPadRemote && swift test`
- `python3 scripts/check_codex_governance.py`
- `~/.codex/scripts/check-agents-instruction-chain.sh --path ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote`
- `git diff --check`
- `xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination generic/platform=iOS -derivedDataPath /private/tmp/walkingpad-issue99-derived CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemoteWatch\ Watch\ App -destination generic/platform=watchOS -derivedDataPath /private/tmp/walkingpad-issue99-watch-derived CODE_SIGNING_ALLOWED=NO build`

## Risks / Notes

- Presentation-only change: no HealthKit qualification, acquisition timing, provider lifecycle, treadmill readiness/control, HR-control, cooldown, Stop, recovery, Telemetry V2, or publication-boundary behavior changed.
- No physical-device, BLE, install, launch, or deploy actions were performed.
- No migration, configuration, deployment, or rollback steps are required.