### PR TITLE
[Debug UX] Share one complete diagnostic bundle

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -223,6 +223,7 @@ let package = Package(
             dependencies: [
                 "TelemetryDomain",
                 "TelemetryPersistence",
+                "TelemetryRuntime",
                 "TelemetryGateCrashWorker",
             ]
         )

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/DiagnosticSupportArtifact.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/DiagnosticSupportArtifact.swift
@@ -1,0 +1,353 @@
+import Foundation
+import TelemetryDomain
+
+public struct DiagnosticSupportSnapshot: Codable, Equatable, Sendable {
+    public struct Runtime: Codable, Equatable, Sendable {
+        public let appVersion: String
+        public let buildNumber: String
+        public let operatingSystemVersion: String
+        public let telemetrySchemaVersion: String
+        public let algorithmVersion: String
+        public let safetyPolicyVersion: String
+        public let workoutProtocolVersion: String
+
+        public init(
+            appVersion: String,
+            buildNumber: String,
+            operatingSystemVersion: String,
+            telemetrySchemaVersion: String,
+            algorithmVersion: String,
+            safetyPolicyVersion: String,
+            workoutProtocolVersion: String
+        ) {
+            self.appVersion = appVersion
+            self.buildNumber = buildNumber
+            self.operatingSystemVersion = operatingSystemVersion
+            self.telemetrySchemaVersion = telemetrySchemaVersion
+            self.algorithmVersion = algorithmVersion
+            self.safetyPolicyVersion = safetyPolicyVersion
+            self.workoutProtocolVersion = workoutProtocolVersion
+        }
+    }
+
+    public struct NativeHeartRatePreflight: Codable, Equatable, Sendable {
+        public let phase: String
+        public let requestedAt: Date?
+        public let providerPreparedAt: Date?
+        public let collectionStartedAt: Date?
+        public let firstNativeCallbackMeasuredAt: Date?
+        public let firstNativeCallbackReceivedAt: Date?
+        public let firstQualifyingLatencySeconds: TimeInterval?
+        public let terminalAt: Date?
+        public let terminalReason: String?
+        public let gateBlockReason: String?
+        public let providerState: String
+        public let providerCleanupInFlight: Bool
+        public let providerGeneration: UInt64
+        public let providerHasBoundAttempt: Bool
+        public let nativeWorkoutCommitted: Bool
+
+        public init(
+            phase: String,
+            requestedAt: Date?,
+            providerPreparedAt: Date?,
+            collectionStartedAt: Date?,
+            firstNativeCallbackMeasuredAt: Date?,
+            firstNativeCallbackReceivedAt: Date?,
+            firstQualifyingLatencySeconds: TimeInterval?,
+            terminalAt: Date?,
+            terminalReason: String?,
+            gateBlockReason: String?,
+            providerState: String,
+            providerCleanupInFlight: Bool,
+            providerGeneration: UInt64,
+            providerHasBoundAttempt: Bool,
+            nativeWorkoutCommitted: Bool
+        ) {
+            self.phase = phase
+            self.requestedAt = requestedAt
+            self.providerPreparedAt = providerPreparedAt
+            self.collectionStartedAt = collectionStartedAt
+            self.firstNativeCallbackMeasuredAt = firstNativeCallbackMeasuredAt
+            self.firstNativeCallbackReceivedAt = firstNativeCallbackReceivedAt
+            self.firstQualifyingLatencySeconds = firstQualifyingLatencySeconds
+            self.terminalAt = terminalAt
+            self.terminalReason = terminalReason
+            self.gateBlockReason = gateBlockReason
+            self.providerState = providerState
+            self.providerCleanupInFlight = providerCleanupInFlight
+            self.providerGeneration = providerGeneration
+            self.providerHasBoundAttempt = providerHasBoundAttempt
+            self.nativeWorkoutCommitted = nativeWorkoutCommitted
+        }
+    }
+
+    public struct ControllerUnits: Codable, Equatable, Sendable {
+        public let status: String
+        public let physicalUnits: String
+        public let observedAt: Date?
+        public let ageSeconds: TimeInterval?
+        public let isFresh: Bool
+        public let gateAllowed: Bool
+        public let blockReason: String?
+        public let evidenceConnectionEpoch: String?
+        public let currentConnectionEpoch: String?
+        public let isCurrentConnection: Bool
+        public let byteCount: Int?
+        public let rawA6Hex: String?
+
+        public init(
+            status: String,
+            physicalUnits: String,
+            observedAt: Date?,
+            ageSeconds: TimeInterval?,
+            isFresh: Bool,
+            gateAllowed: Bool,
+            blockReason: String?,
+            evidenceConnectionEpoch: String?,
+            currentConnectionEpoch: String?,
+            isCurrentConnection: Bool,
+            byteCount: Int?,
+            rawA6Hex: String?
+        ) {
+            self.status = status
+            self.physicalUnits = physicalUnits
+            self.observedAt = observedAt
+            self.ageSeconds = ageSeconds
+            self.isFresh = isFresh
+            self.gateAllowed = gateAllowed
+            self.blockReason = blockReason
+            self.evidenceConnectionEpoch = evidenceConnectionEpoch
+            self.currentConnectionEpoch = currentConnectionEpoch
+            self.isCurrentConnection = isCurrentConnection
+            self.byteCount = byteCount
+            self.rawA6Hex = rawA6Hex
+        }
+    }
+
+    public struct Treadmill: Codable, Equatable, Sendable {
+        public let protocolName: String
+        public let isConnected: Bool
+        public let isControlReady: Bool
+        public let hasCurrentConnectionContext: Bool
+        public let protocolMatchesCurrentConnection: Bool
+        public let connectionEpoch: String?
+
+        public init(
+            protocolName: String,
+            isConnected: Bool,
+            isControlReady: Bool,
+            hasCurrentConnectionContext: Bool,
+            protocolMatchesCurrentConnection: Bool,
+            connectionEpoch: String?
+        ) {
+            self.protocolName = protocolName
+            self.isConnected = isConnected
+            self.isControlReady = isControlReady
+            self.hasCurrentConnectionContext = hasCurrentConnectionContext
+            self.protocolMatchesCurrentConnection = protocolMatchesCurrentConnection
+            self.connectionEpoch = connectionEpoch
+        }
+    }
+
+    public struct WriterHealth: Codable, Equatable, Sendable {
+        public let workoutReadState: String
+        public let runtimeLifecycle: String
+        public let recorderLifecycle: String?
+        public let completeness: String?
+        public let queueDepth: Int
+        public let peakQueueDepth: Int
+        public let coalescedFrameCount: UInt64
+        public let droppedFrameCount: UInt64
+        public let lostNativeCount: UInt64
+        public let lostCriticalCount: UInt64
+        public let writerFailureCount: UInt64
+        public let retryCount: UInt64
+        public let successfulFlushCount: UInt64
+        public let lastCommittedRecorderSequence: UInt64?
+
+        public init(
+            workoutReadState: String,
+            runtimeLifecycle: String,
+            recorderLifecycle: String?,
+            completeness: String?,
+            queueDepth: Int,
+            peakQueueDepth: Int,
+            coalescedFrameCount: UInt64,
+            droppedFrameCount: UInt64,
+            lostNativeCount: UInt64,
+            lostCriticalCount: UInt64,
+            writerFailureCount: UInt64,
+            retryCount: UInt64,
+            successfulFlushCount: UInt64,
+            lastCommittedRecorderSequence: UInt64?
+        ) {
+            self.workoutReadState = workoutReadState
+            self.runtimeLifecycle = runtimeLifecycle
+            self.recorderLifecycle = recorderLifecycle
+            self.completeness = completeness
+            self.queueDepth = queueDepth
+            self.peakQueueDepth = peakQueueDepth
+            self.coalescedFrameCount = coalescedFrameCount
+            self.droppedFrameCount = droppedFrameCount
+            self.lostNativeCount = lostNativeCount
+            self.lostCriticalCount = lostCriticalCount
+            self.writerFailureCount = writerFailureCount
+            self.retryCount = retryCount
+            self.successfulFlushCount = successfulFlushCount
+            self.lastCommittedRecorderSequence = lastCommittedRecorderSequence
+        }
+    }
+
+    public let capturedAt: Date
+    public let runtime: Runtime
+    public let nativeHeartRatePreflight: NativeHeartRatePreflight
+    public let controllerUnits: ControllerUnits
+    public let treadmill: Treadmill
+    public let writerHealth: WriterHealth
+
+    public init(
+        capturedAt: Date,
+        runtime: Runtime,
+        nativeHeartRatePreflight: NativeHeartRatePreflight,
+        controllerUnits: ControllerUnits,
+        treadmill: Treadmill,
+        writerHealth: WriterHealth
+    ) {
+        self.capturedAt = capturedAt
+        self.runtime = runtime
+        self.nativeHeartRatePreflight = nativeHeartRatePreflight
+        self.controllerUnits = controllerUnits
+        self.treadmill = treadmill
+        self.writerHealth = writerHealth
+    }
+}
+
+public struct DiagnosticBundleArtifact: Equatable, Sendable {
+    public let directoryURL: URL
+    public let archiveURL: URL
+    public let containsHealthData: Bool
+    public let exportedWorkoutCount: Int
+    public let exportedRecordCount: Int
+    public let packagingDurationSeconds: TimeInterval
+    public let archiveBytes: UInt64
+    public let maximumChunkBytes: Int
+}
+
+public enum DiagnosticBundlePackager {
+    public static func create(
+        workoutArtifact: WorkoutExportArtifact,
+        supportSnapshot: DiagnosticSupportSnapshot,
+        archiveName: String
+    ) async throws -> DiagnosticBundleArtifact {
+        try await package(
+            workoutArtifact: workoutArtifact,
+            supportSnapshot: supportSnapshot,
+            archiveName: archiveName,
+            workoutEvidenceStatus: "available",
+            workoutEvidenceFailureCategory: nil
+        )
+    }
+
+    public static func createSupportOnly(
+        supportSnapshot: DiagnosticSupportSnapshot,
+        archiveName: String,
+        workoutEvidenceStatus: String = "unavailable",
+        workoutEvidenceFailureCategory: String
+    ) async throws -> DiagnosticBundleArtifact {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WalkingPadSupportExport_\(UUID().uuidString)", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true
+            )
+            return try await package(
+                workoutArtifact: WorkoutExportArtifact(
+                    directoryURL: directoryURL,
+                    fileURLs: [],
+                    exportedWorkoutCount: 0,
+                    exportedRecordCount: 0,
+                    containsHealthData: false
+                ),
+                supportSnapshot: supportSnapshot,
+                archiveName: archiveName,
+                workoutEvidenceStatus: workoutEvidenceStatus,
+                workoutEvidenceFailureCategory: workoutEvidenceFailureCategory
+            )
+        } catch {
+            try? FileManager.default.removeItem(at: directoryURL)
+            throw error
+        }
+    }
+
+    private static func package(
+        workoutArtifact: WorkoutExportArtifact,
+        supportSnapshot: DiagnosticSupportSnapshot,
+        archiveName: String,
+        workoutEvidenceStatus: String,
+        workoutEvidenceFailureCategory: String?
+    ) async throws -> DiagnosticBundleArtifact {
+        let worker = Task.detached(priority: .userInitiated) {
+            try Task.checkCancellation()
+            let supportURL = workoutArtifact.directoryURL.appendingPathComponent(
+                "support_diagnostics_v1.json"
+            )
+            let envelope = DiagnosticSupportArtifactEnvelope(
+                schemaVersion: "walkingpad-support-diagnostics-v1",
+                generatedAt: Date(),
+                exportedWorkoutCount: workoutArtifact.exportedWorkoutCount,
+                exportedRecordCount: workoutArtifact.exportedRecordCount,
+                containsHealthData: workoutArtifact.containsHealthData,
+                workoutEvidenceStatus: workoutEvidenceStatus,
+                workoutEvidenceFailureCategory: workoutEvidenceFailureCategory,
+                support: supportSnapshot
+            )
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            try encoder.encode(envelope).write(to: supportURL, options: .atomic)
+            try Task.checkCancellation()
+
+            let started = ContinuousClock.now
+            let archive = try DiagnosticZipArchive.createWithMetrics(
+                directoryURL: workoutArtifact.directoryURL,
+                fileURLs: workoutArtifact.fileURLs + [supportURL],
+                archiveName: archiveName
+            )
+            return DiagnosticBundleArtifact(
+                directoryURL: workoutArtifact.directoryURL,
+                archiveURL: archive.url,
+                containsHealthData: workoutArtifact.containsHealthData,
+                exportedWorkoutCount: workoutArtifact.exportedWorkoutCount,
+                exportedRecordCount: workoutArtifact.exportedRecordCount,
+                packagingDurationSeconds: started.duration(to: .now).seconds,
+                archiveBytes: archive.outputBytes,
+                maximumChunkBytes: archive.maximumChunkBytes
+            )
+        }
+        return try await withTaskCancellationHandler {
+            try await worker.value
+        } onCancel: {
+            worker.cancel()
+        }
+    }
+}
+
+private struct DiagnosticSupportArtifactEnvelope: Codable {
+    let schemaVersion: String
+    let generatedAt: Date
+    let exportedWorkoutCount: Int
+    let exportedRecordCount: Int
+    let containsHealthData: Bool
+    let workoutEvidenceStatus: String
+    let workoutEvidenceFailureCategory: String?
+    let support: DiagnosticSupportSnapshot
+}
+
+private extension Duration {
+    var seconds: TimeInterval {
+        let parts = components
+        return Double(parts.seconds) + Double(parts.attoseconds) / 1e18
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/DiagnosticZipArchive.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/DiagnosticZipArchive.swift
@@ -1,0 +1,247 @@
+import Foundation
+
+public enum DiagnosticZipArchive {
+    public enum ArchiveError: Error, Equatable {
+        case destinationExists
+        case emptyInput
+        case invalidSource(String)
+        case zip32LimitExceeded(String)
+    }
+
+    private struct Entry {
+        let sourceURL: URL
+        let name: String
+        let nameData: Data
+        let crc32: UInt32
+        let size: UInt32
+        let modificationTime: UInt16
+        let modificationDate: UInt16
+        var localHeaderOffset: UInt32 = 0
+    }
+
+    public static func create(
+        directoryURL: URL,
+        fileURLs: [URL],
+        archiveName: String
+    ) throws -> URL {
+        guard !fileURLs.isEmpty else { throw ArchiveError.emptyInput }
+        guard !archiveName.isEmpty,
+              archiveName == URL(fileURLWithPath: archiveName).lastPathComponent,
+              archiveName.lowercased().hasSuffix(".zip") else {
+            throw ArchiveError.invalidSource(archiveName)
+        }
+
+        let root = directoryURL.standardizedFileURL
+        let archiveURL = root.appendingPathComponent(archiveName, isDirectory: false)
+        guard !FileManager.default.fileExists(atPath: archiveURL.path) else {
+            throw ArchiveError.destinationExists
+        }
+        guard fileURLs.count <= Int(UInt16.max) else {
+            throw ArchiveError.zip32LimitExceeded("file-count")
+        }
+
+        var entries: [Entry] = []
+        var seenNames = Set<String>()
+        for fileURL in fileURLs {
+            let source = fileURL.standardizedFileURL
+            let name = source.lastPathComponent
+            guard source.deletingLastPathComponent() == root,
+                  !name.isEmpty,
+                  name != archiveName,
+                  seenNames.insert(name).inserted else {
+                throw ArchiveError.invalidSource(source.path)
+            }
+            let values = try source.resourceValues(
+                forKeys: [
+                    .isRegularFileKey,
+                    .isSymbolicLinkKey,
+                    .fileSizeKey,
+                    .contentModificationDateKey,
+                ]
+            )
+            guard values.isRegularFile == true,
+                  values.isSymbolicLink != true,
+                  let fileSize = values.fileSize else {
+                throw ArchiveError.invalidSource(source.path)
+            }
+            guard fileSize >= 0, UInt64(fileSize) <= UInt64(UInt32.max) else {
+                throw ArchiveError.zip32LimitExceeded(name)
+            }
+            let nameData = Data(name.utf8)
+            guard nameData.count <= Int(UInt16.max) else {
+                throw ArchiveError.zip32LimitExceeded(name)
+            }
+            let crc32 = try checksum(of: source)
+            let timestamp = dosTimestamp(values.contentModificationDate ?? Date())
+            entries.append(Entry(
+                sourceURL: source,
+                name: name,
+                nameData: nameData,
+                crc32: crc32,
+                size: UInt32(fileSize),
+                modificationTime: timestamp.time,
+                modificationDate: timestamp.date
+            ))
+        }
+
+        guard FileManager.default.createFile(atPath: archiveURL.path, contents: nil) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        let output = try FileHandle(forWritingTo: archiveURL)
+        var offset: UInt64 = 0
+
+        do {
+            for index in entries.indices {
+                guard offset <= UInt64(UInt32.max) else {
+                    throw ArchiveError.zip32LimitExceeded(entries[index].name)
+                }
+                entries[index].localHeaderOffset = UInt32(offset)
+                let entry = entries[index]
+                var header = Data()
+                header.appendLittleEndian(UInt32(0x04034b50))
+                header.appendLittleEndian(UInt16(20))
+                header.appendLittleEndian(UInt16(0x0800))
+                header.appendLittleEndian(UInt16(0))
+                header.appendLittleEndian(entry.modificationTime)
+                header.appendLittleEndian(entry.modificationDate)
+                header.appendLittleEndian(entry.crc32)
+                header.appendLittleEndian(entry.size)
+                header.appendLittleEndian(entry.size)
+                header.appendLittleEndian(UInt16(entry.nameData.count))
+                header.appendLittleEndian(UInt16(0))
+                header.append(entry.nameData)
+                try write(header, to: output, offset: &offset)
+
+                let input = try FileHandle(forReadingFrom: entry.sourceURL)
+                defer { try? input.close() }
+                while let chunk = try input.read(upToCount: 64 * 1024), !chunk.isEmpty {
+                    try write(chunk, to: output, offset: &offset)
+                }
+            }
+
+            guard offset <= UInt64(UInt32.max) else {
+                throw ArchiveError.zip32LimitExceeded("central-directory-offset")
+            }
+            let centralDirectoryOffset = UInt32(offset)
+            for entry in entries {
+                var header = Data()
+                header.appendLittleEndian(UInt32(0x02014b50))
+                header.appendLittleEndian(UInt16(20))
+                header.appendLittleEndian(UInt16(20))
+                header.appendLittleEndian(UInt16(0x0800))
+                header.appendLittleEndian(UInt16(0))
+                header.appendLittleEndian(entry.modificationTime)
+                header.appendLittleEndian(entry.modificationDate)
+                header.appendLittleEndian(entry.crc32)
+                header.appendLittleEndian(entry.size)
+                header.appendLittleEndian(entry.size)
+                header.appendLittleEndian(UInt16(entry.nameData.count))
+                header.appendLittleEndian(UInt16(0))
+                header.appendLittleEndian(UInt16(0))
+                header.appendLittleEndian(UInt16(0))
+                header.appendLittleEndian(UInt16(0))
+                header.appendLittleEndian(UInt32(0))
+                header.appendLittleEndian(entry.localHeaderOffset)
+                header.append(entry.nameData)
+                try write(header, to: output, offset: &offset)
+            }
+
+            let centralDirectorySize = offset - UInt64(centralDirectoryOffset)
+            guard centralDirectorySize <= UInt64(UInt32.max) else {
+                throw ArchiveError.zip32LimitExceeded("central-directory-size")
+            }
+            var footer = Data()
+            footer.appendLittleEndian(UInt32(0x06054b50))
+            footer.appendLittleEndian(UInt16(0))
+            footer.appendLittleEndian(UInt16(0))
+            footer.appendLittleEndian(UInt16(entries.count))
+            footer.appendLittleEndian(UInt16(entries.count))
+            footer.appendLittleEndian(UInt32(centralDirectorySize))
+            footer.appendLittleEndian(centralDirectoryOffset)
+            footer.appendLittleEndian(UInt16(0))
+            try write(footer, to: output, offset: &offset)
+            try output.close()
+            return archiveURL
+        } catch {
+            try? output.close()
+            try? FileManager.default.removeItem(at: archiveURL)
+            throw error
+        }
+    }
+
+    private static func write(
+        _ data: Data,
+        to output: FileHandle,
+        offset: inout UInt64
+    ) throws {
+        try output.write(contentsOf: data)
+        offset += UInt64(data.count)
+        guard offset <= UInt64(UInt32.max) else {
+            throw ArchiveError.zip32LimitExceeded("archive-size")
+        }
+    }
+
+    private static func checksum(of fileURL: URL) throws -> UInt32 {
+        let input = try FileHandle(forReadingFrom: fileURL)
+        defer { try? input.close() }
+        var value = UInt32.max
+        while let chunk = try input.read(upToCount: 64 * 1024), !chunk.isEmpty {
+            for byte in chunk {
+                let index = Int((value ^ UInt32(byte)) & 0xff)
+                value = crcTable[index] ^ (value >> 8)
+            }
+        }
+        return value ^ UInt32.max
+    }
+
+    private static func dosTimestamp(_ date: Date) -> (time: UInt16, date: UInt16) {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let components = calendar.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: date
+        )
+        let year = min(2107, max(1980, components.year ?? 1980))
+        let month = min(12, max(1, components.month ?? 1))
+        let day = min(31, max(1, components.day ?? 1))
+        let hour = min(23, max(0, components.hour ?? 0))
+        let minute = min(59, max(0, components.minute ?? 0))
+        let second = min(59, max(0, components.second ?? 0))
+        return (
+            UInt16((hour << 11) | (minute << 5) | (second / 2)),
+            UInt16(((year - 1980) << 9) | (month << 5) | day)
+        )
+    }
+
+    private static let crcTable: [UInt32] = (0..<256).map { seed in
+        var value = UInt32(seed)
+        for _ in 0..<8 {
+            value = (value & 1) == 1
+                ? 0xedb88320 ^ (value >> 1)
+                : value >> 1
+        }
+        return value
+    }
+}
+
+extension DiagnosticZipArchive.ArchiveError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .destinationExists:
+            return "Диагностический архив уже существует."
+        case .emptyInput:
+            return "В диагностическом пакете нет файлов."
+        case .invalidSource(let source):
+            return "Диагностический пакет содержит недопустимый файл: \(source)"
+        case .zip32LimitExceeded(let item):
+            return "Диагностический пакет слишком велик для ZIP-архива: \(item)"
+        }
+    }
+}
+
+private extension Data {
+    mutating func appendLittleEndian<Integer: FixedWidthInteger>(_ value: Integer) {
+        var littleEndian = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndian) { append(contentsOf: $0) }
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/DiagnosticZipArchive.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/DiagnosticZipArchive.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 public enum DiagnosticZipArchive {
+    public struct Result: Equatable, Sendable {
+        public let url: URL
+        public let outputBytes: UInt64
+        public let maximumChunkBytes: Int
+    }
+
     public enum ArchiveError: Error, Equatable {
         case destinationExists
         case emptyInput
@@ -24,6 +30,33 @@ public enum DiagnosticZipArchive {
         fileURLs: [URL],
         archiveName: String
     ) throws -> URL {
+        try createWithMetrics(
+            directoryURL: directoryURL,
+            fileURLs: fileURLs,
+            archiveName: archiveName
+        ).url
+    }
+
+    public static func createWithMetrics(
+        directoryURL: URL,
+        fileURLs: [URL],
+        archiveName: String
+    ) throws -> Result {
+        try createWithMetrics(
+            directoryURL: directoryURL,
+            fileURLs: fileURLs,
+            archiveName: archiveName,
+            cancellationCheck: { try Task.checkCancellation() }
+        )
+    }
+
+    static func createWithMetrics(
+        directoryURL: URL,
+        fileURLs: [URL],
+        archiveName: String,
+        cancellationCheck: () throws -> Void
+    ) throws -> Result {
+        try cancellationCheck()
         guard !fileURLs.isEmpty else { throw ArchiveError.emptyInput }
         guard !archiveName.isEmpty,
               archiveName == URL(fileURLWithPath: archiveName).lastPathComponent,
@@ -42,7 +75,9 @@ public enum DiagnosticZipArchive {
 
         var entries: [Entry] = []
         var seenNames = Set<String>()
+        var maximumChunkBytes = 0
         for fileURL in fileURLs {
+            try cancellationCheck()
             let source = fileURL.standardizedFileURL
             let name = source.lastPathComponent
             guard source.deletingLastPathComponent() == root,
@@ -71,13 +106,17 @@ public enum DiagnosticZipArchive {
             guard nameData.count <= Int(UInt16.max) else {
                 throw ArchiveError.zip32LimitExceeded(name)
             }
-            let crc32 = try checksum(of: source)
+            let checksum = try checksum(
+                of: source,
+                cancellationCheck: cancellationCheck
+            )
+            maximumChunkBytes = max(maximumChunkBytes, checksum.maximumChunkBytes)
             let timestamp = dosTimestamp(values.contentModificationDate ?? Date())
             entries.append(Entry(
                 sourceURL: source,
                 name: name,
                 nameData: nameData,
-                crc32: crc32,
+                crc32: checksum.value,
                 size: UInt32(fileSize),
                 modificationTime: timestamp.time,
                 modificationDate: timestamp.date
@@ -92,6 +131,7 @@ public enum DiagnosticZipArchive {
 
         do {
             for index in entries.indices {
+                try cancellationCheck()
                 guard offset <= UInt64(UInt32.max) else {
                     throw ArchiveError.zip32LimitExceeded(entries[index].name)
                 }
@@ -115,6 +155,8 @@ public enum DiagnosticZipArchive {
                 let input = try FileHandle(forReadingFrom: entry.sourceURL)
                 defer { try? input.close() }
                 while let chunk = try input.read(upToCount: 64 * 1024), !chunk.isEmpty {
+                    try cancellationCheck()
+                    maximumChunkBytes = max(maximumChunkBytes, chunk.count)
                     try write(chunk, to: output, offset: &offset)
                 }
             }
@@ -124,6 +166,7 @@ public enum DiagnosticZipArchive {
             }
             let centralDirectoryOffset = UInt32(offset)
             for entry in entries {
+                try cancellationCheck()
                 var header = Data()
                 header.appendLittleEndian(UInt32(0x02014b50))
                 header.appendLittleEndian(UInt16(20))
@@ -161,7 +204,11 @@ public enum DiagnosticZipArchive {
             footer.appendLittleEndian(UInt16(0))
             try write(footer, to: output, offset: &offset)
             try output.close()
-            return archiveURL
+            return Result(
+                url: archiveURL,
+                outputBytes: offset,
+                maximumChunkBytes: maximumChunkBytes
+            )
         } catch {
             try? output.close()
             try? FileManager.default.removeItem(at: archiveURL)
@@ -181,17 +228,23 @@ public enum DiagnosticZipArchive {
         }
     }
 
-    private static func checksum(of fileURL: URL) throws -> UInt32 {
+    private static func checksum(
+        of fileURL: URL,
+        cancellationCheck: () throws -> Void
+    ) throws -> (value: UInt32, maximumChunkBytes: Int) {
         let input = try FileHandle(forReadingFrom: fileURL)
         defer { try? input.close() }
         var value = UInt32.max
+        var maximumChunkBytes = 0
         while let chunk = try input.read(upToCount: 64 * 1024), !chunk.isEmpty {
+            try cancellationCheck()
+            maximumChunkBytes = max(maximumChunkBytes, chunk.count)
             for byte in chunk {
                 let index = Int((value ^ UInt32(byte)) & 0xff)
                 value = crcTable[index] ^ (value >> 8)
             }
         }
-        return value ^ UInt32.max
+        return (value ^ UInt32.max, maximumChunkBytes)
     }
 
     private static func dosTimestamp(_ date: Date) -> (time: UInt16, date: UInt16) {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/DiagnosticZipArchiveTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/DiagnosticZipArchiveTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import XCTest
+@testable import TelemetryRuntime
+
+final class DiagnosticZipArchiveTests: XCTestCase {
+    func testArchiveContainsEveryDiagnosticArtifactAndPreservesSources() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let payloads = [
+            "manifest.json": #"{"manifestVersion":"workout-export-manifest-v1"}"#,
+            "raw_evidence_v1.jsonl": #"{"recordType":"heart_rate"}"#,
+            "normalized_evidence_v1.csv": "record_type,heart_rate_bpm\nheart_rate,132\n",
+            "session_summary_v2.jsonl": #"{"recordType":"workout_summary"}"#,
+            "session_summary_v2.csv": "summary_version,warnings\nworkout-session-summary-v2,partial\n",
+        ]
+        let sourceURLs = try payloads.sorted(by: { $0.key < $1.key }).map { name, payload in
+            let url = root.appendingPathComponent(name)
+            try Data(payload.utf8).write(to: url)
+            return url
+        }
+
+        let archiveURL = try DiagnosticZipArchive.create(
+            directoryURL: root,
+            fileURLs: sourceURLs,
+            archiveName: "WalkingPad_Diagnostics.zip"
+        )
+
+        XCTAssertEqual(archiveURL.pathExtension, "zip")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: archiveURL.path))
+        for sourceURL in sourceURLs {
+            XCTAssertEqual(
+                try String(contentsOf: sourceURL, encoding: .utf8),
+                payloads[sourceURL.lastPathComponent]
+            )
+        }
+
+        let listedFiles = try runUnzip(["-Z1", archiveURL.path])
+            .split(separator: "\n")
+            .map(String.init)
+        XCTAssertEqual(Set(listedFiles), Set(payloads.keys))
+        for (name, payload) in payloads {
+            XCTAssertEqual(try runUnzip(["-p", archiveURL.path, name]), payload)
+        }
+    }
+
+    func testArchiveRejectsEvidenceOutsideExportDirectory() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent("outside_\(UUID().uuidString).json")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data("outside".utf8).write(to: outside)
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: outside)
+        }
+
+        XCTAssertThrowsError(
+            try DiagnosticZipArchive.create(
+                directoryURL: root,
+                fileURLs: [outside],
+                archiveName: "WalkingPad_Diagnostics.zip"
+            )
+        ) { error in
+            guard case DiagnosticZipArchive.ArchiveError.invalidSource = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: root.appendingPathComponent("WalkingPad_Diagnostics.zip").path
+            )
+        )
+    }
+
+    private func runUnzip(_ arguments: [String]) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+        process.arguments = arguments
+        let output = Pipe()
+        let error = Pipe()
+        process.standardOutput = output
+        process.standardError = error
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let message = String(
+                decoding: error.fileHandleForReading.readDataToEndOfFile(),
+                as: UTF8.self
+            )
+            throw NSError(
+                domain: "DiagnosticZipArchiveTests",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: message]
+            )
+        }
+        return String(
+            decoding: output.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/DiagnosticZipArchiveTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/DiagnosticZipArchiveTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TelemetryDomain
 import XCTest
 @testable import TelemetryRuntime
 
@@ -72,6 +73,230 @@ final class DiagnosticZipArchiveTests: XCTestCase {
         XCTAssertFalse(
             FileManager.default.fileExists(
                 atPath: root.appendingPathComponent("WalkingPad_Diagnostics.zip").path
+            )
+        )
+    }
+
+    func testCancellationRemovesPartialArchiveAndPreservesSources() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("raw_evidence_v1.jsonl")
+        let payload = Data(repeating: 0x61, count: 512 * 1024)
+        try payload.write(to: source)
+        var cancellationChecks = 0
+
+        XCTAssertThrowsError(try DiagnosticZipArchive.createWithMetrics(
+            directoryURL: root,
+            fileURLs: [source],
+            archiveName: "WalkingPad_Diagnostics.zip",
+            cancellationCheck: {
+                cancellationChecks += 1
+                if cancellationChecks == 12 { throw CancellationError() }
+            }
+        )) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+
+        XCTAssertGreaterThanOrEqual(cancellationChecks, 12)
+        XCTAssertEqual(try Data(contentsOf: source), payload)
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: root.appendingPathComponent("WalkingPad_Diagnostics.zip").path
+        ))
+    }
+
+    func testArchiveMetricsProveBoundedStreamingChunks() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("raw_evidence_v1.jsonl")
+        try Data(repeating: 0x62, count: 180_000).write(to: source)
+
+        let result = try DiagnosticZipArchive.createWithMetrics(
+            directoryURL: root,
+            fileURLs: [source],
+            archiveName: "WalkingPad_Diagnostics.zip"
+        )
+
+        XCTAssertGreaterThan(result.outputBytes, 180_000)
+        XCTAssertEqual(result.maximumChunkBytes, 64 * 1024)
+    }
+
+    func testSupportOnlyBundleContainsBoundedSupportArtifact() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let names = [
+            "raw_evidence_v1.jsonl",
+            "normalized_evidence_v1.csv",
+            "session_summary_v2.jsonl",
+            "session_summary_v2.csv",
+            "manifest.json",
+        ]
+        let files = try names.map { name in
+            let url = root.appendingPathComponent(name)
+            try Data().write(to: url)
+            return url
+        }
+        let workoutArtifact = WorkoutExportArtifact(
+            directoryURL: root,
+            fileURLs: files,
+            exportedWorkoutCount: 0,
+            exportedRecordCount: 0,
+            containsHealthData: false
+        )
+
+        let bundle = try await DiagnosticBundlePackager.create(
+            workoutArtifact: workoutArtifact,
+            supportSnapshot: makeSupportSnapshot(),
+            archiveName: "WalkingPad_Diagnostics.zip"
+        )
+
+        XCTAssertEqual(bundle.exportedWorkoutCount, 0)
+        XCTAssertEqual(bundle.exportedRecordCount, 0)
+        XCTAssertFalse(bundle.containsHealthData)
+        XCTAssertLessThanOrEqual(bundle.maximumChunkBytes, 64 * 1024)
+        let listedFiles = try runUnzip(["-Z1", bundle.archiveURL.path])
+            .split(separator: "\n")
+            .map(String.init)
+        XCTAssertEqual(Set(listedFiles), Set(names + ["support_diagnostics_v1.json"]))
+
+        let support = try runUnzip([
+            "-p", bundle.archiveURL.path, "support_diagnostics_v1.json",
+        ])
+        XCTAssertTrue(support.contains("walkingpad-support-diagnostics-v1"))
+        XCTAssertTrue(support.contains("controller_units_blocked"))
+        XCTAssertTrue(support.contains("rawA6Hex"))
+        XCTAssertFalse(support.contains("profileID"))
+        XCTAssertFalse(support.contains("peripheralID"))
+    }
+
+    func testUnavailableWorkoutEvidenceProducesExplicitSupportOnlyArchive() async throws {
+        let bundle = try await DiagnosticBundlePackager.createSupportOnly(
+            supportSnapshot: makeSupportSnapshot(),
+            archiveName: "WalkingPad_Diagnostics.zip",
+            workoutEvidenceFailureCategory: "unavailable"
+        )
+        defer { try? FileManager.default.removeItem(at: bundle.directoryURL) }
+
+        XCTAssertEqual(bundle.exportedWorkoutCount, 0)
+        XCTAssertFalse(bundle.containsHealthData)
+        let listedFiles = try runUnzip(["-Z1", bundle.archiveURL.path])
+            .split(separator: "\n")
+            .map(String.init)
+        XCTAssertEqual(listedFiles, ["support_diagnostics_v1.json"])
+        let support = try runUnzip([
+            "-p", bundle.archiveURL.path, "support_diagnostics_v1.json",
+        ])
+        XCTAssertTrue(support.contains(#""workoutEvidenceStatus" : "unavailable""#))
+        XCTAssertTrue(support.contains(#""workoutEvidenceFailureCategory" : "unavailable""#))
+    }
+
+    func testPackagerCancellationReachesDetachedWorkerAndLeavesNoArchive() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("raw_evidence_v1.jsonl")
+        try Data(repeating: 0x63, count: 4 * 1024 * 1024).write(to: source)
+        let artifact = WorkoutExportArtifact(
+            directoryURL: root,
+            fileURLs: [source],
+            exportedWorkoutCount: 1,
+            exportedRecordCount: 1,
+            containsHealthData: true
+        )
+
+        let task = Task {
+            try await DiagnosticBundlePackager.create(
+                workoutArtifact: artifact,
+                supportSnapshot: makeSupportSnapshot(),
+                archiveName: "WalkingPad_Diagnostics.zip"
+            )
+        }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Cancelled packaging must not complete")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: root.appendingPathComponent("WalkingPad_Diagnostics.zip").path
+        ))
+    }
+
+    private func makeSupportSnapshot() -> DiagnosticSupportSnapshot {
+        DiagnosticSupportSnapshot(
+            capturedAt: Date(timeIntervalSince1970: 1_000),
+            runtime: .init(
+                appVersion: "1.0",
+                buildNumber: "1",
+                operatingSystemVersion: "test-os",
+                telemetrySchemaVersion: "1.0.0",
+                algorithmVersion: "algorithm-v1",
+                safetyPolicyVersion: "safety-v1",
+                workoutProtocolVersion: "workout-v1"
+            ),
+            nativeHeartRatePreflight: .init(
+                phase: "terminal",
+                requestedAt: Date(timeIntervalSince1970: 900),
+                providerPreparedAt: Date(timeIntervalSince1970: 901),
+                collectionStartedAt: Date(timeIntervalSince1970: 902),
+                firstNativeCallbackMeasuredAt: nil,
+                firstNativeCallbackReceivedAt: nil,
+                firstQualifyingLatencySeconds: nil,
+                terminalAt: Date(timeIntervalSince1970: 930),
+                terminalReason: "timeout",
+                gateBlockReason: "controller_units_blocked",
+                providerState: "idle",
+                providerCleanupInFlight: false,
+                providerGeneration: 3,
+                providerHasBoundAttempt: false,
+                nativeWorkoutCommitted: false
+            ),
+            controllerUnits: .init(
+                status: "valid",
+                physicalUnits: "metric",
+                observedAt: Date(timeIntervalSince1970: 999),
+                ageSeconds: 1,
+                isFresh: true,
+                gateAllowed: true,
+                blockReason: nil,
+                evidenceConnectionEpoch: "ephemeral-evidence-epoch",
+                currentConnectionEpoch: "ephemeral-current-epoch",
+                isCurrentConnection: true,
+                byteCount: 6,
+                rawA6Hex: "f8a6000000ae"
+            ),
+            treadmill: .init(
+                protocolName: "WalkingPad",
+                isConnected: true,
+                isControlReady: true,
+                hasCurrentConnectionContext: true,
+                protocolMatchesCurrentConnection: true,
+                connectionEpoch: "ephemeral-current-epoch"
+            ),
+            writerHealth: .init(
+                workoutReadState: "loaded",
+                runtimeLifecycle: "idle",
+                recorderLifecycle: nil,
+                completeness: nil,
+                queueDepth: 0,
+                peakQueueDepth: 0,
+                coalescedFrameCount: 0,
+                droppedFrameCount: 0,
+                lostNativeCount: 0,
+                lostCriticalCount: 0,
+                writerFailureCount: 0,
+                retryCount: 0,
+                successfulFlushCount: 0,
+                lastCommittedRecorderSequence: nil
             )
         )
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/DiagnosticBundlePerformanceTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/DiagnosticBundlePerformanceTests.swift
@@ -1,0 +1,408 @@
+import Darwin
+import Foundation
+import TelemetryDomain
+@testable import TelemetryPersistence
+import TelemetryRuntime
+import XCTest
+
+private struct DiagnosticBundleBenchmarkResult: Codable {
+    let workload: String
+    let representedMinutes: Int
+    let selection: String
+    let exportedWorkoutCount: Int
+    let exportedRecordCount: Int
+    let exportGenerationSeconds: Double
+    let packagingSeconds: Double
+    let totalSeconds: Double
+    let archiveBytes: UInt64
+    let baselineResidentBytes: UInt64
+    let peakResidentBytes: UInt64
+    let peakResidentDeltaBytes: UInt64
+    let maximumStreamingChunkBytes: Int
+    let mainActorHeartbeatCount: Int
+    let mainActorMaximumGapSeconds: Double
+}
+
+final class DiagnosticBundlePerformanceTests: XCTestCase {
+    func testEmptyStoreProducesSupportOnlyBundle() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let export = try await store.exportWorkouts(
+            WorkoutExportRequest(
+                filter: WorkoutReadFilter(profileScope: .exact("profile-without-workouts")),
+                selection: .latestCompleted(1)
+            )
+        )
+        XCTAssertEqual(export.exportedWorkoutCount, 0)
+        try FileManager.default.removeItem(at: export.directoryURL)
+        let bundle = try await DiagnosticBundlePackager.createSupportOnly(
+            supportSnapshot: benchmarkSupportSnapshot(),
+            archiveName: "WalkingPad_Diagnostics.zip",
+            workoutEvidenceStatus: "not_present",
+            workoutEvidenceFailureCategory: "no_completed_workout"
+        )
+        defer { try? FileManager.default.removeItem(at: bundle.directoryURL) }
+
+        XCTAssertEqual(bundle.exportedWorkoutCount, 0)
+        XCTAssertEqual(bundle.exportedRecordCount, 0)
+        XCTAssertFalse(bundle.containsHealthData)
+        let evidenceFiles = try FileManager.default.contentsOfDirectory(
+            at: bundle.directoryURL,
+            includingPropertiesForKeys: nil
+        ).filter { $0.pathExtension != "zip" }
+        XCTAssertEqual(evidenceFiles.map(\.lastPathComponent), ["support_diagnostics_v1.json"])
+        let support = try Data(contentsOf: bundle.directoryURL.appendingPathComponent(
+            "support_diagnostics_v1.json"
+        ))
+        let supportText = String(decoding: support, as: UTF8.self)
+        XCTAssertTrue(supportText.contains(#""workoutEvidenceStatus" : "not_present""#))
+        XCTAssertTrue(supportText.contains(#""workoutEvidenceFailureCategory" : "no_completed_workout""#))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: bundle.archiveURL.path))
+    }
+
+    func testRepresentativeThirtyMinuteTwoHourAndAllScopeExports() async throws {
+        let workloads: [(String, TelemetryGateProfile, WorkoutExportSelection, Int, Int)] = [
+            (
+                "30-minute-latest",
+                profile(name: "30-minute", sessionCount: 1, secondsPerSession: 1_800),
+                .latestCompleted(1),
+                30,
+                1
+            ),
+            (
+                "120-minute-latest",
+                profile(name: "120-minute", sessionCount: 1, secondsPerSession: 7_200),
+                .latestCompleted(1),
+                120,
+                1
+            ),
+            (
+                "all-active-profile",
+                profile(name: "all-scope", sessionCount: 13, secondsPerSession: 1_800),
+                .all,
+                120,
+                4
+            ),
+        ]
+
+        for (name, profile, selection, representedMinutes, expectedWorkouts) in workloads {
+            let result = try await runWorkload(
+                name: name,
+                profile: profile,
+                selection: selection,
+                representedMinutes: representedMinutes
+            )
+            XCTAssertEqual(result.exportedWorkoutCount, expectedWorkouts)
+            XCTAssertGreaterThan(result.exportedRecordCount, 0)
+            XCTAssertGreaterThan(result.archiveBytes, 0)
+            XCTAssertLessThanOrEqual(result.maximumStreamingChunkBytes, 64 * 1024)
+            XCTAssertGreaterThan(result.mainActorHeartbeatCount, 0)
+            XCTAssertLessThan(result.mainActorMaximumGapSeconds, 1.0)
+            let data = try JSONEncoder.sorted.encode(result)
+            print("DIAGNOSTIC_BUNDLE_BENCHMARK \(String(decoding: data, as: UTF8.self))")
+        }
+    }
+
+    private func runWorkload(
+        name: String,
+        profile: TelemetryGateProfile,
+        selection: WorkoutExportSelection,
+        representedMinutes: Int
+    ) async throws -> DiagnosticBundleBenchmarkResult {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DiagnosticBundleBenchmark_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let generator = TelemetryGateFixtureGenerator(profile: profile)
+        let store = try await Task.detached {
+            try TelemetryStoreFactory.make(.onDisk(root.appendingPathComponent("TelemetryV2.store")))
+        }.value
+        try await persistFixture(generator: generator, store: store)
+
+        let baselineResidentBytes = currentResidentBytes()
+        let memorySampler = Task.detached(priority: .utility) {
+            var peak = currentResidentBytes()
+            while !Task.isCancelled {
+                peak = max(peak, currentResidentBytes())
+                try? await Task.sleep(for: .milliseconds(2))
+            }
+            return peak
+        }
+        let heartbeat = await MainActor.run { BenchmarkMainActorHeartbeat() }
+        let heartbeatTask = Task { @MainActor in
+            await heartbeat.run()
+        }
+        defer {
+            memorySampler.cancel()
+            heartbeatTask.cancel()
+        }
+
+        let totalStarted = ContinuousClock.now
+        let exportStarted = ContinuousClock.now
+        let artifact = try await store.exportWorkouts(
+            WorkoutExportRequest(
+                filter: WorkoutReadFilter(profileScope: .exact("profile-0")),
+                selection: selection,
+                batchSize: 128
+            )
+        )
+        defer { try? FileManager.default.removeItem(at: artifact.directoryURL) }
+        let exportSeconds = exportStarted.duration(to: .now).seconds
+        let bundle = try await DiagnosticBundlePackager.create(
+            workoutArtifact: artifact,
+            supportSnapshot: benchmarkSupportSnapshot(),
+            archiveName: "WalkingPad_Diagnostics.zip"
+        )
+        let totalSeconds = totalStarted.duration(to: .now).seconds
+
+        memorySampler.cancel()
+        heartbeatTask.cancel()
+        let peakResidentBytes = await memorySampler.value
+        _ = await heartbeatTask.result
+        let heartbeatSnapshot = await MainActor.run { heartbeat.snapshot }
+
+        return DiagnosticBundleBenchmarkResult(
+            workload: name,
+            representedMinutes: representedMinutes,
+            selection: selection.description,
+            exportedWorkoutCount: bundle.exportedWorkoutCount,
+            exportedRecordCount: bundle.exportedRecordCount,
+            exportGenerationSeconds: exportSeconds,
+            packagingSeconds: bundle.packagingDurationSeconds,
+            totalSeconds: totalSeconds,
+            archiveBytes: bundle.archiveBytes,
+            baselineResidentBytes: baselineResidentBytes,
+            peakResidentBytes: peakResidentBytes,
+            peakResidentDeltaBytes: peakResidentBytes > baselineResidentBytes
+                ? peakResidentBytes - baselineResidentBytes
+                : 0,
+            maximumStreamingChunkBytes: bundle.maximumChunkBytes,
+            mainActorHeartbeatCount: heartbeatSnapshot.count,
+            mainActorMaximumGapSeconds: heartbeatSnapshot.maximumGapSeconds
+        )
+    }
+
+    private func persistFixture(
+        generator: TelemetryGateFixtureGenerator,
+        store: TelemetryStore
+    ) async throws {
+        var pending: [TelemetryGateRecord] = []
+        pending.reserveCapacity(generator.profile.batchSize)
+
+        func flush(force: Bool = false) async throws {
+            guard !pending.isEmpty,
+                  force || pending.count == generator.profile.batchSize else { return }
+            let batch = pending
+            pending.removeAll(keepingCapacity: true)
+            try await store.insertGateBatch(batch)
+        }
+
+        func append(_ record: TelemetryGateRecord) async throws {
+            pending.append(record)
+            try await flush()
+        }
+
+        for source in generator.sources { try await append(.source(source)) }
+        try await flush(force: true)
+        for sessionIndex in 0..<generator.profile.sessionCount {
+            try await append(.session(generator.session(index: sessionIndex)))
+            try await flush(force: true)
+        }
+        for sessionIndex in 0..<generator.profile.sessionCount {
+            for sampleIndex in 0..<generator.profile.heartRatePerSession {
+                try await append(.heartRate(generator.heartRate(
+                    sessionIndex: sessionIndex,
+                    sampleIndex: sampleIndex
+                )))
+            }
+        }
+        try await flush(force: true)
+        for sessionIndex in 0..<generator.profile.sessionCount {
+            for sampleIndex in 0..<generator.profile.treadmillPerSession {
+                try await append(.treadmill(generator.treadmill(
+                    sessionIndex: sessionIndex,
+                    sampleIndex: sampleIndex
+                )))
+            }
+        }
+        try await flush(force: true)
+        for sessionIndex in 0..<generator.profile.sessionCount {
+            for event in generator.events(sessionIndex: sessionIndex) {
+                try await append(.event(event))
+            }
+        }
+        try await flush(force: true)
+        for sessionIndex in 0..<generator.profile.sessionCount {
+            for second in 0..<generator.profile.secondsPerSession {
+                if let frame = generator.frame(sessionIndex: sessionIndex, elapsedSecond: second) {
+                    try await append(.frame(frame))
+                }
+            }
+        }
+        try await flush(force: true)
+        for sessionIndex in 0..<generator.profile.sessionCount {
+            try await append(.analysis(generator.analysis(sessionIndex: sessionIndex)))
+        }
+        try await flush(force: true)
+    }
+
+    private func profile(
+        name: String,
+        sessionCount: Int,
+        secondsPerSession: Int
+    ) -> TelemetryGateProfile {
+        TelemetryGateProfile(
+            name: name,
+            sessionCount: sessionCount,
+            secondsPerSession: secondsPerSession,
+            frameGapStartSecond: secondsPerSession / 2,
+            frameGapLengthSeconds: 20,
+            heartRateIntervalSeconds: 5,
+            treadmillIntervalSeconds: 15,
+            eventsPerSession: 20,
+            batchSize: 128,
+            queryRepetitions: 1
+        )
+    }
+}
+
+@MainActor
+private final class BenchmarkMainActorHeartbeat {
+    struct Snapshot {
+        let count: Int
+        let maximumGapSeconds: Double
+    }
+
+    private var count = 0
+    private var maximumGapSeconds: Double = 0
+
+    var snapshot: Snapshot {
+        Snapshot(count: count, maximumGapSeconds: maximumGapSeconds)
+    }
+
+    func run() async {
+        var previous = ContinuousClock.now
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .milliseconds(5))
+            let current = ContinuousClock.now
+            maximumGapSeconds = max(
+                maximumGapSeconds,
+                previous.duration(to: current).seconds
+            )
+            previous = current
+            count += 1
+        }
+    }
+}
+
+private func currentResidentBytes() -> UInt64 {
+    var information = mach_task_basic_info()
+    var count = mach_msg_type_number_t(
+        MemoryLayout<mach_task_basic_info>.size / MemoryLayout<natural_t>.size
+    )
+    let result = withUnsafeMutablePointer(to: &information) { pointer in
+        pointer.withMemoryRebound(to: natural_t.self, capacity: Int(count)) {
+            task_info(
+                mach_task_self_,
+                task_flavor_t(MACH_TASK_BASIC_INFO),
+                $0,
+                &count
+            )
+        }
+    }
+    return result == KERN_SUCCESS ? UInt64(information.resident_size) : 0
+}
+
+private func benchmarkSupportSnapshot() -> DiagnosticSupportSnapshot {
+    DiagnosticSupportSnapshot(
+        capturedAt: Date(timeIntervalSince1970: 1_000),
+        runtime: .init(
+            appVersion: "benchmark",
+            buildNumber: "1",
+            operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            telemetrySchemaVersion: "1.0.0",
+            algorithmVersion: "benchmark-v1",
+            safetyPolicyVersion: "benchmark-safety-v1",
+            workoutProtocolVersion: "benchmark-workout-v1"
+        ),
+        nativeHeartRatePreflight: .init(
+            phase: "idle",
+            requestedAt: nil,
+            providerPreparedAt: nil,
+            collectionStartedAt: nil,
+            firstNativeCallbackMeasuredAt: nil,
+            firstNativeCallbackReceivedAt: nil,
+            firstQualifyingLatencySeconds: nil,
+            terminalAt: nil,
+            terminalReason: nil,
+            gateBlockReason: nil,
+            providerState: "idle",
+            providerCleanupInFlight: false,
+            providerGeneration: 0,
+            providerHasBoundAttempt: false,
+            nativeWorkoutCommitted: false
+        ),
+        controllerUnits: .init(
+            status: "not_read",
+            physicalUnits: "unknown",
+            observedAt: nil,
+            ageSeconds: nil,
+            isFresh: false,
+            gateAllowed: false,
+            blockReason: "units_not_read",
+            evidenceConnectionEpoch: nil,
+            currentConnectionEpoch: nil,
+            isCurrentConnection: false,
+            byteCount: nil,
+            rawA6Hex: nil
+        ),
+        treadmill: .init(
+            protocolName: "Unknown",
+            isConnected: false,
+            isControlReady: false,
+            hasCurrentConnectionContext: false,
+            protocolMatchesCurrentConnection: false,
+            connectionEpoch: nil
+        ),
+        writerHealth: .init(
+            workoutReadState: "loaded",
+            runtimeLifecycle: "idle",
+            recorderLifecycle: nil,
+            completeness: nil,
+            queueDepth: 0,
+            peakQueueDepth: 0,
+            coalescedFrameCount: 0,
+            droppedFrameCount: 0,
+            lostNativeCount: 0,
+            lostCriticalCount: 0,
+            writerFailureCount: 0,
+            retryCount: 0,
+            successfulFlushCount: 0,
+            lastCommittedRecorderSequence: nil
+        )
+    )
+}
+
+private extension WorkoutExportSelection {
+    var description: String {
+        switch self {
+        case .all: "all"
+        case .latestCompleted(let count): "latest-completed-\(count)"
+        }
+    }
+}
+
+private extension Duration {
+    var seconds: Double {
+        let parts = components
+        return Double(parts.seconds) + Double(parts.attoseconds) / 1e18
+    }
+}
+
+private extension JSONEncoder {
+    static var sorted: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -2145,15 +2145,153 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         )
     }
 
-    func finalizeTelemetryV2Export(_ artifact: WorkoutExportArtifact, completed: Bool) {
+    func prepareDiagnosticBundle(
+        scope: TrainingLogCsvExportScope,
+        archiveName: String
+    ) async throws -> DiagnosticBundleArtifact {
+        let supportSnapshot = diagnosticSupportSnapshot()
+        let workoutArtifact: WorkoutExportArtifact
+        do {
+            workoutArtifact = try await prepareTelemetryV2Export(scope: scope)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            return try await DiagnosticBundlePackager.createSupportOnly(
+                supportSnapshot: supportSnapshot,
+                archiveName: archiveName,
+                workoutEvidenceFailureCategory: diagnosticWorkoutExportFailureCategory(error)
+            )
+        }
+        if workoutArtifact.exportedWorkoutCount == 0 {
+            try? FileManager.default.removeItem(at: workoutArtifact.directoryURL)
+            return try await DiagnosticBundlePackager.createSupportOnly(
+                supportSnapshot: supportSnapshot,
+                archiveName: archiveName,
+                workoutEvidenceStatus: "not_present",
+                workoutEvidenceFailureCategory: "no_completed_workout"
+            )
+        }
+        do {
+            return try await DiagnosticBundlePackager.create(
+                workoutArtifact: workoutArtifact,
+                supportSnapshot: supportSnapshot,
+                archiveName: archiveName
+            )
+        } catch {
+            try? FileManager.default.removeItem(at: workoutArtifact.directoryURL)
+            throw error
+        }
+    }
+
+    private func diagnosticWorkoutExportFailureCategory(_ error: Error) -> String {
+        guard let error = error as? TelemetryWorkoutReadError else {
+            return "unexpected_error"
+        }
+        return switch error {
+        case .unavailable(_): "unavailable"
+        case .invalidPageSize: "invalid_page_size"
+        case .corruptProjection(_): "corrupt_projection"
+        case .exportFailed(_): "export_failed"
+        }
+    }
+
+    private func diagnosticSupportSnapshot(
+        now: Date = Date()
+    ) -> DiagnosticSupportSnapshot {
+        let preflight = nativeHeartRatePreflightEngine.diagnosticSnapshot
+        let controllerUnits = controllerUnitsDiagnosticSnapshot(now: now)
+        let currentConnection = currentTreadmillControlConnection
+        let writer = telemetryV2WriterHealthSnapshot
+        let app = currentTelemetryV2AppContext
+        let versions = currentTelemetryV2RuntimeVersions
+        return DiagnosticSupportSnapshot(
+            capturedAt: now,
+            runtime: .init(
+                appVersion: app.appVersion,
+                buildNumber: app.buildNumber,
+                operatingSystemVersion: app.operatingSystemVersion,
+                telemetrySchemaVersion: versions.telemetrySchema.rawValue,
+                algorithmVersion: versions.algorithm.rawValue,
+                safetyPolicyVersion: versions.safetyPolicy.rawValue,
+                workoutProtocolVersion: versions.workoutProtocol.rawValue
+            ),
+            nativeHeartRatePreflight: .init(
+                phase: preflight.phase,
+                requestedAt: preflight.requestedAt,
+                providerPreparedAt: preflight.providerPreparedAt,
+                collectionStartedAt: preflight.collectionStartedAt,
+                firstNativeCallbackMeasuredAt: preflight.firstNativeCallbackMeasuredAt,
+                firstNativeCallbackReceivedAt: preflight.firstNativeCallbackReceivedAt,
+                firstQualifyingLatencySeconds: preflight.firstQualifyingLatencySeconds,
+                terminalAt: preflight.terminalAt,
+                terminalReason: preflight.terminalReason,
+                gateBlockReason: preflight.gateBlockReason,
+                providerState: iPhoneHealthKitHeartRateProvider.state.rawValue,
+                providerCleanupInFlight: nativeHeartRateProviderLifecycle.cleanupInFlight,
+                providerGeneration: nativeHeartRateProviderLifecycle.generation,
+                providerHasBoundAttempt: nativeHeartRateProviderLifecycle.attemptID != nil,
+                nativeWorkoutCommitted: nativeHealthKitWorkoutCommitted
+            ),
+            controllerUnits: .init(
+                status: controllerUnits.status.rawValue,
+                physicalUnits: controllerUnits.units.rawValue,
+                observedAt: controllerUnits.observedAt,
+                ageSeconds: controllerUnits.ageSeconds,
+                isFresh: controllerUnits.isFresh,
+                gateAllowed: controllerUnits.gateAllowed,
+                blockReason: controllerUnits.blockReason?.rawValue,
+                evidenceConnectionEpoch: controllerUnits.evidenceConnectionEpoch?.uuidString,
+                currentConnectionEpoch: controllerUnits.currentConnectionEpoch?.uuidString,
+                isCurrentConnection: controllerUnits.isCurrentConnection,
+                byteCount: controllerUnits.byteCount,
+                rawA6Hex: controllerUnits.rawHex
+            ),
+            treadmill: .init(
+                protocolName: treadmillProtocol.rawValue,
+                isConnected: isConnected,
+                isControlReady: isTreadmillControlReady,
+                hasCurrentConnectionContext: currentConnection != nil,
+                protocolMatchesCurrentConnection: currentConnection != nil
+                    && treadmillProtocolConnection == currentConnection,
+                connectionEpoch: currentConnection?.epoch.uuidString
+            ),
+            writerHealth: .init(
+                workoutReadState: telemetryV2WorkoutReadStateDiagnosticValue,
+                runtimeLifecycle: writer.runtimeLifecycle.rawValue,
+                recorderLifecycle: writer.recorderLifecycle?.rawValue,
+                completeness: writer.completeness?.rawValue,
+                queueDepth: writer.queueDepth,
+                peakQueueDepth: writer.peakQueueDepth,
+                coalescedFrameCount: writer.coalescedFrameCount,
+                droppedFrameCount: writer.droppedFrameCount,
+                lostNativeCount: writer.lostNativeCount,
+                lostCriticalCount: writer.lostCriticalCount,
+                writerFailureCount: writer.writerFailureCount,
+                retryCount: writer.retryCount,
+                successfulFlushCount: writer.successfulFlushCount,
+                lastCommittedRecorderSequence: writer.lastCommittedRecorderSequence
+            )
+        )
+    }
+
+    private var telemetryV2WorkoutReadStateDiagnosticValue: String {
+        switch telemetryV2WorkoutHistoryState {
+        case .idle: "idle"
+        case .loading: "loading"
+        case .loaded: "loaded"
+        case .failed(_): "failed"
+        }
+    }
+
+    func finalizeDiagnosticBundle(_ artifact: DiagnosticBundleArtifact, completed: Bool) {
         do {
             try FileManager.default.removeItem(at: artifact.directoryURL)
         } catch {
-            appendLog("Telemetry V2 export temporary cleanup failed: \(error.localizedDescription)")
+            appendLog("Diagnostic bundle temporary cleanup failed: \(error.localizedDescription)")
         }
         infoToastMessage = completed
-            ? "Telemetry V2 export shared. Source evidence was preserved."
-            : "Telemetry V2 export cancelled. Source evidence was preserved."
+            ? "Diagnostic bundle shared. Source evidence was preserved."
+            : "Diagnostic bundle cancelled. Source evidence was preserved."
     }
 
     // Lifecycle
@@ -7642,16 +7780,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             sessionID: sessionID,
             deterministicLegacySessionID: legacySessionID,
             startedAt: startedAt,
-            appContext: AppRuntimeContext(
-                appVersion: Bundle.main.object(
-                    forInfoDictionaryKey: "CFBundleShortVersionString"
-                ) as? String ?? "unknown",
-                buildNumber: Bundle.main.object(
-                    forInfoDictionaryKey: "CFBundleVersion"
-                ) as? String ?? "unknown",
-                operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersionString,
-                deviceModel: deviceModel
-            ),
+            appContext: currentTelemetryV2AppContext(deviceModel: deviceModel),
             configuration: TelemetryV2ConfigurationInput(
                 profileLocalIdentifier: activeUserProfile?.id.uuidString ?? "unknown",
                 workoutMode: .heartRateControlled,
@@ -7676,16 +7805,37 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                     speedIncrementKilometresPerHour: treadmillSpeedIncrementKmh
                 )
             ),
-            versions: RuntimeVersionContext(
-                telemetrySchema: TelemetrySchemaVersion(rawValue: "1.0.0"),
-                algorithm: AlgorithmVersion(rawValue: "legacy-hr-control-2026-08"),
-                safetyPolicy: SafetyPolicyVersion(rawValue: "walkingpad-runtime-safety-2026-08"),
-                workoutProtocol: WorkoutProtocolVersion(rawValue: "hr-workout-v1")
-            ),
+            versions: currentTelemetryV2RuntimeVersions,
             heartRateFreshnessLimitSeconds: TimeInterval(hrStaleThresholdSeconds),
             treadmillFreshnessLimitSeconds: ControllerUnitsSafetyPolicy.freshnessInterval
         )
         telemetryV2Coordinator.beginSession(descriptor)
+    }
+
+    private var currentTelemetryV2AppContext: AppRuntimeContext {
+        currentTelemetryV2AppContext(deviceModel: nil)
+    }
+
+    private func currentTelemetryV2AppContext(deviceModel: String?) -> AppRuntimeContext {
+        AppRuntimeContext(
+            appVersion: Bundle.main.object(
+                forInfoDictionaryKey: "CFBundleShortVersionString"
+            ) as? String ?? "unknown",
+            buildNumber: Bundle.main.object(
+                forInfoDictionaryKey: "CFBundleVersion"
+            ) as? String ?? "unknown",
+            operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            deviceModel: deviceModel
+        )
+    }
+
+    private var currentTelemetryV2RuntimeVersions: RuntimeVersionContext {
+        RuntimeVersionContext(
+            telemetrySchema: TelemetrySchemaVersion(rawValue: "1.0.0"),
+            algorithm: AlgorithmVersion(rawValue: "legacy-hr-control-2026-08"),
+            safetyPolicy: SafetyPolicyVersion(rawValue: "walkingpad-runtime-safety-2026-08"),
+            workoutProtocol: WorkoutProtocolVersion(rawValue: "hr-workout-v1")
+        )
     }
 
     private func endTelemetryV2Session(reason: String) {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -4266,13 +4266,10 @@ private struct DebugView: View {
         ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
     }
 
-    private func trainingLogsMenuItemTitle(
-        scope: TrainingLogCsvExportScope,
-        sessionSummaryOnly: Bool
-    ) -> String {
+    private func trainingLogsMenuItemTitle(scope: TrainingLogCsvExportScope) -> String {
         switch scope {
         case .all:
-            return sessionSummaryOnly ? "Все V2 summary" : "Все V2 evidence"
+            return "Все доступные тренировки"
         case .lastCompletedWorkouts(let limit):
             return "Последние \(limit) завершённых"
         }
@@ -4332,23 +4329,16 @@ private struct DebugView: View {
         let unavailableCount = entries.filter { !$0.quality.unavailableMetrics.isEmpty }.count
         let possibleDuplicateCount = entries.filter(\.quality.possibleDuplicate).count
         let detailLines = [
-            "Export формируется потоково из Telemetry V2 и включает manifest, raw JSONL, normalized CSV и session summary.",
-            "Legacy JSONL и UserDefaults shadow history не читаются, не очищаются и не удаляются.",
-            "Поля HealthKit linkage и version context сохраняются; device/profile identifiers исключены.",
+            "Пакет содержит техническую диагностику тренировок и пульса, включая данные о здоровье.",
+            "В один файл входят полные исходные данные, сводка, версии и признаки качества.",
+            "Legacy evidence не читается и не удаляется; device/profile identifiers исключены.",
             readStatusText,
         ]
 
-        let rawExportOptions = trainingLogScopeOptions.map { scope in
-            DebugTrainingLogsCard.Presentation.ExportOption(
-                id: "raw_\(scope.logDescription)",
-                title: trainingLogsMenuItemTitle(scope: scope, sessionSummaryOnly: false),
-                scope: scope
-            )
-        }
-        let summaryExportOptions = trainingLogScopeOptions.map { scope in
-            DebugTrainingLogsCard.Presentation.ExportOption(
-                id: "summary_\(scope.logDescription)",
-                title: trainingLogsMenuItemTitle(scope: scope, sessionSummaryOnly: true),
+        let diagnosticScopeOptions = trainingLogScopeOptions.map { scope in
+            DebugTrainingLogsCard.Presentation.DiagnosticScopeOption(
+                id: scope.logDescription,
+                title: trainingLogsMenuItemTitle(scope: scope),
                 scope: scope
             )
         }
@@ -4388,15 +4378,12 @@ private struct DebugView: View {
             deviceMetrics: [],
             writerHealthMetrics: telemetryV2WriterHealthMetrics,
             writerHealthDetailLines: telemetryV2WriterHealthDetailLines,
-            rawExportOptions: rawExportOptions,
-            rawExportSubtitle: readReady ? "Raw + normalized + manifest" : "V2 read unavailable",
-            canExportRaw: readReady,
-            sessionSummaryOptions: summaryExportOptions,
-            sessionSummarySubtitle: readReady
-                ? "V2 summary + quality fields"
-                : "V2 read unavailable",
-            canExportSessionSummary: readReady,
-            clearSubtitle: "Source evidence is immutable in this cutover.",
+            diagnosticScopeOptions: diagnosticScopeOptions,
+            diagnosticShareSubtitle: readReady
+                ? "Тренировки, пульс, версии и качество данных"
+                : "Данные Telemetry V2 недоступны",
+            canShareDiagnostics: readReady,
+            clearSubtitle: "Исходные данные остаются без изменений.",
             canClear: false,
             clearConfirmationMessage: "",
             detailLines: detailLines,
@@ -4797,11 +4784,8 @@ private struct DebugView: View {
                                 manager.startTreadmillTestRun()
                             }
                         },
-                        onExportRaw: { scope in
-                            exportTrainingHistoryCsv(manager: manager, scope: scope)
-                        },
-                        onExportSessionSummary: { scope in
-                            exportTrainingSessionSummaryCsv(manager: manager, scope: scope)
+                        onShareDiagnostics: { scope in
+                            shareTrainingDiagnostics(manager: manager, scope: scope)
                         }
                     )
 
@@ -4839,14 +4823,7 @@ private func copyLogs(lastCmd: String, hrStatus: String, log: String) {
     UIPasteboard.general.string = text
 }
 
-private func exportTrainingHistoryCsv(
-    manager: BluetoothManager,
-    scope: TrainingLogCsvExportScope
-) {
-    presentTelemetryV2ExportWarning(manager: manager, scope: scope)
-}
-
-private func exportTrainingSessionSummaryCsv(
+private func shareTrainingDiagnostics(
     manager: BluetoothManager,
     scope: TrainingLogCsvExportScope
 ) {
@@ -4859,17 +4836,31 @@ private func presentTelemetryV2ExportWarning(
 ) {
     guard let root = activeRootViewController() else { return }
     let alert = UIAlertController(
-        title: "Health Data Export",
-        message: "The export contains heart-rate and workout health data. Share it only with a trusted recipient. Source evidence will not be deleted.",
+        title: "Данные о здоровье",
+        message: "Диагностический пакет содержит пульс и данные тренировок. Делитесь им только с доверенным получателем. Исходные данные не будут удалены.",
         preferredStyle: .alert
     )
-    alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-    alert.addAction(UIAlertAction(title: "Continue", style: .default) { _ in
+    alert.addAction(UIAlertAction(title: "Отмена", style: .cancel))
+    alert.addAction(UIAlertAction(title: "Продолжить", style: .default) { _ in
         Task { @MainActor in
             do {
                 let artifact = try await manager.prepareTelemetryV2Export(scope: scope)
+                let archiveURL: URL
+                do {
+                    let archiveName = diagnosticArchiveName()
+                    archiveURL = try await Task.detached(priority: .userInitiated) {
+                        try DiagnosticZipArchive.create(
+                            directoryURL: artifact.directoryURL,
+                            fileURLs: artifact.fileURLs,
+                            archiveName: archiveName
+                        )
+                    }.value
+                } catch {
+                    manager.finalizeTelemetryV2Export(artifact, completed: false)
+                    throw error
+                }
                 let activity = UIActivityViewController(
-                    activityItems: artifact.fileURLs,
+                    activityItems: [archiveURL],
                     applicationActivities: nil
                 )
                 activity.completionWithItemsHandler = { _, completed, _, _ in
@@ -4880,7 +4871,7 @@ private func presentTelemetryV2ExportWarning(
                 activeRootViewController()?.present(activity, animated: true)
             } catch {
                 let failure = UIAlertController(
-                    title: "Telemetry V2 Export Failed",
+                    title: "Не удалось подготовить диагностику",
                     message: error.localizedDescription,
                     preferredStyle: .alert
                 )
@@ -4890,6 +4881,15 @@ private func presentTelemetryV2ExportWarning(
         }
     })
     root.present(alert, animated: true)
+}
+
+private func diagnosticArchiveName(now: Date = Date()) -> String {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+    return "WalkingPad_Diagnostics_\(formatter.string(from: now)).zip"
 }
 
 private func activeRootViewController() -> UIViewController? {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -4257,6 +4257,8 @@ private struct DebugView: View {
     @State private var showHrControlPreview = false
     @State private var hrControlPreviewMode: HrControlPreviewMode = .workout
     @State private var previewNoHrSignal = false
+    @State private var diagnosticBundleTask: Task<Void, Never>?
+    @State private var isPreparingDiagnosticBundle = false
 
     private var trainingLogScopeOptions: [TrainingLogCsvExportScope] {
         [.all, .lastCompletedWorkouts(3), .lastCompletedWorkouts(5)]
@@ -4380,9 +4382,10 @@ private struct DebugView: View {
             writerHealthDetailLines: telemetryV2WriterHealthDetailLines,
             diagnosticScopeOptions: diagnosticScopeOptions,
             diagnosticShareSubtitle: readReady
-                ? "Тренировки, пульс, версии и качество данных"
-                : "Данные Telemetry V2 недоступны",
-            canShareDiagnostics: readReady,
+                ? "Последняя тренировка + support diagnostics"
+                : "Support diagnostics + доступные данные Telemetry V2",
+            canShareDiagnostics: !isPreparingDiagnosticBundle,
+            isPreparingDiagnostics: isPreparingDiagnosticBundle,
             clearSubtitle: "Исходные данные остаются без изменений.",
             canClear: false,
             clearConfirmationMessage: "",
@@ -4785,7 +4788,29 @@ private struct DebugView: View {
                             }
                         },
                         onShareDiagnostics: { scope in
-                            shareTrainingDiagnostics(manager: manager, scope: scope)
+                            presentTelemetryV2ExportWarning {
+                                diagnosticBundleTask?.cancel()
+                                isPreparingDiagnosticBundle = true
+                                diagnosticBundleTask = Task { @MainActor in
+                                    defer {
+                                        isPreparingDiagnosticBundle = false
+                                        diagnosticBundleTask = nil
+                                    }
+                                    do {
+                                        try await prepareAndPresentDiagnosticBundle(
+                                            manager: manager,
+                                            scope: scope
+                                        )
+                                    } catch is CancellationError {
+                                        // User cancellation is already reflected by the card state.
+                                    } catch {
+                                        presentDiagnosticBundleFailure(error)
+                                    }
+                                }
+                            }
+                        },
+                        onCancelDiagnostics: {
+                            diagnosticBundleTask?.cancel()
                         }
                     )
 
@@ -4806,6 +4831,9 @@ private struct DebugView: View {
             .onAppear {
                 manager.refreshWorkoutHistoryFromV2(reset: true)
             }
+            .onDisappear {
+                diagnosticBundleTask?.cancel()
+            }
         }
     }
 }
@@ -4823,16 +4851,8 @@ private func copyLogs(lastCmd: String, hrStatus: String, log: String) {
     UIPasteboard.general.string = text
 }
 
-private func shareTrainingDiagnostics(
-    manager: BluetoothManager,
-    scope: TrainingLogCsvExportScope
-) {
-    presentTelemetryV2ExportWarning(manager: manager, scope: scope)
-}
-
 private func presentTelemetryV2ExportWarning(
-    manager: BluetoothManager,
-    scope: TrainingLogCsvExportScope
+    onContinue: @escaping () -> Void
 ) {
     guard let root = activeRootViewController() else { return }
     let alert = UIAlertController(
@@ -4842,45 +4862,51 @@ private func presentTelemetryV2ExportWarning(
     )
     alert.addAction(UIAlertAction(title: "Отмена", style: .cancel))
     alert.addAction(UIAlertAction(title: "Продолжить", style: .default) { _ in
-        Task { @MainActor in
-            do {
-                let artifact = try await manager.prepareTelemetryV2Export(scope: scope)
-                let archiveURL: URL
-                do {
-                    let archiveName = diagnosticArchiveName()
-                    archiveURL = try await Task.detached(priority: .userInitiated) {
-                        try DiagnosticZipArchive.create(
-                            directoryURL: artifact.directoryURL,
-                            fileURLs: artifact.fileURLs,
-                            archiveName: archiveName
-                        )
-                    }.value
-                } catch {
-                    manager.finalizeTelemetryV2Export(artifact, completed: false)
-                    throw error
-                }
-                let activity = UIActivityViewController(
-                    activityItems: [archiveURL],
-                    applicationActivities: nil
-                )
-                activity.completionWithItemsHandler = { _, completed, _, _ in
-                    Task { @MainActor in
-                        manager.finalizeTelemetryV2Export(artifact, completed: completed)
-                    }
-                }
-                activeRootViewController()?.present(activity, animated: true)
-            } catch {
-                let failure = UIAlertController(
-                    title: "Не удалось подготовить диагностику",
-                    message: error.localizedDescription,
-                    preferredStyle: .alert
-                )
-                failure.addAction(UIAlertAction(title: "OK", style: .default))
-                activeRootViewController()?.present(failure, animated: true)
-            }
-        }
+        onContinue()
     })
     root.present(alert, animated: true)
+}
+
+@MainActor
+private func prepareAndPresentDiagnosticBundle(
+    manager: BluetoothManager,
+    scope: TrainingLogCsvExportScope
+) async throws {
+    let artifact = try await manager.prepareDiagnosticBundle(
+        scope: scope,
+        archiveName: diagnosticArchiveName()
+    )
+    do {
+        try Task.checkCancellation()
+        guard let root = activeRootViewController() else {
+            manager.finalizeDiagnosticBundle(artifact, completed: false)
+            return
+        }
+        let activity = UIActivityViewController(
+            activityItems: [artifact.archiveURL],
+            applicationActivities: nil
+        )
+        activity.completionWithItemsHandler = { _, completed, _, _ in
+            Task { @MainActor in
+                manager.finalizeDiagnosticBundle(artifact, completed: completed)
+            }
+        }
+        root.present(activity, animated: true)
+    } catch {
+        manager.finalizeDiagnosticBundle(artifact, completed: false)
+        throw error
+    }
+}
+
+@MainActor
+private func presentDiagnosticBundleFailure(_ error: Error) {
+    let failure = UIAlertController(
+        title: "Не удалось подготовить диагностику",
+        message: error.localizedDescription,
+        preferredStyle: .alert
+    )
+    failure.addAction(UIAlertAction(title: "OK", style: .default))
+    activeRootViewController()?.present(failure, animated: true)
 }
 
 private func diagnosticArchiveName(now: Date = Date()) -> String {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DebugTrainingLogsCard.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DebugTrainingLogsCard.swift
@@ -9,7 +9,7 @@ struct DebugTrainingLogsCard: View {
             let tint: Color
         }
 
-        struct ExportOption: Identifiable {
+        struct DiagnosticScopeOption: Identifiable {
             let id: String
             let title: String
             let scope: TrainingLogCsvExportScope
@@ -31,12 +31,9 @@ struct DebugTrainingLogsCard: View {
         let deviceMetrics: [Metric]
         let writerHealthMetrics: [Metric]
         let writerHealthDetailLines: [String]
-        let rawExportOptions: [ExportOption]
-        let rawExportSubtitle: String
-        let canExportRaw: Bool
-        let sessionSummaryOptions: [ExportOption]
-        let sessionSummarySubtitle: String
-        let canExportSessionSummary: Bool
+        let diagnosticScopeOptions: [DiagnosticScopeOption]
+        let diagnosticShareSubtitle: String
+        let canShareDiagnostics: Bool
         let clearSubtitle: String
         let canClear: Bool
         let clearConfirmationMessage: String
@@ -46,16 +43,10 @@ struct DebugTrainingLogsCard: View {
 
     let presentation: Presentation
     let onToggleTestRun: () -> Void
-    let onExportRaw: (TrainingLogCsvExportScope) -> Void
-    let onExportSessionSummary: (TrainingLogCsvExportScope) -> Void
+    let onShareDiagnostics: (TrainingLogCsvExportScope) -> Void
 
     private let metricColumns = [
         GridItem(.flexible(), spacing: 10),
-        GridItem(.flexible(), spacing: 10),
-        GridItem(.flexible(), spacing: 10)
-    ]
-
-    private let actionColumns = [
         GridItem(.flexible(), spacing: 10),
         GridItem(.flexible(), spacing: 10)
     ]
@@ -175,39 +166,24 @@ struct DebugTrainingLogsCard: View {
                     }
                 }
 
-                LazyVGrid(columns: actionColumns, spacing: 10) {
-                    Menu {
-                        ForEach(presentation.rawExportOptions) { option in
-                            Button(option.title) {
-                                onExportRaw(option.scope)
-                            }
+                Menu {
+                    ForEach(presentation.diagnosticScopeOptions) { option in
+                        Button(option.title) {
+                            onShareDiagnostics(option.scope)
                         }
-                    } label: {
-                        DebugActionTileLabel(
-                            title: "Export Training CSV",
-                            subtitle: presentation.rawExportSubtitle,
-                            tint: .accentColor,
-                            enabled: presentation.canExportRaw
-                        )
                     }
-                    .disabled(!presentation.canExportRaw)
-
-                    Menu {
-                        ForEach(presentation.sessionSummaryOptions) { option in
-                            Button(option.title) {
-                                onExportSessionSummary(option.scope)
-                            }
-                        }
-                    } label: {
-                        DebugActionTileLabel(
-                            title: "Export Session Summary",
-                            subtitle: presentation.sessionSummarySubtitle,
-                            tint: Color.blue,
-                            enabled: presentation.canExportSessionSummary
-                        )
-                    }
-                    .disabled(!presentation.canExportSessionSummary)
+                } label: {
+                    DebugActionTileLabel(
+                        title: "Поделиться диагностикой",
+                        subtitle: presentation.diagnosticShareSubtitle,
+                        tint: .accentColor,
+                        enabled: presentation.canShareDiagnostics
+                    )
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .disabled(!presentation.canShareDiagnostics)
+                .accessibilityLabel("Поделиться диагностикой")
+                .accessibilityHint("Выберите объём тренировок для диагностического пакета")
 
                 Text(presentation.clearSubtitle)
                     .font(.caption)

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DebugTrainingLogsCard.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/DebugTrainingLogsCard.swift
@@ -34,6 +34,7 @@ struct DebugTrainingLogsCard: View {
         let diagnosticScopeOptions: [DiagnosticScopeOption]
         let diagnosticShareSubtitle: String
         let canShareDiagnostics: Bool
+        let isPreparingDiagnostics: Bool
         let clearSubtitle: String
         let canClear: Bool
         let clearConfirmationMessage: String
@@ -44,6 +45,7 @@ struct DebugTrainingLogsCard: View {
     let presentation: Presentation
     let onToggleTestRun: () -> Void
     let onShareDiagnostics: (TrainingLogCsvExportScope) -> Void
+    let onCancelDiagnostics: () -> Void
 
     private let metricColumns = [
         GridItem(.flexible(), spacing: 10),
@@ -166,24 +168,44 @@ struct DebugTrainingLogsCard: View {
                     }
                 }
 
-                Menu {
-                    ForEach(presentation.diagnosticScopeOptions) { option in
-                        Button(option.title) {
-                            onShareDiagnostics(option.scope)
-                        }
+                if presentation.isPreparingDiagnostics {
+                    Button(action: onCancelDiagnostics) {
+                        DebugActionTileLabel(
+                            title: "Отменить подготовку",
+                            subtitle: "Диагностический пакет формируется…",
+                            tint: .orange,
+                            enabled: true
+                        )
                     }
-                } label: {
-                    DebugActionTileLabel(
-                        title: "Поделиться диагностикой",
-                        subtitle: presentation.diagnosticShareSubtitle,
-                        tint: .accentColor,
-                        enabled: presentation.canShareDiagnostics
-                    )
+                    .buttonStyle(.plain)
+                    .accessibilityHint("Отменяет подготовку и удаляет временные файлы")
+                } else {
+                    Button {
+                        onShareDiagnostics(.lastCompletedWorkouts(1))
+                    } label: {
+                        DebugActionTileLabel(
+                            title: "Поделиться диагностикой",
+                            subtitle: presentation.diagnosticShareSubtitle,
+                            tint: .accentColor,
+                            enabled: presentation.canShareDiagnostics
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!presentation.canShareDiagnostics)
+                    .accessibilityHint("Готовит последнюю тренировку и support diagnostics")
+
+                    Menu {
+                        ForEach(presentation.diagnosticScopeOptions) { option in
+                            Button(option.title) {
+                                onShareDiagnostics(option.scope)
+                            }
+                        }
+                    } label: {
+                        Label("Другой объём", systemImage: "ellipsis.circle")
+                            .font(.caption.weight(.semibold))
+                    }
+                    .disabled(!presentation.canShareDiagnostics)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .disabled(!presentation.canShareDiagnostics)
-                .accessibilityLabel("Поделиться диагностикой")
-                .accessibilityHint("Выберите объём тренировок для диагностического пакета")
 
                 Text(presentation.clearSubtitle)
                     .font(.caption)

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/NativeHeartRatePreflightEngine.swift
@@ -559,6 +559,32 @@ struct NativeHeartRateProviderLifecycle: Equatable {
 struct NativeHeartRatePreflightEngine {
     static let timeoutSeconds: TimeInterval = 30
 
+    struct DiagnosticSnapshot: Equatable {
+        var phase: String
+        var requestedAt: Date?
+        var providerPreparedAt: Date?
+        var collectionStartedAt: Date?
+        var firstNativeCallbackMeasuredAt: Date?
+        var firstNativeCallbackReceivedAt: Date?
+        var firstQualifyingLatencySeconds: TimeInterval?
+        var terminalAt: Date?
+        var terminalReason: String?
+        var gateBlockReason: String?
+
+        static let idle = DiagnosticSnapshot(
+            phase: "idle",
+            requestedAt: nil,
+            providerPreparedAt: nil,
+            collectionStartedAt: nil,
+            firstNativeCallbackMeasuredAt: nil,
+            firstNativeCallbackReceivedAt: nil,
+            firstQualifyingLatencySeconds: nil,
+            terminalAt: nil,
+            terminalReason: nil,
+            gateBlockReason: nil
+        )
+    }
+
     enum RuntimePolicy {
         static func stopInProgress(
             hasObservationLifecycle: Bool,
@@ -721,6 +747,8 @@ struct NativeHeartRatePreflightEngine {
     }
 
     private var phase: Phase = .idle
+    private var latestProviderPreparedAt: Date?
+    private(set) var diagnosticSnapshot: DiagnosticSnapshot = .idle
 
     var isWarmPrepared: Bool { phase == .prepared }
 
@@ -747,7 +775,33 @@ struct NativeHeartRatePreflightEngine {
     }
 
     mutating func requestStart(intent: Intent, safety: SafetyFacts) -> [Effect] {
-        guard safety.permitsStartIntent else { return [] }
+        guard safety.permitsStartIntent else {
+            diagnosticSnapshot = DiagnosticSnapshot(
+                phase: "blocked",
+                requestedAt: intent.requestedAt,
+                providerPreparedAt: latestProviderPreparedAt,
+                collectionStartedAt: nil,
+                firstNativeCallbackMeasuredAt: nil,
+                firstNativeCallbackReceivedAt: nil,
+                firstQualifyingLatencySeconds: nil,
+                terminalAt: intent.requestedAt,
+                terminalReason: "start_blocked",
+                gateBlockReason: Self.startBlockReason(safety)
+            )
+            return []
+        }
+        diagnosticSnapshot = DiagnosticSnapshot(
+            phase: "requested",
+            requestedAt: intent.requestedAt,
+            providerPreparedAt: latestProviderPreparedAt,
+            collectionStartedAt: nil,
+            firstNativeCallbackMeasuredAt: nil,
+            firstNativeCallbackReceivedAt: nil,
+            firstQualifyingLatencySeconds: nil,
+            terminalAt: nil,
+            terminalReason: nil,
+            gateBlockReason: nil
+        )
         switch phase {
         case .idle:
             phase = .preparing(intent)
@@ -768,13 +822,18 @@ struct NativeHeartRatePreflightEngine {
     }
 
     mutating func providerPrepared(at date: Date) -> [Effect] {
+        latestProviderPreparedAt = date
         switch phase {
         case .warming:
             phase = .prepared
             return []
         case .preparing(let intent):
+            if diagnosticSnapshot.requestedAt == intent.requestedAt {
+                diagnosticSnapshot.phase = "provider_prepared"
+                diagnosticSnapshot.providerPreparedAt = date
+            }
             guard !deadlineReached(for: intent, now: date) else {
-                return cancel(reason: .timeout)
+                return cancel(reason: .timeout, now: date)
             }
             phase = .starting(intent, acquisitionStartedAt: date)
             return [.startCollection(intent: intent, acquisitionStartedAt: date)]
@@ -794,13 +853,15 @@ struct NativeHeartRatePreflightEngine {
             return []
         }
         guard !deadlineReached(for: intent, now: now) else {
-            return cancel(reason: .timeout)
+            return cancel(reason: .timeout, now: now)
         }
         phase = .waiting(
             intent,
             acquisitionStartedAt: acquisitionStartedAt,
             observation: nil
         )
+        diagnosticSnapshot.phase = "collecting"
+        diagnosticSnapshot.collectionStartedAt = acquisitionStartedAt
         return []
     }
 
@@ -812,7 +873,12 @@ struct NativeHeartRatePreflightEngine {
     ) -> [Effect] {
         guard let intent = currentIntent else { return [] }
         guard !deadlineReached(for: intent, now: now) else {
-            return cancel(reason: .timeout)
+            return cancel(reason: .timeout, now: now)
+        }
+        if observation.source == .nativeHealthKit,
+           diagnosticSnapshot.firstNativeCallbackReceivedAt == nil {
+            diagnosticSnapshot.firstNativeCallbackMeasuredAt = observation.measuredAt
+            diagnosticSnapshot.firstNativeCallbackReceivedAt = observation.receivedAt
         }
         guard case .waiting(let intent, let acquisitionStartedAt, _) = phase,
               observation.isQualifying(
@@ -822,6 +888,14 @@ struct NativeHeartRatePreflightEngine {
               ) else {
             return []
         }
+        diagnosticSnapshot.phase = "qualifying_hr_received"
+        diagnosticSnapshot.firstQualifyingLatencySeconds = max(
+            0,
+            observation.receivedAt.timeIntervalSince(acquisitionStartedAt)
+        )
+        diagnosticSnapshot.gateBlockReason = safety.controllerUnitsAllowed
+            ? nil
+            : "controller_units_blocked"
         phase = .waiting(
             intent,
             acquisitionStartedAt: acquisitionStartedAt,
@@ -837,16 +911,16 @@ struct NativeHeartRatePreflightEngine {
     ) -> [Effect] {
         guard ownsUncommittedWorkout else { return [] }
         if let intent = currentIntent, deadlineReached(for: intent, now: now) {
-            return cancel(reason: .timeout)
+            return cancel(reason: .timeout, now: now)
         }
         if safety.appActivity == .background {
-            return cancel(reason: .appBackgrounded)
+            return cancel(reason: .appBackgrounded, now: now)
         }
         if !safety.treadmillControlReady || !safety.transportValid {
-            return cancel(reason: .treadmillControlLost)
+            return cancel(reason: .treadmillControlLost, now: now)
         }
         if safety.hasConflictingWorkout || safety.stopInProgress {
-            return cancel(reason: .superseded)
+            return cancel(reason: .superseded, now: now)
         }
         return commitIfAllowed(safety: safety, now: now, freshnessLimit: freshnessLimit)
     }
@@ -856,12 +930,15 @@ struct NativeHeartRatePreflightEngine {
               deadlineReached(for: intent, now: now) else {
             return []
         }
-        return cancel(reason: .timeout)
+        return cancel(reason: .timeout, now: now)
     }
 
-    mutating func cancel(reason: CancellationReason) -> [Effect] {
+    mutating func cancel(reason: CancellationReason, now: Date = Date()) -> [Effect] {
         guard phase != .idle else { return [] }
         phase = .idle
+        diagnosticSnapshot.phase = "terminal"
+        diagnosticSnapshot.terminalAt = now
+        diagnosticSnapshot.terminalReason = reason.rawValue
         return [.discard(reason: reason)]
     }
 
@@ -889,7 +966,7 @@ struct NativeHeartRatePreflightEngine {
             return []
         }
         guard !deadlineReached(for: intent, now: now) else {
-            return cancel(reason: .timeout)
+            return cancel(reason: .timeout, now: now)
         }
         guard safety.permitsCommit,
               observation.isQualifying(
@@ -900,6 +977,10 @@ struct NativeHeartRatePreflightEngine {
             return []
         }
         phase = .idle
+        diagnosticSnapshot.phase = "committed"
+        diagnosticSnapshot.terminalAt = now
+        diagnosticSnapshot.terminalReason = "committed"
+        diagnosticSnapshot.gateBlockReason = nil
         return [.commit(
             intent: intent,
             observation: observation,
@@ -909,5 +990,14 @@ struct NativeHeartRatePreflightEngine {
 
     private func deadlineReached(for intent: Intent, now: Date) -> Bool {
         now >= intent.requestedAt.addingTimeInterval(Self.timeoutSeconds)
+    }
+
+    private static func startBlockReason(_ safety: SafetyFacts) -> String {
+        if safety.appActivity != .active { return "app_not_active" }
+        if !safety.treadmillControlReady { return "treadmill_not_ready" }
+        if !safety.transportValid { return "transport_invalid" }
+        if safety.hasConflictingWorkout { return "conflicting_workout" }
+        if safety.stopInProgress { return "stop_in_progress" }
+        return "unknown"
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
@@ -150,6 +150,104 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
         ])
     }
 
+    func testDiagnosticSnapshotRecordsBlockedStartWithoutChangingEffectsOrWarmState() {
+        var engine = preparedEngine()
+        let intent = makeIntent()
+
+        let effects = engine.requestStart(
+            intent: intent,
+            safety: safeFacts(treadmillControlReady: false)
+        )
+
+        XCTAssertEqual(effects, [])
+        XCTAssertTrue(engine.isWarmPrepared)
+        XCTAssertFalse(engine.hasStartIntent)
+        XCTAssertEqual(engine.diagnosticSnapshot.phase, "blocked")
+        XCTAssertEqual(engine.diagnosticSnapshot.requestedAt, intent.requestedAt)
+        XCTAssertEqual(engine.diagnosticSnapshot.terminalAt, intent.requestedAt)
+        XCTAssertEqual(engine.diagnosticSnapshot.terminalReason, "start_blocked")
+        XCTAssertEqual(engine.diagnosticSnapshot.gateBlockReason, "treadmill_not_ready")
+    }
+
+    func testDiagnosticSnapshotTracksQualifyingLatencyWithoutChangingDeferredCommit() {
+        var engine = waitingEngine()
+        let observation = nativeObservation(
+            measuredAt: now.addingTimeInterval(1.25),
+            receivedAt: now.addingTimeInterval(1.5)
+        )
+
+        let blockedEffects = engine.receive(
+            observation,
+            safety: safeFacts(controllerUnitsAllowed: false),
+            now: now.addingTimeInterval(2),
+            freshnessLimit: 7
+        )
+
+        XCTAssertEqual(blockedEffects, [])
+        XCTAssertTrue(engine.hasStartIntent)
+        XCTAssertEqual(engine.diagnosticSnapshot.phase, "qualifying_hr_received")
+        XCTAssertEqual(engine.diagnosticSnapshot.firstNativeCallbackMeasuredAt, observation.measuredAt)
+        XCTAssertEqual(engine.diagnosticSnapshot.firstNativeCallbackReceivedAt, observation.receivedAt)
+        XCTAssertEqual(engine.diagnosticSnapshot.firstQualifyingLatencySeconds, 1.5)
+        XCTAssertEqual(engine.diagnosticSnapshot.gateBlockReason, "controller_units_blocked")
+
+        let commitEffects = engine.safetyChanged(
+            safeFacts(),
+            now: now.addingTimeInterval(3),
+            freshnessLimit: 7
+        )
+        XCTAssertEqual(commitEffects.count, 1)
+        guard case .commit = commitEffects[0] else {
+            return XCTFail("Expected existing commit effect")
+        }
+        XCTAssertEqual(engine.diagnosticSnapshot.phase, "committed")
+        XCTAssertEqual(engine.diagnosticSnapshot.terminalAt, now.addingTimeInterval(3))
+        XCTAssertEqual(engine.diagnosticSnapshot.terminalReason, "committed")
+        XCTAssertNil(engine.diagnosticSnapshot.gateBlockReason)
+    }
+
+    func testDiagnosticSnapshotRecordsTerminalCancellationWithoutAddingEffects() {
+        var engine = waitingEngine()
+        let cancelledAt = now.addingTimeInterval(4)
+
+        XCTAssertEqual(
+            engine.cancel(reason: .providerFailure, now: cancelledAt),
+            [.discard(reason: .providerFailure)]
+        )
+        XCTAssertEqual(engine.cancel(reason: .providerFailure, now: cancelledAt), [])
+        XCTAssertEqual(engine.diagnosticSnapshot.phase, "terminal")
+        XCTAssertEqual(engine.diagnosticSnapshot.terminalAt, cancelledAt)
+        XCTAssertEqual(engine.diagnosticSnapshot.terminalReason, "providerFailure")
+    }
+
+    func testWarmPreparationCannotOverwriteBlockedOrTerminalDiagnosticSnapshot() {
+        var blockedEngine = NativeHeartRatePreflightEngine()
+        let blockedIntent = makeIntent()
+        XCTAssertEqual(blockedEngine.requestStart(
+            intent: blockedIntent,
+            safety: safeFacts(treadmillControlReady: false)
+        ), [])
+        let blockedSnapshot = blockedEngine.diagnosticSnapshot
+
+        XCTAssertEqual(blockedEngine.requestWarmPreparation(), [.prepare])
+        XCTAssertEqual(blockedEngine.providerPrepared(at: now.addingTimeInterval(5)), [])
+        XCTAssertEqual(blockedEngine.diagnosticSnapshot, blockedSnapshot)
+
+        var terminalEngine = waitingEngine()
+        XCTAssertEqual(
+            terminalEngine.cancel(
+                reason: .providerFailure,
+                now: now.addingTimeInterval(6)
+            ),
+            [.discard(reason: .providerFailure)]
+        )
+        let terminalSnapshot = terminalEngine.diagnosticSnapshot
+
+        XCTAssertEqual(terminalEngine.requestWarmPreparation(), [.prepare])
+        XCTAssertEqual(terminalEngine.providerPrepared(at: now.addingTimeInterval(7)), [])
+        XCTAssertEqual(terminalEngine.diagnosticSnapshot, terminalSnapshot)
+    }
+
     func testHeartRateAtDeadlineCannotCommitWithoutTimerTick() {
         var engine = waitingEngine()
 
@@ -850,6 +948,7 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
     private func safeFacts(
         appActivity: NativeHeartRatePreflightEngine.AppActivity = .active,
         treadmillControlReady: Bool = true,
+        controllerUnitsAllowed: Bool = true,
         hasConflictingWorkout: Bool = false,
         stopInProgress: Bool = false,
         telemetryAvailability: NativeHeartRatePreflightEngine.TelemetryAvailability = .healthy
@@ -858,7 +957,7 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
             appActivity: appActivity,
             treadmillControlReady: treadmillControlReady,
             transportValid: true,
-            controllerUnitsAllowed: true,
+            controllerUnitsAllowed: controllerUnitsAllowed,
             hasConflictingWorkout: hasConflictingWorkout,
             stopInProgress: stopInProgress,
             telemetryAvailability: telemetryAvailability

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WorkoutReadCutoverContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WorkoutReadCutoverContractTests.swift
@@ -9,16 +9,19 @@ final class WorkoutReadCutoverContractTests: XCTestCase {
     func testNormalHistoryStatisticsAndExportUIUseOnlyTelemetryV2() {
         XCTAssertTrue(contentSource.contains("manager.telemetryV2WorkoutHistory"))
         XCTAssertTrue(contentSource.contains("manager.telemetryV2Statistics"))
-        XCTAssertTrue(contentSource.contains("manager.prepareTelemetryV2Export"))
+        XCTAssertTrue(contentSource.contains("manager.prepareDiagnosticBundle"))
+        XCTAssertTrue(managerSource.contains("prepareTelemetryV2Export"))
         XCTAssertFalse(contentSource.contains("manager.workoutHistory"))
         XCTAssertFalse(contentSource.contains("manager.prepareTrainingLogsCsvExport"))
         XCTAssertFalse(contentSource.contains("manager.prepareTrainingSessionSummaryCsvExport"))
         XCTAssertFalse(contentSource.contains("manager.clearTrainingLogsForActiveProfile"))
     }
 
-    func testDebugSharesOneCompleteDiagnosticItemBehindPlainLanguageScopes() {
+    func testDebugSharesOneCancellableDiagnosticItemWithRecentDefault() {
         XCTAssertTrue(trainingLogsCardSource.contains("Поделиться диагностикой"))
+        XCTAssertTrue(trainingLogsCardSource.contains(".lastCompletedWorkouts(1)"))
         XCTAssertTrue(trainingLogsCardSource.contains("presentation.diagnosticScopeOptions"))
+        XCTAssertTrue(trainingLogsCardSource.contains("Отменить подготовку"))
         XCTAssertTrue(trainingLogsCardSource.contains("controllerUnitsDiagnosticReport"))
         XCTAssertTrue(trainingLogsCardSource.contains("heartRateDiagnosticReport"))
         XCTAssertFalse(trainingLogsCardSource.contains("Export Training CSV"))
@@ -29,9 +32,12 @@ final class WorkoutReadCutoverContractTests: XCTestCase {
         XCTAssertTrue(contentSource.contains("Все доступные тренировки"))
         XCTAssertTrue(contentSource.contains("Последние "))
         XCTAssertTrue(contentSource.contains("Данные о здоровье"))
-        XCTAssertTrue(contentSource.contains("activityItems: [archiveURL]"))
+        XCTAssertTrue(contentSource.contains("activityItems: [artifact.archiveURL]"))
         XCTAssertFalse(contentSource.contains("activityItems: artifact.fileURLs"))
-        XCTAssertTrue(contentSource.contains("manager.finalizeTelemetryV2Export"))
+        XCTAssertTrue(contentSource.contains("manager.finalizeDiagnosticBundle"))
+        XCTAssertTrue(contentSource.contains("diagnosticBundleTask?.cancel()"))
+        XCTAssertTrue(managerSource.contains("diagnosticSupportSnapshot"))
+        XCTAssertTrue(managerSource.contains("DiagnosticBundlePackager.create"))
     }
 
     func testLegacyHistoryIsPrivateShadowEvidenceAndCannotGateStart() throws {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WorkoutReadCutoverContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WorkoutReadCutoverContractTests.swift
@@ -4,6 +4,7 @@ import XCTest
 final class WorkoutReadCutoverContractTests: XCTestCase {
     private lazy var managerSource = source("BluetoothManager.swift")
     private lazy var contentSource = source("ContentView.swift")
+    private lazy var trainingLogsCardSource = source("DebugTrainingLogsCard.swift")
 
     func testNormalHistoryStatisticsAndExportUIUseOnlyTelemetryV2() {
         XCTAssertTrue(contentSource.contains("manager.telemetryV2WorkoutHistory"))
@@ -13,6 +14,24 @@ final class WorkoutReadCutoverContractTests: XCTestCase {
         XCTAssertFalse(contentSource.contains("manager.prepareTrainingLogsCsvExport"))
         XCTAssertFalse(contentSource.contains("manager.prepareTrainingSessionSummaryCsvExport"))
         XCTAssertFalse(contentSource.contains("manager.clearTrainingLogsForActiveProfile"))
+    }
+
+    func testDebugSharesOneCompleteDiagnosticItemBehindPlainLanguageScopes() {
+        XCTAssertTrue(trainingLogsCardSource.contains("Поделиться диагностикой"))
+        XCTAssertTrue(trainingLogsCardSource.contains("presentation.diagnosticScopeOptions"))
+        XCTAssertTrue(trainingLogsCardSource.contains("controllerUnitsDiagnosticReport"))
+        XCTAssertTrue(trainingLogsCardSource.contains("heartRateDiagnosticReport"))
+        XCTAssertFalse(trainingLogsCardSource.contains("Export Training CSV"))
+        XCTAssertFalse(trainingLogsCardSource.contains("Export Session Summary"))
+        XCTAssertFalse(trainingLogsCardSource.contains("onExportRaw"))
+        XCTAssertFalse(trainingLogsCardSource.contains("onExportSessionSummary"))
+
+        XCTAssertTrue(contentSource.contains("Все доступные тренировки"))
+        XCTAssertTrue(contentSource.contains("Последние "))
+        XCTAssertTrue(contentSource.contains("Данные о здоровье"))
+        XCTAssertTrue(contentSource.contains("activityItems: [archiveURL]"))
+        XCTAssertFalse(contentSource.contains("activityItems: artifact.fileURLs"))
+        XCTAssertTrue(contentSource.contains("manager.finalizeTelemetryV2Export"))
     }
 
     func testLegacyHistoryIsPrivateShadowEvidenceAndCannotGateStart() throws {


### PR DESCRIPTION
## Summary

- Add a bounded support artifact to every diagnostic bundle with preflight timestamps and terminal/gate outcome, native provider lifecycle, controller-units/A6/current-epoch truth, treadmill readiness/context, Telemetry V2 writer/read health, and runtime version context.
- Make the normal one-tap scope the latest completed workout plus support diagnostics; keep latest 3, latest 5, and all active-profile workouts as optional scopes.
- Produce an explicit support-only archive when no completed workout exists or V2 evidence is unavailable, without fabricating workout evidence or adding another logger.
- Retain cancellable off-main export/streaming ZIP ownership and remove temporary artifacts on cancellation, failure, or share completion.

Closes #112

## Verification

- `swift test` — all Swift package targets passed; the opt-in 1000-hour full profile was skipped by its existing environment gate.
- Focused diagnostic archive, cancellation, support-only, preflight safety, and cutover contract tests passed.
- Deterministic diagnostic benchmark passed:
  - 30-minute latest: 0.222 s total, 3,335,622-byte archive, 4,964,352-byte peak RSS delta, 6.07 ms maximum MainActor heartbeat gap.
  - 120-minute latest: 0.851 s total, 13,387,783-byte archive, 16,449,536-byte peak RSS delta, 6.11 ms maximum MainActor heartbeat gap.
  - all active-profile fixture: 0.854 s total, 13,330,238-byte archive, 8,994,816-byte peak RSS delta, 6.09 ms maximum MainActor heartbeat gap.
  - all cases kept the maximum streaming chunk at 65,536 bytes.
- `xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` — passed, including the embedded watchOS target.
- `python3 scripts/check_codex_governance.py` — passed.
- `git diff --cached --check` — passed before commit.
- Independent final safety/scope review — no P0-P2 findings.
- Initial local verification exposed a stale cutover assertion, a test-side ZIP filtering assertion, and a missing app-side `return`; each was corrected and its focused/final check rerun successfully.
- The presentation-only UI scope checker reports the PM-required runtime files as forbidden; this mixed runtime/performance addendum is outside that checkers presentation-only contract.

## Risks / Notes

- Support diagnostics remain passive and bounded. No HR gate/effect, BLE command, treadmill control, recorder semantics, or source evidence is changed.
- The support artifact omits profile, peripheral, installation, and device-model identifiers. Raw A6 and ephemeral connection epochs are included only as required diagnostic context.
- Existing ZIP32 limits remain explicit; oversized bundles fail instead of truncating evidence.
- No migration, configuration, dependency, deployment, install, or physical-device step is required. Existing V2 evidence files remain compatible; the archive adds `support_diagnostics_v1.json`.
- Rollback is a code revert; no persisted data needs rollback.
- Existing unrelated compiler warnings remain in `ControllerUnitsSafetyPolicy.swift` and `BluetoothManager.swift`.