### PR TITLE
Preserve factual WalkingPad speed across workouts

### DIFF
--- a/docs/telemetry-v2/issue-33-post-workout-analysis.md
+++ b/docs/telemetry-v2/issue-33-post-workout-analysis.md
@@ -3,7 +3,7 @@
 Status: implemented Analyzer V1 contract.
 
 This document owns the concrete metric definitions and lifecycle for
-`workout-analyzer-v1`. The canonical evidence, causal, and safety rules remain
+`workout-analyzer-v1.1`. The canonical evidence, causal, and safety rules remain
 owned by the [data contract](data-contract.md),
 [treadmill truth contract](treadmill-truth-and-command-lifecycle.md), and
 [safety boundary](safety-boundary.md).
@@ -55,9 +55,24 @@ from covered-duration denominators and is never counted as zero, in-zone,
 error-free, stable, or recovered. Sample count is used only for event/evidence
 counts and distributions; it is never duration.
 
-Canonical frames participate in the deterministic evidence hash but not in V1
-metric timelines. They cannot create a native sample, factual speed, or hold,
-and cannot bridge or backfill a gap.
+The workout-level factual average speed uses the persisted one-second canonical
+frame ledger when frames are present. A second is covered only when that frame
+contains factual normalized speed and explicitly marks the referenced native
+observation fresh; a stale or missing frame remains uncovered. This is a
+materialized bounded hold of decoded factual evidence, not interpolation or a
+desired/commanded/estimated-speed fallback. Inputs without canonical frames use
+the existing native-observation five-second hold as a deterministic legacy
+fallback.
+
+The average is available only when this factual-speed coverage is at least 90%
+of the terminal session duration. This reuses Analyzer V1's accepted
+high-coverage boundary so a small startup slice cannot be presented as a
+representative full-workout average. Lower coverage keeps the average
+unavailable and `workout-session-summary-v2` exports covered seconds, uncovered
+seconds, the coverage ratio, the required ratio, and an explicit warning.
+Desired, commanded, controller-target, expected, and modeled speed never fill
+coverage. Canonical frames still cannot turn missing or non-factual native
+evidence into factual speed or bridge a missing frame.
 
 ## Data quality
 
@@ -167,9 +182,9 @@ unavailable because V1 has no typed persisted blocker evidence.
 
 Analyzer metadata includes:
 
-- analyzer version `workout-analyzer-v1`;
+- analyzer version `workout-analyzer-v1.1`;
 - detail schema version `1`;
-- metric definition `timestamp-hold-metrics-v1`;
+- metric definition `timestamp-hold-metrics-v2`;
 - accepted telemetry schema range `1.0.0...1.0.0`;
 - complete analyzer policy;
 - generation timestamp;
@@ -183,7 +198,9 @@ if its logical payload differs, persistence reports a conflict rather than
 overwriting evidence or the prior result.
 
 On store preparation, terminal sessions are scanned in deterministic session
-order and missing results are recomputed. Completed, incomplete, and cancelled
+order and results missing the current analyzer identity are recomputed. The
+version bump prevents a stored `workout-analyzer-v1` partial-speed result from
+being reused as the current result. Completed, incomplete, and cancelled
 sessions are eligible; created, running, and paused sessions are not. Analyzer
 failure is contained as an analysis failure and cannot change recorder
 finalization or product session completion.

--- a/docs/telemetry-v2/treadmill-truth-and-command-lifecycle.md
+++ b/docs/telemetry-v2/treadmill-truth-and-command-lifecycle.md
@@ -23,12 +23,21 @@ control, queueing, retry, units, HR, cooldown, Start, or stop behavior.
 - FE01 reports speed as native controller-unit tenths.
 - The raw tenths value is retained before the legacy `raw / 10` presentation and
   control conversion.
