### PR TITLE
Keep Training readiness chips equal width

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -1083,13 +1083,19 @@ private struct TrainingReadinessStrip: View {
     @ViewBuilder
     private var readinessItems: some View {
         ForEach(items) { item in
-            let chip = readinessChip(item)
-            if item.id == "treadmill", treadmillInteractive {
-                Button(action: onTreadmillTap) { chip }
-                    .buttonStyle(.plain)
-            } else {
-                chip
-            }
+            readinessItem(item)
+                .frame(maxWidth: .infinity)
+        }
+    }
+
+    @ViewBuilder
+    private func readinessItem(_ item: TrainingHubPresentation.Readiness) -> some View {
+        let chip = readinessChip(item)
+        if item.id == "treadmill", treadmillInteractive {
+            Button(action: onTreadmillTap) { chip }
+                .buttonStyle(.plain)
+        } else {
+            chip
         }
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -359,6 +359,68 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         )
     }
 
+    func testTrainingReadinessStripKeepsEqualOuterWidthsAndFallback() throws {
+        let strip = try functionBody(
+            "private struct TrainingReadinessStrip: View",
+            in: contentViewSource
+        )
+        let body = try functionBody("var body: some View", in: strip)
+        let readinessItems = try functionBody(
+            "private var readinessItems: some View",
+            in: strip
+        )
+        let readinessItem = try functionBody(
+            "private func readinessItem(",
+            in: strip
+        )
+        let readinessChip = try functionBody(
+            "private func readinessChip(",
+            in: strip
+        )
+        let previewFixtures = try functionBody(
+            "private func trainingHubPreviewPresentation(named name: String)",
+            in: contentViewSource
+        )
+
+        XCTAssertTrue(body.contains("ViewThatFits(in: .horizontal)"))
+        assertOrdered(
+            [
+                "HStack(spacing: 8) { readinessItems }",
+                "VStack(spacing: 6) { readinessItems }",
+            ],
+            in: body
+        )
+        assertOrdered(
+            [
+                "ForEach(items)",
+                "readinessItem(item)",
+                ".frame(maxWidth: .infinity)",
+            ],
+            in: readinessItems
+        )
+        XCTAssertFalse(readinessItems.contains("Button("))
+
+        XCTAssertTrue(
+            readinessItem.contains("if item.id == \"treadmill\", treadmillInteractive")
+        )
+        XCTAssertTrue(readinessItem.contains("Button(action: onTreadmillTap) { chip }"))
+        XCTAssertTrue(readinessItem.contains(".buttonStyle(.plain)"))
+        XCTAssertTrue(readinessItem.contains("else {\n            chip"))
+        XCTAssertTrue(
+            readinessChip.contains(".frame(maxWidth: .infinity, alignment: .leading)")
+        )
+
+        XCTAssertTrue(previewFixtures.contains("treadmillReady: Bool = true"))
+        XCTAssertTrue(previewFixtures.contains("hrReady: Bool = true"))
+        XCTAssertTrue(previewFixtures.contains("bpm: Int? = 138"))
+        XCTAssertTrue(previewFixtures.contains("return hrControl(source: \"Apple Watch\")"))
+        XCTAssertTrue(
+            previewFixtures.contains(
+                "return hrControl(hrReady: false, bpm: nil, startEnabled: false)"
+            )
+        )
+    }
+
     func testTrainingTreadmillUIPublicationCannotBecomeFactualTruth() throws {
         let activePresentation = try functionBody(
             "private func makeProductionActiveWorkoutPresentation(",


### PR DESCRIPTION
## Summary

- Apply the same outer flexible-width frame to every Training readiness item after selecting its interactive Button or static chip representation.
- Preserve the treadmill tap/accessibility behavior and the existing horizontal-to-vertical `ViewThatFits` fallback.
- Add a focused structural regression for interactive treadmill, ready HR with BPM/source, unavailable HR, and both strip compositions.

Closes #100

## Verification

- `swift test --filter HeartRateLegacyBehaviorContractTests.testTrainingReadinessStripKeepsEqualOuterWidthsAndFallback`
- `swift test --filter HeartRateLegacyBehaviorContractTests.testTrainingHubPresentationStaysGenericAndPreviewOnlyModesCannotStart`
- `cd ios/WalkingPadRemote/WalkingPadRemote && swift test`
- `python3 scripts/check_codex_governance.py`
- `~/.codex/scripts/check-agents-instruction-chain.sh --path ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote`
- `git diff --check`
- `xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination generic/platform=iOS -derivedDataPath /private/tmp/walkingpad-issue100-derived CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemoteWatch\ Watch\ App -destination generic/platform=watchOS -derivedDataPath /private/tmp/walkingpad-issue100-watch-derived CODE_SIGNING_ALLOWED=NO build`

## Risks / Notes

- Layout-only change in `TrainingReadinessStrip`; no HR, BLE, control, HealthKit, safety, telemetry, or Training observation semantics changed.
- No physical-device, BLE, install, launch, or deploy actions were performed.
- No migration, configuration, deployment, or rollback steps are required.