### PR TITLE
Correct A6 controller-units parsing from physical evidence

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BLETransportCodec.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BLETransportCodec.swift
@@ -97,10 +97,16 @@ enum BLETransportCodec {
     }
 
     static func parseWalkingPadParams(_ data: Data) -> WalkingPadParams? {
-        guard data.count == 16,
-              data[0] == 0xF8,
+        switch data.count {
+        case 16, 20:
+            break
+        default:
+            return nil
+        }
+
+        guard data[0] == 0xF8,
               data[1] == 0xA6,
-              data[15] == 0xFD else {
+              data[data.count - 1] == 0xFD else {
             return nil
         }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BLETransportCodecParamsTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BLETransportCodecParamsTests.swift
@@ -19,6 +19,21 @@ final class BLETransportCodecParamsTests: XCTestCase {
         XCTAssertEqual(params?.startSpeedRawTenths, 0x14)
     }
 
+    func testParsesExactPhysicalTwentyByteMetricResponse() {
+        let frame = Data([
+            0xF8, 0xA6, 0x00, 0x00, 0x00, 0x00, 0x00, 0x78, 0x08, 0x00,
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x28, 0xFD,
+        ])
+
+        let params = BLETransportCodec.parseWalkingPadParams(frame)
+
+        XCTAssertEqual(params?.rawControllerUnit, 0)
+        XCTAssertEqual(params?.checksumOk, true)
+        XCTAssertEqual(params?.maxSpeedRawTenths, 0x78)
+        XCTAssertEqual(params?.startSpeedRawTenths, 0x08)
+        XCTAssertEqual(params?.rawHex, "F8 A6 00 00 00 00 00 78 08 00 02 00 00 00 00 00 00 00 28 FD")
+    }
+
     func testParsesValidImperialResponse() {
         let params = BLETransportCodec.parseWalkingPadParams(frame(unit: 1))
 
@@ -42,6 +57,27 @@ final class BLETransportCodecParamsTests: XCTestCase {
         XCTAssertEqual(params?.checksumOk, false)
     }
 
+    func testTwentyByteResponsePreservesImperialAndUnknownUnitEvidence() {
+        XCTAssertEqual(
+            BLETransportCodec.parseWalkingPadParams(physicalFrame(unit: 1))?.rawControllerUnit,
+            1
+        )
+        XCTAssertEqual(
+            BLETransportCodec.parseWalkingPadParams(physicalFrame(unit: 2))?.rawControllerUnit,
+            2
+        )
+    }
+
+    func testRejectsTwentyByteResponseWithWrongHeaderOrTerminator() {
+        var wrongHeader = [UInt8](physicalFrame(unit: 0))
+        wrongHeader[1] = 0xA2
+        XCTAssertNil(BLETransportCodec.parseWalkingPadParams(Data(wrongHeader)))
+
+        var wrongTerminator = [UInt8](physicalFrame(unit: 0))
+        wrongTerminator[19] = 0x00
+        XCTAssertNil(BLETransportCodec.parseWalkingPadParams(Data(wrongTerminator)))
+    }
+
     func testRejectsMalformedFramesAndMissingTerminator() {
         XCTAssertNil(BLETransportCodec.parseWalkingPadParams(Data([0xF8, 0xA6])))
         XCTAssertNil(BLETransportCodec.parseWalkingPadParams(Data([0xF8, 0xA2] + Array(repeating: 0, count: 14))))
@@ -53,6 +89,17 @@ final class BLETransportCodecParamsTests: XCTestCase {
         var extraByte = [UInt8](frame(unit: 0))
         extraByte.append(0x00)
         XCTAssertNil(BLETransportCodec.parseWalkingPadParams(Data(extraByte)))
+
+        for unsupportedLength in [14, 15, 17, 18, 19, 21, 24] {
+            var unsupported = Array(repeating: UInt8(0), count: unsupportedLength)
+            unsupported[0] = 0xF8
+            unsupported[1] = 0xA6
+            unsupported[unsupportedLength - 1] = 0xFD
+            XCTAssertNil(
+                BLETransportCodec.parseWalkingPadParams(Data(unsupported)),
+                "Unexpectedly accepted A6 frame length \(unsupportedLength)"
+            )
+        }
     }
 
     func testParsesWalkingPadStatusRawEvidenceWithoutChangingUnits() {
@@ -85,6 +132,15 @@ final class BLETransportCodecParamsTests: XCTestCase {
             0x3C, 0x14, 0x01, 0x03, 0x7F, 0x00, unit, 0x00, 0xFD
         ]
         bytes[14] = UInt8(bytes[1..<14].reduce(UInt16(0)) { ($0 + UInt16($1)) & 0xFF })
+        return Data(bytes)
+    }
+
+    private func physicalFrame(unit: UInt8) -> Data {
+        var bytes: [UInt8] = [
+            0xF8, 0xA6, 0x00, 0x00, 0x00, 0x00, 0x00, 0x78, 0x08, 0x00,
+            0x02, 0x00, 0x00, unit, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFD,
+        ]
+        bytes[18] = UInt8(bytes[1..<18].reduce(UInt16(0)) { ($0 + UInt16($1)) & 0xFF })
         return Data(bytes)
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsReadOnlyContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsReadOnlyContractTests.swift
@@ -63,7 +63,7 @@ final class ControllerUnitsReadOnlyContractTests: XCTestCase {
         }
     }
 
-    func testControllerParamsParserContractRemainsExactAndUnchanged() throws {
+    func testControllerParamsParserContractAcceptsOnlyProvenShapes() throws {
         let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
         let codec = try String(
             contentsOf: testsDirectory
@@ -76,10 +76,12 @@ final class ControllerUnitsReadOnlyContractTests: XCTestCase {
             in: codec
         )
 
-        XCTAssertTrue(parser.contains("data.count == 16"))
+        XCTAssertTrue(parser.contains("case 16, 20:"))
+        XCTAssertTrue(parser.contains("default:\n            return nil"))
         XCTAssertTrue(parser.contains("data[0] == 0xF8"))
         XCTAssertTrue(parser.contains("data[1] == 0xA6"))
-        XCTAssertTrue(parser.contains("data[15] == 0xFD"))
+        XCTAssertTrue(parser.contains("data[data.count - 1] == 0xFD"))
+        XCTAssertTrue(parser.contains("rawControllerUnit: data[13]"))
     }
 
     private func functionBody(_ signature: String, in source: String) throws -> String {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsSafetyPolicyTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsSafetyPolicyTests.swift
@@ -14,6 +14,45 @@ final class ControllerUnitsSafetyPolicyTests: XCTestCase {
         }
     }
 
+    func testPhysicalTwentyByteMetricResponseAllowsBothCoveredAutomatedPaths() throws {
+        let frame = Data([
+            0xF8, 0xA6, 0x00, 0x00, 0x00, 0x00, 0x00, 0x78, 0x08, 0x00,
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x28, 0xFD,
+        ])
+        let params = try XCTUnwrap(BLETransportCodec.parseWalkingPadParams(frame))
+        var tracker = ControllerUnitsTruthTracker()
+        tracker.beginConnection(epoch: epoch)
+        tracker.record(params, for: epoch, at: now)
+
+        for path in ControllerAutomatedMotionPath.allCases {
+            let decision = evaluate(path: path, state: tracker.state)
+            XCTAssertTrue(decision.allowed, "Expected physical metric evidence to allow \(path.rawValue)")
+            XCTAssertNil(decision.blockReason)
+        }
+    }
+
+    func testTwentyByteUnknownAndInvalidChecksumResponsesFailClosedForBothPaths() throws {
+        let unknownBytes = [UInt8](physicalFrame(unit: 2))
+        var invalidChecksumBytes = [UInt8](physicalFrame(unit: 0))
+        invalidChecksumBytes[18] ^= 0x01
+
+        for (frame, expectedReason) in [
+            (Data(unknownBytes), ControllerUnitsBlockReason.unknown),
+            (Data(invalidChecksumBytes), ControllerUnitsBlockReason.invalidChecksum),
+        ] {
+            let params = try XCTUnwrap(BLETransportCodec.parseWalkingPadParams(frame))
+            var tracker = ControllerUnitsTruthTracker()
+            tracker.beginConnection(epoch: epoch)
+            tracker.record(params, for: epoch, at: now)
+
+            for path in ControllerAutomatedMotionPath.allCases {
+                let decision = evaluate(path: path, state: tracker.state)
+                XCTAssertFalse(decision.allowed)
+                XCTAssertEqual(decision.blockReason, expectedReason)
+            }
+        }
+    }
+
     func testFreshImperialBlocksBothCoveredAutomatedPaths() {
         for path in ControllerAutomatedMotionPath.allCases {
             let decision = evaluate(path: path, state: truth(units: .imperial))
@@ -408,5 +447,14 @@ final class ControllerUnitsSafetyPolicyTests: XCTestCase {
             checksumOk: true,
             rawHex: "F8 A6 ... FD"
         )
+    }
+
+    private func physicalFrame(unit: UInt8) -> Data {
+        var bytes: [UInt8] = [
+            0xF8, 0xA6, 0x00, 0x00, 0x00, 0x00, 0x00, 0x78, 0x08, 0x00,
+            0x02, 0x00, 0x00, unit, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFD,
+        ]
+        bytes[18] = UInt8(bytes[1..<18].reduce(UInt16(0)) { ($0 + UInt16($1)) & 0xFF })
+        return Data(bytes)
     }
 }


### PR DESCRIPTION
## Summary

- accept only the proven 16-byte and 20-byte WalkingPad A6 controller-params response shapes
- keep the existing header, terminator, penultimate additive checksum, and unit-offset validation
- add the exact physical 20-byte fixture plus fail-closed codec and automated-motion gate regressions

Closes #106

## Verification

- `swift test --filter 'BLETransportCodecParamsTests|ControllerUnitsSafetyPolicyTests|ControllerUnitsReadOnlyContractTests'` — 32 tests passed
- `cd ios/WalkingPadRemote/WalkingPadRemote && swift test` — passed
- `python3 scripts/check_codex_governance.py` — passed
- `python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py` — passed
- `git diff origin/main...HEAD --check` — passed
- unsigned `WalkingPadRemote` generic iOS build — passed
- unsigned `WalkingPadRemoteWatch Watch App` generic watchOS build — passed
- independent safety scope challenge — GO, no P0-P2 findings

## Risks / Notes

- No physical-device, BLE, treadmill, install, or launch action was performed.
- The 20-byte support is intentionally limited to the PM-approved shape contract and supplied physical fixture. Any other A6 length remains malformed and fail-closed.
- Invalid checksum, unknown units, imperial units, stale evidence, and prior-connection evidence remain blocked by the existing safety policy.
- No controller unit/preference write path was added.
