### PR TITLE
Surface raw controller units evidence in Debug

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -6980,6 +6980,17 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         )
     }
 
+    func controllerUnitsDiagnosticSnapshot(
+        now: Date = Date()
+    ) -> ControllerUnitsDiagnosticSnapshot {
+        ControllerUnitsDiagnosticSnapshot.capture(
+            truth: controllerUnitsTruth,
+            currentConnectionEpoch: controllerUnitsConnectionEpoch,
+            now: now,
+            requiresFreshMetricTruth: controllerUnitsTruthRequired
+        )
+    }
+
     private func controllerUnitsTelemetryFields(
         action: String,
         now: Date = Date(),

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -4271,6 +4271,7 @@ private struct DebugView: View {
 
     private var trainingLogsCardPresentation: DebugTrainingLogsCard.Presentation {
         let entries = manager.telemetryV2WorkoutHistory
+        let controllerUnitsDiagnostic = manager.controllerUnitsDiagnosticSnapshot()
         let heartRateDiagnostic = manager.treadmillTestRunHeartRateDiagnosticSnapshot
         let readReady = manager.telemetryV2WorkoutHistoryState == .loaded
         let readStatusText: String = {
@@ -4312,6 +4313,16 @@ private struct DebugView: View {
             testRunActive: manager.treadmillTestRunIsActive,
             testRunStatusText: manager.treadmillTestRunDisplayText,
             canStartTestRun: manager.canStartTreadmillTestRun,
+            controllerUnitsDiagnosticStatusText: controllerUnitsDiagnosticStatusText(
+                controllerUnitsDiagnostic
+            ),
+            controllerUnitsDiagnosticMetrics: controllerUnitsDiagnosticMetrics(
+                controllerUnitsDiagnostic
+            ),
+            controllerUnitsDiagnosticDetailLines: controllerUnitsDiagnosticDetailLines(
+                controllerUnitsDiagnostic
+            ),
+            controllerUnitsDiagnosticReport: controllerUnitsDiagnostic.reportText,
             heartRateDiagnosticStatusText: testRunHeartRateDiagnosticStatusText(
                 heartRateDiagnostic
             ),
@@ -4349,6 +4360,66 @@ private struct DebugView: View {
                 ? "Для анализа лучше накопить хотя бы 3 завершённые тренировки."
                 : nil
         )
+    }
+
+    private func controllerUnitsDiagnosticStatusText(
+        _ snapshot: ControllerUnitsDiagnosticSnapshot
+    ) -> String {
+        let context = snapshot.isCurrentConnection ? "current connection" : "no current evidence"
+        let gate = snapshot.gateAllowed ? "gate allowed" : "gate blocked"
+        return "\(context) · \(gate)"
+    }
+
+    private func controllerUnitsDiagnosticMetrics(
+        _ snapshot: ControllerUnitsDiagnosticSnapshot
+    ) -> [DebugTrainingLogsCard.Presentation.Metric] {
+        let age = snapshot.ageSeconds.map { String(format: "%.1f s", $0) } ?? "—"
+        return [
+            .init(
+                id: "units_status",
+                title: "Status",
+                value: snapshot.status.rawValue,
+                tint: snapshot.status == .valid ? .green : .orange
+            ),
+            .init(
+                id: "units_value",
+                title: "Units",
+                value: snapshot.units.rawValue,
+                tint: snapshot.units == .metric ? .green : .orange
+            ),
+            .init(id: "units_age", title: "Age", value: age, tint: .secondary),
+            .init(
+                id: "units_fresh",
+                title: "Fresh",
+                value: snapshot.isFresh ? "yes" : "no",
+                tint: snapshot.isFresh ? .green : .orange
+            ),
+            .init(
+                id: "units_gate",
+                title: "Test Run gate",
+                value: snapshot.gateAllowed ? "allowed" : "blocked",
+                tint: snapshot.gateAllowed ? .green : .red
+            ),
+            .init(
+                id: "units_bytes",
+                title: "A6 bytes",
+                value: snapshot.byteCount.map(String.init) ?? "—",
+                tint: .blue
+            ),
+        ]
+    }
+
+    private func controllerUnitsDiagnosticDetailLines(
+        _ snapshot: ControllerUnitsDiagnosticSnapshot
+    ) -> [String] {
+        [
+            "observed_at: \(testRunHeartRateDiagnosticDate(snapshot.observedAt))",
+            "block_reason: \(snapshot.blockReason?.rawValue ?? "none")",
+            "current_connection_context: \(snapshot.isCurrentConnection)",
+            "evidence_connection_epoch: \(snapshot.evidenceConnectionEpoch?.uuidString ?? "unavailable")",
+            "current_connection_epoch: \(snapshot.currentConnectionEpoch?.uuidString ?? "unavailable")",
+            "raw_hex: \(snapshot.rawHex ?? "unavailable")",
+        ]
     }
 
     private func testRunHeartRateDiagnosticStatusText(

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ControllerUnitsSafetyPolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ControllerUnitsSafetyPolicy.swift
@@ -121,6 +121,91 @@ struct ControllerUnitsGateDecision: Equatable {
     let ageSeconds: TimeInterval?
 }
 
+struct ControllerUnitsDiagnosticSnapshot: Equatable {
+    let status: ControllerUnitsTruthStatus
+    let units: ControllerUnits
+    let observedAt: Date?
+    let ageSeconds: TimeInterval?
+    let isFresh: Bool
+    let gateAllowed: Bool
+    let blockReason: ControllerUnitsBlockReason?
+    let evidenceConnectionEpoch: UUID?
+    let currentConnectionEpoch: UUID?
+    let isCurrentConnection: Bool
+    let rawHex: String?
+    let byteCount: Int?
+
+    static func capture(
+        truth: ControllerUnitsTruth,
+        currentConnectionEpoch: UUID?,
+        now: Date,
+        requiresFreshMetricTruth: Bool
+    ) -> ControllerUnitsDiagnosticSnapshot {
+        let decision = ControllerUnitsSafetyPolicy.evaluate(
+            path: .testRun,
+            state: truth,
+            currentConnectionEpoch: currentConnectionEpoch,
+            now: now,
+            requiresFreshMetricTruth: requiresFreshMetricTruth
+        )
+        let isCurrentConnection = currentConnectionEpoch != nil
+            && truth.connectionEpoch == currentConnectionEpoch
+        let currentRawHex = isCurrentConnection ? truth.rawHex : nil
+        let currentObservedAt = isCurrentConnection ? truth.observedAt : nil
+        let age = isCurrentConnection ? truth.age(at: now) : nil
+        let isFresh = isCurrentConnection
+            && truth.status == .valid
+            && (age.map { $0 <= ControllerUnitsSafetyPolicy.freshnessInterval } ?? false)
+        return ControllerUnitsDiagnosticSnapshot(
+            status: isCurrentConnection ? truth.status : .notRead,
+            units: isCurrentConnection ? truth.units : .unknown,
+            observedAt: currentObservedAt,
+            ageSeconds: age,
+            isFresh: isFresh,
+            gateAllowed: decision.allowed,
+            blockReason: decision.blockReason,
+            evidenceConnectionEpoch: truth.connectionEpoch,
+            currentConnectionEpoch: currentConnectionEpoch,
+            isCurrentConnection: isCurrentConnection,
+            rawHex: currentRawHex,
+            byteCount: currentRawHex.flatMap(byteCount),
+        )
+    }
+
+    var reportText: String {
+        let formatter = ISO8601DateFormatter()
+        let observed = observedAt.map(formatter.string(from:)) ?? "unavailable"
+        let age = ageSeconds.map { String(format: "%.3f", $0) } ?? "unavailable"
+        return [
+            "WalkingPad controller units diagnostic",
+            "status: \(status.rawValue)",
+            "units: \(units.rawValue)",
+            "observed_at: \(observed)",
+            "age_s: \(age)",
+            "freshness_limit_s: \(Int(ControllerUnitsSafetyPolicy.freshnessInterval))",
+            "fresh: \(isFresh)",
+            "test_run_gate_allowed: \(gateAllowed)",
+            "block_reason: \(blockReason?.rawValue ?? "none")",
+            "evidence_connection_epoch: \(evidenceConnectionEpoch?.uuidString ?? "unavailable")",
+            "current_connection_epoch: \(currentConnectionEpoch?.uuidString ?? "unavailable")",
+            "current_connection_context: \(isCurrentConnection)",
+            "byte_count: \(byteCount.map(String.init) ?? "unavailable")",
+            "raw_hex: \(rawHex ?? "unavailable")",
+        ].joined(separator: "\n")
+    }
+
+    private static func byteCount(_ rawHex: String) -> Int? {
+        let tokens = rawHex.split(whereSeparator: \.isWhitespace)
+        guard !tokens.isEmpty,
+              tokens.allSatisfy({ token in
+                  token.count == 2 && token.allSatisfy(\.isHexDigit)
+              }) else {
+            return nil
+        }
+        return tokens.count
+    }
+}
+
 enum ControllerUnitsRefreshTrigger: String, Equatable {
     case connectionReady = "connection_ready"
     case gateBlockedAuto = "gate_blocked_auto"

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DebugTrainingLogsCard.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DebugTrainingLogsCard.swift
@@ -18,6 +18,10 @@ struct DebugTrainingLogsCard: View {
         let testRunActive: Bool
         let testRunStatusText: String
         let canStartTestRun: Bool
+        let controllerUnitsDiagnosticStatusText: String
+        let controllerUnitsDiagnosticMetrics: [Metric]
+        let controllerUnitsDiagnosticDetailLines: [String]
+        let controllerUnitsDiagnosticReport: String
         let heartRateDiagnosticStatusText: String
         let heartRateDiagnosticMetrics: [Metric]
         let heartRateDiagnosticDetailLines: [String]
@@ -79,6 +83,40 @@ struct DebugTrainingLogsCard: View {
                     }
                     .buttonStyle(.plain)
                     .disabled(!presentation.testRunActive && !presentation.canStartTestRun)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Controller units diagnostic")
+                            .font(.caption.weight(.medium))
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        ShareLink(item: presentation.controllerUnitsDiagnosticReport) {
+                            Label("Report", systemImage: "square.and.arrow.up")
+                                .font(.caption.weight(.semibold))
+                        }
+                    }
+
+                    Text(presentation.controllerUnitsDiagnosticStatusText)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    metricsSection(
+                        title: "A6 controller params",
+                        items: presentation.controllerUnitsDiagnosticMetrics
+                    )
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(
+                            Array(presentation.controllerUnitsDiagnosticDetailLines.enumerated()),
+                            id: \.offset
+                        ) { _, line in
+                            Text(line)
+                                .font(.system(.caption2, design: .monospaced))
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .textSelection(.enabled)
                 }
 
                 if !presentation.heartRateDiagnosticMetrics.isEmpty {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsReadOnlyContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsReadOnlyContractTests.swift
@@ -26,4 +26,79 @@ final class ControllerUnitsReadOnlyContractTests: XCTestCase {
             }
         }
     }
+
+    func testDebugDiagnosticIsShareableAndDoesNotBecomeControlAuthority() throws {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let sourceDirectory = testsDirectory.deletingLastPathComponent().appendingPathComponent(
+            "WalkingPadRemote"
+        )
+        let manager = try String(
+            contentsOf: sourceDirectory.appendingPathComponent("BluetoothManager.swift"),
+            encoding: .utf8
+        )
+        let content = try String(
+            contentsOf: sourceDirectory.appendingPathComponent("ContentView.swift"),
+            encoding: .utf8
+        )
+        let card = try String(
+            contentsOf: sourceDirectory.appendingPathComponent("DebugTrainingLogsCard.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertEqual(
+            manager.components(separatedBy: "ControllerUnitsDiagnosticSnapshot").count - 1,
+            2
+        )
+        XCTAssertTrue(content.contains("manager.controllerUnitsDiagnosticSnapshot()"))
+        XCTAssertTrue(card.contains("ShareLink(item: presentation.controllerUnitsDiagnosticReport)"))
+        XCTAssertTrue(card.contains("presentation.controllerUnitsDiagnosticDetailLines"))
+
+        for controlSignature in [
+            "func startTreadmillTestRun()",
+            "private func controllerUnitsGateDecision(",
+            "private func commitNativeHeartRatePreflight(",
+        ] {
+            let body = try functionBody(controlSignature, in: manager)
+            XCTAssertFalse(body.contains("ControllerUnitsDiagnostic"))
+        }
+    }
+
+    func testControllerParamsParserContractRemainsExactAndUnchanged() throws {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let codec = try String(
+            contentsOf: testsDirectory
+                .deletingLastPathComponent()
+                .appendingPathComponent("WalkingPadRemote/BLETransportCodec.swift"),
+            encoding: .utf8
+        )
+        let parser = try functionBody(
+            "static func parseWalkingPadParams(_ data: Data)",
+            in: codec
+        )
+
+        XCTAssertTrue(parser.contains("data.count == 16"))
+        XCTAssertTrue(parser.contains("data[0] == 0xF8"))
+        XCTAssertTrue(parser.contains("data[1] == 0xA6"))
+        XCTAssertTrue(parser.contains("data[15] == 0xFD"))
+    }
+
+    private func functionBody(_ signature: String, in source: String) throws -> String {
+        guard let signatureRange = source.range(of: signature),
+              let openingBrace = source[signatureRange.upperBound...].firstIndex(of: "{") else {
+            throw NSError(domain: "ControllerUnitsReadOnlyContractTests", code: 1)
+        }
+        var depth = 0
+        var index = openingBrace
+        while index < source.endIndex {
+            switch source[index] {
+            case "{": depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 { return String(source[openingBrace...index]) }
+            default: break
+            }
+            index = source.index(after: index)
+        }
+        throw NSError(domain: "ControllerUnitsReadOnlyContractTests", code: 2)
+    }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsSafetyPolicyTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsSafetyPolicyTests.swift
@@ -272,6 +272,97 @@ final class ControllerUnitsSafetyPolicyTests: XCTestCase {
         ))
     }
 
+    func testMalformedDiagnosticKeepsRawEvidenceByteCountAndBlockedGate() {
+        let rawHex = "F8 A6 08 00 3C 00 00 00 14 00 00 00 00 00 5E"
+        var tracker = ControllerUnitsTruthTracker()
+        tracker.beginConnection(epoch: epoch)
+        tracker.recordMalformed(rawHex: rawHex, for: epoch, at: now.addingTimeInterval(-2))
+
+        let snapshot = ControllerUnitsDiagnosticSnapshot.capture(
+            truth: tracker.state,
+            currentConnectionEpoch: epoch,
+            now: now,
+            requiresFreshMetricTruth: true
+        )
+
+        XCTAssertEqual(snapshot.status, .malformed)
+        XCTAssertEqual(snapshot.units, .unknown)
+        XCTAssertEqual(snapshot.ageSeconds, 2)
+        XCTAssertFalse(snapshot.isFresh)
+        XCTAssertFalse(snapshot.gateAllowed)
+        XCTAssertEqual(snapshot.blockReason, .malformed)
+        XCTAssertTrue(snapshot.isCurrentConnection)
+        XCTAssertEqual(snapshot.rawHex, rawHex)
+        XCTAssertEqual(snapshot.byteCount, 15)
+        XCTAssertTrue(snapshot.reportText.contains("byte_count: 15"))
+        XCTAssertTrue(snapshot.reportText.contains("raw_hex: \(rawHex)"))
+    }
+
+    func testValidDiagnosticKeepsEvidenceWithoutChangingGateBehavior() {
+        let rawHex = "F8 A6 08 00 3C 00 00 00 14 00 00 00 00 00 5E FD"
+        var tracker = ControllerUnitsTruthTracker()
+        tracker.beginConnection(epoch: epoch)
+        tracker.record(
+            BLETransportCodec.WalkingPadParams(
+                maxSpeedRawTenths: 60,
+                startSpeedRawTenths: 20,
+                rawControllerUnit: 0,
+                checksumOk: true,
+                rawHex: rawHex
+            ),
+            for: epoch,
+            at: now.addingTimeInterval(-1)
+        )
+
+        let snapshot = ControllerUnitsDiagnosticSnapshot.capture(
+            truth: tracker.state,
+            currentConnectionEpoch: epoch,
+            now: now,
+            requiresFreshMetricTruth: true
+        )
+        let existingDecision = evaluate(path: .testRun, state: tracker.state)
+
+        XCTAssertEqual(snapshot.status, .valid)
+        XCTAssertEqual(snapshot.units, .metric)
+        XCTAssertTrue(snapshot.isFresh)
+        XCTAssertEqual(snapshot.gateAllowed, existingDecision.allowed)
+        XCTAssertEqual(snapshot.blockReason, existingDecision.blockReason)
+        XCTAssertEqual(snapshot.rawHex, rawHex)
+        XCTAssertEqual(snapshot.byteCount, 16)
+    }
+
+    func testPriorEpochDiagnosticCannotExposeRawEvidenceAsCurrent() {
+        let priorRawHex = "F8 A6 08 00 3C 00 00 00 14 00 00 00 00 00 5E FD"
+        let priorTruth = ControllerUnitsTruth(
+            connectionEpoch: epoch,
+            units: .metric,
+            status: .valid,
+            observedAt: now.addingTimeInterval(-1),
+            rawHex: priorRawHex
+        )
+        let currentEpoch = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+
+        let snapshot = ControllerUnitsDiagnosticSnapshot.capture(
+            truth: priorTruth,
+            currentConnectionEpoch: currentEpoch,
+            now: now,
+            requiresFreshMetricTruth: true
+        )
+
+        XCTAssertFalse(snapshot.isCurrentConnection)
+        XCTAssertEqual(snapshot.status, .notRead)
+        XCTAssertEqual(snapshot.units, .unknown)
+        XCTAssertNil(snapshot.observedAt)
+        XCTAssertNil(snapshot.ageSeconds)
+        XCTAssertFalse(snapshot.isFresh)
+        XCTAssertFalse(snapshot.gateAllowed)
+        XCTAssertEqual(snapshot.blockReason, .notRead)
+        XCTAssertNil(snapshot.rawHex)
+        XCTAssertNil(snapshot.byteCount)
+        XCTAssertTrue(snapshot.reportText.contains("current_connection_context: false"))
+        XCTAssertTrue(snapshot.reportText.contains("raw_hex: unavailable"))
+    }
+
     private func evaluate(
         path: ControllerAutomatedMotionPath = .hrControl,
         state: ControllerUnitsTruth


### PR DESCRIPTION
## Summary

- Surface current connection-scoped controller-units evidence in the existing Debug/Test Run card: status, interpreted units, age/freshness, gate result, block reason, byte count, raw A6 hex, and connection epochs.
- Add a shareable diagnostic report while suppressing prior-epoch evidence from the current connection view.
- Preserve the existing parser, checksum and units mapping, 30-second freshness policy, and fail-closed motion gates.

Closes #105

## Verification

- `swift test` — passed; 360 core tests plus the additional telemetry suites, with the configured 1000-hour full-profile benchmark skipped as designed.
- `swift run --quiet telemetry-soak --minutes 2 --hr-ms 1000 --treadmill-ms 1000 --burst-every-seconds 30 --burst-native-records 32 --flush-every-seconds 5` plus CI assertions — passed with no losses or queued frames.
- `xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' -derivedDataPath /tmp/issue105-derived-data CODE_SIGNING_ALLOWED=NO build` — passed for iOS/watchOS.
- `xcodebuild -list -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj` — passed.
- `python3 scripts/check_codex_governance.py` — passed.
- `python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py` — passed.
- `git diff --check HEAD^ HEAD` — passed.
- Physical-device, BLE, and deployment validation were not run, per issue scope.

## Risks / Notes

- The new surface is diagnostic-only and derives its gate result from the existing authoritative safety policy; it cannot authorize Test Run or HR-control motion.
- No parser, checksum, controller-units mapping, freshness, command, Stop/cooldown, BLE, HealthKit, or Telemetry V2 behavior changed.
- No migrations, configuration changes, deployment steps, or backward-compatibility impact. Rollback is a revert of this single commit.
