### PR TITLE
Add compact per-workout analysis export

### DIFF
--- a/docs/design/qa-ledger.md
+++ b/docs/design/qa-ledger.md
@@ -1,6 +1,17 @@
 # Redesign QA ledger
 
-Status: passed for the binding Issue #116 Training presentation follow-up.
+Status: passed for the binding Issue #113 workout-analysis export interaction.
+
+## Issue #113 — workout analysis export action
+
+| Pass | State / form factor | Severity | Finding | Evidence | Owner path | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| Baseline | Native V2 workout history row, iPhone / iPad adaptive layout | P1 | `Экспорт данных тренировки` is a native full-width bordered button in the existing scroll flow, shown only for native V2 workouts. It has a symbol, a progress state, an explicit VoiceOver label, and disables duplicate export taps while work is active. | Focused source-contract test plus unsigned generic iOS + embedded Watch build | `ContentView.swift` | Pass |
+| Baseline | Health-data confirmation and share completion | P0 | Export requires an explicit health-data confirmation, shares exactly one CSV, cleans only its temporary directory on cancel/failure/share completion, and states that source data is not changed or deleted. | Focused persistence/runtime/source-contract tests | `ContentView.swift`, `BluetoothManager.swift` | Pass |
+| Final review | Missing / imported workout selection | P0 | Imported rows expose no analysis action; typed native session plus exact active-profile ownership is revalidated by the store before any frame/event page is read. | Cross-profile, missing-native, historical UUID-case, and source-contract tests | `WorkoutReadProjection.swift`, `TelemetryWorkoutAnalysisExportStore.swift` | Pass |
+| Final review | Simulator screenshot | P3 | A clean simulator has no retained native V2 workout row, so the selected-history action cannot be captured without fabricating persisted product evidence. Source order, hit target behavior, accessibility label, localization resilience, and adaptive scroll placement were verified by inspection and build instead. | QA environment limitation; no device, BLE, treadmill, or fabricated persistence fixture used | QA environment | Accepted limitation; no P0–P2 finding. |
+
+No visual correction pass was required. The export generation runs through the isolated SwiftData actor; the history view only coordinates progress, confirmation, and the system share sheet.
 
 ## Issue #116 — active/cooldown presentation polish
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/WorkoutReadProjection.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryDomain/WorkoutReadProjection.swift
@@ -380,6 +380,68 @@ public struct WorkoutExportManifest: Codable, Hashable, Sendable {
     }
 }
 