-- Physical km/h is produced only when the current connection epoch has fresh,
-  checksum-valid controller-unit truth.
-- Metric tenths normalize directly. Imperial tenths convert with 1 mile =
-  1.609344 km.
-- Unknown, not-read, stale, malformed, invalid-checksum, or old-epoch unit truth
-  retains the native evidence but produces no factual physical km/h.
+- Physical km/h is produced only when the current connection epoch has
+  checksum-valid metric controller-unit truth.
+- During an active HR-controlled workout and cooldown, the existing read-only
+  `A6 key=0` query refreshes unit truth on a 20-second cadence only in a proven
+  motion-idle window: the command queue is empty, no write is processing, the
+  existing WalkingPad write-spacing deadline has passed, and more than two
+  seconds remain before the next scheduled HR/cooldown motion decision.
+- If no such idle window exists, the query is skipped and factual telemetry may
+  degrade when unit truth reaches the existing 30-second limit. The query never
+  delays a scheduled motion write; high-priority Stop retains its existing queue
+  reset and spacing bypass. The motion gate remains independently unchanged and
+  a later Start still requires fresh unit evidence under the same fail-closed
+  rule.
+- Imperial, unknown, not-read, stale, malformed, invalid-checksum, or old-epoch
+  unit truth retains the native evidence but produces no factual physical km/h.
 - The callback exposes receive time, not device measurement time, so
   `measuredAt` is nil.
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryAnalysis/WorkoutAnalyzerV1.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryAnalysis/WorkoutAnalyzerV1.swift
@@ -10,8 +10,9 @@ public enum WorkoutAnalyzerError: Error, Equatable, Sendable {
 }
 
 public enum WorkoutAnalyzerV1 {
-    public static let analyzerVersion = AnalyzerVersion(rawValue: "workout-analyzer-v1")
-    public static let metricDefinitionVersion = "timestamp-hold-metrics-v1"
+    public static let analyzerVersion = AnalyzerVersion(rawValue: "workout-analyzer-v1.1")
+    public static let metricDefinitionVersion = "timestamp-hold-metrics-v2"
+    public static let minimumAverageFactualSpeedCoverageRatio = 0.9
 
     static func secondsDetail(_ seconds: Double) -> String {
         String(
@@ -82,13 +83,19 @@ public enum WorkoutAnalyzerV1 {
             connectionBoundaries: connectionTransitionBoundaries(input.events),
             freshnessSeconds: policy.treadmillFreshnessSeconds
         )
+        let factualSpeedMetric = FactualSpeedMetricTimeline(
+            frames: input.frames,
+            nativeFallback: treadmill,
+            sessionEnd: sessionEnd,
+            phaseTimeline: phaseTimeline
+        )
         let causal = CausalAnalysis(events: input.events)
         let quality = makeQuality(
             input: input,
             sessionEnd: sessionEnd,
             phases: phaseTimeline,
             heartRate: heartRate,
-            treadmill: treadmill,
+            factualSpeedMetric: factualSpeedMetric,
             causal: causal,
             configurationAvailable: configuration != nil
         )
@@ -130,7 +137,10 @@ public enum WorkoutAnalyzerV1 {
             return (lhs.detail ?? "") < (rhs.detail ?? "")
         }
         let weightedHeartRate = heartRate.weightedAverage(in: nil)
-        let weightedSpeed = treadmill.weightedAverage(in: nil)
+        let speedCoverage = quality.treadmillFactualCoverage.coverageRatio
+        let weightedSpeed = speedCoverage.map {
+            $0 >= minimumAverageFactualSpeedCoverageRatio
+        } == true ? factualSpeedMetric.weightedAverage(in: nil) : nil
         let identity = "\(input.session.sessionID.description)|\(analyzerVersion.rawValue)|\(hash.lowercaseHexDigest)"
         return WorkoutAnalysisResult(
             analysisID: AnalysisID(rawValue: deterministicUUID("analysis|\(identity)")),
@@ -546,6 +556,73 @@ private extension WorkoutAnalyzerV1 {
         }
 
         func clippedSegments(in range: Range<Double>?) -> [SpeedSegment] {
+            guard let range else { return segments }
+            return segments.compactMap { segment in
+                let start = max(segment.start, range.lowerBound)
+                let end = min(segment.end, range.upperBound)
+                guard end > start else { return nil }
+                return SpeedSegment(
+                    start: start,
+                    end: end,
+                    speed: segment.speed,
+                    phase: segment.phase
+                )
+            }
+        }
+    }
+
+    struct FactualSpeedMetricTimeline {
+        let segments: [SpeedSegment]
+
+        init(
+            frames: [CanonicalFrame],
+            nativeFallback: TreadmillTimeline,
+            sessionEnd: Double,
+            phaseTimeline: PhaseTimeline
+        ) {
+            guard !frames.isEmpty else {
+                segments = nativeFallback.segments
+                return
+            }
+            var seenSeconds: Set<Int64> = []
+            var built: [SpeedSegment] = []
+            for frame in frames.sorted(by: frameEvidenceOrder) {
+                guard seenSeconds.insert(frame.canonicalElapsedSecond).inserted,
+                      frame.canonicalElapsedSecond >= 0,
+                      let evidence = frame.treadmillEvidence,
+                      evidence.freshness == .fresh,
+                      let factual = evidence.factualSpeed else {
+                    continue
+                }
+                let start = min(sessionEnd, Double(frame.canonicalElapsedSecond))
+                let end = min(sessionEnd, start + 1)
+                guard end > start else { continue }
+                let boundaries = phaseTimeline.boundaries(in: start..<end)
+                let points = [start] + boundaries + [end]
+                for pair in zip(points, points.dropFirst()) where pair.1 > pair.0 {
+                    built.append(SpeedSegment(
+                        start: pair.0,
+                        end: pair.1,
+                        speed: factual.value,
+                        phase: phaseTimeline.phase(at: pair.0)
+                    ))
+                }
+            }
+            segments = built
+        }
+
+        func coveredSeconds(in range: Range<Double>?) -> Double {
+            clippedSegments(in: range).reduce(0) { $0 + $1.duration }
+        }
+
+        func weightedAverage(in range: Range<Double>?) -> Double? {
+            let clipped = clippedSegments(in: range)
+            let duration = clipped.reduce(0) { $0 + $1.duration }
+            guard duration > 0 else { return nil }
+            return clipped.reduce(0) { $0 + $1.speed * $1.duration } / duration
+        }
+
+        private func clippedSegments(in range: Range<Double>?) -> [SpeedSegment] {
             guard let range else { return segments }
             return segments.compactMap { segment in
                 let start = max(segment.start, range.lowerBound)
@@ -1133,12 +1210,12 @@ private extension WorkoutAnalyzerV1 {
         sessionEnd: Double,
         phases: PhaseTimeline,
         heartRate: HeartRateTimeline,
-        treadmill: TreadmillTimeline,
+        factualSpeedMetric: FactualSpeedMetricTimeline,
         causal: CausalAnalysis,
         configurationAvailable: Bool
     ) -> WorkoutDataQualityV1 {
         let heartRateCovered = heartRate.coveredSeconds(in: nil)
-        let treadmillCovered = treadmill.coveredSeconds(in: nil)
+        let treadmillCovered = factualSpeedMetric.coveredSeconds(in: nil)
         let hrCoverage = DurationCoverage(
             coveredSeconds: heartRateCovered,
             uncoveredSeconds: max(0, sessionEnd - heartRateCovered)
@@ -1265,6 +1342,20 @@ private extension WorkoutAnalyzerV1 {
                 detail: secondsDetail(treadmillCoverage.uncoveredSeconds)
             ))
         }
+        if treadmillCoverage.coverageRatio.map({
+            $0 < minimumAverageFactualSpeedCoverageRatio
+        }) ?? true {
+            let ratio = treadmillCoverage.coverageRatio ?? 0
+            issues.append(AnalysisQualityIssue(
+                category: .sourceCoverageUnavailable,
+                code: "average-factual-speed-insufficient-coverage",
+                detail: String(
+                    format: "coverage=%.6f required=%.6f",
+                    locale: Locale(identifier: "en_US_POSIX"),
+                    arguments: [ratio, minimumAverageFactualSpeedCoverageRatio]
+                )
+            ))
+        }
         if !configurationAvailable {
             issues.append(AnalysisQualityIssue(
                 category: .malformedCorruptEvidence,
@@ -1306,7 +1397,7 @@ private extension WorkoutAnalyzerV1 {
                 let range = interval.start..<interval.end
                 let duration = interval.end - interval.start
                 let hr = heartRate.coveredSeconds(in: range)
-                let speed = treadmill.coveredSeconds(in: range)
+                let speed = factualSpeedMetric.coveredSeconds(in: range)
                 let coverage = DurationCoverage(
                     coveredSeconds: hr,
                     uncoveredSeconds: max(0, duration - hr)

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/TreadmillTruth.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/TreadmillTruth.swift
@@ -98,6 +98,7 @@ public enum TreadmillObservationQualityFlag: String, Codable, Hashable, Sendable
     case invalidNativeValue
     case unitsNotRead
     case unitsUnknown
+    case unitsImperial
     case unitsStale
     case unitsMalformed
     case unitsInvalidChecksum
@@ -419,13 +420,14 @@ public struct TreadmillObservationNormalizer: Sendable {
                     quality.insert(.unitsStale)
                     return nil
                 }
-                let nativeUnit: TreadmillNativeSpeedUnit = unit == .milesPerHour
-                    ? .milesPerHour
-                    : .kilometresPerHour
+                guard unit == .kilometresPerHour else {
+                    quality.insert(.unitsImperial)
+                    return nil
+                }
                 return FactualSpeedKilometresPerHour.normalized(
                     from: NativeTreadmillSpeed(
                         value: nativeSpeed.scaledValue,
-                        unit: nativeUnit
+                        unit: .kilometresPerHour
                     ),
                     provenance: .decodedDeviceReport
                 )

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/WorkoutReadProjection.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/WorkoutReadProjection.swift
@@ -58,6 +58,25 @@ public struct WorkoutSpeedProjection: Codable, Hashable, Sendable {
     }
 }
 
+public struct WorkoutFactualSpeedCoverageProjection: Codable, Hashable, Sendable {
+    public let coveredSeconds: Double
+    public let uncoveredSeconds: Double
+    public let coverageRatio: Double?
+    public let requiredRatio: Double
+
+    public init(
+        coveredSeconds: Double,
+        uncoveredSeconds: Double,
+        coverageRatio: Double?,
+        requiredRatio: Double
+    ) {
+        self.coveredSeconds = coveredSeconds
+        self.uncoveredSeconds = uncoveredSeconds
+        self.coverageRatio = coverageRatio
+        self.requiredRatio = requiredRatio
+    }
+}
+
 public struct WorkoutProjectionQuality: Codable, Hashable, Sendable {
     public let lifecycleState: String
     public let recorderComplete: Bool?
@@ -113,6 +132,7 @@ public struct WorkoutHistoryProjection: Codable, Hashable, Identifiable, Sendabl
     public let algorithmVersion: String?
     public let analyzerVersion: String?
     public let quality: WorkoutProjectionQuality
+    public let factualSpeedCoverage: WorkoutFactualSpeedCoverageProjection?
 
     public init(
         id: String,
@@ -131,7 +151,8 @@ public struct WorkoutHistoryProjection: Codable, Hashable, Identifiable, Sendabl
         buildNumber: String?,
         algorithmVersion: String?,
         analyzerVersion: String?,
-        quality: WorkoutProjectionQuality
+        quality: WorkoutProjectionQuality,
+        factualSpeedCoverage: WorkoutFactualSpeedCoverageProjection? = nil
     ) {
         self.id = id
         self.origin = origin
@@ -150,6 +171,7 @@ public struct WorkoutHistoryProjection: Codable, Hashable, Identifiable, Sendabl
         self.algorithmVersion = algorithmVersion
         self.analyzerVersion = analyzerVersion
         self.quality = quality
+        self.factualSpeedCoverage = factualSpeedCoverage
     }
 }
 
@@ -301,7 +323,7 @@ public struct WorkoutExportManifestQuality: Codable, Hashable, Sendable {
 
 public struct WorkoutExportManifest: Codable, Hashable, Sendable {
     public static let formatVersion = "workout-export-manifest-v1"
-    public static let sessionSummaryVersion = "workout-session-summary-v1"
+    public static let sessionSummaryVersion = "workout-session-summary-v2"
 
     public let manifestVersion: String
     public let sessionSummaryVersion: String

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutExportStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutExportStore.swift
@@ -147,8 +147,8 @@ private final class WorkoutExportStream {
         directoryURL = root
         rawURL = root.appendingPathComponent("raw_evidence_v1.jsonl")
         normalizedURL = root.appendingPathComponent("normalized_evidence_v1.csv")
-        summaryJSONLURL = root.appendingPathComponent("session_summary_v1.jsonl")
-        summaryCSVURL = root.appendingPathComponent("session_summary_v1.csv")
+        summaryJSONLURL = root.appendingPathComponent("session_summary_v2.jsonl")
+        summaryCSVURL = root.appendingPathComponent("session_summary_v2.csv")
         manifestURL = root.appendingPathComponent("manifest.json")
 
         try FileManager.default.createDirectory(
@@ -179,7 +179,9 @@ private final class WorkoutExportStream {
             [
                 "summary_version", "id", "origin", "started_at", "ended_at",
                 "duration_s", "target_bpm", "average_hr_bpm", "average_speed_kmh",
-                "average_speed_evidence", "beats_per_metre", "zone_1_s", "zone_2_s",
+                "average_speed_evidence", "factual_speed_covered_s",
+                "factual_speed_uncovered_s", "factual_speed_coverage_ratio",
+                "factual_speed_required_ratio", "beats_per_metre", "zone_1_s", "zone_2_s",
                 "zone_3_s", "zone_4_s", "zone_5_s", "healthkit_workout_uuid",
                 "lifecycle_state", "recorder_complete", "analysis_grade",
                 "identity_status", "possible_duplicate", "adaptation_eligible",
@@ -231,6 +233,10 @@ private final class WorkoutExportStream {
                 Self.numberString(projection.averageHeartRate),
                 Self.numberString(projection.averageSpeed?.kilometresPerHour),
                 projection.averageSpeed?.evidenceKind.rawValue ?? "",
+                Self.numberString(projection.factualSpeedCoverage?.coveredSeconds),
+                Self.numberString(projection.factualSpeedCoverage?.uncoveredSeconds),
+                Self.numberString(projection.factualSpeedCoverage?.coverageRatio),
+                Self.numberString(projection.factualSpeedCoverage?.requiredRatio),
                 Self.numberString(projection.beatsPerMetre),
                 Self.numberString(zones[safe: 0] ?? nil),
                 Self.numberString(zones[safe: 1] ?? nil),

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutReadStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutReadStore.swift
@@ -692,6 +692,20 @@ private extension TelemetryStore {
                 provenance: "telemetry-v2-analysis-factual"
             )
         }
+        let factualSpeedCoverage = detail.map {
+            WorkoutFactualSpeedCoverageProjection(
+                coveredSeconds: $0.quality.treadmillFactualCoverage.coveredSeconds,
+                uncoveredSeconds: $0.quality.treadmillFactualCoverage.uncoveredSeconds,
+                coverageRatio: $0.quality.treadmillFactualCoverage.coverageRatio,
+                requiredRatio: WorkoutAnalyzerV1.minimumAverageFactualSpeedCoverageRatio
+            )
+        }
+        let factualSpeedCoverageWarnings: [String] = factualSpeedCoverage.flatMap { coverage in
+            guard coverage.coverageRatio.map({ $0 >= coverage.requiredRatio }) == true else {
+                return ["average-factual-speed-unavailable-insufficient-coverage"]
+            }
+            return []
+        } ?? []
         var unavailable: [String] = []
         if durationSeconds == nil { unavailable.append("duration") }
         if configuration?.targetHeartRate == nil { unavailable.append("targetHeartRate") }
@@ -738,7 +752,9 @@ private extension TelemetryStore {
                 unavailableMetrics: unavailable,
                 warnings: (model.incompleteReason.map { [$0] } ?? [])
                     + exactImportedHealthKitEvidence.warnings
-            )
+                    + factualSpeedCoverageWarnings
+            ),
+            factualSpeedCoverage: factualSpeedCoverage
         )
     }
 
@@ -936,8 +952,12 @@ private extension TelemetryStore {
     func latestAnalysisModel(
         sessionID: String
     ) throws -> TelemetryWorkoutAnalysisV1? {
+        let currentAnalyzerVersion = WorkoutAnalyzerV1.analyzerVersion.rawValue
         var descriptor = FetchDescriptor<TelemetryWorkoutAnalysisV1>(
-            predicate: #Predicate { $0.sessionID == sessionID },
+            predicate: #Predicate {
+                $0.sessionID == sessionID
+                    && $0.analyzerVersion == currentAnalyzerVersion
+            },
             sortBy: [
                 SortDescriptor(\.generatedAt, order: .reverse),
                 SortDescriptor(\.analysisID),

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryAnalysisTests/WorkoutAnalyzerV1Tests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryAnalysisTests/WorkoutAnalyzerV1Tests.swift
@@ -35,6 +35,123 @@ final class WorkoutAnalyzerV1Tests: XCTestCase {
         )
     }
 
+    func testTinyStartupFactualSpeedSliceCannotBecomeWorkoutAverage() throws {
+        let fixture = AnalysisFixture(sessionSeconds: 1_620)
+        let treadmill = stride(from: 0, through: 20, by: 5).enumerated().map {
+            fixture.treadmill(
+                ordinal: $0.offset + 1,
+                seconds: Double($0.element),
+                speed: Double(2 + $0.offset),
+                factual: true
+            )
+        }
+        let result = try WorkoutAnalyzerV1.analyze(
+            fixture.input(
+                treadmill: treadmill,
+                events: fixture.phaseEvents(mainAt: 0, finishedAt: 1_620)
+            ),
+            generatedAt: fixture.baseDate.addingTimeInterval(1_700)
+        )
+        let detail = try decodeDetail(result)
+
+        XCTAssertNil(result.keyMetrics.averageFactualSpeedKilometresPerHour)
+        XCTAssertEqual(
+            detail.quality.treadmillFactualCoverage.coveredSeconds,
+            25,
+            accuracy: 0.000_001
+        )
+        XCTAssertEqual(
+            detail.quality.treadmillFactualCoverage.coverageRatio!,
+            25.0 / 1_620.0,
+            accuracy: 0.000_001
+        )
+        XCTAssertTrue(detail.quality.issues.contains {
+            $0.code == "average-factual-speed-insufficient-coverage"
+                && $0.detail?.contains("required=0.900000") == true
+        })
+        XCTAssertTrue(result.exclusions.contains {
+            $0.code == "sourceCoverageUnavailable.average-factual-speed-insufficient-coverage"
+        })
+    }
+
+    func testAdequateFactualCoverageProducesNormalWorkoutAverage() throws {
+        let fixture = AnalysisFixture(sessionSeconds: 100)
+        let treadmill = stride(from: 0, through: 85, by: 5).enumerated().map {
+            fixture.treadmill(
+                ordinal: $0.offset + 1,
+                seconds: Double($0.element),
+                speed: $0.offset.isMultiple(of: 2) ? 4 : 6,
+                factual: true
+            )
+        }
+        let result = try WorkoutAnalyzerV1.analyze(
+            fixture.input(
+                treadmill: treadmill,
+                events: fixture.phaseEvents(mainAt: 0, finishedAt: 100)
+            ),
+            generatedAt: fixture.baseDate.addingTimeInterval(120)
+        )
+        let detail = try decodeDetail(result)
+
+        XCTAssertEqual(
+            detail.quality.treadmillFactualCoverage.coverageRatio!,
+            WorkoutAnalyzerV1.minimumAverageFactualSpeedCoverageRatio,
+            accuracy: 0.000_001
+        )
+        XCTAssertEqual(
+            result.keyMetrics.averageFactualSpeedKilometresPerHour!,
+            5,
+            accuracy: 0.000_001
+        )
+        XCTAssertFalse(detail.quality.issues.contains {
+            $0.code == "average-factual-speed-insufficient-coverage"
+        })
+    }
+
+    func testRealisticSparseSessionUsesFreshCanonicalCoverageAcrossCooldown() throws {
+        let sessionSeconds = 1_620
+        let fixture = AnalysisFixture(sessionSeconds: Double(sessionSeconds))
+        let spacing = Double(sessionSeconds) / 49.0
+        let treadmill = (0..<49).map { index in
+            fixture.treadmill(
+                ordinal: index + 1,
+                seconds: Double(index) * spacing,
+                speed: index < 40 ? 6 : 3,
+                factual: true
+            )
+        }
+        let frames = (0..<sessionSeconds).map { second -> CanonicalFrame in
+            let observationIndex = min(48, Int(Double(second) / spacing))
+            let observation = treadmill[observationIndex]
+            let age = Double(second) - Double(observationIndex) * spacing
+            return fixture.treadmillFrame(
+                observation: observation,
+                second: Int64(second),
+                freshness: age <= 30 ? .fresh : .stale
+            )
+        }
+        let result = try WorkoutAnalyzerV1.analyze(
+            fixture.input(
+                treadmill: treadmill,
+                events: fixture.cooldownEvents(start: 1_320, end: 1_620, target: 115),
+                frames: frames
+            ),
+            generatedAt: fixture.baseDate.addingTimeInterval(1_700)
+        )
+        let detail = try decodeDetail(result)
+
+        XCTAssertEqual(treadmill.count, 49)
+        XCTAssertGreaterThanOrEqual(
+            try XCTUnwrap(detail.quality.treadmillFactualCoverage.coverageRatio),
+            WorkoutAnalyzerV1.minimumAverageFactualSpeedCoverageRatio
+        )
+        XCTAssertNotNil(result.keyMetrics.averageFactualSpeedKilometresPerHour)
+        XCTAssertTrue(detail.quality.phases.allSatisfy {
+            ($0.treadmillCoverage.coverageRatio ?? 0)
+                >= WorkoutAnalyzerV1.minimumAverageFactualSpeedCoverageRatio
+        })
+    }
+
     func testDuplicateAndOutOfOrderNativeSamplesCannotChangeDurationMetrics() throws {
         let fixture = AnalysisFixture(sessionSeconds: 20)
         let heartRate = [
@@ -1946,6 +2063,40 @@ private struct AnalysisFixture {
             precedingGap: CanonicalGapBoundary(
                 missingSinceElapsedSecond: 7,
                 kind: .noObservation
+            )
+        )
+    }
+
+    func treadmillFrame(
+        observation: TreadmillObservation,
+        second: Int64,
+        freshness: FreshnessState
+    ) -> CanonicalFrame {
+        CanonicalFrame(
+            frameID: FrameID(rawValue: uuid(9_000 + Int(second))),
+            recordID: RecordID(rawValue: uuid(11_000 + Int(second))),
+            sessionID: session.sessionID,
+            canonicalElapsedSecond: second,
+            materializedAt: RecordTimestamp(
+                recordedAt: baseDate.addingTimeInterval(Double(second)),
+                elapsed: elapsed(Double(second))
+            ),
+            heartRateEvidence: nil,
+            treadmillEvidence: TreadmillFrameEvidence(
+                observationID: observation.observationID,
+                recordID: observation.recordID,
+                sourceID: observation.source.id,
+                nativeSpeed: observation.nativeSpeed,
+                factualSpeed: observation.factualSpeed,
+                deviceState: observation.deviceState,
+                measuredAt: observation.timestamp.measuredAt,
+                receivedAt: observation.timestamp.receivedAt,
+                evidenceElapsed: observation.timestamp.effectiveElapsed,
+                ageAtMaterialization: elapsed(
+                    max(0, Double(second) - observation.timestamp.effectiveElapsed.seconds)
+                ),
+                freshness: freshness,
+                provenance: observation.provenance
             )
         )
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/TreadmillTruthTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryDomainTests/TreadmillTruthTests.swift
@@ -36,7 +36,7 @@ final class TreadmillTruthTests: XCTestCase {
         XCTAssertEqual(evidence.connectionEpoch, epoch)
     }
 
-    func testWalkingPadImperialTruthNormalizesThroughExplicitPhysicalUnit() throws {
+    func testWalkingPadImperialTruthRemainsNativeAndNeverBecomesMetricFactualTruth() {
         let epoch = connectionEpoch(2)
         var normalizer = TreadmillObservationNormalizer()
         let evidence = normalizer.normalize(
@@ -57,12 +57,76 @@ final class TreadmillTruthTests: XCTestCase {
             recordedAt: recordedAt
         )
 
-        XCTAssertEqual(
-            try XCTUnwrap(evidence.factualSpeed).value,
-            2.5 * 1.609_344,
-            accuracy: 0.000_001
+        XCTAssertEqual(evidence.nativeSpeed?.scaledValue, 2.5)
+        XCTAssertNil(evidence.factualSpeed)
+        XCTAssertTrue(evidence.quality.contains(.unitsImperial))
+    }
+
+    func testWalkingPadRefreshedMetricTruthRetainsSparseFactualSpeedThroughCooldown() throws {
+        let epoch = connectionEpoch(20)
+        var normalizer = TreadmillObservationNormalizer()
+
+        for second in stride(from: 0, through: 1_860, by: 33) {
+            let observationAt = receivedAt.addingTimeInterval(TimeInterval(second))
+            let refreshSecond = second < 22 ? 0 : 22 + ((second - 22) / 20) * 20
+            let evidence = normalizer.normalize(
+                .walkingPad(
+                    speedRawTenths: min(97, 20 + (second % 78)),
+                    rawState: 1,
+                    deviceState: .moving,
+                    checksumValid: true,
+                    connectionEpoch: epoch,
+                    receivedAt: observationAt
+                ),
+                unitsTruth: .valid(
+                    unit: .kilometresPerHour,
+                    connectionEpoch: epoch,
+                    observedAt: receivedAt.addingTimeInterval(TimeInterval(refreshSecond))
+                ),
+                observationID: ObservationID(),
+                recordedAt: observationAt
+            )
+
+            XCTAssertNotNil(evidence.factualSpeed, "Expected factual speed at second \(second)")
+            XCTAssertFalse(evidence.quality.contains(.unitsStale))
+        }
+    }
+
+    func testWalkingPadStaleTruthNeedsNewValidEvidenceBeforeFactualSpeedReturns() throws {
+        let epoch = connectionEpoch(21)
+        let input = TreadmillProviderObservation.walkingPad(
+            speedRawTenths: 42,
+            rawState: 1,
+            deviceState: .moving,
+            checksumValid: true,
+            connectionEpoch: epoch,
+            receivedAt: receivedAt
         )
-        XCTAssertEqual(evidence.quality.values, [.missingMeasurementTime])
+        var normalizer = TreadmillObservationNormalizer()
+        let stale = normalizer.normalize(
+            input,
+            unitsTruth: .valid(
+                unit: .kilometresPerHour,
+                connectionEpoch: epoch,
+                observedAt: receivedAt.addingTimeInterval(-31)
+            ),
+            observationID: ObservationID(),
+            recordedAt: recordedAt
+        )
+        let refreshed = normalizer.normalize(
+            input,
+            unitsTruth: .valid(
+                unit: .kilometresPerHour,
+                connectionEpoch: epoch,
+                observedAt: receivedAt
+            ),
+            observationID: ObservationID(),
+            recordedAt: recordedAt
+        )
+
+        XCTAssertNil(stale.factualSpeed)
+        XCTAssertTrue(stale.quality.contains(.unitsStale))
+        XCTAssertEqual(try XCTUnwrap(refreshed.factualSpeed).value, 4.2, accuracy: 0.000_001)
     }
 
     func testWalkingPadUnknownStaleMalformedAndOldEpochTruthNeverNormalizes() {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryPostWorkoutAnalysisTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryPostWorkoutAnalysisTests.swift
@@ -94,6 +94,47 @@ final class TelemetryPostWorkoutAnalysisTests: XCTestCase {
         XCTAssertGreaterThan(detail.quality.heartRateCoverage.coveredSeconds, 0)
     }
 
+    func testCurrentAnalyzerDoesNotReuseLegacyPartialSpeedAnalysis() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = fixtureSession(seed: 42, lifecycle: .completed)
+        try await store.insertSession(session)
+        let legacy = TelemetryPersistenceFixtures.analysis(
+            seed: 42,
+            session: session,
+            version: "workout-analyzer-v1"
+        )
+        try await store.insertAnalysis(legacy)
+        let before = try await store.fetchWorkoutHistoryPage(
+            filter: WorkoutReadFilter(profileScope: .exact("profile-a")),
+            after: nil,
+            limit: 10
+        )
+        XCTAssertNil(before.items.first?.analyzerVersion)
+        XCTAssertNil(before.items.first?.averageSpeed)
+
+        let outcome = try await store.analyzeTerminalWorkout(
+            sessionID: session.sessionID,
+            generatedAt: session.endedAt!.addingTimeInterval(1)
+        )
+
+        XCTAssertEqual(outcome.triggerResult, .inserted)
+        XCTAssertEqual(outcome.analysis?.analyzerVersion, WorkoutAnalyzerV1.analyzerVersion)
+        XCTAssertNotEqual(outcome.analysis?.analysisID, legacy.analysisID)
+        let counts = try await store.counts()
+        let current = try await store.fetchAnalyses(
+            sessionID: session.sessionID,
+            analyzerVersion: WorkoutAnalyzerV1.analyzerVersion
+        )
+        let after = try await store.fetchWorkoutHistoryPage(
+            filter: WorkoutReadFilter(profileScope: .exact("profile-a")),
+            after: nil,
+            limit: 10
+        )
+        XCTAssertEqual(counts.analyses, 2)
+        XCTAssertEqual(current.count, 1)
+        XCTAssertEqual(after.items.first?.analyzerVersion, WorkoutAnalyzerV1.analyzerVersion.rawValue)
+    }
+
     func testResumeAnalyzesEveryPendingTerminalSessionWithoutDuplicatingExistingResult() async throws {
         let store = try TelemetryStoreFactory.make(.inMemory)
         let complete = fixtureSession(seed: 50, lifecycle: .completed)

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryWorkoutReadAndExportTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/TelemetryWorkoutReadAndExportTests.swift
@@ -271,7 +271,7 @@ final class TelemetryWorkoutReadAndExportTests: XCTestCase {
                 analysisID: AnalysisID(rawValue: uuid(810_001)),
                 recordID: RecordID(rawValue: uuid(810_002)),
                 sessionID: storedSession.sessionID,
-                analyzerVersion: AnalyzerVersion(rawValue: "low-quality-fixture"),
+                analyzerVersion: WorkoutAnalyzerV1.analyzerVersion,
                 evidenceHash: ContentHash(
                     algorithm: .sha256,
                     lowercaseHexDigest: String(repeating: "d", count: 64)
@@ -302,6 +302,94 @@ final class TelemetryWorkoutReadAndExportTests: XCTestCase {
         XCTAssertNil(item.zoneSeconds)
         XCTAssertFalse(item.quality.adaptationEligible)
         XCTAssertTrue(item.quality.includedInStatistics)
+    }
+
+    func testInsufficientFactualSpeedCoverageIsExplicitInHistoryAndExport() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let storedSession = session(
+            index: 71,
+            profile: "profile-speed-coverage",
+            startedAt: Date(timeIntervalSince1970: 1_900_100_071)
+        )
+        let heartRateSource = TelemetryPersistenceFixtures.source(
+            seed: 71,
+            kind: .healthKitSelected
+        )
+        let treadmillSource = TelemetryPersistenceFixtures.source(
+            seed: 72,
+            kind: .treadmillProtocol
+        )
+        let heartRate = TelemetryPersistenceFixtures.heartRate(
+            seed: 71,
+            session: storedSession,
+            source: heartRateSource,
+            arrivalOrder: 0,
+            bpm: 120
+        )
+        let treadmill = TelemetryPersistenceFixtures.treadmill(
+            seed: 72,
+            session: storedSession,
+            source: treadmillSource,
+            arrivalOrder: 0,
+            unit: .kilometresPerHour
+        )
+        let analysis = try WorkoutAnalyzerV1.analyze(
+            WorkoutAnalysisInput(
+                session: storedSession,
+                heartRate: [heartRate],
+                treadmill: [treadmill],
+                events: [],
+                frames: []
+            ),
+            generatedAt: storedSession.endedAt!.addingTimeInterval(1)
+        )
+        XCTAssertNil(analysis.keyMetrics.averageFactualSpeedKilometresPerHour)
+        try await store.insertSession(storedSession)
+        try await store.insertAnalysis(analysis)
+
+        let page = try await store.fetchWorkoutHistoryPage(
+            filter: WorkoutReadFilter(profileScope: .exact("profile-speed-coverage")),
+            after: nil,
+            limit: 10
+        )
+        let item = try XCTUnwrap(page.items.first)
+        let coverage = try XCTUnwrap(item.factualSpeedCoverage)
+        XCTAssertNil(item.averageSpeed)
+        XCTAssertEqual(coverage.coveredSeconds, 5, accuracy: 0.000_001)
+        XCTAssertEqual(coverage.uncoveredSeconds, 595, accuracy: 0.000_001)
+        XCTAssertEqual(coverage.coverageRatio!, 5.0 / 600.0, accuracy: 0.000_001)
+        XCTAssertEqual(
+            coverage.requiredRatio,
+            WorkoutAnalyzerV1.minimumAverageFactualSpeedCoverageRatio
+        )
+        XCTAssertTrue(item.quality.unavailableMetrics.contains("averageFactualSpeed"))
+        XCTAssertTrue(item.quality.warnings.contains(
+            "average-factual-speed-unavailable-insufficient-coverage"
+        ))
+
+        let artifact = try await store.exportWorkouts(
+            WorkoutExportRequest(
+                filter: WorkoutReadFilter(profileScope: .exact("profile-speed-coverage")),
+                selection: .all,
+                batchSize: 10
+            )
+        )
+        defer { try? FileManager.default.removeItem(at: artifact.directoryURL) }
+        let summaryCSV = try String(
+            contentsOf: artifact.directoryURL.appendingPathComponent("session_summary_v2.csv"),
+            encoding: .utf8
+        )
+        let summaryJSONL = try String(
+            contentsOf: artifact.directoryURL.appendingPathComponent("session_summary_v2.jsonl"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(summaryCSV.contains("factual_speed_coverage_ratio"))
+        XCTAssertTrue(summaryCSV.contains("5.000000,595.000000,0.008333,0.900000"))
+        XCTAssertTrue(summaryCSV.contains(
+            "average-factual-speed-unavailable-insufficient-coverage"
+        ))
+        XCTAssertTrue(summaryJSONL.contains("\"factualSpeedCoverage\""))
+        XCTAssertTrue(summaryJSONL.contains("\"requiredRatio\":0.9"))
     }
 
     func testExactImportedDuplicateEnrichesNativeHealthKitLinkageInHistoryAndExport() async throws {
@@ -361,7 +449,7 @@ final class TelemetryWorkoutReadAndExportTests: XCTestCase {
         )
         defer { try? FileManager.default.removeItem(at: artifact.directoryURL) }
         let summary = try String(
-            contentsOf: artifact.directoryURL.appendingPathComponent("session_summary_v1.jsonl"),
+            contentsOf: artifact.directoryURL.appendingPathComponent("session_summary_v2.jsonl"),
             encoding: .utf8
         )
         XCTAssertTrue(summary.lowercased().contains(healthKitIdentifier.uuidString.lowercased()))
@@ -563,8 +651,8 @@ final class TelemetryWorkoutReadAndExportTests: XCTestCase {
         XCTAssertEqual(Set(artifact.fileURLs.map(\.lastPathComponent)), Set([
             "raw_evidence_v1.jsonl",
             "normalized_evidence_v1.csv",
-            "session_summary_v1.jsonl",
-            "session_summary_v1.csv",
+            "session_summary_v2.jsonl",
+            "session_summary_v2.csv",
             "manifest.json",
         ]))
         let decoder = JSONDecoder()
@@ -675,7 +763,7 @@ final class TelemetryWorkoutReadAndExportTests: XCTestCase {
                 analysisID: AnalysisID(rawValue: uuid(800_001)),
                 recordID: RecordID(rawValue: uuid(800_002)),
                 sessionID: storedSession.sessionID,
-                analyzerVersion: AnalyzerVersion(rawValue: "malformed-fixture"),
+                analyzerVersion: WorkoutAnalyzerV1.analyzerVersion,
                 evidenceHash: ContentHash(
                     algorithm: .sha256,
                     lowercaseHexDigest: String(repeating: "c", count: 64)

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -6204,6 +6204,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             }
         }
         updateTreadmillStatus()
+        maintainControllerUnitsTruthDuringActiveWorkout(now: Date())
     }
 
     private func updateTreadmillStatus() {
@@ -7110,6 +7111,30 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         )
         guard let trigger = refreshDecision.trigger else { return }
         requestControllerUnitsTruth(trigger: trigger.rawValue, now: now)
+    }
+
+    private func maintainControllerUnitsTruthDuringActiveWorkout(now: Date) {
+        let refreshDecision = ControllerUnitsRefreshPolicy.activeWorkoutRefresh(
+            isHrControlRunning: isHrControlRunning,
+            transportReady: controllerUnitsQueryTransportReady,
+            motionQueueIdle: commandQueue.isEmpty
+                && !isCommandQueueProcessing
+                && nextCommandAllowedAt <= now,
+            secondsUntilNextScheduledMotion: controllerUnitsNextScheduledMotionLeadSeconds,
+            lastQueryAt: lastControllerUnitsQueryAt,
+            now: now
+        )
+        guard let trigger = refreshDecision.trigger else { return }
+        requestControllerUnitsTruth(trigger: trigger.rawValue, now: now)
+    }
+
+    private var controllerUnitsNextScheduledMotionLeadSeconds: Int {
+        if let cooldownState = cooldownRuntimeState {
+            let interval = max(1, cooldownState.stepIntervalSeconds)
+            let remainder = cooldownState.elapsedSeconds % interval
+            return remainder == 0 ? interval : interval - remainder
+        }
+        return min(hrNextDecisionSeconds, hrRemainingSeconds)
     }
 
     private func controllerUnitsResponseContext(

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -988,7 +988,7 @@ private func trainingResultPreview(named name: String) -> TrainingResultPreview?
         appVersion: "1.0",
         buildNumber: "1",
         algorithmVersion: "legacy-hr-control-2026-08",
-        analyzerVersion: "workout-analyzer-v1",
+        analyzerVersion: "workout-analyzer-v1.1",
         quality: WorkoutProjectionQuality(
             lifecycleState: "completed",
             recorderComplete: true,

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ControllerUnitsSafetyPolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ControllerUnitsSafetyPolicy.swift
@@ -209,6 +209,7 @@ struct ControllerUnitsDiagnosticSnapshot: Equatable {
 enum ControllerUnitsRefreshTrigger: String, Equatable {
     case connectionReady = "connection_ready"
     case gateBlockedAuto = "gate_blocked_auto"
+    case activeWorkoutIdleWindow = "active_workout_idle_window"
 }
 
 struct ControllerUnitsRefreshDecision: Equatable {
@@ -219,6 +220,8 @@ struct ControllerUnitsRefreshDecision: Equatable {
 
 enum ControllerUnitsRefreshPolicy {
     static let minimumQueryInterval: TimeInterval = 5
+    static let activeWorkoutQueryInterval: TimeInterval = 20
+    static let requiredMotionLeadSeconds = 2
 
     static func initialQuery(
         transportReady: Bool,
@@ -247,6 +250,26 @@ enum ControllerUnitsRefreshPolicy {
             return ControllerUnitsRefreshDecision(trigger: nil)
         }
         return ControllerUnitsRefreshDecision(trigger: .gateBlockedAuto)
+    }
+
+    static func activeWorkoutRefresh(
+        isHrControlRunning: Bool,
+        transportReady: Bool,
+        motionQueueIdle: Bool,
+        secondsUntilNextScheduledMotion: Int,
+        lastQueryAt: Date?,
+        now: Date
+    ) -> ControllerUnitsRefreshDecision {
+        guard isHrControlRunning,
+              transportReady,
+              motionQueueIdle,
+              secondsUntilNextScheduledMotion > requiredMotionLeadSeconds,
+              lastQueryAt.map({
+                  now.timeIntervalSince($0) >= activeWorkoutQueryInterval
+              }) ?? true else {
+            return ControllerUnitsRefreshDecision(trigger: nil)
+        }
+        return ControllerUnitsRefreshDecision(trigger: .activeWorkoutIdleWindow)
     }
 
     static func throttleAllowsQuery(lastQueryAt: Date?, now: Date) -> Bool {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsReadOnlyContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsReadOnlyContractTests.swift
@@ -84,6 +84,32 @@ final class ControllerUnitsReadOnlyContractTests: XCTestCase {
         XCTAssertTrue(parser.contains("rawControllerUnit: data[13]"))
     }
 
+    func testActiveUnitsRefreshUsesOnlyProvenMotionIdleWindow() throws {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let manager = try String(
+            contentsOf: testsDirectory
+                .deletingLastPathComponent()
+                .appendingPathComponent("WalkingPadRemote/BluetoothManager.swift"),
+            encoding: .utf8
+        )
+        let tick = try functionBody("private func tickTelemetry()", in: manager)
+        let maintenance = try functionBody(
+            "private func maintainControllerUnitsTruthDuringActiveWorkout(",
+            in: manager
+        )
+        let request = try functionBody("private func requestControllerUnitsTruth(", in: manager)
+
+        XCTAssertTrue(tick.contains("maintainControllerUnitsTruthDuringActiveWorkout"))
+        XCTAssertTrue(maintenance.contains("motionQueueIdle: commandQueue.isEmpty"))
+        XCTAssertTrue(maintenance.contains("!isCommandQueueProcessing"))
+        XCTAssertTrue(maintenance.contains("nextCommandAllowedAt <= now"))
+        XCTAssertTrue(maintenance.contains("controllerUnitsNextScheduledMotionLeadSeconds"))
+        XCTAssertTrue(maintenance.contains("ControllerUnitsRefreshPolicy.activeWorkoutRefresh"))
+        XCTAssertTrue(request.contains("BLETransportCodec.buildWalkingPadQueryParamsPacket()"))
+        XCTAssertFalse(maintenance.contains("sendTreadmill"))
+        XCTAssertFalse(maintenance.contains("isHrControlStartAllowed ="))
+    }
+
     private func functionBody(_ signature: String, in source: String) throws -> String {
         guard let signatureRange = source.range(of: signature),
               let openingBrace = source[signatureRange.upperBound...].firstIndex(of: "{") else {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsSafetyPolicyTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsSafetyPolicyTests.swift
@@ -279,6 +279,65 @@ final class ControllerUnitsSafetyPolicyTests: XCTestCase {
         ).trigger, .connectionReady)
     }
 
+    func testActiveWorkoutRefreshUsesIdleWindowsWithoutChangingMotionGate() {
+        XCTAssertEqual(ControllerUnitsSafetyPolicy.freshnessInterval, 30)
+        XCTAssertEqual(ControllerUnitsRefreshPolicy.activeWorkoutQueryInterval, 20)
+        let gateBefore = evaluate(state: truth(units: .metric))
+        var lastQueryAt: Date? = now
+        var refreshSeconds: [Int] = []
+
+        for second in 1...1_800 {
+            let remainder = second % 10
+            let queueIdle = remainder >= 2
+            let lead = remainder == 0 ? 0 : 10 - remainder
+            let tick = now.addingTimeInterval(TimeInterval(second))
+            let decision = ControllerUnitsRefreshPolicy.activeWorkoutRefresh(
+                isHrControlRunning: true,
+                transportReady: true,
+                motionQueueIdle: queueIdle,
+                secondsUntilNextScheduledMotion: lead,
+                lastQueryAt: lastQueryAt,
+                now: tick
+            )
+            if decision.shouldRequest {
+                XCTAssertEqual(decision.trigger, .activeWorkoutIdleWindow)
+                refreshSeconds.append(second)
+                lastQueryAt = tick
+            }
+        }
+        let gateAfter = evaluate(state: truth(units: .metric))
+
+        XCTAssertEqual(refreshSeconds.first, 22)
+        XCTAssertEqual(refreshSeconds.last, 1_782)
+        XCTAssertEqual(refreshSeconds.count, 89)
+        XCTAssertTrue(zip(refreshSeconds, refreshSeconds.dropFirst()).allSatisfy {
+            $1 - $0 == 20
+        })
+        XCTAssertEqual(gateAfter, gateBefore)
+    }
+
+    func testActiveWorkoutRefreshNeverOccupiesMotionSpacingOrImmediateLeadWindow() {
+        let dueAt = now.addingTimeInterval(-20)
+        for (queueIdle, lead) in [(false, 10), (true, 2), (true, 1), (true, 0)] {
+            XCTAssertFalse(ControllerUnitsRefreshPolicy.activeWorkoutRefresh(
+                isHrControlRunning: true,
+                transportReady: true,
+                motionQueueIdle: queueIdle,
+                secondsUntilNextScheduledMotion: lead,
+                lastQueryAt: dueAt,
+                now: now
+            ).shouldRequest)
+        }
+        XCTAssertTrue(ControllerUnitsRefreshPolicy.activeWorkoutRefresh(
+            isHrControlRunning: true,
+            transportReady: true,
+            motionQueueIdle: true,
+            secondsUntilNextScheduledMotion: 3,
+            lastQueryAt: dueAt,
+            now: now
+        ).shouldRequest)
+    }
+
     func testResponseContextRejectsPeripheralEpochAndCharacteristicChanges() {
         final class CharacteristicToken {}
         let currentCharacteristic = CharacteristicToken()


### PR DESCRIPTION
## Summary

- Keep WalkingPad controller-unit truth fresh during active HR workouts and cooldown by issuing the existing read-only A6 query only in a proven motion-idle window.
- Require at least 90% fresh factual canonical-frame coverage before publishing workout average speed; otherwise expose the metric as unavailable with explicit coverage and warning evidence.
- Version the corrected analyzer identity and portable session summary as `workout-analyzer-v1.1`, `timestamp-hold-metrics-v2`, and `workout-session-summary-v2` so legacy partial-speed analyses are not reused.

## Why

Issue #111 showed a real completed workout where decoded native speed continued after controller-unit truth expired, while factual speed disappeared and a tiny startup slice produced a misleading workout average.

The refresh path preserves the existing 30-second motion authorization gate. It skips A6 whenever the command queue, write spacing, or next scheduled HR/cooldown motion does not provide a safe idle window; telemetry then degrades honestly instead of delaying control output or inventing unit truth.

Closes #111.

## Testing

- [x] `python3 -m compileall -q scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py`
- [x] `cd ios/WalkingPadRemote/WalkingPadRemote && swift test` — 622 tests, 0 failures, 1 intentional full-profile gate skip
- [x] `xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -configuration Debug -destination 'generic/platform=iOS' -derivedDataPath /private/tmp/walkingpad-issue111-derived-final CODE_SIGNING_ALLOWED=NO build` — iOS app and embedded watchOS app built successfully
- [x] Focused controller-units, treadmill truth, analyzer, persistence/read/export tests
- [x] Short deterministic Telemetry V2 soak — all produced records persisted; zero lost/dropped records; complete result
- [x] `python3 scripts/check_codex_governance.py`
- [x] `~/.codex/scripts/check-agents-instruction-chain.sh --path ios/WalkingPadRemote/WalkingPadRemote`
- [x] `git diff --check origin/main`
- [x] Independent safety challenge and final review — GO

## Hardware / environment

- Treadmill model: Not run; prohibited by Issue #111 scope
- Protocol: WalkingPad contract and deterministic fixtures only
- iPhone / iOS: Generic unsigned iOS build with local Xcode beta / iPhoneOS 27 SDK
- Apple Watch / watchOS: Embedded watchOS target built as part of the unsigned app build

## Screenshots or logs

No UI behavior change; screenshots are not applicable. No physical BLE/device logs were collected.

## Notes for reviewers

- Risk areas: idle-window scheduling around HR/cooldown motion, connection-scoped unit evidence, canonical-frame coverage, analyzer identity selection, and session-summary schema versioning.
- Follow-up work: repeat the authorized physical real-evidence gate for #37 after review; this PR does not claim device/hardware GO.
- Docs updated: treadmill truth/command lifecycle and Analyzer V1 metric contract.
- Rollback: revert this commit; no migration, setting, or deployment step is required. Existing legacy analysis rows remain immutable and are ignored in favor of the current analyzer identity.
