### PR TITLE
[Debug/Test Run] Add native HR diagnostic probe

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -151,6 +151,7 @@ let package = Package(
                 "StopTruthExperimentObservationService.swift",
                 "StopTruthExperimentPlanService.swift",
                 "StopTruthExperimentSessionService.swift",
+                "TestRunHeartRateDiagnosticService.swift",
                 "TreadmillTestRunService.swift",
                 "TrainingTelemetryWriter.swift",
                 "ZonePlanProgress.swift",

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -127,6 +127,11 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var treadmillTestRunService = TreadmillTestRunService()
     private var treadmillTestRunTimer: Timer?
     private var treadmillTestRunContext: TreadmillTestRunConnectionContext?
+    private var treadmillTestRunHeartRateDiagnosticService =
+        TestRunHeartRateDiagnosticService()
+    private var treadmillTestRunHeartRateProvider: IPhoneHealthKitLiveHeartRateProvider?
+    private var treadmillTestRunHeartRateCleanupInFlight = false
+    private var treadmillTestRunHeartRateProviderGeneration: UInt64 = 0
 
     // Peripheral/characteristics
     private var connectedPeripheral: CBPeripheral?
@@ -1036,6 +1041,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @Published private(set) var controllerUnitsTruth: ControllerUnitsTruth = .disconnected
     @Published private(set) var treadmillTestRunIsActive = false
     @Published private(set) var treadmillTestRunStatusText = "READY"
+    @Published private(set) var treadmillTestRunHeartRateDiagnosticSnapshot =
+        TestRunHeartRateDiagnosticService.Snapshot.idle
 #if STOP_TRUTH_EXPERIMENT_CAPABILITY
     @Published private(set) var stopTruthExperimentStatus: String = "disabled"
     @Published private(set) var stopTruthExperimentArtifactPath: String = ""
@@ -3634,6 +3641,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         syncTreadmillTestRunPresentation()
         startTreadmillTestRunTimer(runID: runID)
         executeTreadmillTestRunActions(transition.actions)
+        startTreadmillTestRunHeartRateDiagnostic(runID: runID)
     }
 
     func stopTreadmillTestRun() {
@@ -3674,6 +3682,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     private func advanceTreadmillTestRun(expectedRunID: UUID) {
         guard treadmillTestRunService.activeRunID == expectedRunID else { return }
+        tickTreadmillTestRunHeartRateDiagnostic(expectedRunID: expectedRunID)
         guard treadmillTestRunContext == currentTreadmillTestRunContext() else {
             cancelTreadmillTestRunForConnectionInvalidation()
             return
@@ -3690,6 +3699,12 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             invalidateTreadmillTestRunScheduling()
         }
         executeTreadmillTestRunActions(transition.actions)
+        if !treadmillTestRunService.isActive {
+            finishTreadmillTestRunHeartRateDiagnostic(
+                expectedRunID: expectedRunID,
+                reason: .testRunCompleted
+            )
+        }
     }
 
     private func cancelTreadmillTestRun(
@@ -3709,6 +3724,12 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             resetCommandQueue(reason: "Test Run cancelled without safe Stop context")
         }
         executeTreadmillTestRunActions(transition.actions)
+        if let runID = treadmillTestRunHeartRateDiagnosticSnapshot.runID {
+            finishTreadmillTestRunHeartRateDiagnostic(
+                expectedRunID: runID,
+                reason: treadmillTestRunHeartRateTerminalReason(for: reason)
+            )
+        }
     }
 
     private func cancelTreadmillTestRunForConnectionInvalidation() {
@@ -3727,6 +3748,201 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private func syncTreadmillTestRunPresentation() {
         treadmillTestRunIsActive = treadmillTestRunService.isActive
         treadmillTestRunStatusText = treadmillTestRunService.statusText
+    }
+
+    private func startTreadmillTestRunHeartRateDiagnostic(runID: UUID) {
+        let now = Date()
+        guard IPhoneHealthKitLiveHeartRateProvider.isSupported else {
+            treadmillTestRunHeartRateDiagnosticService.markUnavailable(
+                runID: runID,
+                at: now,
+                detail: "Native HealthKit heart-rate provider is unsupported"
+            )
+            syncTreadmillTestRunHeartRateDiagnosticPresentation(now: now)
+            return
+        }
+        guard treadmillTestRunHeartRateProvider == nil,
+              !treadmillTestRunHeartRateCleanupInFlight,
+              iPhoneHealthKitHeartRateProvider.state == .idle,
+              !nativeHeartRatePreflightEngine.ownsUncommittedWorkout,
+              !hasOutstandingNativeWorkoutRecovery,
+              !nativeHealthKitWorkoutCommitted,
+              !nativeHealthKitWorkoutFinishInFlight,
+              !isHrControlRunning else {
+            treadmillTestRunHeartRateDiagnosticService.markUnavailable(
+                runID: runID,
+                at: now,
+                detail: "Production HealthKit provider or workout recovery owns the session"
+            )
+            syncTreadmillTestRunHeartRateDiagnosticPresentation(now: now)
+            return
+        }
+
+        treadmillTestRunHeartRateProviderGeneration &+= 1
+        let providerGeneration = treadmillTestRunHeartRateProviderGeneration
+        treadmillTestRunHeartRateDiagnosticService.start(runID: runID, at: now)
+        let provider = IPhoneHealthKitLiveHeartRateProvider(healthStore: healthStore)
+        provider.onObservation = { [weak self] observation in
+            self?.handleTreadmillTestRunHeartRateObservation(
+                observation,
+                expectedRunID: runID
+            )
+        }
+        provider.onFailure = { [weak self] context in
+            guard context.providerGeneration == providerGeneration,
+                  context.attemptID == runID else { return }
+            self?.treadmillTestRunHeartRateProviderFailed(
+                expectedRunID: runID,
+                detail: "HealthKit runtime failure"
+            )
+        }
+        treadmillTestRunHeartRateProvider = provider
+        syncTreadmillTestRunHeartRateDiagnosticPresentation(now: now)
+
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = .walking
+        configuration.locationType = .indoor
+        Task { @MainActor [weak self, weak provider] in
+            guard let self, let provider else { return }
+            do {
+                try await provider.prepare(
+                    configuration: configuration,
+                    failureContext: IPhoneHealthKitRuntimeFailureContext(
+                        providerGeneration: providerGeneration,
+                        attemptID: runID
+                    )
+                )
+                guard treadmillTestRunHeartRateProvider === provider,
+                      treadmillTestRunService.activeRunID == runID else {
+                    await provider.discard(at: Date())
+                    return
+                }
+                treadmillTestRunHeartRateDiagnosticService.updateProviderState(
+                    provider.state.rawValue,
+                    expectedRunID: runID
+                )
+                syncTreadmillTestRunHeartRateDiagnosticPresentation()
+                let collectionStartedAt = Date()
+                treadmillTestRunHeartRateDiagnosticService.updateProviderState(
+                    IPhoneHealthKitHeartRateProviderState.starting.rawValue,
+                    expectedRunID: runID
+                )
+                syncTreadmillTestRunHeartRateDiagnosticPresentation()
+                try await provider.start(at: collectionStartedAt)
+                guard treadmillTestRunHeartRateProvider === provider,
+                      treadmillTestRunService.activeRunID == runID else {
+                    await provider.discard(at: Date())
+                    return
+                }
+                treadmillTestRunHeartRateDiagnosticService.collectionStarted(
+                    expectedRunID: runID,
+                    at: collectionStartedAt
+                )
+                syncTreadmillTestRunHeartRateDiagnosticPresentation()
+            } catch {
+                treadmillTestRunHeartRateProviderFailed(
+                    expectedRunID: runID,
+                    detail: String(describing: error)
+                )
+            }
+        }
+    }
+
+    private func handleTreadmillTestRunHeartRateObservation(
+        _ observation: HeartRateProviderObservation,
+        expectedRunID: UUID
+    ) {
+        guard treadmillTestRunHeartRateProvider?.state == .collecting else { return }
+        let now = Date()
+        treadmillTestRunHeartRateDiagnosticService.receive(
+            NativeHeartRatePreflightEngine.Observation(
+                source: .nativeHealthKit,
+                beatsPerMinute: observation.beatsPerMinute,
+                measuredAt: observation.measuredAt,
+                receivedAt: observation.receivedAt
+            ),
+            expectedRunID: expectedRunID,
+            now: now,
+            freshnessLimit: TimeInterval(hrStaleThresholdSeconds)
+        )
+        syncTreadmillTestRunHeartRateDiagnosticPresentation(now: now)
+    }
+
+    private func tickTreadmillTestRunHeartRateDiagnostic(expectedRunID: UUID) {
+        let now = Date()
+        if treadmillTestRunHeartRateDiagnosticService.timeoutIfNeeded(
+            expectedRunID: expectedRunID,
+            now: now
+        ) {
+            syncTreadmillTestRunHeartRateDiagnosticPresentation(now: now)
+            discardTreadmillTestRunHeartRateProvider(expectedRunID: expectedRunID)
+        } else {
+            syncTreadmillTestRunHeartRateDiagnosticPresentation(now: now)
+        }
+    }
+
+    private func treadmillTestRunHeartRateProviderFailed(
+        expectedRunID: UUID,
+        detail: String
+    ) {
+        finishTreadmillTestRunHeartRateDiagnostic(
+            expectedRunID: expectedRunID,
+            reason: .providerFailure,
+            detail: detail
+        )
+    }
+
+    private func finishTreadmillTestRunHeartRateDiagnostic(
+        expectedRunID: UUID,
+        reason: TestRunHeartRateDiagnosticService.TerminalReason,
+        detail: String? = nil
+    ) {
+        guard treadmillTestRunHeartRateDiagnosticService.isActive else { return }
+        treadmillTestRunHeartRateDiagnosticService.finish(
+            expectedRunID: expectedRunID,
+            reason: reason,
+            detail: detail
+        )
+        syncTreadmillTestRunHeartRateDiagnosticPresentation()
+        discardTreadmillTestRunHeartRateProvider(expectedRunID: expectedRunID)
+    }
+
+    private func discardTreadmillTestRunHeartRateProvider(expectedRunID: UUID) {
+        guard let provider = treadmillTestRunHeartRateProvider,
+              !treadmillTestRunHeartRateCleanupInFlight else { return }
+        treadmillTestRunHeartRateCleanupInFlight = true
+        Task { @MainActor [weak self, weak provider] in
+            guard let self, let provider else { return }
+            await provider.discard(at: Date())
+            guard treadmillTestRunHeartRateProvider === provider else { return }
+            treadmillTestRunHeartRateProvider = nil
+            treadmillTestRunHeartRateCleanupInFlight = false
+            treadmillTestRunHeartRateDiagnosticService.providerDiscarded(
+                expectedRunID: expectedRunID
+            )
+            syncTreadmillTestRunHeartRateDiagnosticPresentation()
+            warmNativeHeartRateProviderIfPossible()
+        }
+    }
+
+    private func syncTreadmillTestRunHeartRateDiagnosticPresentation(
+        now: Date = Date()
+    ) {
+        treadmillTestRunHeartRateDiagnosticSnapshot =
+            treadmillTestRunHeartRateDiagnosticService.snapshot(
+                now: now,
+                freshnessLimit: TimeInterval(hrStaleThresholdSeconds)
+            )
+    }
+
+    private func treadmillTestRunHeartRateTerminalReason(
+        for reason: TreadmillTestRunService.CancellationReason
+    ) -> TestRunHeartRateDiagnosticService.TerminalReason {
+        switch reason {
+        case .userRequested: return .userRequested
+        case .appInactive: return .appInactive
+        case .connectionInvalidated: return .connectionInvalidated
+        }
     }
 
     private func executeTreadmillTestRunActions(_ actions: [TreadmillTestRunService.Action]) {
@@ -4935,6 +5151,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     private func warmNativeHeartRateProviderIfPossible() {
         guard !nativeHeartRateProviderLifecycle.cleanupInFlight,
+              treadmillTestRunHeartRateProvider == nil,
+              !treadmillTestRunHeartRateCleanupInFlight,
+              !treadmillTestRunIsActive,
               !hasOutstandingNativeWorkoutRecovery,
               NativeHeartRatePreflightEngine.RuntimePolicy.canWarmPrepare(
             isTrainingHubVisible: isTrainingHubVisible,
@@ -4951,6 +5170,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 .canPrepareWithoutAuthorizationPrompt()
             guard canPrepare,
                   !nativeHeartRateProviderLifecycle.cleanupInFlight,
+                  treadmillTestRunHeartRateProvider == nil,
+                  !treadmillTestRunHeartRateCleanupInFlight,
+                  !treadmillTestRunIsActive,
                   !hasOutstandingNativeWorkoutRecovery,
                   NativeHeartRatePreflightEngine.RuntimePolicy.canWarmPrepare(
                     isTrainingHubVisible: isTrainingHubVisible,

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -130,6 +130,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var treadmillTestRunHeartRateDiagnosticService =
         TestRunHeartRateDiagnosticService()
     private var treadmillTestRunHeartRateProvider: IPhoneHealthKitLiveHeartRateProvider?
+    private var treadmillTestRunHeartRateProviderOwnership =
+        TestRunHeartRateDiagnosticProviderOwnership()
     private var treadmillTestRunHeartRateCleanupInFlight = false
     private var treadmillTestRunHeartRateProviderGeneration: UInt64 = 0
 
@@ -3700,7 +3702,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
         executeTreadmillTestRunActions(transition.actions)
         if !treadmillTestRunService.isActive {
-            finishTreadmillTestRunHeartRateDiagnostic(
+            finishCurrentTreadmillTestRunHeartRateDiagnostic(
                 expectedRunID: expectedRunID,
                 reason: .testRunCompleted
             )
@@ -3725,7 +3727,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
         executeTreadmillTestRunActions(transition.actions)
         if let runID = treadmillTestRunHeartRateDiagnosticSnapshot.runID {
-            finishTreadmillTestRunHeartRateDiagnostic(
+            finishCurrentTreadmillTestRunHeartRateDiagnostic(
                 expectedRunID: runID,
                 reason: treadmillTestRunHeartRateTerminalReason(for: reason)
             )
@@ -3782,17 +3784,27 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let providerGeneration = treadmillTestRunHeartRateProviderGeneration
         treadmillTestRunHeartRateDiagnosticService.start(runID: runID, at: now)
         let provider = IPhoneHealthKitLiveHeartRateProvider(healthStore: healthStore)
-        provider.onObservation = { [weak self] observation in
+        let attempt = TestRunHeartRateDiagnosticProviderAttempt(
+            runID: runID,
+            generation: providerGeneration,
+            providerIdentity: ObjectIdentifier(provider)
+        )
+        treadmillTestRunHeartRateProviderOwnership.bind(attempt)
+        provider.onObservation = { [weak self, weak provider] observation in
+            guard let provider else { return }
             self?.handleTreadmillTestRunHeartRateObservation(
                 observation,
-                expectedRunID: runID
+                expectedAttempt: attempt,
+                provider: provider
             )
         }
-        provider.onFailure = { [weak self] context in
+        provider.onFailure = { [weak self, weak provider] context in
+            guard let provider else { return }
             guard context.providerGeneration == providerGeneration,
                   context.attemptID == runID else { return }
             self?.treadmillTestRunHeartRateProviderFailed(
-                expectedRunID: runID,
+                expectedAttempt: attempt,
+                provider: provider,
                 detail: "HealthKit runtime failure"
             )
         }
@@ -3812,7 +3824,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                         attemptID: runID
                     )
                 )
-                guard treadmillTestRunHeartRateProvider === provider,
+                guard ownsTreadmillTestRunHeartRateProvider(
+                    attempt,
+                    provider: provider
+                ),
                       treadmillTestRunService.activeRunID == runID else {
                     await provider.discard(at: Date())
                     return
@@ -3829,7 +3844,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 )
                 syncTreadmillTestRunHeartRateDiagnosticPresentation()
                 try await provider.start(at: collectionStartedAt)
-                guard treadmillTestRunHeartRateProvider === provider,
+                guard ownsTreadmillTestRunHeartRateProvider(
+                    attempt,
+                    provider: provider
+                ),
                       treadmillTestRunService.activeRunID == runID else {
                     await provider.discard(at: Date())
                     return
@@ -3841,7 +3859,8 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 syncTreadmillTestRunHeartRateDiagnosticPresentation()
             } catch {
                 treadmillTestRunHeartRateProviderFailed(
-                    expectedRunID: runID,
+                    expectedAttempt: attempt,
+                    provider: provider,
                     detail: String(describing: error)
                 )
             }
@@ -3850,18 +3869,26 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
 
     private func handleTreadmillTestRunHeartRateObservation(
         _ observation: HeartRateProviderObservation,
-        expectedRunID: UUID
+        expectedAttempt: TestRunHeartRateDiagnosticProviderAttempt,
+        provider: IPhoneHealthKitLiveHeartRateProvider
     ) {
-        guard treadmillTestRunHeartRateProvider?.state == .collecting else { return }
+        guard ownsTreadmillTestRunHeartRateProvider(
+            expectedAttempt,
+            provider: provider
+        ), provider.state == .collecting else { return }
         let now = Date()
         treadmillTestRunHeartRateDiagnosticService.receive(
-            NativeHeartRatePreflightEngine.Observation(
-                source: .nativeHealthKit,
-                beatsPerMinute: observation.beatsPerMinute,
-                measuredAt: observation.measuredAt,
-                receivedAt: observation.receivedAt
+            TestRunHeartRateDiagnosticService.Sample(
+                qualificationObservation: NativeHeartRatePreflightEngine.Observation(
+                    source: .nativeHealthKit,
+                    beatsPerMinute: observation.beatsPerMinute,
+                    measuredAt: observation.measuredAt,
+                    receivedAt: observation.receivedAt
+                ),
+                sourceCallbackObservedAt: observation.sourceCallbackObservedAt,
+                providerNativeIdentity: observation.providerNativeIdentity?.identifier
             ),
-            expectedRunID: expectedRunID,
+            expectedRunID: expectedAttempt.runID,
             now: now,
             freshnessLimit: TimeInterval(hrStaleThresholdSeconds)
         )
@@ -3875,54 +3902,107 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             now: now
         ) {
             syncTreadmillTestRunHeartRateDiagnosticPresentation(now: now)
-            discardTreadmillTestRunHeartRateProvider(expectedRunID: expectedRunID)
+            guard let attempt = treadmillTestRunHeartRateProviderOwnership.currentAttempt,
+                  attempt.runID == expectedRunID,
+                  let provider = treadmillTestRunHeartRateProvider else { return }
+            discardTreadmillTestRunHeartRateProvider(
+                expectedAttempt: attempt,
+                provider: provider
+            )
         } else {
             syncTreadmillTestRunHeartRateDiagnosticPresentation(now: now)
         }
     }
 
     private func treadmillTestRunHeartRateProviderFailed(
-        expectedRunID: UUID,
+        expectedAttempt: TestRunHeartRateDiagnosticProviderAttempt,
+        provider: IPhoneHealthKitLiveHeartRateProvider,
         detail: String
     ) {
         finishTreadmillTestRunHeartRateDiagnostic(
-            expectedRunID: expectedRunID,
+            expectedAttempt: expectedAttempt,
+            provider: provider,
             reason: .providerFailure,
             detail: detail
         )
     }
 
-    private func finishTreadmillTestRunHeartRateDiagnostic(
+    private func finishCurrentTreadmillTestRunHeartRateDiagnostic(
         expectedRunID: UUID,
+        reason: TestRunHeartRateDiagnosticService.TerminalReason
+    ) {
+        guard let attempt = treadmillTestRunHeartRateProviderOwnership.currentAttempt,
+              attempt.runID == expectedRunID,
+              let provider = treadmillTestRunHeartRateProvider else { return }
+        finishTreadmillTestRunHeartRateDiagnostic(
+            expectedAttempt: attempt,
+            provider: provider,
+            reason: reason
+        )
+    }
+
+    private func finishTreadmillTestRunHeartRateDiagnostic(
+        expectedAttempt: TestRunHeartRateDiagnosticProviderAttempt,
+        provider: IPhoneHealthKitLiveHeartRateProvider,
         reason: TestRunHeartRateDiagnosticService.TerminalReason,
         detail: String? = nil
     ) {
-        guard treadmillTestRunHeartRateDiagnosticService.isActive else { return }
+        guard ownsTreadmillTestRunHeartRateProvider(
+            expectedAttempt,
+            provider: provider
+        ),
+              treadmillTestRunHeartRateDiagnosticSnapshot.runID == expectedAttempt.runID,
+              treadmillTestRunHeartRateDiagnosticService.isActive else { return }
         treadmillTestRunHeartRateDiagnosticService.finish(
-            expectedRunID: expectedRunID,
+            expectedRunID: expectedAttempt.runID,
             reason: reason,
             detail: detail
         )
         syncTreadmillTestRunHeartRateDiagnosticPresentation()
-        discardTreadmillTestRunHeartRateProvider(expectedRunID: expectedRunID)
+        discardTreadmillTestRunHeartRateProvider(
+            expectedAttempt: expectedAttempt,
+            provider: provider
+        )
     }
 
-    private func discardTreadmillTestRunHeartRateProvider(expectedRunID: UUID) {
-        guard let provider = treadmillTestRunHeartRateProvider,
+    private func discardTreadmillTestRunHeartRateProvider(
+        expectedAttempt: TestRunHeartRateDiagnosticProviderAttempt,
+        provider: IPhoneHealthKitLiveHeartRateProvider
+    ) {
+        guard ownsTreadmillTestRunHeartRateProvider(
+            expectedAttempt,
+            provider: provider
+        ),
               !treadmillTestRunHeartRateCleanupInFlight else { return }
         treadmillTestRunHeartRateCleanupInFlight = true
         Task { @MainActor [weak self, weak provider] in
             guard let self, let provider else { return }
             await provider.discard(at: Date())
-            guard treadmillTestRunHeartRateProvider === provider else { return }
+            guard ownsTreadmillTestRunHeartRateProvider(
+                expectedAttempt,
+                provider: provider
+            ), treadmillTestRunHeartRateProviderOwnership.release(expectedAttempt) else {
+                return
+            }
             treadmillTestRunHeartRateProvider = nil
             treadmillTestRunHeartRateCleanupInFlight = false
             treadmillTestRunHeartRateDiagnosticService.providerDiscarded(
-                expectedRunID: expectedRunID
+                expectedRunID: expectedAttempt.runID
             )
             syncTreadmillTestRunHeartRateDiagnosticPresentation()
             warmNativeHeartRateProviderIfPossible()
         }
+    }
+
+    private func ownsTreadmillTestRunHeartRateProvider(
+        _ attempt: TestRunHeartRateDiagnosticProviderAttempt,
+        provider: IPhoneHealthKitLiveHeartRateProvider
+    ) -> Bool {
+        treadmillTestRunHeartRateProvider === provider
+            && treadmillTestRunHeartRateProviderOwnership.accepts(
+                attempt,
+                provider: provider
+            )
     }
 
     private func syncTreadmillTestRunHeartRateDiagnosticPresentation(

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -4399,7 +4399,12 @@ private struct DebugView: View {
                 value: "\(snapshot.qualifyingSampleCount) / \(snapshot.rejectedSampleCount)",
                 tint: .blue
             ),
-            .init(id: "hr_probe_total", title: "Received", value: "\(snapshot.receivedSampleCount)", tint: .secondary),
+            .init(
+                id: "hr_probe_fresh_total",
+                title: "Fresh / total",
+                value: "\(snapshot.displayFreshSampleCount) / \(snapshot.receivedSampleCount)",
+                tint: .secondary
+            ),
         ]
     }
 
@@ -4408,15 +4413,22 @@ private struct DebugView: View {
     ) -> [String] {
         guard snapshot.runID != nil else { return [] }
         let age = snapshot.latestAgeSeconds.map { String(format: "%.1f s", $0) } ?? "—"
+        let qualifyingLatency = snapshot.firstQualifyingSampleLatencySeconds.map {
+            String(format: "%.3f s", $0)
+        } ?? "—"
         return [
             "started_at: \(testRunHeartRateDiagnosticDate(snapshot.startedAt))",
             "collection_started_at: \(testRunHeartRateDiagnosticDate(snapshot.collectionStartedAt))",
             "first_sample_received_at: \(testRunHeartRateDiagnosticDate(snapshot.firstSampleReceivedAt))",
+            "first_qualifying_latency_from_acquisition: \(qualifyingLatency)",
             "latest_measured_at: \(testRunHeartRateDiagnosticDate(snapshot.latestMeasuredAt))",
+            "latest_callback_observed_at: \(testRunHeartRateDiagnosticDate(snapshot.latestSourceCallbackObservedAt))",
             "latest_received_at: \(testRunHeartRateDiagnosticDate(snapshot.latestReceivedAt))",
             "latest_source: \(snapshot.latestSource ?? "—")",
+            "latest_provider_native_identity: \(snapshot.latestProviderNativeIdentity ?? "unavailable")",
             "latest_age: \(age)",
             "latest_rejection: \(snapshot.latestRejectionReason?.rawValue ?? "—")",
+            "rejections_by_reason: \(testRunHeartRateDiagnosticRejectionSummary(snapshot))",
         ]
     }
 
@@ -4434,11 +4446,20 @@ private struct DebugView: View {
             "latest_display_fresh: \(snapshot.latestDisplayFresh)",
             "latest_start_qualified: \(snapshot.latestStartQualified)",
             "samples_received: \(snapshot.receivedSampleCount)",
+            "samples_display_fresh: \(snapshot.displayFreshSampleCount)",
             "samples_qualifying: \(snapshot.qualifyingSampleCount)",
             "samples_rejected: \(snapshot.rejectedSampleCount)",
             "latest_rejection: \(snapshot.latestRejectionReason?.rawValue ?? "—")",
         ] + testRunHeartRateDiagnosticDetailLines(snapshot)
         return lines.joined(separator: "\n")
+    }
+
+    private func testRunHeartRateDiagnosticRejectionSummary(
+        _ snapshot: TestRunHeartRateDiagnosticService.Snapshot
+    ) -> String {
+        TestRunHeartRateDiagnosticService.RejectionReason.allCases.map { reason in
+            "\(reason.rawValue)=\(snapshot.rejectionCountsByReason[reason, default: 0])"
+        }.joined(separator: ",")
     }
 
     private func testRunHeartRateDiagnosticDate(_ date: Date?) -> String {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -4271,6 +4271,7 @@ private struct DebugView: View {
 
     private var trainingLogsCardPresentation: DebugTrainingLogsCard.Presentation {
         let entries = manager.telemetryV2WorkoutHistory
+        let heartRateDiagnostic = manager.treadmillTestRunHeartRateDiagnosticSnapshot
         let readReady = manager.telemetryV2WorkoutHistoryState == .loaded
         let readStatusText: String = {
             switch manager.telemetryV2WorkoutHistoryState {
@@ -4311,6 +4312,18 @@ private struct DebugView: View {
             testRunActive: manager.treadmillTestRunIsActive,
             testRunStatusText: manager.treadmillTestRunDisplayText,
             canStartTestRun: manager.canStartTreadmillTestRun,
+            heartRateDiagnosticStatusText: testRunHeartRateDiagnosticStatusText(
+                heartRateDiagnostic
+            ),
+            heartRateDiagnosticMetrics: testRunHeartRateDiagnosticMetrics(
+                heartRateDiagnostic
+            ),
+            heartRateDiagnosticDetailLines: testRunHeartRateDiagnosticDetailLines(
+                heartRateDiagnostic
+            ),
+            heartRateDiagnosticReport: testRunHeartRateDiagnosticReport(
+                heartRateDiagnostic
+            ),
             subtitle: "Telemetry V2 · активный профиль: \(manager.activeUserProfileLabel)",
             profileMetrics: [
                 .init(id: "profile_loaded", title: "Загружено", value: "\(entries.count)", tint: .accentColor),
@@ -4336,6 +4349,101 @@ private struct DebugView: View {
                 ? "Для анализа лучше накопить хотя бы 3 завершённые тренировки."
                 : nil
         )
+    }
+
+    private func testRunHeartRateDiagnosticStatusText(
+        _ snapshot: TestRunHeartRateDiagnosticService.Snapshot
+    ) -> String {
+        guard snapshot.runID != nil else {
+            return "Запускается параллельно Test Run и не управляет дорожкой."
+        }
+        if let detail = snapshot.detail, !detail.isEmpty {
+            return "\(snapshot.phase.rawValue) · \(detail)"
+        }
+        if let reason = snapshot.terminalReason {
+            return "\(snapshot.phase.rawValue) · \(reason.rawValue)"
+        }
+        return "\(snapshot.phase.rawValue) · provider \(snapshot.providerState)"
+    }
+
+    private func testRunHeartRateDiagnosticMetrics(
+        _ snapshot: TestRunHeartRateDiagnosticService.Snapshot
+    ) -> [DebugTrainingLogsCard.Presentation.Metric] {
+        guard snapshot.runID != nil else { return [] }
+        let bpm = snapshot.latestBPM.map(String.init) ?? "—"
+        let freshness = snapshot.latestDisplayFresh ? "fresh" : "not fresh"
+        let qualification = snapshot.latestStartQualified ? "qualified" : "not qualified"
+        return [
+            .init(
+                id: "hr_probe_provider",
+                title: "Provider",
+                value: snapshot.providerState,
+                tint: .accentColor
+            ),
+            .init(id: "hr_probe_bpm", title: "HR", value: "\(bpm) bpm", tint: .red),
+            .init(
+                id: "hr_probe_fresh",
+                title: "Display",
+                value: freshness,
+                tint: snapshot.latestDisplayFresh ? .green : .orange
+            ),
+            .init(
+                id: "hr_probe_qualified",
+                title: "Start gate",
+                value: qualification,
+                tint: snapshot.latestStartQualified ? .green : .orange
+            ),
+            .init(
+                id: "hr_probe_counts",
+                title: "Samples Q / R",
+                value: "\(snapshot.qualifyingSampleCount) / \(snapshot.rejectedSampleCount)",
+                tint: .blue
+            ),
+            .init(id: "hr_probe_total", title: "Received", value: "\(snapshot.receivedSampleCount)", tint: .secondary),
+        ]
+    }
+
+    private func testRunHeartRateDiagnosticDetailLines(
+        _ snapshot: TestRunHeartRateDiagnosticService.Snapshot
+    ) -> [String] {
+        guard snapshot.runID != nil else { return [] }
+        let age = snapshot.latestAgeSeconds.map { String(format: "%.1f s", $0) } ?? "—"
+        return [
+            "started_at: \(testRunHeartRateDiagnosticDate(snapshot.startedAt))",
+            "collection_started_at: \(testRunHeartRateDiagnosticDate(snapshot.collectionStartedAt))",
+            "first_sample_received_at: \(testRunHeartRateDiagnosticDate(snapshot.firstSampleReceivedAt))",
+            "latest_measured_at: \(testRunHeartRateDiagnosticDate(snapshot.latestMeasuredAt))",
+            "latest_received_at: \(testRunHeartRateDiagnosticDate(snapshot.latestReceivedAt))",
+            "latest_source: \(snapshot.latestSource ?? "—")",
+            "latest_age: \(age)",
+            "latest_rejection: \(snapshot.latestRejectionReason?.rawValue ?? "—")",
+        ]
+    }
+
+    private func testRunHeartRateDiagnosticReport(
+        _ snapshot: TestRunHeartRateDiagnosticService.Snapshot
+    ) -> String {
+        let lines = [
+            "WalkingPad Test Run HR diagnostic",
+            "run_id: \(snapshot.runID?.uuidString ?? "—")",
+            "phase: \(snapshot.phase.rawValue)",
+            "provider_state: \(snapshot.providerState)",
+            "terminal_reason: \(snapshot.terminalReason?.rawValue ?? "—")",
+            "detail: \(snapshot.detail ?? "—")",
+            "latest_bpm: \(snapshot.latestBPM.map(String.init) ?? "—")",
+            "latest_display_fresh: \(snapshot.latestDisplayFresh)",
+            "latest_start_qualified: \(snapshot.latestStartQualified)",
+            "samples_received: \(snapshot.receivedSampleCount)",
+            "samples_qualifying: \(snapshot.qualifyingSampleCount)",
+            "samples_rejected: \(snapshot.rejectedSampleCount)",
+            "latest_rejection: \(snapshot.latestRejectionReason?.rawValue ?? "—")",
+        ] + testRunHeartRateDiagnosticDetailLines(snapshot)
+        return lines.joined(separator: "\n")
+    }
+
+    private func testRunHeartRateDiagnosticDate(_ date: Date?) -> String {
+        guard let date else { return "—" }
+        return ISO8601DateFormatter().string(from: date)
     }
 
     private var hrFailuresCardPresentation: DebugHrFailuresCard.Presentation {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DebugTrainingLogsCard.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DebugTrainingLogsCard.swift
@@ -18,6 +18,10 @@ struct DebugTrainingLogsCard: View {
         let testRunActive: Bool
         let testRunStatusText: String
         let canStartTestRun: Bool
+        let heartRateDiagnosticStatusText: String
+        let heartRateDiagnosticMetrics: [Metric]
+        let heartRateDiagnosticDetailLines: [String]
+        let heartRateDiagnosticReport: String
         let subtitle: String
         let profileMetrics: [Metric]
         let deviceMetrics: [Metric]
@@ -75,6 +79,42 @@ struct DebugTrainingLogsCard: View {
                     }
                     .buttonStyle(.plain)
                     .disabled(!presentation.testRunActive && !presentation.canStartTestRun)
+                }
+
+                if !presentation.heartRateDiagnosticMetrics.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("HR diagnostic probe")
+                                .font(.caption.weight(.medium))
+                                .foregroundColor(.secondary)
+                            Spacer()
+                            ShareLink(item: presentation.heartRateDiagnosticReport) {
+                                Label("Report", systemImage: "square.and.arrow.up")
+                                    .font(.caption.weight(.semibold))
+                            }
+                        }
+
+                        Text(presentation.heartRateDiagnosticStatusText)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                        metricsSection(
+                            title: "Native HealthKit",
+                            items: presentation.heartRateDiagnosticMetrics
+                        )
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            ForEach(
+                                Array(presentation.heartRateDiagnosticDetailLines.enumerated()),
+                                id: \.offset
+                            ) { _, line in
+                                Text(line)
+                                    .font(.system(.caption2, design: .monospaced))
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .textSelection(.enabled)
+                    }
                 }
 
                 metricsSection(title: "Активный профиль", items: presentation.profileMetrics)

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TestRunHeartRateDiagnosticService.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TestRunHeartRateDiagnosticService.swift
@@ -1,0 +1,268 @@
+import Foundation
+
+struct TestRunHeartRateDiagnosticService {
+    static let firstQualifyingSampleTimeoutSeconds: TimeInterval = 30
+
+    enum TerminalReason: String, Equatable {
+        case testRunCompleted = "test_run_completed"
+        case userRequested = "user_requested"
+        case appInactive = "app_inactive"
+        case connectionInvalidated = "connection_invalidated"
+        case providerFailure = "provider_failure"
+        case timeout = "first_qualifying_sample_timeout"
+    }
+
+    enum Phase: String, Equatable {
+        case idle
+        case preparing
+        case collecting
+        case completed
+        case cancelled
+        case failed
+        case unavailable
+    }
+
+    enum RejectionReason: String, Equatable {
+        case sourceIsNotNativeHealthKit = "source_not_native_healthkit"
+        case invalidBPM = "invalid_bpm"
+        case receivedBeforeCollection = "received_before_collection"
+        case measuredBeforeCollection = "measured_before_collection"
+        case stale = "stale"
+    }
+
+    struct Snapshot: Equatable {
+        let runID: UUID?
+        let phase: Phase
+        let providerState: String
+        let startedAt: Date?
+        let collectionStartedAt: Date?
+        let firstSampleReceivedAt: Date?
+        let latestMeasuredAt: Date?
+        let latestReceivedAt: Date?
+        let latestBPM: Int?
+        let latestSource: String?
+        let latestAgeSeconds: TimeInterval?
+        let latestDisplayFresh: Bool
+        let latestStartQualified: Bool
+        let receivedSampleCount: Int
+        let qualifyingSampleCount: Int
+        let rejectedSampleCount: Int
+        let latestRejectionReason: RejectionReason?
+        let terminalReason: TerminalReason?
+        let detail: String?
+
+        static let idle = Snapshot(
+            runID: nil,
+            phase: .idle,
+            providerState: "idle",
+            startedAt: nil,
+            collectionStartedAt: nil,
+            firstSampleReceivedAt: nil,
+            latestMeasuredAt: nil,
+            latestReceivedAt: nil,
+            latestBPM: nil,
+            latestSource: nil,
+            latestAgeSeconds: nil,
+            latestDisplayFresh: false,
+            latestStartQualified: false,
+            receivedSampleCount: 0,
+            qualifyingSampleCount: 0,
+            rejectedSampleCount: 0,
+            latestRejectionReason: nil,
+            terminalReason: nil,
+            detail: nil
+        )
+    }
+
+    private var runID: UUID?
+    private var phase: Phase = .idle
+    private var providerState = "idle"
+    private var startedAt: Date?
+    private var collectionStartedAt: Date?
+    private var firstSampleReceivedAt: Date?
+    private var latestObservation: NativeHeartRatePreflightEngine.Observation?
+    private var latestStartQualified = false
+    private var receivedSampleCount = 0
+    private var qualifyingSampleCount = 0
+    private var rejectedSampleCount = 0
+    private var latestRejectionReason: RejectionReason?
+    private var terminalReason: TerminalReason?
+    private var detail: String?
+
+    var isActive: Bool {
+        phase == .preparing || phase == .collecting
+    }
+
+    mutating func start(runID: UUID, at date: Date) {
+        self.runID = runID
+        phase = .preparing
+        providerState = "authorizing_or_preparing"
+        startedAt = date
+        collectionStartedAt = nil
+        firstSampleReceivedAt = nil
+        latestObservation = nil
+        latestStartQualified = false
+        receivedSampleCount = 0
+        qualifyingSampleCount = 0
+        rejectedSampleCount = 0
+        latestRejectionReason = nil
+        terminalReason = nil
+        detail = nil
+    }
+
+    mutating func markUnavailable(runID: UUID, at date: Date, detail: String) {
+        start(runID: runID, at: date)
+        phase = .unavailable
+        providerState = "unavailable"
+        self.detail = detail
+    }
+
+    mutating func updateProviderState(_ state: String, expectedRunID: UUID) {
+        guard runID == expectedRunID, isActive else { return }
+        providerState = state
+    }
+
+    mutating func collectionStarted(expectedRunID: UUID, at date: Date) {
+        guard runID == expectedRunID, phase == .preparing else { return }
+        phase = .collecting
+        providerState = "collecting"
+        collectionStartedAt = date
+    }
+
+    mutating func receive(
+        _ observation: NativeHeartRatePreflightEngine.Observation,
+        expectedRunID: UUID,
+        now: Date,
+        freshnessLimit: TimeInterval
+    ) {
+        guard runID == expectedRunID,
+              phase == .collecting,
+              let collectionStartedAt else { return }
+
+        receivedSampleCount += 1
+        if firstSampleReceivedAt == nil {
+            firstSampleReceivedAt = observation.receivedAt
+        }
+        latestObservation = observation
+        let qualifies = observation.isQualifying(
+            collectionStartedAt: collectionStartedAt,
+            now: now,
+            freshnessLimit: freshnessLimit
+        )
+        latestStartQualified = qualifies
+        if qualifies {
+            qualifyingSampleCount += 1
+            latestRejectionReason = nil
+        } else {
+            rejectedSampleCount += 1
+            latestRejectionReason = rejectionReason(
+                for: observation,
+                collectionStartedAt: collectionStartedAt,
+                now: now,
+                freshnessLimit: freshnessLimit
+            )
+        }
+    }
+
+    mutating func timeoutIfNeeded(expectedRunID: UUID, now: Date) -> Bool {
+        guard runID == expectedRunID,
+              isActive,
+              qualifyingSampleCount == 0,
+              let startedAt,
+              now.timeIntervalSince(startedAt) >= Self.firstQualifyingSampleTimeoutSeconds else {
+            return false
+        }
+        finish(
+            expectedRunID: expectedRunID,
+            reason: .timeout,
+            detail: "No qualifying native HealthKit sample within 30 seconds"
+        )
+        return true
+    }
+
+    mutating func finish(
+        expectedRunID: UUID,
+        reason: TerminalReason,
+        detail: String? = nil
+    ) {
+        guard runID == expectedRunID, isActive else { return }
+        terminalReason = reason
+        self.detail = detail
+        providerState = "discarding"
+        switch reason {
+        case .testRunCompleted:
+            phase = .completed
+        case .providerFailure, .timeout:
+            phase = .failed
+        case .userRequested, .appInactive, .connectionInvalidated:
+            phase = .cancelled
+        }
+    }
+
+    mutating func providerDiscarded(expectedRunID: UUID) {
+        guard runID == expectedRunID, !isActive else { return }
+        providerState = "idle_discarded"
+    }
+
+    func snapshot(now: Date, freshnessLimit: TimeInterval) -> Snapshot {
+        let factualDate = latestObservation.map { $0.measuredAt ?? $0.receivedAt }
+        let age = factualDate.map { max(0, now.timeIntervalSince($0)) }
+        let displayFresh = latestObservation.map {
+            HRDomainService.heartRateStreamIsActive(
+                beatsPerMinute: $0.beatsPerMinute,
+                hasLastReceivedAt: latestObservation != nil,
+                ageSeconds: Int(age ?? 0),
+                staleThresholdSeconds: Int(freshnessLimit)
+            )
+        } ?? false
+        return Snapshot(
+            runID: runID,
+            phase: phase,
+            providerState: providerState,
+            startedAt: startedAt,
+            collectionStartedAt: collectionStartedAt,
+            firstSampleReceivedAt: firstSampleReceivedAt,
+            latestMeasuredAt: latestObservation?.measuredAt,
+            latestReceivedAt: latestObservation?.receivedAt,
+            latestBPM: latestObservation?.beatsPerMinute,
+            latestSource: latestObservation.map { observation in
+                switch observation.source {
+                case .nativeHealthKit: return "native_healthkit"
+                case .legacyWatch: return "legacy_watch"
+                }
+            },
+            latestAgeSeconds: age,
+            latestDisplayFresh: displayFresh,
+            latestStartQualified: latestStartQualified,
+            receivedSampleCount: receivedSampleCount,
+            qualifyingSampleCount: qualifyingSampleCount,
+            rejectedSampleCount: rejectedSampleCount,
+            latestRejectionReason: latestRejectionReason,
+            terminalReason: terminalReason,
+            detail: detail
+        )
+    }
+
+    private func rejectionReason(
+        for observation: NativeHeartRatePreflightEngine.Observation,
+        collectionStartedAt: Date,
+        now: Date,
+        freshnessLimit: TimeInterval
+    ) -> RejectionReason {
+        guard observation.source == .nativeHealthKit else {
+            return .sourceIsNotNativeHealthKit
+        }
+        guard observation.beatsPerMinute > 0 else { return .invalidBPM }
+        guard observation.receivedAt >= collectionStartedAt else {
+            return .receivedBeforeCollection
+        }
+        let factualDate = observation.measuredAt ?? observation.receivedAt
+        guard factualDate >= collectionStartedAt else {
+            return .measuredBeforeCollection
+        }
+        if now.timeIntervalSince(factualDate) > freshnessLimit {
+            return .stale
+        }
+        return .stale
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TestRunHeartRateDiagnosticService.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/TestRunHeartRateDiagnosticService.swift
@@ -1,5 +1,33 @@
 import Foundation
 
+struct TestRunHeartRateDiagnosticProviderAttempt: Equatable {
+    let runID: UUID
+    let generation: UInt64
+    let providerIdentity: ObjectIdentifier
+}
+
+struct TestRunHeartRateDiagnosticProviderOwnership {
+    private(set) var currentAttempt: TestRunHeartRateDiagnosticProviderAttempt?
+
+    mutating func bind(_ attempt: TestRunHeartRateDiagnosticProviderAttempt) {
+        currentAttempt = attempt
+    }
+
+    func accepts(
+        _ attempt: TestRunHeartRateDiagnosticProviderAttempt,
+        provider: AnyObject
+    ) -> Bool {
+        currentAttempt == attempt
+            && attempt.providerIdentity == ObjectIdentifier(provider)
+    }
+
+    mutating func release(_ attempt: TestRunHeartRateDiagnosticProviderAttempt) -> Bool {
+        guard currentAttempt == attempt else { return false }
+        currentAttempt = nil
+        return true
+    }
+}
+
 struct TestRunHeartRateDiagnosticService {
     static let firstQualifyingSampleTimeoutSeconds: TimeInterval = 30
 
@@ -22,12 +50,18 @@ struct TestRunHeartRateDiagnosticService {
         case unavailable
     }
 
-    enum RejectionReason: String, Equatable {
+    enum RejectionReason: String, CaseIterable, Hashable {
         case sourceIsNotNativeHealthKit = "source_not_native_healthkit"
         case invalidBPM = "invalid_bpm"
         case receivedBeforeCollection = "received_before_collection"
         case measuredBeforeCollection = "measured_before_collection"
         case stale = "stale"
+    }
+
+    struct Sample: Equatable {
+        let qualificationObservation: NativeHeartRatePreflightEngine.Observation
+        let sourceCallbackObservedAt: Date?
+        let providerNativeIdentity: String?
     }
 
     struct Snapshot: Equatable {
@@ -38,15 +72,20 @@ struct TestRunHeartRateDiagnosticService {
         let collectionStartedAt: Date?
         let firstSampleReceivedAt: Date?
         let latestMeasuredAt: Date?
+        let latestSourceCallbackObservedAt: Date?
         let latestReceivedAt: Date?
         let latestBPM: Int?
         let latestSource: String?
+        let latestProviderNativeIdentity: String?
         let latestAgeSeconds: TimeInterval?
         let latestDisplayFresh: Bool
         let latestStartQualified: Bool
         let receivedSampleCount: Int
+        let displayFreshSampleCount: Int
         let qualifyingSampleCount: Int
         let rejectedSampleCount: Int
+        let rejectionCountsByReason: [RejectionReason: Int]
+        let firstQualifyingSampleLatencySeconds: TimeInterval?
         let latestRejectionReason: RejectionReason?
         let terminalReason: TerminalReason?
         let detail: String?
@@ -59,15 +98,20 @@ struct TestRunHeartRateDiagnosticService {
             collectionStartedAt: nil,
             firstSampleReceivedAt: nil,
             latestMeasuredAt: nil,
+            latestSourceCallbackObservedAt: nil,
             latestReceivedAt: nil,
             latestBPM: nil,
             latestSource: nil,
+            latestProviderNativeIdentity: nil,
             latestAgeSeconds: nil,
             latestDisplayFresh: false,
             latestStartQualified: false,
             receivedSampleCount: 0,
+            displayFreshSampleCount: 0,
             qualifyingSampleCount: 0,
             rejectedSampleCount: 0,
+            rejectionCountsByReason: [:],
+            firstQualifyingSampleLatencySeconds: nil,
             latestRejectionReason: nil,
             terminalReason: nil,
             detail: nil
@@ -80,11 +124,14 @@ struct TestRunHeartRateDiagnosticService {
     private var startedAt: Date?
     private var collectionStartedAt: Date?
     private var firstSampleReceivedAt: Date?
-    private var latestObservation: NativeHeartRatePreflightEngine.Observation?
+    private var latestSample: Sample?
     private var latestStartQualified = false
     private var receivedSampleCount = 0
+    private var displayFreshSampleCount = 0
     private var qualifyingSampleCount = 0
     private var rejectedSampleCount = 0
+    private var rejectionCountsByReason: [RejectionReason: Int] = [:]
+    private var firstQualifyingSampleLatencySeconds: TimeInterval?
     private var latestRejectionReason: RejectionReason?
     private var terminalReason: TerminalReason?
     private var detail: String?
@@ -100,11 +147,14 @@ struct TestRunHeartRateDiagnosticService {
         startedAt = date
         collectionStartedAt = nil
         firstSampleReceivedAt = nil
-        latestObservation = nil
+        latestSample = nil
         latestStartQualified = false
         receivedSampleCount = 0
+        displayFreshSampleCount = 0
         qualifyingSampleCount = 0
         rejectedSampleCount = 0
+        rejectionCountsByReason = [:]
+        firstQualifyingSampleLatencySeconds = nil
         latestRejectionReason = nil
         terminalReason = nil
         detail = nil
@@ -130,7 +180,7 @@ struct TestRunHeartRateDiagnosticService {
     }
 
     mutating func receive(
-        _ observation: NativeHeartRatePreflightEngine.Observation,
+        _ sample: Sample,
         expectedRunID: UUID,
         now: Date,
         freshnessLimit: TimeInterval
@@ -139,11 +189,19 @@ struct TestRunHeartRateDiagnosticService {
               phase == .collecting,
               let collectionStartedAt else { return }
 
+        let observation = sample.qualificationObservation
         receivedSampleCount += 1
         if firstSampleReceivedAt == nil {
             firstSampleReceivedAt = observation.receivedAt
         }
-        latestObservation = observation
+        latestSample = sample
+        if isDisplayFresh(
+            observation,
+            now: now,
+            freshnessLimit: freshnessLimit
+        ) {
+            displayFreshSampleCount += 1
+        }
         let qualifies = observation.isQualifying(
             collectionStartedAt: collectionStartedAt,
             now: now,
@@ -152,15 +210,23 @@ struct TestRunHeartRateDiagnosticService {
         latestStartQualified = qualifies
         if qualifies {
             qualifyingSampleCount += 1
+            if firstQualifyingSampleLatencySeconds == nil {
+                firstQualifyingSampleLatencySeconds = max(
+                    0,
+                    observation.receivedAt.timeIntervalSince(collectionStartedAt)
+                )
+            }
             latestRejectionReason = nil
         } else {
             rejectedSampleCount += 1
-            latestRejectionReason = rejectionReason(
+            let reason = rejectionReason(
                 for: observation,
                 collectionStartedAt: collectionStartedAt,
                 now: now,
                 freshnessLimit: freshnessLimit
             )
+            rejectionCountsByReason[reason, default: 0] += 1
+            latestRejectionReason = reason
         }
     }
 
@@ -205,15 +271,11 @@ struct TestRunHeartRateDiagnosticService {
     }
 
     func snapshot(now: Date, freshnessLimit: TimeInterval) -> Snapshot {
+        let latestObservation = latestSample?.qualificationObservation
         let factualDate = latestObservation.map { $0.measuredAt ?? $0.receivedAt }
         let age = factualDate.map { max(0, now.timeIntervalSince($0)) }
         let displayFresh = latestObservation.map {
-            HRDomainService.heartRateStreamIsActive(
-                beatsPerMinute: $0.beatsPerMinute,
-                hasLastReceivedAt: latestObservation != nil,
-                ageSeconds: Int(age ?? 0),
-                staleThresholdSeconds: Int(freshnessLimit)
-            )
+            isDisplayFresh($0, now: now, freshnessLimit: freshnessLimit)
         } ?? false
         return Snapshot(
             runID: runID,
@@ -223,6 +285,7 @@ struct TestRunHeartRateDiagnosticService {
             collectionStartedAt: collectionStartedAt,
             firstSampleReceivedAt: firstSampleReceivedAt,
             latestMeasuredAt: latestObservation?.measuredAt,
+            latestSourceCallbackObservedAt: latestSample?.sourceCallbackObservedAt,
             latestReceivedAt: latestObservation?.receivedAt,
             latestBPM: latestObservation?.beatsPerMinute,
             latestSource: latestObservation.map { observation in
@@ -231,15 +294,34 @@ struct TestRunHeartRateDiagnosticService {
                 case .legacyWatch: return "legacy_watch"
                 }
             },
+            latestProviderNativeIdentity: latestSample?.providerNativeIdentity,
             latestAgeSeconds: age,
             latestDisplayFresh: displayFresh,
             latestStartQualified: latestStartQualified,
             receivedSampleCount: receivedSampleCount,
+            displayFreshSampleCount: displayFreshSampleCount,
             qualifyingSampleCount: qualifyingSampleCount,
             rejectedSampleCount: rejectedSampleCount,
+            rejectionCountsByReason: rejectionCountsByReason,
+            firstQualifyingSampleLatencySeconds: firstQualifyingSampleLatencySeconds,
             latestRejectionReason: latestRejectionReason,
             terminalReason: terminalReason,
             detail: detail
+        )
+    }
+
+    private func isDisplayFresh(
+        _ observation: NativeHeartRatePreflightEngine.Observation,
+        now: Date,
+        freshnessLimit: TimeInterval
+    ) -> Bool {
+        let factualDate = observation.measuredAt ?? observation.receivedAt
+        let ageSeconds = max(0, Int(now.timeIntervalSince(factualDate)))
+        return HRDomainService.heartRateStreamIsActive(
+            beatsPerMinute: observation.beatsPerMinute,
+            hasLastReceivedAt: true,
+            ageSeconds: ageSeconds,
+            staleThresholdSeconds: Int(freshnessLimit)
         )
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TestRunHeartRateDiagnosticIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TestRunHeartRateDiagnosticIntegrationContractTests.swift
@@ -35,7 +35,12 @@ final class TestRunHeartRateDiagnosticIntegrationContractTests: XCTestCase {
         XCTAssertTrue(start.contains("HKWorkoutConfiguration()"))
         XCTAssertTrue(start.contains("provider.prepare("))
         XCTAssertTrue(start.contains("provider.start(at: collectionStartedAt)"))
+        XCTAssertTrue(start.contains("providerIdentity: ObjectIdentifier(provider)"))
+        XCTAssertTrue(start.contains("treadmillTestRunHeartRateProviderOwnership.bind(attempt)"))
+        XCTAssertTrue(receive.contains("ownsTreadmillTestRunHeartRateProvider("))
         XCTAssertTrue(receive.contains("NativeHeartRatePreflightEngine.Observation("))
+        XCTAssertTrue(receive.contains("sourceCallbackObservedAt: observation.sourceCallbackObservedAt"))
+        XCTAssertTrue(receive.contains("observation.providerNativeIdentity?.identifier"))
         XCTAssertTrue(diagnosticSource.contains("observation.isQualifying("))
         XCTAssertTrue(diagnosticSource.contains("HRDomainService.heartRateStreamIsActive("))
         for forbidden in [
@@ -59,7 +64,7 @@ final class TestRunHeartRateDiagnosticIntegrationContractTests: XCTestCase {
             in: managerSource
         )
         let discard = try functionBody(
-            "private func discardTreadmillTestRunHeartRateProvider(expectedRunID: UUID)",
+            "private func discardTreadmillTestRunHeartRateProvider(",
             in: managerSource
         )
 
@@ -69,6 +74,8 @@ final class TestRunHeartRateDiagnosticIntegrationContractTests: XCTestCase {
         XCTAssertTrue(start.contains("!nativeHealthKitWorkoutCommitted"))
         XCTAssertTrue(start.contains("!nativeHealthKitWorkoutFinishInFlight"))
         XCTAssertTrue(discard.contains("provider.discard(at: Date())"))
+        XCTAssertTrue(discard.contains("ownsTreadmillTestRunHeartRateProvider("))
+        XCTAssertTrue(discard.contains("treadmillTestRunHeartRateProviderOwnership.release(expectedAttempt)"))
         for body in [start, finish, discard] {
             XCTAssertFalse(body.contains("provider.finish("))
             XCTAssertFalse(body.contains("persistNativeWorkoutRecoveryRecord"))
@@ -122,8 +129,22 @@ final class TestRunHeartRateDiagnosticIntegrationContractTests: XCTestCase {
         XCTAssertTrue(timeout.contains("timeoutIfNeeded("))
         XCTAssertTrue(timeout.contains("discardTreadmillTestRunHeartRateProvider"))
         XCTAssertTrue(failure.contains("reason: .providerFailure"))
+        XCTAssertTrue(failure.contains("expectedAttempt: expectedAttempt"))
+        XCTAssertTrue(failure.contains("provider: provider"))
         XCTAssertTrue(managerSource.contains("case .appInactive: return .appInactive"))
         XCTAssertTrue(managerSource.contains("case .connectionInvalidated: return .connectionInvalidated"))
+    }
+
+    func testDiagnosticReportModelRetainsRequestedEvidence() {
+        for field in [
+            "latestSourceCallbackObservedAt",
+            "latestProviderNativeIdentity",
+            "displayFreshSampleCount",
+            "rejectionCountsByReason",
+            "firstQualifyingSampleLatencySeconds",
+        ] {
+            XCTAssertTrue(diagnosticSource.contains(field), "Missing diagnostic field: \(field)")
+        }
     }
 
     private func source(_ relativePath: String) throws -> String {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TestRunHeartRateDiagnosticIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TestRunHeartRateDiagnosticIntegrationContractTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+
+final class TestRunHeartRateDiagnosticIntegrationContractTests: XCTestCase {
+    private lazy var packageDirectory = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    private lazy var managerSource = try! source("WalkingPadRemote/BluetoothManager.swift")
+    private lazy var diagnosticSource = try! source(
+        "WalkingPadRemote/TestRunHeartRateDiagnosticService.swift"
+    )
+
+    func testTreadmillStartRemainsIndependentAndRunsBeforeDiagnosticProbe() throws {
+        let start = try functionBody("func startTreadmillTestRun()", in: managerSource)
+
+        assertOrdered([
+            "treadmillTestRunService.start(",
+            "executeTreadmillTestRunActions(transition.actions)",
+            "startTreadmillTestRunHeartRateDiagnostic(runID: runID)",
+        ], in: start)
+        XCTAssertFalse(start.contains("guard startTreadmillTestRunHeartRateDiagnostic"))
+        XCTAssertFalse(start.contains("await"))
+    }
+
+    func testDiagnosticReusesProductionProviderAndQualificationBoundaries() throws {
+        let start = try functionBody(
+            "private func startTreadmillTestRunHeartRateDiagnostic(runID: UUID)",
+            in: managerSource
+        )
+        let receive = try functionBody(
+            "private func handleTreadmillTestRunHeartRateObservation(",
+            in: managerSource
+        )
+
+        XCTAssertTrue(start.contains("IPhoneHealthKitLiveHeartRateProvider(healthStore: healthStore)"))
+        XCTAssertTrue(start.contains("HKWorkoutConfiguration()"))
+        XCTAssertTrue(start.contains("provider.prepare("))
+        XCTAssertTrue(start.contains("provider.start(at: collectionStartedAt)"))
+        XCTAssertTrue(receive.contains("NativeHeartRatePreflightEngine.Observation("))
+        XCTAssertTrue(diagnosticSource.contains("observation.isQualifying("))
+        XCTAssertTrue(diagnosticSource.contains("HRDomainService.heartRateStreamIsActive("))
+        for forbidden in [
+            "heartRateBPM =",
+            "hrStreamingActive =",
+            "isNativeHeartRateCurrent =",
+            "publishHeartRateNormalization",
+            "recordHrSample",
+        ] {
+            XCTAssertFalse(receive.contains(forbidden))
+        }
+    }
+
+    func testDiagnosticCannotTakeProductionOwnershipOrPersistWorkout() throws {
+        let start = try functionBody(
+            "private func startTreadmillTestRunHeartRateDiagnostic(runID: UUID)",
+            in: managerSource
+        )
+        let finish = try functionBody(
+            "private func finishTreadmillTestRunHeartRateDiagnostic(",
+            in: managerSource
+        )
+        let discard = try functionBody(
+            "private func discardTreadmillTestRunHeartRateProvider(expectedRunID: UUID)",
+            in: managerSource
+        )
+
+        XCTAssertTrue(start.contains("iPhoneHealthKitHeartRateProvider.state == .idle"))
+        XCTAssertTrue(start.contains("!nativeHeartRatePreflightEngine.ownsUncommittedWorkout"))
+        XCTAssertTrue(start.contains("!hasOutstandingNativeWorkoutRecovery"))
+        XCTAssertTrue(start.contains("!nativeHealthKitWorkoutCommitted"))
+        XCTAssertTrue(start.contains("!nativeHealthKitWorkoutFinishInFlight"))
+        XCTAssertTrue(discard.contains("provider.discard(at: Date())"))
+        for body in [start, finish, discard] {
+            XCTAssertFalse(body.contains("provider.finish("))
+            XCTAssertFalse(body.contains("persistNativeWorkoutRecoveryRecord"))
+            XCTAssertFalse(body.contains("beginTelemetryV2Session"))
+            XCTAssertFalse(body.contains("startWithSpeed"))
+            XCTAssertFalse(body.contains("setTargetSpeed"))
+            XCTAssertFalse(body.contains("manualStop"))
+        }
+    }
+
+    func testProductionWarmPreparationYieldsToActiveDiagnosticSlot() throws {
+        let warm = try functionBody(
+            "private func warmNativeHeartRateProviderIfPossible()",
+            in: managerSource
+        )
+
+        XCTAssertEqual(
+            warm.components(separatedBy: "treadmillTestRunHeartRateProvider == nil").count - 1,
+            2
+        )
+        XCTAssertEqual(
+            warm.components(separatedBy: "!treadmillTestRunHeartRateCleanupInFlight").count - 1,
+            2
+        )
+        XCTAssertEqual(
+            warm.components(separatedBy: "!treadmillTestRunIsActive").count - 1,
+            2
+        )
+    }
+
+    func testAllTreadmillTerminalPathsDiscardDiagnosticProvider() throws {
+        let advance = try functionBody(
+            "private func advanceTreadmillTestRun(expectedRunID: UUID)",
+            in: managerSource
+        )
+        let cancel = try functionBody(
+            "private func cancelTreadmillTestRun(",
+            in: managerSource
+        )
+        let timeout = try functionBody(
+            "private func tickTreadmillTestRunHeartRateDiagnostic(expectedRunID: UUID)",
+            in: managerSource
+        )
+        let failure = try functionBody(
+            "private func treadmillTestRunHeartRateProviderFailed(",
+            in: managerSource
+        )
+
+        XCTAssertTrue(advance.contains("reason: .testRunCompleted"))
+        XCTAssertTrue(cancel.contains("treadmillTestRunHeartRateTerminalReason(for: reason)"))
+        XCTAssertTrue(timeout.contains("timeoutIfNeeded("))
+        XCTAssertTrue(timeout.contains("discardTreadmillTestRunHeartRateProvider"))
+        XCTAssertTrue(failure.contains("reason: .providerFailure"))
+        XCTAssertTrue(managerSource.contains("case .appInactive: return .appInactive"))
+        XCTAssertTrue(managerSource.contains("case .connectionInvalidated: return .connectionInvalidated"))
+    }
+
+    private func source(_ relativePath: String) throws -> String {
+        try String(
+            contentsOf: packageDirectory.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+
+    private func functionBody(_ signature: String, in source: String) throws -> String {
+        guard let signatureRange = source.range(of: signature),
+              let openingBrace = source[signatureRange.upperBound...].firstIndex(of: "{") else {
+            throw NSError(domain: "TestRunHeartRateDiagnosticIntegrationContractTests", code: 1)
+        }
+        var depth = 0
+        var index = openingBrace
+        while index < source.endIndex {
+            switch source[index] {
+            case "{": depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 { return String(source[openingBrace...index]) }
+            default: break
+            }
+            index = source.index(after: index)
+        }
+        throw NSError(domain: "TestRunHeartRateDiagnosticIntegrationContractTests", code: 2)
+    }
+
+    private func assertOrdered(
+        _ fragments: [String],
+        in text: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        var cursor = text.startIndex
+        for fragment in fragments {
+            guard let range = text[cursor...].range(of: fragment) else {
+                XCTFail("Missing or out-of-order fragment: \(fragment)", file: file, line: line)
+                return
+            }
+            cursor = range.upperBound
+        }
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TestRunHeartRateDiagnosticServiceTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TestRunHeartRateDiagnosticServiceTests.swift
@@ -11,7 +11,13 @@ final class TestRunHeartRateDiagnosticServiceTests: XCTestCase {
         service.collectionStarted(expectedRunID: runID, at: startedAt)
 
         service.receive(
-            observation(bpm: 128, measuredAt: startedAt.addingTimeInterval(1)),
+            observation(
+                bpm: 128,
+                measuredAt: startedAt.addingTimeInterval(1),
+                receivedAt: startedAt.addingTimeInterval(1.75),
+                callbackObservedAt: startedAt.addingTimeInterval(1.5),
+                providerNativeIdentity: "provider-sample-1"
+            ),
             expectedRunID: runID,
             now: startedAt.addingTimeInterval(2),
             freshnessLimit: 7
@@ -22,9 +28,16 @@ final class TestRunHeartRateDiagnosticServiceTests: XCTestCase {
             freshnessLimit: 7
         )
         XCTAssertEqual(current.receivedSampleCount, 1)
+        XCTAssertEqual(current.displayFreshSampleCount, 1)
         XCTAssertEqual(current.qualifyingSampleCount, 1)
         XCTAssertEqual(current.rejectedSampleCount, 0)
         XCTAssertEqual(current.latestSource, "native_healthkit")
+        XCTAssertEqual(
+            current.latestSourceCallbackObservedAt,
+            startedAt.addingTimeInterval(1.5)
+        )
+        XCTAssertEqual(current.latestProviderNativeIdentity, "provider-sample-1")
+        XCTAssertEqual(current.firstQualifyingSampleLatencySeconds, 1.75)
         XCTAssertTrue(current.latestStartQualified)
         XCTAssertTrue(current.latestDisplayFresh)
 
@@ -66,6 +79,8 @@ final class TestRunHeartRateDiagnosticServiceTests: XCTestCase {
         XCTAssertEqual(snapshot.latestRejectionReason, .stale)
         XCTAssertEqual(snapshot.receivedSampleCount, 2)
         XCTAssertEqual(snapshot.rejectedSampleCount, 2)
+        XCTAssertEqual(snapshot.rejectionCountsByReason[.receivedBeforeCollection], 1)
+        XCTAssertEqual(snapshot.rejectionCountsByReason[.stale], 1)
         XCTAssertFalse(snapshot.latestStartQualified)
     }
 
@@ -122,16 +137,84 @@ final class TestRunHeartRateDiagnosticServiceTests: XCTestCase {
         )
     }
 
+    func testDelayedObservationFromOldAttemptCannotMutateNewAttempt() {
+        let providerA = FakeDiagnosticProvider()
+        let providerB = FakeDiagnosticProvider()
+        let attemptA = TestRunHeartRateDiagnosticProviderAttempt(
+            runID: runID,
+            generation: 1,
+            providerIdentity: ObjectIdentifier(providerA)
+        )
+        let runB = UUID()
+        let attemptB = TestRunHeartRateDiagnosticProviderAttempt(
+            runID: runB,
+            generation: 2,
+            providerIdentity: ObjectIdentifier(providerB)
+        )
+        var ownership = TestRunHeartRateDiagnosticProviderOwnership()
+        ownership.bind(attemptA)
+        XCTAssertTrue(ownership.release(attemptA))
+        ownership.bind(attemptB)
+
+        var service = TestRunHeartRateDiagnosticService()
+        service.start(runID: runB, at: startedAt)
+        service.collectionStarted(expectedRunID: runB, at: startedAt)
+        service.receive(
+            observation(bpm: 140, measuredAt: startedAt.addingTimeInterval(1)),
+            expectedRunID: attemptA.runID,
+            now: startedAt.addingTimeInterval(1),
+            freshnessLimit: 7
+        )
+
+        XCTAssertFalse(ownership.accepts(attemptA, provider: providerA))
+        XCTAssertEqual(ownership.currentAttempt, attemptB)
+        XCTAssertTrue(ownership.accepts(attemptB, provider: providerB))
+        XCTAssertEqual(
+            service.snapshot(now: startedAt.addingTimeInterval(1), freshnessLimit: 7)
+                .receivedSampleCount,
+            0
+        )
+    }
+
+    func testDelayedFailureFromOldAttemptCannotReleaseNewAttempt() {
+        let providerA = FakeDiagnosticProvider()
+        let providerB = FakeDiagnosticProvider()
+        let attemptA = TestRunHeartRateDiagnosticProviderAttempt(
+            runID: runID,
+            generation: 1,
+            providerIdentity: ObjectIdentifier(providerA)
+        )
+        let attemptB = TestRunHeartRateDiagnosticProviderAttempt(
+            runID: UUID(),
+            generation: 2,
+            providerIdentity: ObjectIdentifier(providerB)
+        )
+        var ownership = TestRunHeartRateDiagnosticProviderOwnership()
+        ownership.bind(attemptB)
+
+        XCTAssertFalse(ownership.release(attemptA))
+        XCTAssertEqual(ownership.currentAttempt, attemptB)
+        XCTAssertTrue(ownership.accepts(attemptB, provider: providerB))
+    }
+
     private func observation(
         bpm: Int,
         measuredAt: Date,
-        receivedAt: Date? = nil
-    ) -> NativeHeartRatePreflightEngine.Observation {
-        NativeHeartRatePreflightEngine.Observation(
-            source: .nativeHealthKit,
-            beatsPerMinute: bpm,
-            measuredAt: measuredAt,
-            receivedAt: receivedAt ?? measuredAt
+        receivedAt: Date? = nil,
+        callbackObservedAt: Date? = nil,
+        providerNativeIdentity: String? = nil
+    ) -> TestRunHeartRateDiagnosticService.Sample {
+        TestRunHeartRateDiagnosticService.Sample(
+            qualificationObservation: NativeHeartRatePreflightEngine.Observation(
+                source: .nativeHealthKit,
+                beatsPerMinute: bpm,
+                measuredAt: measuredAt,
+                receivedAt: receivedAt ?? measuredAt
+            ),
+            sourceCallbackObservedAt: callbackObservedAt,
+            providerNativeIdentity: providerNativeIdentity
         )
     }
 }
+
+private final class FakeDiagnosticProvider {}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TestRunHeartRateDiagnosticServiceTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/TestRunHeartRateDiagnosticServiceTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class TestRunHeartRateDiagnosticServiceTests: XCTestCase {
+    private let runID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+    private let startedAt = Date(timeIntervalSince1970: 1_000)
+
+    func testUsesProductionQualificationSemanticsAndTracksFreshnessSeparately() {
+        var service = TestRunHeartRateDiagnosticService()
+        service.start(runID: runID, at: startedAt)
+        service.collectionStarted(expectedRunID: runID, at: startedAt)
+
+        service.receive(
+            observation(bpm: 128, measuredAt: startedAt.addingTimeInterval(1)),
+            expectedRunID: runID,
+            now: startedAt.addingTimeInterval(2),
+            freshnessLimit: 7
+        )
+
+        let current = service.snapshot(
+            now: startedAt.addingTimeInterval(2),
+            freshnessLimit: 7
+        )
+        XCTAssertEqual(current.receivedSampleCount, 1)
+        XCTAssertEqual(current.qualifyingSampleCount, 1)
+        XCTAssertEqual(current.rejectedSampleCount, 0)
+        XCTAssertEqual(current.latestSource, "native_healthkit")
+        XCTAssertTrue(current.latestStartQualified)
+        XCTAssertTrue(current.latestDisplayFresh)
+
+        let staleDisplay = service.snapshot(
+            now: startedAt.addingTimeInterval(20),
+            freshnessLimit: 7
+        )
+        XCTAssertTrue(staleDisplay.latestStartQualified)
+        XCTAssertFalse(staleDisplay.latestDisplayFresh)
+    }
+
+    func testPreCollectionAndStaleSamplesExposeExactRejectionReasons() {
+        var service = TestRunHeartRateDiagnosticService()
+        service.start(runID: runID, at: startedAt)
+        service.collectionStarted(expectedRunID: runID, at: startedAt)
+
+        service.receive(
+            observation(bpm: 120, measuredAt: startedAt.addingTimeInterval(-1)),
+            expectedRunID: runID,
+            now: startedAt,
+            freshnessLimit: 7
+        )
+        XCTAssertEqual(
+            service.snapshot(now: startedAt, freshnessLimit: 7).latestRejectionReason,
+            .receivedBeforeCollection
+        )
+
+        service.receive(
+            observation(
+                bpm: 121,
+                measuredAt: startedAt.addingTimeInterval(1),
+                receivedAt: startedAt.addingTimeInterval(2)
+            ),
+            expectedRunID: runID,
+            now: startedAt.addingTimeInterval(20),
+            freshnessLimit: 7
+        )
+        let snapshot = service.snapshot(now: startedAt.addingTimeInterval(20), freshnessLimit: 7)
+        XCTAssertEqual(snapshot.latestRejectionReason, .stale)
+        XCTAssertEqual(snapshot.receivedSampleCount, 2)
+        XCTAssertEqual(snapshot.rejectedSampleCount, 2)
+        XCTAssertFalse(snapshot.latestStartQualified)
+    }
+
+    func testFirstQualifyingSampleTimeoutIsTerminalAndStaleRunCannotMutateIt() {
+        var service = TestRunHeartRateDiagnosticService()
+        service.start(runID: runID, at: startedAt)
+        service.collectionStarted(expectedRunID: runID, at: startedAt)
+
+        XCTAssertFalse(service.timeoutIfNeeded(
+            expectedRunID: runID,
+            now: startedAt.addingTimeInterval(29.9)
+        ))
+        XCTAssertTrue(service.timeoutIfNeeded(
+            expectedRunID: runID,
+            now: startedAt.addingTimeInterval(30)
+        ))
+        service.receive(
+            observation(bpm: 130, measuredAt: startedAt.addingTimeInterval(31)),
+            expectedRunID: UUID(),
+            now: startedAt.addingTimeInterval(31),
+            freshnessLimit: 7
+        )
+
+        let snapshot = service.snapshot(now: startedAt.addingTimeInterval(31), freshnessLimit: 7)
+        XCTAssertEqual(snapshot.phase, .failed)
+        XCTAssertEqual(snapshot.terminalReason, .timeout)
+        XCTAssertEqual(snapshot.receivedSampleCount, 0)
+    }
+
+    func testCompletionAndCancellationKeepCountersForReport() {
+        var service = TestRunHeartRateDiagnosticService()
+        service.start(runID: runID, at: startedAt)
+        service.collectionStarted(expectedRunID: runID, at: startedAt)
+        service.receive(
+            observation(bpm: 126, measuredAt: startedAt.addingTimeInterval(1)),
+            expectedRunID: runID,
+            now: startedAt.addingTimeInterval(1),
+            freshnessLimit: 7
+        )
+        service.finish(expectedRunID: runID, reason: .testRunCompleted)
+        service.providerDiscarded(expectedRunID: runID)
+
+        let completed = service.snapshot(now: startedAt.addingTimeInterval(85), freshnessLimit: 7)
+        XCTAssertEqual(completed.phase, .completed)
+        XCTAssertEqual(completed.providerState, "idle_discarded")
+        XCTAssertEqual(completed.qualifyingSampleCount, 1)
+
+        let secondRunID = UUID()
+        service.start(runID: secondRunID, at: startedAt.addingTimeInterval(100))
+        service.finish(expectedRunID: secondRunID, reason: .appInactive)
+        XCTAssertEqual(
+            service.snapshot(now: startedAt.addingTimeInterval(101), freshnessLimit: 7).phase,
+            .cancelled
+        )
+    }
+
+    private func observation(
+        bpm: Int,
+        measuredAt: Date,
+        receivedAt: Date? = nil
+    ) -> NativeHeartRatePreflightEngine.Observation {
+        NativeHeartRatePreflightEngine.Observation(
+            source: .nativeHealthKit,
+            beatsPerMinute: bpm,
+            measuredAt: measuredAt,
+            receivedAt: receivedAt ?? measuredAt
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Run a native HealthKit heart-rate diagnostic probe alongside the existing treadmill Test Run without making HR a motion requirement.
- Bind every observation, failure, finish, and discard action to the exact diagnostic run, provider generation, and provider identity, so delayed callbacks from an older attempt cannot mutate or tear down a newer attempt.
- Reuse production `NativeHeartRatePreflightEngine.Observation.isQualifying` as the authoritative qualification gate while reporting callback-observed time, proven provider identity (or explicit `unavailable`), display-fresh/start-qualified/rejected counters, grouped rejection counts, and first qualifying-sample latency from acquisition start.
- Discard the temporary HealthKit workout on completion, cancellation, inactivity, connection invalidation, provider failure, or first-sample timeout; no workout history or Telemetry V2 records are created.

Closes #101

## Verification

- `swift test --filter '(NativeHeartRatePreflightIntegrationContractTests|TestRunHeartRateDiagnostic|TreadmillTestRunServiceTests)'` — passed, 33 tests.
- `swift test` — passed; all test suites completed with zero failures. The 1000-hour gate profile remained intentionally skipped unless `TELEMETRY_GATE_PROFILE=full` is set.
- `xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' -derivedDataPath /tmp/issue101-derived-data CODE_SIGNING_ALLOWED=NO build` — passed.
- `git diff --check` — passed.
- Physical treadmill, iPhone HealthKit authorization, and live heart-rate sample acquisition were not run in this environment.

## Risks / Notes

- Production HR qualification and safety semantics remain unchanged; the diagnostic only observes the existing production qualification result.
- The treadmill action sequence and timing are unchanged; the diagnostic starts only after the first treadmill action is issued and cannot send motion commands.
- Provider/device identity is never inferred: the report shows the provider-native identifier only when supplied, otherwise `unavailable`.
- No migrations, configuration changes, deployment steps, backward-compatibility changes, or special rollback steps. Reverting the two PR commits removes the diagnostic path.