+public struct WorkoutAnalysisExportRequest: Codable, Hashable, Sendable {
+    public let sessionID: SessionID
+    public let exactProfileLocalIdentifier: String
+    public let batchSize: Int
+
+    public init(
+        sessionID: SessionID,
+        exactProfileLocalIdentifier: String,
+        batchSize: Int = 128
+    ) {
+        self.sessionID = sessionID
+        self.exactProfileLocalIdentifier = exactProfileLocalIdentifier
+        self.batchSize = batchSize
+    }
+}
+
+public struct WorkoutAnalysisExportDiagnostics: Codable, Hashable, Sendable {
+    public let frameRowCount: Int
+    public let eventRowCount: Int
+    public let metadataRowCount: Int
+    public let fileByteCount: Int64
+    public let storeFetchCount: Int
+    public let maximumStoreFetchLimit: Int
+    public let maximumBufferedTimelineRows: Int
+
+    public init(
+        frameRowCount: Int,
+        eventRowCount: Int,
+        metadataRowCount: Int,
+        fileByteCount: Int64,
+        storeFetchCount: Int,
+        maximumStoreFetchLimit: Int,
+        maximumBufferedTimelineRows: Int
+    ) {
+        self.frameRowCount = frameRowCount
+        self.eventRowCount = eventRowCount
+        self.metadataRowCount = metadataRowCount
+        self.fileByteCount = fileByteCount
+        self.storeFetchCount = storeFetchCount
+        self.maximumStoreFetchLimit = maximumStoreFetchLimit
+        self.maximumBufferedTimelineRows = maximumBufferedTimelineRows
+    }
+}
+
+public struct WorkoutAnalysisExportArtifact: Codable, Hashable, Sendable {
+    public static let schemaVersion = "workout-analysis-timeline-v1"
+
+    public let fileURL: URL
+    public let diagnostics: WorkoutAnalysisExportDiagnostics
+    public let containsHealthData: Bool
+
+    public init(
+        fileURL: URL,
+        diagnostics: WorkoutAnalysisExportDiagnostics,
+        containsHealthData: Bool
+    ) {
+        self.fileURL = fileURL
+        self.diagnostics = diagnostics
+        self.containsHealthData = containsHealthData
+    }
+}
+
 public enum TelemetryWorkoutReadError: Error, Codable, Equatable, Sendable {
     case unavailable(String)
     case invalidPageSize
@@ -415,6 +477,10 @@ public protocol TelemetryWorkoutReadCapability: Sendable {
     ) async throws -> WorkoutStatisticsProjection
 
     func exportWorkouts(_ request: WorkoutExportRequest) async throws -> WorkoutExportArtifact
+
+    func exportWorkoutAnalysis(
+        _ request: WorkoutAnalysisExportRequest
+    ) async throws -> WorkoutAnalysisExportArtifact
 }
 
 public protocol TelemetryHealthKitWorkoutLinkageCapability: Sendable {

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutAnalysisExportStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutAnalysisExportStore.swift
@@ -1,0 +1,935 @@
+import CryptoKit
+import Foundation
+import SwiftData
+import TelemetryDomain
+
+private struct WorkoutAnalysisEventProjection {
+    let elapsedMicroseconds: Int64
+    let occurredAt: Date
+    let kind: String
+    let name: String
+    let detail: String?
+    let phase: WorkoutPhase?
+    let targetHeartRate: Int?
+    let decisionReference: String?
+    let commandReference: String?
+    let attemptReference: String?
+    let configurationReference: String?
+    let decisionAction: String?
+    let decisionReason: String?
+    let desiredSpeedKilometresPerHour: Double?
+    let commandedSpeedNativeValue: Double?
+    let commandedSpeedNativeUnit: String?
+    let commandAttemptNumber: Int?
+    let endReason: String?
+}
+
+private final class WorkoutAnalysisCSVStream {
+    static let headers = [
+        "schema_version", "row_type", "row_order", "elapsed_s", "timestamp",
+        "phase", "target_bpm", "hr_bpm", "hr_evidence_ref",
+        "hr_evidence_elapsed_s", "hr_age_s", "hr_freshness", "hr_provenance",
+        "factual_speed_kmh", "treadmill_evidence_ref",
+        "treadmill_evidence_elapsed_s", "treadmill_age_s", "treadmill_freshness",
+        "treadmill_availability", "treadmill_state", "treadmill_provenance",
+        "gap_missing_since_s", "gap_kind", "event_kind", "event_name",
+        "event_detail", "decision_ref", "command_ref", "attempt_ref",
+        "configuration_ref", "decision_action", "decision_reason",
+        "desired_speed_kmh", "commanded_speed_native_value",
+        "commanded_speed_native_unit", "command_attempt_number",
+        "metadata_key", "metadata_value", "quality_flags",
+    ]
+
+    let fileURL: URL
+    private let handle: FileHandle
+    private(set) var rowOrder = 0
+    private var closed = false
+
+    init(fileURL: URL) throws {
+        self.fileURL = fileURL
+        FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+        handle = try FileHandle(forWritingTo: fileURL)
+        try write(Self.headers)
+    }
+
+    deinit { close() }
+
+    func writeTimeline(
+        elapsedMicroseconds: Int64,
+        timestamp: Date,
+        phase: String,
+        targetHeartRate: Int?,
+        values: [String: String]
+    ) throws {
+        rowOrder += 1
+        var fields = Self.emptyRow
+        fields[0] = WorkoutAnalysisExportArtifact.schemaVersion
+        fields[1] = values["row_type"] ?? ""
+        fields[2] = String(rowOrder)
+        fields[3] = Self.seconds(elapsedMicroseconds)
+        fields[4] = Self.date(timestamp)
+        fields[5] = phase
+        fields[6] = targetHeartRate.map(String.init) ?? ""
+        for (header, value) in values where header != "row_type" {
+            if let index = Self.headerIndexes[header] { fields[index] = value }
+        }
+        try write(fields)
+    }
+
+    func writeMetadata(key: String, value: String) throws {
+        rowOrder += 1
+        var fields = Self.emptyRow
+        fields[0] = WorkoutAnalysisExportArtifact.schemaVersion
+        fields[1] = "metadata"
+        fields[2] = String(rowOrder)
+        fields[36] = key
+        fields[37] = value
+        try write(fields)
+    }
+
+    func close() {
+        guard !closed else { return }
+        closed = true
+        try? handle.close()
+    }
+
+    static func number(_ value: Double?) -> String {
+        value.map {
+            String(format: "%.6f", locale: Locale(identifier: "en_US_POSIX"), $0)
+        } ?? ""
+    }
+
+    static func seconds(_ microseconds: Int64?) -> String {
+        guard let microseconds else { return "" }
+        return number(Double(microseconds) / 1_000_000)
+    }
+
+    static func date(_ value: Date?) -> String {
+        guard let value else { return "" }
+        return dateFormatter.string(from: value)
+    }
+
+    private func write(_ fields: [String]) throws {
+        let line = fields.map(Self.escape).joined(separator: ",") + "\n"
+        try handle.write(contentsOf: Data(line.utf8))
+    }
+
+    private static let emptyRow = Array(repeating: "", count: headers.count)
+    private static let headerIndexes = Dictionary(
+        uniqueKeysWithValues: headers.enumerated().map { ($1, $0) }
+    )
+    private static let dateFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+
+    private static func escape(_ value: String) -> String {
+        guard value.contains(",") || value.contains("\"")
+                || value.contains("\n") || value.contains("\r") else {
+            return value
+        }
+        return "\"\(value.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+}
+
+public extension TelemetryStore {
+    func exportWorkoutAnalysis(
+        _ request: WorkoutAnalysisExportRequest
+    ) async throws -> WorkoutAnalysisExportArtifact {
+        let batchSize = min(256, max(1, request.batchSize))
+        let sessionKey = request.sessionID.description
+        let profileKey = request.exactProfileLocalIdentifier
+        let alternateProfileKey = UUID(uuidString: profileKey)?.uuidString.lowercased()
+            ?? profileKey
+        var sessionDescriptor = FetchDescriptor<TelemetryWorkoutSessionV1>(
+            predicate: #Predicate {
+                $0.sessionID == sessionKey
+                    && ($0.profileLocalIdentifier == profileKey
+                        || $0.profileLocalIdentifier == alternateProfileKey)
+            }
+        )
+        sessionDescriptor.fetchLimit = 1
+        guard let session = try modelContext.fetch(sessionDescriptor).first else {
+            throw TelemetryWorkoutReadError.unavailable("selected-native-workout-unavailable")
+        }
+
+        let directoryURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "WorkoutAnalysisExport_\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let fileURL = directoryURL.appendingPathComponent(
+            "Workout_Analysis_\(Self.analysisFileTimestamp(session.startedAt)).csv"
+        )
+        do {
+            try FileManager.default.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true
+            )
+            let stream = try WorkoutAnalysisCSVStream(fileURL: fileURL)
+            defer { stream.close() }
+
+            let configuration = try Self.decode(
+                PrivacySafeConfigurationExportRecord.self,
+                from: session.configuration?.canonicalPayload ?? Data("{}".utf8)
+            )
+            let analysis = try latestStoredAnalysis(sessionID: sessionKey)
+            var fetchCount = 2
+            var maximumBufferedRows = 0
+            var frameRows = 0
+            var eventRows = 0
+            var heartRateFrameRows = 0
+            var factualSpeedFrameRows = 0
+            var gapBoundaryRows = 0
+            var phase = WorkoutPhase.unknown
+            var targetHeartRate = configuration.targetHeartRate
+            var endReason = Self.lifecycleReason(session.incompleteReason)
+
+            var frames: [CanonicalFrame] = []
+            var events: [WorkoutAnalysisEventProjection] = []
+            var frameIndex = 0
+            var eventIndex = 0
+            var lastFrameSecond: Int64?
+            var lastFrameID = ""
+            var lastEventElapsed: Int64?
+            var lastEventID = ""
+            var framesFinished = false
+            var eventsFinished = false
+
+            func loadFramesIfNeeded() throws {
+                guard frameIndex == frames.count, !framesFinished else { return }
+                let page = try analysisFramePage(
+                    sessionID: sessionKey,
+                    afterSecond: lastFrameSecond,
+                    afterID: lastFrameID,
+                    limit: batchSize
+                )
+                fetchCount += 1
+                frames = page
+                frameIndex = 0
+                if let last = page.last {
+                    lastFrameSecond = last.canonicalElapsedSecond
+                    lastFrameID = last.frameID.description
+                }
+                framesFinished = page.count < batchSize
+            }
+
+            func loadEventsIfNeeded() throws {
+                guard eventIndex == events.count, !eventsFinished else { return }
+                let page = try analysisEventPage(
+                    sessionID: sessionKey,
+                    sessionReference: request.sessionID,
+                    afterElapsed: lastEventElapsed,
+                    afterID: lastEventID,
+                    limit: batchSize
+                )
+                fetchCount += 1
+                events = page.projections
+                eventIndex = 0
+                lastEventElapsed = page.cursorElapsed
+                lastEventID = page.cursorID
+                eventsFinished = page.fetchedCount < batchSize
+            }
+
+            while true {
+                try Task.checkCancellation()
+                try loadFramesIfNeeded()
+                try loadEventsIfNeeded()
+                maximumBufferedRows = max(
+                    maximumBufferedRows,
+                    (frames.count - frameIndex) + (events.count - eventIndex)
+                )
+                let frame = frameIndex < frames.count ? frames[frameIndex] : nil
+                let event = eventIndex < events.count ? events[eventIndex] : nil
+                guard frame != nil || event != nil else { break }
+
+                if let event,
+                   frame == nil
+                    || event.elapsedMicroseconds <= frame!.materializedAt.elapsed.microseconds {
+                    if let eventPhase = event.phase { phase = eventPhase }
+                    if let eventTarget = event.targetHeartRate { targetHeartRate = eventTarget }
+                    if let eventEndReason = event.endReason { endReason = eventEndReason }
+                    try stream.writeAnalysisEvent(
+                        event,
+                        phase: Self.phaseString(phase),
+                        targetHeartRate: targetHeartRate
+                    )
+                    eventRows += 1
+                    eventIndex += 1
+                } else if let frame {
+                    try stream.writeAnalysisFrame(
+                        frame,
+                        sessionID: request.sessionID,
+                        phase: Self.phaseString(phase),
+                        targetHeartRate: targetHeartRate
+                    )
+                    frameRows += 1
+                    if frame.heartRateEvidence != nil { heartRateFrameRows += 1 }
+                    if frame.treadmillEvidence?.factualSpeed != nil {
+                        factualSpeedFrameRows += 1
+                    }
+                    if frame.precedingGap != nil { gapBoundaryRows += 1 }
+                    frameIndex += 1
+                }
+            }
+
+            var warnings: [String] = []
+            if !session.recorderIsComplete { warnings.append("recorder-incomplete") }
+            if session.lostCriticalRecordCount > 0 {
+                warnings.append("lost-critical-records:\(session.lostCriticalRecordCount)")
+            }
+            if session.lostNativeRecordCount > 0 {
+                warnings.append("lost-native-records:\(session.lostNativeRecordCount)")
+            }
+            if frameRows == 0 { warnings.append("canonical-frames-unavailable") }
+            if heartRateFrameRows < frameRows {
+                warnings.append("heart-rate-frame-coverage-partial")
+            }
+            if factualSpeedFrameRows < frameRows {
+                warnings.append("factual-speed-frame-coverage-partial")
+            }
+            if gapBoundaryRows > 0 {
+                warnings.append("canonical-gaps-present:\(gapBoundaryRows)")
+            }
+            if analysis == nil { warnings.append("stored-analysis-unavailable") }
+            if let analysis,
+               let qualityGrade = AnalysisQualityGrade(rawValue: analysis.qualityGradeKey),
+               qualityGrade != .high {
+                warnings.append("analysis-quality:\(qualityGrade.rawValue)")
+            }
+            let exclusions = try analysis.map {
+                try Self.decode([AnalysisExclusion].self, from: $0.exclusionsPayload)
+            } ?? []
+            warnings.append(contentsOf: exclusions.map {
+                "analysis-exclusion:\(Self.analysisExclusionCode($0.code))"
+            })
+
+            let metadata = Self.analysisMetadata(
+                session: session,
+                configuration: configuration,
+                analysis: analysis,
+                frameRows: frameRows,
+                eventRows: eventRows,
+                heartRateFrameRows: heartRateFrameRows,
+                factualSpeedFrameRows: factualSpeedFrameRows,
+                gapBoundaryRows: gapBoundaryRows,
+                endReason: endReason,
+                warnings: warnings,
+                sessionID: request.sessionID
+            )
+            for item in metadata {
+                try stream.writeMetadata(key: item.key, value: item.value)
+            }
+            stream.close()
+            let byteCount = try fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+            return WorkoutAnalysisExportArtifact(
+                fileURL: fileURL,
+                diagnostics: WorkoutAnalysisExportDiagnostics(
+                    frameRowCount: frameRows,
+                    eventRowCount: eventRows,
+                    metadataRowCount: metadata.count,
+                    fileByteCount: Int64(byteCount),
+                    storeFetchCount: fetchCount,
+                    maximumStoreFetchLimit: batchSize,
+                    maximumBufferedTimelineRows: maximumBufferedRows
+                ),
+                containsHealthData: frameRows > 0
+            )
+        } catch is CancellationError {
+            try? FileManager.default.removeItem(at: directoryURL)
+            throw CancellationError()
+        } catch {
+            try? FileManager.default.removeItem(at: directoryURL)
+            if let readError = error as? TelemetryWorkoutReadError { throw readError }
+            throw TelemetryWorkoutReadError.exportFailed(String(describing: error))
+        }
+    }
+}
+
+private extension TelemetryStore {
+    struct AnalysisEventPage {
+        let projections: [WorkoutAnalysisEventProjection]
+        let fetchedCount: Int
+        let cursorElapsed: Int64?
+        let cursorID: String
+    }
+
+    func latestStoredAnalysis(sessionID: String) throws -> TelemetryWorkoutAnalysisV1? {
+        var descriptor = FetchDescriptor<TelemetryWorkoutAnalysisV1>(
+            predicate: #Predicate { $0.sessionID == sessionID },
+            sortBy: [
+                SortDescriptor(\.generatedAt, order: .reverse),
+                SortDescriptor(\.analysisID, order: .reverse),
+            ]
+        )
+        descriptor.fetchLimit = 1
+        return try modelContext.fetch(descriptor).first
+    }
+
+    func analysisFramePage(
+        sessionID: String,
+        afterSecond: Int64?,
+        afterID: String,
+        limit: Int
+    ) throws -> [CanonicalFrame] {
+        var descriptor: FetchDescriptor<TelemetryWorkoutFrameV1>
+        if let afterSecond {
+            descriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    $0.sessionID == sessionID
+                        && ($0.canonicalElapsedSecond > afterSecond
+                            || ($0.canonicalElapsedSecond == afterSecond && $0.frameID > afterID))
+                },
+                sortBy: [SortDescriptor(\.canonicalElapsedSecond), SortDescriptor(\.frameID)]
+            )
+        } else {
+            descriptor = FetchDescriptor(
+                predicate: #Predicate { $0.sessionID == sessionID },
+                sortBy: [SortDescriptor(\.canonicalElapsedSecond), SortDescriptor(\.frameID)]
+            )
+        }
+        descriptor.fetchLimit = limit
+        return try modelContext.fetch(descriptor).map(Self.domainFrame)
+    }
+
+    func analysisEventPage(
+        sessionID: String,
+        sessionReference: SessionID,
+        afterElapsed: Int64?,
+        afterID: String,
+        limit: Int
+    ) throws -> AnalysisEventPage {
+        let lifecycle = WorkoutEventKind.sessionLifecycle.rawValue
+        let phase = WorkoutEventKind.workoutPhase.rawValue
+        let source = WorkoutEventKind.sourceTransition.rawValue
+        let connection = WorkoutEventKind.connectionTransition.rawValue
+        let decision = WorkoutEventKind.controlDecision.rawValue
+        let command = WorkoutEventKind.commandLifecycle.rawValue
+        let cooldown = WorkoutEventKind.cooldown.rawValue
+        let manualStop = WorkoutEventKind.manualStop.rawValue
+        let safety = WorkoutEventKind.safety.rawValue
+        let stopEvidence = WorkoutEventKind.stopEvidence.rawValue
+        let recorderHealth = WorkoutEventKind.recorderHealth.rawValue
+        let selectedKinds = [
+            lifecycle, phase, source, connection, decision, command, cooldown,
+            manualStop, safety, stopEvidence, recorderHealth,
+        ]
+        var descriptor: FetchDescriptor<TelemetryWorkoutEventV1>
+        if let afterElapsed {
+            descriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    $0.sessionID == sessionID
+                        && selectedKinds.contains($0.kindKey)
+                        && ($0.occurredElapsedMicroseconds > afterElapsed
+                            || ($0.occurredElapsedMicroseconds == afterElapsed
+                                && $0.recordID > afterID))
+                },
+                sortBy: [
+                    SortDescriptor(\.occurredElapsedMicroseconds),
+                    SortDescriptor(\.recordID),
+                ]
+            )
+        } else {
+            descriptor = FetchDescriptor(
+                predicate: #Predicate {
+                    $0.sessionID == sessionID
+                        && selectedKinds.contains($0.kindKey)
+                },
+                sortBy: [
+                    SortDescriptor(\.occurredElapsedMicroseconds),
+                    SortDescriptor(\.recordID),
+                ]
+            )
+        }
+        descriptor.fetchLimit = limit
+        let models = try modelContext.fetch(descriptor)
+        return AnalysisEventPage(
+            projections: try models.map {
+                try Self.analysisEventProjection(
+                    Self.domainEvent($0),
+                    sessionID: sessionReference
+                )
+            },
+            fetchedCount: models.count,
+            cursorElapsed: models.last?.occurredElapsedMicroseconds ?? afterElapsed,
+            cursorID: models.last?.recordID ?? afterID
+        )
+    }
+
+    static func analysisEventProjection(
+        _ event: WorkoutEvent,
+        sessionID: SessionID
+    ) throws -> WorkoutAnalysisEventProjection {
+        let decisionRef = event.decisionID.map { reference("decision", $0.description, sessionID) }
+        let commandRef = event.commandID.map { reference("command", $0.description, sessionID) }
+        let attemptRef = event.attemptID.map { reference("attempt", $0.description, sessionID) }
+        let common = (
+            event.timestamp.occurredElapsed.microseconds,
+            event.timestamp.occurredAt,
+            event.kind.rawValue,
+            decisionRef,
+            commandRef,
+            attemptRef
+        )
+        switch event.payload.payload {
+        case let .sessionLifecycle(value):
+            let reason = lifecycleReason(value.reason ?? value.incompleteReason)
+            return .init(
+                elapsedMicroseconds: common.0, occurredAt: common.1, kind: common.2,
+                name: "lifecycle_\(value.current.rawValue)", detail: reason,
+                phase: nil, targetHeartRate: nil, decisionReference: nil,
+                commandReference: nil, attemptReference: nil, configurationReference: nil,
+                decisionAction: nil, decisionReason: nil,
+                desiredSpeedKilometresPerHour: nil, commandedSpeedNativeValue: nil,
+                commandedSpeedNativeUnit: nil, commandAttemptNumber: nil,
+                endReason: reason
+            )
+        case let .workoutPhase(value):
+            return .init(
+                elapsedMicroseconds: common.0, occurredAt: common.1, kind: common.2,
+                name: "phase_transition", detail: phaseString(value.previous),
+                phase: value.current, targetHeartRate: nil, decisionReference: nil,
+                commandReference: nil, attemptReference: nil, configurationReference: nil,
+                decisionAction: nil, decisionReason: nil,
+                desiredSpeedKilometresPerHour: nil, commandedSpeedNativeValue: nil,
+                commandedSpeedNativeUnit: nil, commandAttemptNumber: nil, endReason: nil
+            )
+        case let .sourceTransition(value):
+            let previous = value.previousSourceID == nil ? "unavailable" : "available"
+            let current = value.currentSourceID == nil ? "unavailable" : "available"
+            return simpleEvent(
+                common,
+                name: "source_transition",
+                detail: "\(previous)->\(current);reason-present"
+            )
+        case let .connectionTransition(value):
+            return simpleEvent(
+                common,
+                name: "connection_transition",
+                detail: "\(value.previous.rawValue)->\(value.current.rawValue)"
+                    + (value.reason == nil ? "" : ";reason-present")
+            )
+        case let .controlDecision(value):
+            let target = targetHeartRate(value.target)
+            let action = controlAction(value.action)
+            return .init(
+                elapsedMicroseconds: common.0, occurredAt: common.1, kind: common.2,
+                name: "control_decision", detail: nil, phase: nil,
+                targetHeartRate: target, decisionReference: common.3,
+                commandReference: nil, attemptReference: nil,
+                configurationReference: reference(
+                    "configuration", value.configurationSnapshotID.description, sessionID
+                ),
+                decisionAction: action.name,
+                decisionReason: controlReason(value.reason),
+                desiredSpeedKilometresPerHour: action.desiredSpeed,
+                commandedSpeedNativeValue: nil, commandedSpeedNativeUnit: nil,
+                commandAttemptNumber: nil, endReason: nil
+            )
+        case let .commandLifecycle(value):
+            let lifecycle = commandLifecycle(value.lifecycle)
+            return .init(
+                elapsedMicroseconds: common.0, occurredAt: common.1, kind: common.2,
+                name: lifecycle.name, detail: lifecycle.detail, phase: nil,
+                targetHeartRate: nil, decisionReference: common.3,
+                commandReference: common.4, attemptReference: common.5,
+                configurationReference: nil, decisionAction: nil, decisionReason: nil,
+                desiredSpeedKilometresPerHour: nil,
+                commandedSpeedNativeValue: lifecycle.commandedValue,
+                commandedSpeedNativeUnit: lifecycle.commandedUnit,
+                commandAttemptNumber: lifecycle.attemptNumber, endReason: nil
+            )
+        case let .cooldown(value):
+            return .init(
+                elapsedMicroseconds: common.0, occurredAt: common.1, kind: common.2,
+                name: "cooldown_\(value.lifecycle.rawValue)", detail: nil,
+                phase: value.lifecycle == .started ? .cooldown : nil,
+                targetHeartRate: value.targetHeartRate.map(Int.init),
+                decisionReference: nil, commandReference: nil, attemptReference: nil,
+                configurationReference: nil, decisionAction: nil, decisionReason: nil,
+                desiredSpeedKilometresPerHour: nil, commandedSpeedNativeValue: nil,
+                commandedSpeedNativeUnit: nil, commandAttemptNumber: nil, endReason: nil
+            )
+        case let .manualStop(value):
+            return simpleEvent(
+                common,
+                name: "manual_stop",
+                detail: value.reason == nil ? nil : "reason-present"
+            )
+        case let .safety(value):
+            return simpleEvent(
+                common,
+                name: "safety_\(value.outcome.rawValue)",
+                detail: "policy-and-gate-recorded"
+            )
+        case let .stopEvidence(value):
+            return simpleEvent(
+                common,
+                name: "stop_evidence",
+                detail: stopConclusion(value.conclusion)
+            )
+        case let .recorderHealth(value):
+            return simpleEvent(
+                common,
+                name: "recorder_\(value.kind.rawValue)",
+                detail: [
+                    recorderRecordClass(value.affectedRecordClass),
+                    recorderDetailCode(value.detailCode),
+                ].compactMap { $0 }
+                    .joined(separator: ";")
+            )
+        case .heartRateEvidence, .treadmillEvidence:
+            throw TelemetryWorkoutReadError.corruptProjection("unselected-analysis-event-kind")
+        }
+    }
+
+    static func simpleEvent(
+        _ common: (Int64, Date, String, String?, String?, String?),
+        name: String,
+        detail: String?
+    ) -> WorkoutAnalysisEventProjection {
+        .init(
+            elapsedMicroseconds: common.0, occurredAt: common.1, kind: common.2,
+            name: name, detail: detail, phase: nil, targetHeartRate: nil,
+            decisionReference: common.3, commandReference: common.4,
+            attemptReference: common.5, configurationReference: nil,
+            decisionAction: nil, decisionReason: nil,
+            desiredSpeedKilometresPerHour: nil, commandedSpeedNativeValue: nil,
+            commandedSpeedNativeUnit: nil, commandAttemptNumber: nil, endReason: nil
+        )
+    }
+
+    static func analysisMetadata(
+        session: TelemetryWorkoutSessionV1,
+        configuration: PrivacySafeConfigurationExportRecord,
+        analysis: TelemetryWorkoutAnalysisV1?,
+        frameRows: Int,
+        eventRows: Int,
+        heartRateFrameRows: Int,
+        factualSpeedFrameRows: Int,
+        gapBoundaryRows: Int,
+        endReason: String?,
+        warnings: [String],
+        sessionID: SessionID
+    ) -> [(key: String, value: String)] {
+        let treadmill = configuration.treadmill
+        return [
+            ("schema_version", WorkoutAnalysisExportArtifact.schemaVersion),
+            ("workout_ref", reference("workout", sessionID.description, sessionID)),
+            ("lifecycle_state", session.lifecycleStateKey),
+            ("started_at", WorkoutAnalysisCSVStream.date(session.startedAt)),
+            ("ended_at", WorkoutAnalysisCSVStream.date(session.endedAt)),
+            ("ended_elapsed_s", WorkoutAnalysisCSVStream.seconds(session.endedElapsedMicroseconds)),
+            ("end_reason", endReason ?? ""),
+            ("app_version", session.appVersion),
+            ("build_number", session.buildNumber),
+            ("operating_system_version", session.operatingSystemVersion),
+            ("telemetry_schema_version", session.telemetrySchemaVersion),
+            ("analyzer_version", analysis?.analyzerVersion ?? ""),
+            ("algorithm_version", session.algorithmVersion),
+            ("safety_policy_version", session.safetyPolicyVersion),
+            ("workout_protocol_version", session.workoutProtocolVersion),
+            ("configuration_hash", session.configuration?.contentHashDigest ?? ""),
+            ("workout_mode", workoutModeString(configuration.workoutMode)),
+            ("target_bpm", configuration.targetHeartRate.map(String.init) ?? ""),
+            ("duration_minutes", configuration.durationMinutes.map(String.init) ?? ""),
+            ("decision_interval_s", configuration.decisionIntervalSeconds.map(String.init) ?? ""),
+            ("adaptive_step_enabled", configuration.adaptiveStepEnabled.map(String.init) ?? ""),
+            ("maximum_step_kmh", WorkoutAnalysisCSVStream.number(configuration.maximumStepKilometresPerHour)),
+            ("heart_rate_zones_bpm", configuration.heartRateZones?.map(String.init).joined(separator: ";") ?? ""),
+            ("cooldown_target_bpm", configuration.cooldownTargetHeartRate.map(String.init) ?? ""),
+            ("cooldown_minimum_speed_kmh", WorkoutAnalysisCSVStream.number(configuration.cooldownMinimumSpeedKilometresPerHour)),
+            ("cooldown_maximum_minutes", configuration.cooldownMaximumMinutes.map(String.init) ?? ""),
+            ("treadmill_protocol", treadmill?.protocolName ?? ""),
+            ("treadmill_protocol_version", treadmill?.protocolVersion ?? ""),
+            ("treadmill_minimum_speed_kmh", WorkoutAnalysisCSVStream.number(treadmill?.minimumSpeedKilometresPerHour)),
+            ("treadmill_maximum_speed_kmh", WorkoutAnalysisCSVStream.number(treadmill?.maximumSpeedKilometresPerHour)),
+            ("treadmill_speed_increment_kmh", WorkoutAnalysisCSVStream.number(treadmill?.speedIncrementKilometresPerHour)),
+            ("recorder_complete", String(session.recorderIsComplete)),
+            ("lost_critical_record_count", String(session.lostCriticalRecordCount)),
+            ("lost_native_record_count", String(session.lostNativeRecordCount)),
+            ("analysis_quality_grade", analysis.flatMap {
+                AnalysisQualityGrade(rawValue: $0.qualityGradeKey)?.rawValue
+            } ?? ""),
+            ("frame_row_count", String(frameRows)),
+            ("event_row_count", String(eventRows)),
+            ("heart_rate_frame_row_count", String(heartRateFrameRows)),
+            ("heart_rate_frame_coverage_ratio", coverage(heartRateFrameRows, frameRows)),
+            ("factual_speed_frame_row_count", String(factualSpeedFrameRows)),
+            ("factual_speed_frame_coverage_ratio", coverage(factualSpeedFrameRows, frameRows)),
+            ("gap_boundary_row_count", String(gapBoundaryRows)),
+            ("quality_warnings", warnings.sorted().joined(separator: ";")),
+            ("omitted_identifier_kinds", "profile;device;source;healthkit;raw-record;raw-command"),
+        ]
+    }
+
+    static func analysisFileTimestamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+        return formatter.string(from: date)
+    }
+
+    static func coverage(_ available: Int, _ total: Int) -> String {
+        guard total > 0 else { return "" }
+        return WorkoutAnalysisCSVStream.number(Double(available) / Double(total))
+    }
+
+    static func reference(_ kind: String, _ raw: String, _ sessionID: SessionID) -> String {
+        let digest = SHA256.hash(data: Data("\(sessionID.description)|\(kind)|\(raw)".utf8))
+        return "\(kind)-\(digest.prefix(8).map { String(format: "%02x", $0) }.joined())"
+    }
+
+    static func phaseString(_ phase: WorkoutPhase?) -> String {
+        guard let phase else { return "" }
+        return switch phase {
+        case .warmup: "warmup"
+        case .main: "main"
+        case .cooldown: "cooldown"
+        case .finished: "finished"
+        case .unknown: "unknown"
+        case .other: "other"
+        }
+    }
+
+    static func workoutModeString(_ mode: WorkoutMode?) -> String {
+        guard let mode else { return "" }
+        return switch mode {
+        case .heartRateControlled: "heart-rate-controlled"
+        case .manual: "manual"
+        case .other: "other"
+        }
+    }
+
+    static func targetHeartRate(_ target: ControlTarget) -> Int? {
+        if case let .heartRate(beatsPerMinute) = target { return Int(beatsPerMinute) }
+        return nil
+    }
+
+    static func controlAction(_ action: ControlAction) -> (name: String, desiredSpeed: Double?) {
+        switch action {
+        case .noCommand: ("hold", nil)
+        case let .enqueueSpeed(speed): ("enqueue-speed", speed.value)
+        case .enqueueStop: ("enqueue-stop", nil)
+        }
+    }
+
+    static func controlReason(_ reason: ControlDecisionReason) -> String {
+        switch reason {
+        case .withinTarget: "within-target"
+        case .belowTarget: "below-target"
+        case .aboveTarget: "above-target"
+        case .safetyGate: "safety-gate"
+        case .manual: "manual"
+        case let .other(value) where value == "inertiaHold": "inertia-hold"
+        case let .other(value) where value == "speedLimit": "speed-limit"
+        case .other: "other"
+        }
+    }
+
+    static func commandLifecycle(
+        _ lifecycle: CommandLifecycle
+    ) -> (name: String, detail: String?, commandedValue: Double?, commandedUnit: String?, attemptNumber: Int?) {
+        switch lifecycle {
+        case let .enqueued(kind):
+            switch kind {
+            case let .setSpeed(speed):
+                return ("command_enqueued_set_speed", nil, speed.nativeValue, nativeUnit(speed.nativeUnit), nil)
+            case .stop:
+                return ("command_enqueued_stop", nil, nil, nil, nil)
+            case .other:
+                return ("command_enqueued_other", "opaque-command-kind", nil, nil, nil)
+            }
+        case let .sendAttempt(_, attemptNumber):
+            return ("command_send_attempt", nil, nil, nil, Int(attemptNumber))
+        case .acknowledged:
+            return ("command_acknowledged", nil, nil, nil, nil)
+        case .timedOut:
+            return ("command_timed_out", nil, nil, nil, nil)
+        case let .retryScheduled(_, _, nextAttemptNumber):
+            return ("command_retry_scheduled", nil, nil, nil, Int(nextAttemptNumber))
+        case let .cancelled(reason):
+            return ("command_cancelled", cancellationReason(reason), nil, nil, nil)
+        case let .failed(_, reason):
+            return ("command_failed", failureReason(reason), nil, nil, nil)
+        }
+    }
+
+    static func nativeUnit(_ unit: TreadmillNativeSpeedUnit) -> String {
+        switch unit {
+        case .kilometresPerHour: "km/h"
+        case .milesPerHour: "mph"
+        case let .controllerNative(code):
+            switch code {
+            case "walkingpad_controller_tenths", "walkingPad-tenths", "tenths":
+                "controller-native:walkingpad-tenths"
+            case "ftms_hundredths_kmh":
+                "controller-native:ftms-hundredths-kmh"
+            case "fitshow_tenths_kmh":
+                "controller-native:fitshow-tenths-kmh"
+            default:
+                "controller-native"
+            }
+        case .unknown: "unknown"
+        }
+    }
+
+    static func cancellationReason(_ reason: CommandCancellationReason) -> String {
+        switch reason {
+        case .superseded: "superseded"
+        case .sessionEnded: "session-ended"
+        case .safetyGate: "safety-gate"
+        case .other: "other"
+        }
+    }
+
+    static func failureReason(_ reason: CommandFailureReason) -> String {
+        switch reason {
+        case .transportUnavailable: "transport-unavailable"
+        case .encodingFailed: "encoding-failed"
+        case .rejected: "rejected"
+        case .other: "other"
+        }
+    }
+
+    static func stopConclusion(_ conclusion: StopEvidenceConclusion) -> String {
+        switch conclusion {
+        case .confirmedByFreshFactualObservation: "confirmed-fresh-factual"
+        case .unconfirmed: "unconfirmed"
+        case .contradictory: "contradictory"
+        }
+    }
+
+    static func lifecycleReason(_ rawValue: String?) -> String? {
+        guard let rawValue else { return nil }
+        let allowed = [
+            "authorized-start", "manual_stop", "ble_disconnected",
+            "hr_control_not_ready", "hr_no_signal", "cooldown_stable_reached",
+            "cooldown_timeout", "pre-recorder-staging-overflow",
+            "recorder-cancelled", "recorder-terminated", "forced-process-interruption",
+        ]
+        return allowed.contains(rawValue) ? rawValue : "opaque-reason"
+    }
+
+    static func recorderRecordClass(_ rawValue: String?) -> String? {
+        guard let rawValue else { return nil }
+        return ["critical", "native", "bulkFrame", "all"].contains(rawValue)
+            ? rawValue
+            : "opaque-record-class"
+    }
+
+    static func recorderDetailCode(_ rawValue: String?) -> String? {
+        guard let rawValue else { return nil }
+        return rawValue == "pre-recorder-staging-overflow"
+            ? rawValue
+            : "opaque-detail-code"
+    }
+
+    static func analysisExclusionCode(_ rawValue: String) -> String {
+        let allowed = [
+            "recorderEvidenceLoss.recorder-loss",
+            "protocolRuntimeCausalAmbiguity.unknown-command-ack-association",
+            "protocolRuntimeCausalAmbiguity.unknown-command-factual-response-association",
+            "malformedCorruptEvidence.unsupported-persisted-command-ack-causal-claim",
+            "malformedCorruptEvidence.unsupported-persisted-command-factual-response-causal-claim",
+            "sourceCoverageUnavailable.heart-rate-uncovered-time",
+            "sourceCoverageUnavailable.factual-treadmill-uncovered-time",
+            "sourceCoverageUnavailable.average-factual-speed-insufficient-coverage",
+            "malformedCorruptEvidence.configuration-payload-unavailable",
+            "malformedCorruptEvidence.malformed-or-invalid-native-evidence",
+            "malformedCorruptEvidence.invalid-workout-phase-transition-evidence",
+            "sourceCoverageUnavailable.incomplete-session",
+        ]
+        return allowed.contains(rawValue) ? rawValue : "opaque-analysis-exclusion"
+    }
+}
+
+private extension WorkoutAnalysisCSVStream {
+    func writeAnalysisFrame(
+        _ frame: CanonicalFrame,
+        sessionID: SessionID,
+        phase: String,
+        targetHeartRate: Int?
+    ) throws {
+        let heartRate = frame.heartRateEvidence
+        let treadmill = frame.treadmillEvidence
+        let treadmillAvailability: String
+        if treadmill?.factualSpeed != nil {
+            treadmillAvailability = "factual"
+        } else if treadmill != nil {
+            treadmillAvailability = "non-factual-evidence-only"
+        } else {
+            treadmillAvailability = "unavailable"
+        }
+        var quality: [String] = []
+        if heartRate == nil { quality.append("heart-rate-unavailable") }
+        if treadmill?.factualSpeed == nil { quality.append("factual-speed-unavailable") }
+        if let gap = frame.precedingGap { quality.append("preceding-gap:\(gap.kind.rawValue)") }
+        try writeTimeline(
+            elapsedMicroseconds: frame.materializedAt.elapsed.microseconds,
+            timestamp: frame.materializedAt.recordedAt,
+            phase: phase,
+            targetHeartRate: targetHeartRate,
+            values: [
+                "row_type": "frame",
+                "hr_bpm": heartRate.map { String($0.beatsPerMinute) } ?? "",
+                "hr_evidence_ref": heartRate.map {
+                    TelemetryStore.reference("hr-evidence", $0.observationID.description, sessionID)
+                } ?? "",
+                "hr_evidence_elapsed_s": Self.seconds(heartRate?.evidenceElapsed.microseconds),
+                "hr_age_s": Self.seconds(heartRate?.ageAtMaterialization.microseconds),
+                "hr_freshness": heartRate?.freshness.rawValue ?? "",
+                "hr_provenance": heartRate?.provenance.rawValue ?? "",
+                "factual_speed_kmh": Self.number(treadmill?.factualSpeed?.value),
+                "treadmill_evidence_ref": treadmill.map {
+                    TelemetryStore.reference(
+                        "treadmill-evidence", $0.observationID.description, sessionID
+                    )
+                } ?? "",
+                "treadmill_evidence_elapsed_s": Self.seconds(treadmill?.evidenceElapsed.microseconds),
+                "treadmill_age_s": Self.seconds(treadmill?.ageAtMaterialization.microseconds),
+                "treadmill_freshness": treadmill?.freshness.rawValue ?? "",
+                "treadmill_availability": treadmillAvailability,
+                "treadmill_state": treadmill?.deviceState.rawValue ?? "",
+                "treadmill_provenance": treadmill?.provenance.rawValue ?? "",
+                "gap_missing_since_s": frame.precedingGap.map {
+                    String($0.missingSinceElapsedSecond)
+                } ?? "",
+                "gap_kind": frame.precedingGap?.kind.rawValue ?? "",
+                "quality_flags": quality.joined(separator: ";"),
+            ]
+        )
+    }
+
+    func writeAnalysisEvent(
+        _ event: WorkoutAnalysisEventProjection,
+        phase: String,
+        targetHeartRate: Int?
+    ) throws {
+        try writeTimeline(
+            elapsedMicroseconds: event.elapsedMicroseconds,
+            timestamp: event.occurredAt,
+            phase: phase,
+            targetHeartRate: targetHeartRate,
+            values: [
+                "row_type": "event",
+                "event_kind": event.kind,
+                "event_name": event.name,
+                "event_detail": event.detail ?? "",
+                "decision_ref": event.decisionReference ?? "",
+                "command_ref": event.commandReference ?? "",
+                "attempt_ref": event.attemptReference ?? "",
+                "configuration_ref": event.configurationReference ?? "",
+                "decision_action": event.decisionAction ?? "",
+                "decision_reason": event.decisionReason ?? "",
+                "desired_speed_kmh": Self.number(event.desiredSpeedKilometresPerHour),
+                "commanded_speed_native_value": Self.number(event.commandedSpeedNativeValue),
+                "commanded_speed_native_unit": event.commandedSpeedNativeUnit ?? "",
+                "command_attempt_number": event.commandAttemptNumber.map(String.init) ?? "",
+            ]
+        )
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutExportStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutExportStore.swift
@@ -34,7 +34,7 @@ private struct NativeSessionExportRecord: Encodable {
     let configurationHashDigest: String?
 }
 
-private struct PrivacySafeConfigurationExportRecord: Codable {
+struct PrivacySafeConfigurationExportRecord: Codable {
     let workoutMode: WorkoutMode?
     let targetHeartRate: Int?
     let durationMinutes: Int?
@@ -49,7 +49,7 @@ private struct PrivacySafeConfigurationExportRecord: Codable {
     let treadmill: PrivacySafeTreadmillConfigurationExportRecord?
 }
 
-private struct PrivacySafeTreadmillConfigurationExportRecord: Codable {
+struct PrivacySafeTreadmillConfigurationExportRecord: Codable {
     let protocolName: String?
     let protocolVersion: String?
     let minimumSpeedKilometresPerHour: Double?

--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift
@@ -610,6 +610,15 @@ public final class TelemetryV2RuntimeCoordinator: HeartRateTelemetrySink,
         return try await reader.exportWorkouts(request)
     }
 
+    public func exportWorkoutAnalysis(
+        _ request: WorkoutAnalysisExportRequest
+    ) async throws -> WorkoutAnalysisExportArtifact {
+        guard let reader = workoutReadCapability() else {
+            throw TelemetryWorkoutReadError.unavailable("telemetry-v2-store-not-ready")
+        }
+        return try await reader.exportWorkoutAnalysis(request)
+    }
+
     public func associateHealthKitWorkout(
         sessionID: SessionID,
         workoutIdentifier: UUID

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/WorkoutAnalysisExportTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/WorkoutAnalysisExportTests.swift
@@ -1,0 +1,652 @@
+import Foundation
+import TelemetryDomain
+@testable import TelemetryPersistence
+import XCTest
+
+final class WorkoutAnalysisExportTests: XCTestCase {
+    func testSingleWorkoutCSVPreservesTruthTimelineMetadataPrivacyAndDeterminism() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let configuration = ImmutableConfigurationSnapshot(
+            id: ConfigurationSnapshotID(rawValue: uuid(900)),
+            formatVersion: 1,
+            format: .canonicalJSON,
+            canonicalPayload: Data(
+                #"{"targetHeartRate":135,"durationMinutes":30,"decisionIntervalSeconds":10,"adaptiveStepEnabled":true,"maximumStepKilometresPerHour":0.4,"heartRateZones":[100,120,140,160,180,200],"cooldownTargetHeartRate":115,"cooldownMinimumSpeedKilometresPerHour":1.0,"cooldownMaximumMinutes":5,"treadmill":{"protocolName":"ftms","protocolVersion":"1","minimumSpeedKilometresPerHour":0.5,"maximumSpeedKilometresPerHour":12.0,"speedIncrementKilometresPerHour":0.1}}"#.utf8
+            ),
+            contentHash: ContentHash(
+                algorithm: .sha256,
+                lowercaseHexDigest: String(repeating: "c", count: 64)
+            )
+        )
+        let session = session(profile: "private-profile-id", configuration: configuration)
+        try await store.insertSession(session)
+        try await store.insertAnalysis(
+            TelemetryPersistenceFixtures.analysis(
+                seed: 20,
+                session: session,
+                version: "analyzer-v1"
+            )
+        )
+
+        let heartRateSource = TelemetryPersistenceFixtures.source(seed: 21)
+        let treadmillSource = TelemetryPersistenceFixtures.source(seed: 22, kind: .bluetooth)
+        let heartRate = TelemetryPersistenceFixtures.heartRate(
+            seed: 23,
+            session: session,
+            source: heartRateSource,
+            arrivalOrder: 0,
+            bpm: 128
+        )
+        let treadmill = treadmillEvidence(source: treadmillSource)
+        try await store.insertFrame(
+            frame(
+                seed: 1,
+                session: session,
+                second: 0,
+                heartRate: heartRate,
+                treadmill: treadmill
+            )
+        )
+        try await store.insertFrame(
+            frame(
+                seed: 2,
+                session: session,
+                second: 1,
+                heartRate: heartRate,
+                treadmill: nil
+            )
+        )
+        try await store.insertFrame(
+            frame(
+                seed: 3,
+                session: session,
+                second: 3,
+                heartRate: nil,
+                treadmill: nil,
+                gap: CanonicalGapBoundary(
+                    missingSinceElapsedSecond: 2,
+                    kind: .runtimeSuspensionOrStall
+                )
+            )
+        )
+
+        let decisionID = DecisionID(rawValue: uuid(300))
+        let commandID = CommandID(rawValue: uuid(301))
+        let attemptID = CommandAttemptID(rawValue: uuid(302))
+        let events: [WorkoutEvent] = [
+            event(
+                seed: 10,
+                session: session,
+                elapsedMicroseconds: 0,
+                payload: .workoutPhase(WorkoutPhaseTransition(previous: nil, current: .main))
+            ),
+            event(
+                seed: 11,
+                session: session,
+                elapsedMicroseconds: 1_200_000,
+                payload: .controlDecision(
+                    ControlDecision(
+                        decisionID: decisionID,
+                        observationsUsed: [.heartRate(heartRate.observationID)],
+                        target: .heartRate(beatsPerMinute: 135),
+                        action: .enqueueSpeed(DesiredSpeedKilometresPerHour(value: 5.6)),
+                        reason: .belowTarget,
+                        versions: session.versions,
+                        configurationSnapshotID: configuration.id
+                    )
+                )
+            ),
+            event(
+                seed: 12,
+                session: session,
+                elapsedMicroseconds: 1_300_000,
+                payload: .commandLifecycle(
+                    CommandLifecycleRecord(
+                        commandID: commandID,
+                        decisionID: decisionID,
+                        lifecycle: .enqueued(
+                            kind: .setSpeed(
+                                CommandedSpeed(
+                                    nativeValue: 560,
+                                    nativeUnit: .controllerNative(code: "ftms_hundredths_kmh")
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            event(
+                seed: 13,
+                session: session,
+                elapsedMicroseconds: 1_400_000,
+                payload: .commandLifecycle(
+                    CommandLifecycleRecord(
+                        commandID: commandID,
+                        decisionID: decisionID,
+                        lifecycle: .sendAttempt(attemptID: attemptID, attemptNumber: 1)
+                    )
+                )
+            ),
+            event(
+                seed: 14,
+                session: session,
+                elapsedMicroseconds: 2_000_000,
+                payload: .cooldown(CooldownEvent(lifecycle: .started, targetHeartRate: 115))
+            ),
+            event(
+                seed: 15,
+                session: session,
+                elapsedMicroseconds: 2_100_000,
+                payload: .treadmillEvidence(
+                    .unitsTruth(
+                        TreadmillUnitsTruthEvidence(
+                            truth: .notRead(
+                                connectionEpoch: TreadmillConnectionEpoch(rawValue: uuid(400))
+                            ),
+                            observedAt: session.startedAt
+                        )
+                    )
+                )
+            ),
+        ]
+        for event in events { try await store.insertEvent(event) }
+
+        let request = WorkoutAnalysisExportRequest(
+            sessionID: session.sessionID,
+            exactProfileLocalIdentifier: session.profileLocalIdentifier,
+            batchSize: 2
+        )
+        let beforeCounts = try await store.counts()
+        let first = try await store.exportWorkoutAnalysis(request)
+        defer { try? FileManager.default.removeItem(at: first.fileURL.deletingLastPathComponent()) }
+        let second = try await store.exportWorkoutAnalysis(request)
+        defer { try? FileManager.default.removeItem(at: second.fileURL.deletingLastPathComponent()) }
+
+        XCTAssertEqual(
+            try Data(contentsOf: first.fileURL),
+            try Data(contentsOf: second.fileURL),
+            "The same stored workout must produce byte-identical CSV content"
+        )
+        XCTAssertEqual(
+            try FileManager.default.contentsOfDirectory(
+                at: first.fileURL.deletingLastPathComponent(),
+                includingPropertiesForKeys: nil
+            ).count,
+            1
+        )
+        XCTAssertEqual(first.diagnostics.frameRowCount, 3)
+        XCTAssertEqual(first.diagnostics.eventRowCount, 5)
+        XCTAssertLessThanOrEqual(first.diagnostics.maximumStoreFetchLimit, 2)
+        XCTAssertLessThanOrEqual(first.diagnostics.maximumBufferedTimelineRows, 4)
+        let afterCounts = try await store.counts()
+        XCTAssertEqual(afterCounts, beforeCounts)
+
+        let rows = try parseCSV(first.fileURL)
+        XCTAssertTrue(rows.allSatisfy { $0.count == rows[0].count })
+        let header = rows[0]
+        let timeline = rows.dropFirst().map { Dictionary(uniqueKeysWithValues: zip(header, $0)) }
+        let frames = timeline.filter { $0["row_type"] == "frame" }
+        let exportedEvents = timeline.filter { $0["row_type"] == "event" }
+        let metadata = Dictionary(
+            uniqueKeysWithValues: timeline.filter { $0["row_type"] == "metadata" }.map {
+                ($0["metadata_key"]!, $0["metadata_value"]!)
+            }
+        )
+
+        XCTAssertEqual(frames.map { $0["elapsed_s"]! }, ["0.000000", "1.000000", "3.000000"])
+        XCTAssertEqual(frames[0]["phase"], "main", "Exact event must precede a same-time frame")
+        XCTAssertEqual(frames[0]["hr_evidence_ref"], frames[1]["hr_evidence_ref"])
+        XCTAssertNotEqual(frames[0]["hr_evidence_ref"], heartRate.observationID.description)
+        XCTAssertEqual(frames[1]["factual_speed_kmh"], "")
+        XCTAssertEqual(frames[1]["treadmill_availability"], "unavailable")
+        XCTAssertEqual(frames[2]["hr_bpm"], "")
+        XCTAssertEqual(frames[2]["factual_speed_kmh"], "")
+        XCTAssertEqual(frames[2]["gap_missing_since_s"], "2")
+        XCTAssertEqual(frames[2]["gap_kind"], "runtimeSuspensionOrStall")
+        XCTAssertTrue(frames[2]["quality_flags"]!.contains("factual-speed-unavailable"))
+        XCTAssertFalse(frames[2].values.contains("0.000000"), "Missing evidence must not become zero")
+
+        let decision = try XCTUnwrap(exportedEvents.first { $0["event_name"] == "control_decision" })
+        XCTAssertEqual(decision["desired_speed_kmh"], "5.600000")
+        XCTAssertEqual(decision["commanded_speed_native_value"], "")
+        let enqueued = try XCTUnwrap(exportedEvents.first { $0["event_name"] == "command_enqueued_set_speed" })
+        XCTAssertEqual(enqueued["desired_speed_kmh"], "")
+        XCTAssertEqual(enqueued["commanded_speed_native_value"], "560.000000")
+        XCTAssertEqual(enqueued["commanded_speed_native_unit"], "controller-native:ftms-hundredths-kmh")
+        XCTAssertFalse(exportedEvents.contains { $0["event_kind"] == "treadmillEvidence" })
+        XCTAssertEqual(metadata["schema_version"], WorkoutAnalysisExportArtifact.schemaVersion)
+        XCTAssertEqual(metadata["analyzer_version"], "analyzer-v1")
+        XCTAssertEqual(metadata["heart_rate_zones_bpm"], "100;120;140;160;180;200")
+        XCTAssertEqual(metadata["treadmill_protocol"], "ftms")
+        XCTAssertEqual(metadata["frame_row_count"], "3")
+        XCTAssertEqual(metadata["event_row_count"], "5")
+        XCTAssertEqual(metadata["heart_rate_frame_coverage_ratio"], "0.666667")
+        XCTAssertEqual(metadata["factual_speed_frame_coverage_ratio"], "0.333333")
+        XCTAssertEqual(metadata["gap_boundary_row_count"], "1")
+        XCTAssertTrue(metadata["quality_warnings"]!.contains("canonical-gaps-present:1"))
+
+        let csv = try String(contentsOf: first.fileURL, encoding: .utf8)
+        for privateValue in [
+            "private-profile-id", "private-device-model", "private-treadmill-id",
+            heartRateSource.stableLocalKey, treadmillSource.stableLocalKey,
+            heartRate.observationID.description, commandID.description, attemptID.description,
+        ] {
+            XCTAssertFalse(csv.contains(privateValue), "CSV leaked \(privateValue)")
+        }
+    }
+
+    func testCrossProfileAndNonNativeSessionRequestsAreRejectedBeforeTimelineReads() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = session(profile: "profile-a", configuration: configuration(target: 135))
+        try await store.insertSession(session)
+
+        for request in [
+            WorkoutAnalysisExportRequest(
+                sessionID: session.sessionID,
+                exactProfileLocalIdentifier: "profile-b"
+            ),
+            WorkoutAnalysisExportRequest(
+                sessionID: SessionID(rawValue: uuid(999)),
+                exactProfileLocalIdentifier: "profile-a"
+            ),
+        ] {
+            do {
+                _ = try await store.exportWorkoutAnalysis(request)
+                XCTFail("Unowned or non-native selection must be rejected")
+            } catch let error as TelemetryWorkoutReadError {
+                XCTAssertEqual(error, .unavailable("selected-native-workout-unavailable"))
+            }
+        }
+        let uuidProfile = "A1000000-0000-0000-0000-000000000001"
+        let historicalCaseSession = self.session(
+            profile: uuidProfile.lowercased(),
+            configuration: configuration(target: 135),
+            seed: 2
+        )
+        try await store.insertSession(historicalCaseSession)
+        let historicalCaseArtifact = try await store.exportWorkoutAnalysis(
+            WorkoutAnalysisExportRequest(
+                sessionID: historicalCaseSession.sessionID,
+                exactProfileLocalIdentifier: uuidProfile
+            )
+        )
+        defer {
+            try? FileManager.default.removeItem(
+                at: historicalCaseArtifact.fileURL.deletingLastPathComponent()
+            )
+        }
+        let counts = try await store.counts()
+        XCTAssertEqual(counts.sessions, 2)
+    }
+
+    func testSelectedWorkoutExportIsIndependentOfUnrelatedHistorySize() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let selected = session(
+            profile: "profile-selected",
+            configuration: configuration(target: 135),
+            seed: 10
+        )
+        try await store.insertSession(selected)
+        try await store.insertFrame(
+            frame(
+                seed: 50,
+                session: selected,
+                second: 0,
+                heartRate: nil,
+                treadmill: nil
+            )
+        )
+        let request = WorkoutAnalysisExportRequest(
+            sessionID: selected.sessionID,
+            exactProfileLocalIdentifier: selected.profileLocalIdentifier,
+            batchSize: 16
+        )
+        let before = try await store.exportWorkoutAnalysis(request)
+        defer { try? FileManager.default.removeItem(at: before.fileURL.deletingLastPathComponent()) }
+
+        for index in 0..<500 {
+            try await store.insertSession(
+                session(
+                    profile: "unrelated-profile-\(index)",
+                    configuration: configuration(target: 135),
+                    seed: 1_000 + index
+                )
+            )
+        }
+        let after = try await store.exportWorkoutAnalysis(request)
+        defer { try? FileManager.default.removeItem(at: after.fileURL.deletingLastPathComponent()) }
+
+        XCTAssertEqual(try Data(contentsOf: before.fileURL), try Data(contentsOf: after.fileURL))
+        XCTAssertEqual(before.diagnostics.storeFetchCount, after.diagnostics.storeFetchCount)
+        XCTAssertEqual(before.diagnostics.frameRowCount, after.diagnostics.frameRowCount)
+        XCTAssertEqual(before.diagnostics.eventRowCount, after.diagnostics.eventRowCount)
+    }
+
+    func testFreeFormDomainStringsAreRedactedFromAnalysisCSV() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let sentinel = "private-person@example.com/device-123"
+        let session = session(
+            profile: "profile-private-strings",
+            configuration: configuration(target: 135),
+            seed: 15,
+            incompleteReason: sentinel
+        )
+        try await store.insertSession(session)
+        let decisionID = DecisionID(rawValue: uuid(610))
+        let commandID = CommandID(rawValue: uuid(611))
+        let events: [WorkoutEventPayload] = [
+            .sessionLifecycle(SessionLifecycleEvent(
+                previous: .running,
+                current: .incomplete,
+                incompleteReason: sentinel,
+                reason: sentinel
+            )),
+            .workoutPhase(WorkoutPhaseTransition(previous: .main, current: .other(sentinel))),
+            .sourceTransition(SourceTransition(
+                previousSourceID: nil,
+                currentSourceID: SourceID(rawValue: uuid(612)),
+                reason: sentinel
+            )),
+            .connectionTransition(ConnectionTransition(
+                previous: .connected,
+                current: .degraded,
+                reason: sentinel
+            )),
+            .controlDecision(ControlDecision(
+                decisionID: decisionID,
+                observationsUsed: [],
+                target: .heartRate(beatsPerMinute: 135),
+                action: .noCommand,
+                reason: .safetyGate(sentinel),
+                versions: session.versions,
+                configurationSnapshotID: session.configuration.id
+            )),
+            .commandLifecycle(CommandLifecycleRecord(
+                commandID: commandID,
+                decisionID: decisionID,
+                lifecycle: .enqueued(kind: .other(sentinel))
+            )),
+            .commandLifecycle(CommandLifecycleRecord(
+                commandID: commandID,
+                decisionID: decisionID,
+                lifecycle: .cancelled(reason: .other(sentinel))
+            )),
+            .manualStop(ManualStopEvent(reason: sentinel)),
+            .safety(SafetyEvent(
+                policy: SafetyPolicyVersion(rawValue: sentinel),
+                gate: sentinel,
+                outcome: .blocked,
+                evidence: []
+            )),
+            .stopEvidence(StopEvidenceEvent(
+                conclusion: .unconfirmed(reason: sentinel),
+                freshness: nil,
+                deviceState: nil,
+                factualSpeed: nil
+            )),
+            .recorderHealth(RecorderHealthEvent(
+                kind: .loss,
+                affectedRecordClass: sentinel,
+                count: 1,
+                detailCode: sentinel
+            )),
+        ]
+        for (index, payload) in events.enumerated() {
+            try await store.insertEvent(event(
+                seed: 100 + index,
+                session: session,
+                elapsedMicroseconds: Int64(index) * 1_000,
+                payload: payload
+            ))
+        }
+
+        let artifact = try await store.exportWorkoutAnalysis(
+            WorkoutAnalysisExportRequest(
+                sessionID: session.sessionID,
+                exactProfileLocalIdentifier: session.profileLocalIdentifier,
+                batchSize: 2
+            )
+        )
+        defer { try? FileManager.default.removeItem(at: artifact.fileURL.deletingLastPathComponent()) }
+        let csv = try String(contentsOf: artifact.fileURL, encoding: .utf8)
+
+        XCTAssertFalse(csv.contains(sentinel))
+        XCTAssertTrue(csv.contains("opaque-reason"))
+        XCTAssertTrue(csv.contains("reason-present"))
+        XCTAssertTrue(csv.contains("opaque-command-kind"))
+        XCTAssertTrue(csv.contains("opaque-record-class"))
+        XCTAssertTrue(csv.contains("opaque-detail-code"))
+    }
+
+    func testCancelledWorkoutAnalysisExportRemovesOnlyTemporaryFile() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = session(
+            profile: "profile-cancel",
+            configuration: configuration(target: 135),
+            seed: 20
+        )
+        try await store.insertSession(session)
+        for second in 0..<200 {
+            try await store.insertFrame(
+                frame(
+                    seed: 1_000 + second,
+                    session: session,
+                    second: Int64(second),
+                    heartRate: nil,
+                    treadmill: nil
+                )
+            )
+        }
+        let beforeDirectories = try analysisExportDirectories()
+        let beforeCounts = try await store.counts()
+        let task = Task {
+            try await store.exportWorkoutAnalysis(
+                WorkoutAnalysisExportRequest(
+                    sessionID: session.sessionID,
+                    exactProfileLocalIdentifier: session.profileLocalIdentifier,
+                    batchSize: 1
+                )
+            )
+        }
+        let startedDeadline = ContinuousClock.now.advanced(by: .seconds(5))
+        var activeDirectories = beforeDirectories
+        while activeDirectories == beforeDirectories, ContinuousClock.now < startedDeadline {
+            await Task.yield()
+            activeDirectories = try analysisExportDirectories()
+        }
+        XCTAssertNotEqual(
+            activeDirectories,
+            beforeDirectories,
+            "Cancellation must occur after the export creates its temporary directory"
+        )
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("Cancelled analysis export unexpectedly completed")
+        } catch is CancellationError {
+            // Expected.
+        }
+        XCTAssertEqual(try analysisExportDirectories(), beforeDirectories)
+        let afterCounts = try await store.counts()
+        XCTAssertEqual(afterCounts, beforeCounts)
+    }
+
+    private func session(
+        profile: String,
+        configuration: ImmutableConfigurationSnapshot,
+        seed: Int = 1,
+        incompleteReason: String? = nil
+    ) -> WorkoutSessionRecord {
+        WorkoutSessionRecord(
+            recordID: RecordID(rawValue: uuid(seed * 2 + 1)),
+            sessionID: SessionID(rawValue: uuid(seed * 2 + 2)),
+            profileLocalIdentifier: profile,
+            lifecycleState: .completed,
+            workoutMode: .heartRateControlled,
+            startedAt: TelemetryPersistenceFixtures.baseDate,
+            endedAt: TelemetryPersistenceFixtures.baseDate.addingTimeInterval(600),
+            endedElapsed: ElapsedDuration(microseconds: 600_000_000),
+            incompleteReason: incompleteReason,
+            appContext: AppRuntimeContext(
+                appVersion: "1.2.3",
+                buildNumber: "456",
+                operatingSystemVersion: "iOS 26",
+                deviceModel: "private-device-model"
+            ),
+            versions: TelemetryPersistenceFixtures.versions(),
+            configuration: configuration,
+            healthKitWorkoutIdentifier: uuid(700),
+            treadmill: KnownTreadmillMetadata(
+                stableLocalIdentifier: "private-treadmill-id",
+                model: "private-treadmill-model",
+                protocolName: "ftms"
+            ),
+            recorderHealth: RecorderHealthSummary(
+                isComplete: true,
+                lostCriticalRecordCount: 0,
+                lostNativeRecordCount: 0,
+                lastPersistedElapsed: ElapsedDuration(microseconds: 600_000_000)
+            )
+        )
+    }
+
+    private func configuration(target: Int) -> ImmutableConfigurationSnapshot {
+        ImmutableConfigurationSnapshot(
+            id: ConfigurationSnapshotID(rawValue: uuid(800)),
+            formatVersion: 1,
+            format: .canonicalJSON,
+            canonicalPayload: Data("{\"targetHeartRate\":\(target)}".utf8),
+            contentHash: ContentHash(
+                algorithm: .sha256,
+                lowercaseHexDigest: String(repeating: "d", count: 64)
+            )
+        )
+    }
+
+    private func treadmillEvidence(source: SignalSourceIdentity) -> TreadmillFrameEvidence {
+        let native = NativeTreadmillSpeed(value: 5.5, unit: .kilometresPerHour)
+        return TreadmillFrameEvidence(
+            observationID: ObservationID(rawValue: uuid(200)),
+            recordID: RecordID(rawValue: uuid(201)),
+            sourceID: source.id,
+            nativeSpeed: native,
+            factualSpeed: FactualSpeedKilometresPerHour.normalized(
+                from: native,
+                provenance: .decodedDeviceReport
+            ),
+            deviceState: .moving,
+            measuredAt: TelemetryPersistenceFixtures.baseDate,
+            receivedAt: TelemetryPersistenceFixtures.baseDate,
+            evidenceElapsed: ElapsedDuration(microseconds: 0),
+            ageAtMaterialization: ElapsedDuration(microseconds: 0),
+            freshness: .fresh,
+            provenance: .decodedDeviceReport
+        )
+    }
+
+    private func frame(
+        seed: Int,
+        session: WorkoutSessionRecord,
+        second: Int64,
+        heartRate: HeartRateObservation?,
+        treadmill: TreadmillFrameEvidence?,
+        gap: CanonicalGapBoundary? = nil
+    ) -> CanonicalFrame {
+        let heartRateEvidence = heartRate.map {
+            HeartRateFrameEvidence(
+                observationID: $0.observationID,
+                recordID: $0.recordID,
+                sourceID: $0.source.id,
+                beatsPerMinute: $0.beatsPerMinute,
+                measuredAt: $0.timestamp.measuredAt,
+                receivedAt: $0.timestamp.receivedAt,
+                evidenceElapsed: $0.timestamp.effectiveElapsed,
+                ageAtMaterialization: ElapsedDuration(microseconds: second * 1_000_000),
+                freshness: second == 0 ? .fresh : .stale,
+                provenance: $0.provenance
+            )
+        }
+        return CanonicalFrame(
+            frameID: FrameID(rawValue: uuid(100 + seed)),
+            recordID: RecordID(rawValue: uuid(110 + seed)),
+            sessionID: session.sessionID,
+            canonicalElapsedSecond: second,
+            materializedAt: RecordTimestamp(
+                recordedAt: session.startedAt.addingTimeInterval(Double(second)),
+                elapsed: ElapsedDuration(microseconds: second * 1_000_000)
+            ),
+            heartRateEvidence: heartRateEvidence,
+            treadmillEvidence: treadmill,
+            precedingGap: gap
+        )
+    }
+
+    private func event(
+        seed: Int,
+        session: WorkoutSessionRecord,
+        elapsedMicroseconds: Int64,
+        payload: WorkoutEventPayload
+    ) -> WorkoutEvent {
+        WorkoutEvent(
+            recordID: RecordID(rawValue: uuid(500 + seed)),
+            sessionID: session.sessionID,
+            timestamp: EventTimestamp(
+                occurredAt: session.startedAt.addingTimeInterval(
+                    Double(elapsedMicroseconds) / 1_000_000
+                ),
+                recordedAt: session.startedAt.addingTimeInterval(
+                    Double(elapsedMicroseconds + 1_000) / 1_000_000
+                ),
+                occurredElapsed: ElapsedDuration(microseconds: elapsedMicroseconds),
+                recordedElapsed: ElapsedDuration(microseconds: elapsedMicroseconds + 1_000)
+            ),
+            payload: EventPayloadEnvelope(schemaVersion: 1, payload: payload)
+        )
+    }
+
+    private func parseCSV(_ url: URL) throws -> [[String]] {
+        let text = try String(contentsOf: url, encoding: .utf8)
+        var rows: [[String]] = []
+        var row: [String] = []
+        var field = ""
+        var quoted = false
+        var index = text.startIndex
+        while index < text.endIndex {
+            let character = text[index]
+            if character == "\"" {
+                let next = text.index(after: index)
+                if quoted, next < text.endIndex, text[next] == "\"" {
+                    field.append("\"")
+                    index = next
+                } else {
+                    quoted.toggle()
+                }
+            } else if character == ",", !quoted {
+                row.append(field)
+                field = ""
+            } else if character == "\n", !quoted {
+                row.append(field)
+                rows.append(row)
+                row = []
+                field = ""
+            } else if character != "\r" || quoted {
+                field.append(character)
+            }
+            index = text.index(after: index)
+        }
+        return rows
+    }
+
+    private func analysisExportDirectories() throws -> Set<String> {
+        Set(
+            try FileManager.default.contentsOfDirectory(
+                at: FileManager.default.temporaryDirectory,
+                includingPropertiesForKeys: nil
+            ).map(\.lastPathComponent).filter { $0.hasPrefix("WorkoutAnalysisExport_") }
+        )
+    }
+
+    private func uuid(_ value: Int) -> UUID {
+        UUID(uuidString: String(format: "00000000-0000-4000-8000-%012llx", value))!
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryRuntimeTests/TelemetryV2RuntimeCoordinatorTests.swift
@@ -201,6 +201,43 @@ final class TelemetryV2RuntimeCoordinatorTests: XCTestCase {
         try await eventually { await persistence.finalizations.count == 1 }
     }
 
+    func testWorkoutAnalysisExportCannotColdPrepareStoreOrResumeAnalyzer() async throws {
+        let persistence = RuntimePersistence()
+        let factoryCallCount = LockedCounter()
+        let coordinator = TelemetryV2RuntimeCoordinator {
+            factoryCallCount.increment()
+            return persistence
+        }
+        let request = WorkoutAnalysisExportRequest(
+            sessionID: SessionID(rawValue: UUID()),
+            exactProfileLocalIdentifier: "profile-a"
+        )
+
+        do {
+            _ = try await coordinator.exportWorkoutAnalysis(request)
+            XCTFail("A cold export must not prepare the store as a side effect")
+        } catch let error as TelemetryWorkoutReadError {
+            XCTAssertEqual(error, .unavailable("telemetry-v2-store-not-ready"))
+        }
+        XCTAssertEqual(factoryCallCount.value, 0)
+        let coldResumeCount = await persistence.pendingAnalysisResumeCallCount
+        let coldRecoveryCount = await persistence.unfinishedCallCount
+        XCTAssertEqual(coldResumeCount, 0)
+        XCTAssertEqual(coldRecoveryCount, 0)
+
+        coordinator.prepareStoreAndRecover()
+        try await eventually { coordinator.status == .idle && factoryCallCount.value == 1 }
+        try await eventually { await persistence.pendingAnalysisResumeCallCount == 1 }
+        do {
+            _ = try await coordinator.exportWorkoutAnalysis(request)
+            XCTFail("The injected read failure must be surfaced")
+        } catch let error as TelemetryWorkoutReadError {
+            XCTAssertEqual(error, .unavailable("injected-read-failure"))
+        }
+        let preparedResumeCount = await persistence.pendingAnalysisResumeCallCount
+        XCTAssertEqual(preparedResumeCount, 1)
+    }
+
     func testReadBeforeFailedStorePreparationSurfacesExplicitUnavailableError() async throws {
         enum FactoryFailure: Error { case unavailable }
         let coordinator = TelemetryV2RuntimeCoordinator {
@@ -1381,6 +1418,19 @@ private final class ManualRuntimeClock: TelemetryV2RuntimeClock, @unchecked Send
     }
 }
 
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue = 0
+
+    var value: Int {
+        lock.withLock { storedValue }
+    }
+
+    func increment() {
+        lock.withLock { storedValue += 1 }
+    }
+}
+
 private actor RuntimePersistence:
     TelemetryRecorderPersistence,
     TelemetryPostWorkoutAnalysisCapability,
@@ -1415,6 +1465,7 @@ private actor RuntimePersistence:
     private var analysisContinuation: CheckedContinuation<Void, Never>?
     private var migrationContinuation: CheckedContinuation<Void, Never>?
     private(set) var analysisSessionIDs: [SessionID] = []
+    private(set) var pendingAnalysisResumeCallCount = 0
     private(set) var migrationRequests: [LegacyTelemetryMigrationRequest] = []
     private(set) var migrationCallCount = 0
     private(set) var migrationCompletionCount = 0
@@ -1488,6 +1539,12 @@ private actor RuntimePersistence:
         throw TelemetryWorkoutReadError.unavailable("injected-read-failure")
     }
 
+    func exportWorkoutAnalysis(
+        _ request: WorkoutAnalysisExportRequest
+    ) async throws -> WorkoutAnalysisExportArtifact {
+        throw TelemetryWorkoutReadError.unavailable("injected-read-failure")
+    }
+
     func unfinishedSessions() async throws -> [WorkoutSessionRecord] {
         unfinishedCallCount += 1
         return []
@@ -1504,7 +1561,8 @@ private actor RuntimePersistence:
     }
 
     func resumePendingWorkoutAnalyses() async -> [PostWorkoutAnalysisTriggerResult] {
-        []
+        pendingAnalysisResumeCallCount += 1
+        return []
     }
 
     func migrateLegacyTelemetry(

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/DiagnosticBundlePerformanceTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/DiagnosticBundlePerformanceTests.swift
@@ -23,6 +23,23 @@ private struct DiagnosticBundleBenchmarkResult: Codable {
     let mainActorMaximumGapSeconds: Double
 }
 
+private struct WorkoutAnalysisExportBenchmarkResult: Codable {
+    let representedMinutes: Int
+    let frameRowCount: Int
+    let eventRowCount: Int
+    let metadataRowCount: Int
+    let fileBytes: Int64
+    let wallTimeSeconds: Double
+    let storeFetchCount: Int
+    let maximumStoreFetchLimit: Int
+    let maximumBufferedTimelineRows: Int
+    let baselineResidentBytes: UInt64
+    let peakResidentBytes: UInt64
+    let peakResidentDeltaBytes: UInt64
+    let mainActorHeartbeatCount: Int
+    let mainActorMaximumGapSeconds: Double
+}
+
 final class DiagnosticBundlePerformanceTests: XCTestCase {
     func testEmptyStoreProducesSupportOnlyBundle() async throws {
         let store = try TelemetryStoreFactory.make(.inMemory)
@@ -100,6 +117,107 @@ final class DiagnosticBundlePerformanceTests: XCTestCase {
             let data = try JSONEncoder.sorted.encode(result)
             print("DIAGNOSTIC_BUNDLE_BENCHMARK \(String(decoding: data, as: UTF8.self))")
         }
+    }
+
+    func testWorkoutAnalysisThirtyAndOneHundredTwentyMinutePerformance() async throws {
+        for representedMinutes in [30, 120] {
+            let result = try await runWorkoutAnalysisWorkload(
+                representedMinutes: representedMinutes
+            )
+            XCTAssertEqual(result.frameRowCount, representedMinutes * 60 - 20)
+            XCTAssertGreaterThan(result.eventRowCount, 0)
+            XCTAssertLessThanOrEqual(result.eventRowCount, 20)
+            XCTAssertGreaterThan(result.metadataRowCount, 0)
+            XCTAssertGreaterThan(result.fileBytes, 0)
+            XCTAssertLessThan(result.fileBytes, Int64(representedMinutes) * 150_000)
+            XCTAssertLessThan(result.wallTimeSeconds, 10)
+            XCTAssertLessThanOrEqual(result.maximumStoreFetchLimit, 128)
+            XCTAssertLessThanOrEqual(result.maximumBufferedTimelineRows, 256)
+            XCTAssertLessThanOrEqual(
+                result.storeFetchCount,
+                5 + ((result.frameRowCount + 127) / 128)
+            )
+            XCTAssertLessThan(result.peakResidentDeltaBytes, 128 * 1024 * 1024)
+            XCTAssertGreaterThan(result.mainActorHeartbeatCount, 0)
+            XCTAssertLessThan(result.mainActorMaximumGapSeconds, 1.0)
+            let data = try JSONEncoder.sorted.encode(result)
+            print("WORKOUT_ANALYSIS_EXPORT_BENCHMARK \(String(decoding: data, as: UTF8.self))")
+        }
+    }
+
+    private func runWorkoutAnalysisWorkload(
+        representedMinutes: Int
+    ) async throws -> WorkoutAnalysisExportBenchmarkResult {
+        let profile = profile(
+            name: "analysis-\(representedMinutes)-minute",
+            sessionCount: 1,
+            secondsPerSession: representedMinutes * 60
+        )
+        let generator = TelemetryGateFixtureGenerator(profile: profile)
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "WorkoutAnalysisBenchmark_\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = try await Task.detached {
+            try TelemetryStoreFactory.make(.onDisk(root.appendingPathComponent("TelemetryV2.store")))
+        }.value
+        try await persistFixture(generator: generator, store: store)
+
+        let baselineResidentBytes = currentResidentBytes()
+        let memorySampler = Task.detached(priority: .utility) {
+            var peak = currentResidentBytes()
+            while !Task.isCancelled {
+                peak = max(peak, currentResidentBytes())
+                try? await Task.sleep(for: .milliseconds(2))
+            }
+            return peak
+        }
+        let heartbeat = await MainActor.run { BenchmarkMainActorHeartbeat() }
+        let heartbeatTask = Task { @MainActor in await heartbeat.run() }
+        defer {
+            memorySampler.cancel()
+            heartbeatTask.cancel()
+        }
+
+        let started = ContinuousClock.now
+        let session = generator.session(index: 0)
+        let artifact = try await store.exportWorkoutAnalysis(
+            WorkoutAnalysisExportRequest(
+                sessionID: session.sessionID,
+                exactProfileLocalIdentifier: session.profileLocalIdentifier,
+                batchSize: 128
+            )
+        )
+        defer {
+            try? FileManager.default.removeItem(at: artifact.fileURL.deletingLastPathComponent())
+        }
+        let wallTimeSeconds = started.duration(to: .now).seconds
+        memorySampler.cancel()
+        heartbeatTask.cancel()
+        let peakResidentBytes = await memorySampler.value
+        _ = await heartbeatTask.result
+        let heartbeatSnapshot = await MainActor.run { heartbeat.snapshot }
+        let diagnostics = artifact.diagnostics
+        return WorkoutAnalysisExportBenchmarkResult(
+            representedMinutes: representedMinutes,
+            frameRowCount: diagnostics.frameRowCount,
+            eventRowCount: diagnostics.eventRowCount,
+            metadataRowCount: diagnostics.metadataRowCount,
+            fileBytes: diagnostics.fileByteCount,
+            wallTimeSeconds: wallTimeSeconds,
+            storeFetchCount: diagnostics.storeFetchCount,
+            maximumStoreFetchLimit: diagnostics.maximumStoreFetchLimit,
+            maximumBufferedTimelineRows: diagnostics.maximumBufferedTimelineRows,
+            baselineResidentBytes: baselineResidentBytes,
+            peakResidentBytes: peakResidentBytes,
+            peakResidentDeltaBytes: peakResidentBytes > baselineResidentBytes
+                ? peakResidentBytes - baselineResidentBytes
+                : 0,
+            mainActorHeartbeatCount: heartbeatSnapshot.count,
+            mainActorMaximumGapSeconds: heartbeatSnapshot.maximumGapSeconds
+        )
     }
 
     private func runWorkload(

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -2145,6 +2145,29 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         )
     }
 
+    func prepareWorkoutAnalysisExport(
+        for entry: WorkoutHistoryProjection
+    ) async throws -> WorkoutAnalysisExportArtifact {
+        guard entry.origin == .nativeV2,
+              entry.id.hasPrefix("native:"),
+              let profileID = activeUserProfileID,
+              let sessionUUID = UUID(uuidString: String(entry.id.dropFirst("native:".count))) else {
+            throw TelemetryWorkoutReadError.unavailable("selected-native-workout-unavailable")
+        }
+        return try await telemetryV2Coordinator.exportWorkoutAnalysis(
+            WorkoutAnalysisExportRequest(
+                sessionID: SessionID(rawValue: sessionUUID),
+                exactProfileLocalIdentifier: profileID.uuidString
+            )
+        )
+    }
+
+    func finalizeWorkoutAnalysisExport(_ artifact: WorkoutAnalysisExportArtifact) {
+        try? FileManager.default.removeItem(
+            at: artifact.fileURL.deletingLastPathComponent()
+        )
+    }
+
     func prepareDiagnosticBundle(
         scope: TrainingLogCsvExportScope,
         archiveName: String

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -3598,6 +3598,8 @@ private struct WorkoutStatsView: View {
     @State private var monthOffset: Int = 0
     @State private var showPlanSheet: Bool = false
     @State private var pageHeights: [StatsScope: CGFloat] = [:]
+    @State private var workoutAnalysisExportTask: Task<Void, Never>?
+    @State private var exportingWorkoutID: String?
 
     private var scopeSelection: Binding<StatsScope> {
         Binding(
@@ -3634,8 +3636,10 @@ private struct WorkoutStatsView: View {
                         entries: manager.telemetryV2WorkoutHistory,
                         readState: manager.telemetryV2WorkoutHistoryState,
                         hasMore: manager.telemetryV2WorkoutHistoryHasMore,
+                        exportingWorkoutID: exportingWorkoutID,
                         onRetry: { manager.refreshWorkoutHistoryFromV2(reset: true) },
-                        onLoadMore: { manager.loadNextWorkoutHistoryPageFromV2() }
+                        onLoadMore: { manager.loadNextWorkoutHistoryPageFromV2() },
+                        onExportAnalysis: startWorkoutAnalysisExport
                     )
                     .padding(.horizontal)
                     .padding(.bottom)
@@ -3648,6 +3652,34 @@ private struct WorkoutStatsView: View {
             }
             .sheet(isPresented: $showPlanSheet) {
                 ZonePlanSheet(planMinutes: $manager.zonePlanMinutes, ranges: zoneRanges)
+            }
+            .onDisappear {
+                workoutAnalysisExportTask?.cancel()
+                workoutAnalysisExportTask = nil
+                exportingWorkoutID = nil
+            }
+        }
+    }
+
+    private func startWorkoutAnalysisExport(_ entry: WorkoutHistoryProjection) {
+        presentWorkoutAnalysisExportWarning {
+            workoutAnalysisExportTask?.cancel()
+            exportingWorkoutID = entry.id
+            workoutAnalysisExportTask = Task { @MainActor in
+                defer {
+                    exportingWorkoutID = nil
+                    workoutAnalysisExportTask = nil
+                }
+                do {
+                    try await prepareAndPresentWorkoutAnalysisExport(
+                        manager: manager,
+                        entry: entry
+                    )
+                } catch is CancellationError {
+                    // Cancellation removes only the temporary export artifact.
+                } catch {
+                    presentWorkoutAnalysisExportFailure(error)
+                }
             }
         }
     }
@@ -4075,8 +4107,10 @@ private struct WorkoutHistoryCard: View {
     let entries: [WorkoutHistoryProjection]
     let readState: BluetoothManager.WorkoutReadState
     let hasMore: Bool
+    let exportingWorkoutID: String?
     let onRetry: () -> Void
     let onLoadMore: () -> Void
+    let onExportAnalysis: (WorkoutHistoryProjection) -> Void
 
     private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -4147,6 +4181,27 @@ private struct WorkoutHistoryCard: View {
                                     .font(.caption2.weight(.semibold))
                                     .foregroundColor(entry.averageHeartRate == nil ? .secondary : .red)
                             }
+                        }
+                        if entry.origin == .nativeV2 {
+                            Button {
+                                onExportAnalysis(entry)
+                            } label: {
+                                HStack(spacing: 6) {
+                                    if exportingWorkoutID == entry.id {
+                                        ProgressView()
+                                            .controlSize(.small)
+                                    } else {
+                                        Image(systemName: "square.and.arrow.up")
+                                    }
+                                    Text("Экспорт данных тренировки")
+                                }
+                                .font(.caption.weight(.semibold))
+                                .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.large)
+                            .disabled(exportingWorkoutID != nil)
+                            .accessibilityLabel("Экспорт данных тренировки")
                         }
                         if entry.id != entries.last?.id {
                             Divider()
@@ -4865,6 +4920,61 @@ private func presentTelemetryV2ExportWarning(
         onContinue()
     })
     root.present(alert, animated: true)
+}
+
+private func presentWorkoutAnalysisExportWarning(
+    onContinue: @escaping () -> Void
+) {
+    guard let root = activeRootViewController() else { return }
+    let alert = UIAlertController(
+        title: "Данные о здоровье",
+        message: "Файл содержит пульс и данные выбранной тренировки. Делитесь им только с доверенным получателем. Исходные данные не будут изменены или удалены.",
+        preferredStyle: .alert
+    )
+    alert.addAction(UIAlertAction(title: "Отмена", style: .cancel))
+    alert.addAction(UIAlertAction(title: "Продолжить", style: .default) { _ in
+        onContinue()
+    })
+    root.present(alert, animated: true)
+}
+
+@MainActor
+private func prepareAndPresentWorkoutAnalysisExport(
+    manager: BluetoothManager,
+    entry: WorkoutHistoryProjection
+) async throws {
+    let artifact = try await manager.prepareWorkoutAnalysisExport(for: entry)
+    do {
+        try Task.checkCancellation()
+        guard let root = activeRootViewController() else {
+            manager.finalizeWorkoutAnalysisExport(artifact)
+            return
+        }
+        let activity = UIActivityViewController(
+            activityItems: [artifact.fileURL],
+            applicationActivities: nil
+        )
+        activity.completionWithItemsHandler = { _, _, _, _ in
+            Task { @MainActor in
+                manager.finalizeWorkoutAnalysisExport(artifact)
+            }
+        }
+        root.present(activity, animated: true)
+    } catch {
+        manager.finalizeWorkoutAnalysisExport(artifact)
+        throw error
+    }
+}
+
+@MainActor
+private func presentWorkoutAnalysisExportFailure(_ error: Error) {
+    let failure = UIAlertController(
+        title: "Не удалось экспортировать тренировку",
+        message: error.localizedDescription,
+        preferredStyle: .alert
+    )
+    failure.addAction(UIAlertAction(title: "OK", style: .default))
+    activeRootViewController()?.present(failure, animated: true)
 }
 
 @MainActor

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WorkoutAnalysisExportIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WorkoutAnalysisExportIntegrationContractTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import XCTest
+
+final class WorkoutAnalysisExportIntegrationContractTests: XCTestCase {
+    func testHistoryExposesOnlyNativeWorkoutAnalysisAction() throws {
+        let content = try source("WalkingPadRemote/ContentView.swift")
+        XCTAssertTrue(content.contains("if entry.origin == .nativeV2"))
+        XCTAssertTrue(content.contains("Text(\"Экспорт данных тренировки\")"))
+        XCTAssertTrue(content.contains("onExportAnalysis(entry)"))
+        XCTAssertTrue(content.contains(".controlSize(.large)"))
+        XCTAssertTrue(content.contains(".disabled(exportingWorkoutID != nil)"))
+        XCTAssertTrue(content.contains("Исходные данные не будут изменены или удалены."))
+    }
+
+    func testUIRoutesTypedExactProfileRequestWithoutDiagnosticExport() throws {
+        let manager = try source("WalkingPadRemote/BluetoothManager.swift")
+        let method = try slice(
+            manager,
+            from: "func prepareWorkoutAnalysisExport(",
+            through: "func finalizeWorkoutAnalysisExport("
+        )
+        XCTAssertTrue(method.contains("entry.origin == .nativeV2"))
+        XCTAssertTrue(method.contains("WorkoutAnalysisExportRequest("))
+        XCTAssertTrue(method.contains("exactProfileLocalIdentifier: profileID.uuidString"))
+        XCTAssertTrue(method.contains("telemetryV2Coordinator.exportWorkoutAnalysis"))
+        XCTAssertFalse(method.contains("prepareDiagnosticBundle"))
+        XCTAssertFalse(method.contains("prepareTelemetryV2Export"))
+    }
+
+    func testExportPathIsReadOnlyAndDoesNotRunAnalyzerOrDiagnosticReduction() throws {
+        let coordinator = try source("Sources/TelemetryRuntime/TelemetryV2RuntimeCoordinator.swift")
+        let coordinatorMethod = try slice(
+            coordinator,
+            from: "public func exportWorkoutAnalysis(",
+            through: "public func associateHealthKitWorkout("
+        )
+        XCTAssertTrue(coordinatorMethod.contains("workoutReadCapability()"))
+        XCTAssertFalse(coordinatorMethod.contains("prepareStoreAndRecover"))
+        XCTAssertFalse(coordinatorMethod.contains("resumePendingWorkoutAnalyses"))
+
+        let exporter = try source(
+            "Sources/TelemetryPersistence/TelemetryWorkoutAnalysisExportStore.swift"
+        )
+        XCTAssertFalse(exporter.contains("WorkoutAnalyzerV1"))
+        XCTAssertFalse(exporter.contains("exportWorkouts("))
+        XCTAssertFalse(exporter.contains("modelContext.delete"))
+        XCTAssertFalse(exporter.contains("removeItem(at: session"))
+        XCTAssertTrue(exporter.contains("selectedKinds.contains($0.kindKey)"))
+    }
+
+    private func source(_ relativePath: String) throws -> String {
+        let packageDirectory = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(
+            contentsOf: packageDirectory.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+
+    private func slice(
+        _ source: String,
+        from startMarker: String,
+        through endMarker: String
+    ) throws -> Substring {
+        let start = try XCTUnwrap(source.range(of: startMarker)?.lowerBound)
+        let end = try XCTUnwrap(
+            source.range(of: endMarker, range: start..<source.endIndex)?.lowerBound
+        )
+        return source[start..<end]
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Экспорт данных тренировки` to native Telemetry V2 workout history rows and share exactly one versioned CSV for the selected workout.
- Stream observed canonical frames and sparse typed events with bounded keyset reads, preserving gaps, missing values, and factual/desired/commanded truth boundaries.
- Include deterministic workout metadata, quality/coverage markers, privacy-safe local references, and free-form payload redaction.

Closes #113

## Why

The existing diagnostic package is too heavy and support-oriented for routine workout analysis, while summary exports lose the HR/speed/phase/control timeline needed for comparisons and recommendations.

## Verification

- `cd ios/WalkingPadRemote/WalkingPadRemote && swift test` — passed; the opt-in 1000-hour profile was skipped because `TELEMETRY_GATE_PROFILE=full` was not set.
- `swift test --filter WorkoutAnalysisExportTests` — 5 passed.
- `swift test --filter DiagnosticBundlePerformanceTests.testWorkoutAnalysisThirtyAndOneHundredTwentyMinutePerformance` — passed.
  - 30 min: 1,780 frame rows, 20 event rows, 526,548 bytes, 0.220 s.
  - 120 min: 7,180 frame rows, 20 event rows, 2,115,889 bytes, 0.885 s.
  - Maximum fetch limit 128, maximum buffered timeline rows 148, MainActor maximum gap below 0.007 s.
- `xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build` — passed, including the embedded Watch target.
- `python3 scripts/check_codex_governance.py` — passed.
- `~/.codex/scripts/check-agents-instruction-chain.sh --path ios/WalkingPadRemote/WalkingPadRemote` — passed.
- `git diff --check 60dcc4f6e7f2af05ac8ee65d4121800261da0564...HEAD` — passed.
- Independent safety/scope review — GO, no P0-P3 findings after privacy and cancellation regressions.

## Hardware / environment

- Treadmill model: Not used.
- Protocol: No BLE/protocol operation performed.
- iPhone / iOS: No device install or launch performed.
- Apple Watch / watchOS: No device install or launch performed.

## Screenshots or logs

No screenshot was fabricated: the clean simulator has no retained native Telemetry V2 workout to expose the history-only action honestly. Source contracts and the unsigned app build verify placement and compilation.

## Risks / Notes

- No migrations, configuration changes, deployment steps, or persistence/control/HR/BLE/Stop behavior changes.
- The action is intentionally available only for native Telemetry V2 workout rows; imported rows remain unchanged.
- Export artifacts are temporary and source evidence is read-only. Rollback is a revert of this commit; no data rollback is required.
- Docs updated: `docs/design/qa-ledger.md`.