### PR TITLE
Make enabled Debug logging bounded

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -134,6 +134,7 @@ let package = Package(
             sources: [
                 "AutoConnectRetryPolicy.swift",
                 "BLETransportCodec.swift",
+                "BoundedDebugLog.swift",
                 "ControllerUnitsSafetyPolicy.swift",
                 "CooldownRuntimeEngine.swift",
                 "DeterministicControlReplay.swift",

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -1180,38 +1180,63 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     @Published var hrFailureReports: [HrFailureReport] = []
     @Published var loggingEnabled: Bool = false
     @Published var lastCommandLine: String = ""
-    @Published var debugLog: String = ""
+    @Published private(set) var debugLog: String = ""
     @Published var lastTrainingLogPath: String = ""
     @Published private(set) var trainingLogsInventory: TrainingTelemetryWriter.TrainingLogsInventory = .empty
+    private let debugLogStore = DebugLogStore()
+    private var debugLogPublicationState = DebugLogPublicationState()
+    private var debugLogPresentationTimer: Timer?
 
     private func appendLog(_ line: String) {
         guard loggingEnabled else { return }
         let entry = "[\(Date().formatted(date: .omitted, time: .standard))] \(line)"
-        DispatchQueue.main.async {
-            // Keep a rolling log: cap by lines and by total UTF-8 bytes
-            let maxLines = 4000
-            let maxBytes = 250_000 // ~250 KB
-            var lines = self.debugLog.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-            lines.append(entry)
-            // Enforce line cap first
-            if lines.count > maxLines {
-                lines.removeFirst(lines.count - maxLines)
+        debugLogStore.append(entry)
+    }
+
+    func startDebugLogPresentation() {
+        guard debugLogPresentationTimer == nil else { return }
+
+        refreshDebugLogSnapshot()
+        let timer = Timer(timeInterval: DebugLogPublicationPolicy.refreshInterval, repeats: true) {
+            [weak self] _ in
+            self?.refreshDebugLogSnapshot()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        debugLogPresentationTimer = timer
+    }
+
+    func stopDebugLogPresentation() {
+        debugLogPresentationTimer?.invalidate()
+        debugLogPresentationTimer = nil
+    }
+
+    func makeDebugLogSnapshot(completion: @escaping (String) -> Void) {
+        debugLogStore.snapshot(after: nil) { snapshot in
+            DispatchQueue.main.async {
+                completion(snapshot?.text ?? "")
             }
-            // Enforce byte cap by keeping the newest suffix that fits
-            var kept: [String] = []
-            kept.reserveCapacity(min(lines.count, maxLines))
-            var totalBytes = 0
-            for l in lines.reversed() {
-                let bytes = l.lengthOfBytes(using: .utf8) + 1 // + newline
-                if totalBytes + bytes > maxBytes { break }
-                kept.append(l)
-                totalBytes += bytes
-                if kept.count >= maxLines { break }
+        }
+    }
+
+    func clearDebugLog() {
+        debugLogStore.clear { [weak self] revision in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.debugLogPublicationState.markPublished(revision: revision)
+                self.debugLog = ""
             }
-            if kept.isEmpty {
-                kept = [lines.last ?? entry]
+        }
+    }
+
+    private func refreshDebugLogSnapshot() {
+        let publishedRevision = debugLogPublicationState.publishedRevision
+        debugLogStore.snapshot(after: publishedRevision) { [weak self] snapshot in
+            guard let snapshot else { return }
+            DispatchQueue.main.async {
+                guard let self,
+                      let text = self.debugLogPublicationState.consume(snapshot) else { return }
+                self.debugLog = text
             }
-            self.debugLog = kept.reversed().joined(separator: "\n")
         }
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BoundedDebugLog.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BoundedDebugLog.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+struct DebugLogRetentionPolicy: Equatable, Sendable {
+    static let production = DebugLogRetentionPolicy(
+        maxLines: 4_000,
+        maxUTF8Bytes: 250_000
+    )
+
+    let maxLines: Int
+    let maxUTF8Bytes: Int
+
+    init(maxLines: Int, maxUTF8Bytes: Int) {
+        precondition(maxLines > 0)
+        precondition(maxUTF8Bytes > 1)
+        self.maxLines = maxLines
+        self.maxUTF8Bytes = maxUTF8Bytes
+    }
+}
+
+struct BoundedDebugLogBuffer: Sendable {
+    struct Snapshot: Equatable, Sendable {
+        let revision: UInt64
+        let text: String
+        let lineCount: Int
+        let retainedUTF8Bytes: Int
+    }
+
+    struct Diagnostics: Equatable, Sendable {
+        let appendCount: UInt64
+        let evictedLineCount: UInt64
+        let snapshotAssemblyCount: UInt64
+    }
+
+    private struct Entry: Sendable {
+        let utf8: [UInt8]
+
+        var retainedUTF8Bytes: Int {
+            utf8.count + 1
+        }
+    }
+
+    let policy: DebugLogRetentionPolicy
+
+    private var storage: [Entry?]
+    private var headIndex = 0
+    private(set) var lineCount = 0
+    private(set) var retainedUTF8Bytes = 0
+    private(set) var revision: UInt64 = 0
+    private var appendCount: UInt64 = 0
+    private var evictedLineCount: UInt64 = 0
+    private var snapshotAssemblyCount: UInt64 = 0
+
+    init(policy: DebugLogRetentionPolicy = .production) {
+        self.policy = policy
+        storage = Array(repeating: nil, count: policy.maxLines)
+    }
+
+    var diagnostics: Diagnostics {
+        Diagnostics(
+            appendCount: appendCount,
+            evictedLineCount: evictedLineCount,
+            snapshotAssemblyCount: snapshotAssemblyCount
+        )
+    }
+
+    mutating func append(_ line: String) {
+        let logicalLines = line.split(separator: "\n", omittingEmptySubsequences: false)
+        if logicalLines.isEmpty {
+            appendEntry(Entry(utf8: []))
+        } else {
+            for logicalLine in logicalLines {
+                appendEntry(Entry(utf8: boundedUTF8(logicalLine)))
+            }
+        }
+
+        appendCount &+= 1
+        revision &+= 1
+    }
+
+    mutating func clear() {
+        guard lineCount > 0 else { return }
+
+        storage = Array(repeating: nil, count: policy.maxLines)
+        headIndex = 0
+        lineCount = 0
+        retainedUTF8Bytes = 0
+        revision &+= 1
+    }
+
+    mutating func snapshot() -> Snapshot {
+        snapshotAssemblyCount &+= 1
+
+        var text = ""
+        text.reserveCapacity(retainedUTF8Bytes)
+        for offset in 0..<lineCount {
+            if offset > 0 {
+                text.append("\n")
+            }
+            let index = (headIndex + offset) % storage.count
+            if let entry = storage[index] {
+                text.append(String(decoding: entry.utf8, as: UTF8.self))
+            }
+        }
+
+        return Snapshot(
+            revision: revision,
+            text: text,
+            lineCount: lineCount,
+            retainedUTF8Bytes: retainedUTF8Bytes
+        )
+    }
+
+    private mutating func appendEntry(_ entry: Entry) {
+        while lineCount > 0 && (
+            lineCount >= policy.maxLines
+                || retainedUTF8Bytes + entry.retainedUTF8Bytes > policy.maxUTF8Bytes
+        ) {
+            removeOldest()
+        }
+
+        let insertionIndex = (headIndex + lineCount) % storage.count
+        storage[insertionIndex] = entry
+        lineCount += 1
+        retainedUTF8Bytes += entry.retainedUTF8Bytes
+    }
+
+    private mutating func removeOldest() {
+        guard lineCount > 0, let entry = storage[headIndex] else { return }
+
+        retainedUTF8Bytes -= entry.retainedUTF8Bytes
+        storage[headIndex] = nil
+        headIndex = (headIndex + 1) % storage.count
+        lineCount -= 1
+        evictedLineCount &+= 1
+    }
+
+    private func boundedUTF8(_ line: Substring) -> [UInt8] {
+        let maxLineBytes = policy.maxUTF8Bytes - 1
+        if line.utf8.count <= maxLineBytes {
+            return Array(line.utf8)
+        }
+        var bytes = Array(line.utf8.prefix(maxLineBytes))
+
+        // A byte prefix can end inside a multi-byte scalar. Removing at most
+        // three continuation bytes restores a valid UTF-8 prefix.
+        while !bytes.isEmpty && String(bytes: bytes, encoding: .utf8) == nil {
+            bytes.removeLast()
+        }
+        return bytes
+    }
+}
+
+enum DebugLogPublicationPolicy {
+    static let refreshInterval: TimeInterval = 0.5
+}
+
+struct DebugLogPublicationState: Sendable {
+    private(set) var publishedRevision: UInt64 = 0
+
+    mutating func consume(_ snapshot: BoundedDebugLogBuffer.Snapshot) -> String? {
+        guard snapshot.revision != publishedRevision else { return nil }
+        publishedRevision = snapshot.revision
+        return snapshot.text
+    }
+
+    mutating func markPublished(revision: UInt64) {
+        publishedRevision = revision
+    }
+}
+
+final class DebugLogStore: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "BluetoothManager.debugLog")
+    private var buffer: BoundedDebugLogBuffer
+
+    init(policy: DebugLogRetentionPolicy = .production) {
+        buffer = BoundedDebugLogBuffer(policy: policy)
+    }
+
+    func append(_ line: String) {
+        queue.async { [self] in
+            buffer.append(line)
+        }
+    }
+
+    func snapshot(
+        after revision: UInt64?,
+        completion: @escaping (BoundedDebugLogBuffer.Snapshot?) -> Void
+    ) {
+        queue.async { [self] in
+            if let revision, revision == buffer.revision {
+                completion(nil)
+                return
+            }
+            completion(buffer.snapshot())
+        }
+    }
+
+    func clear(completion: @escaping (UInt64) -> Void) {
+        queue.async { [self] in
+            buffer.clear()
+            completion(buffer.revision)
+        }
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -4733,16 +4733,20 @@ private struct DebugView: View {
                         VStack(alignment: .leading, spacing: 12) {
                             HStack {
                                 Button("Copy Logs") {
-                                    copyLogs(
-                                        lastCmd: manager.lastCommandLine,
-                                        hrStatus: manager.hrStatusLine,
-                                        log: manager.debugLog
-                                    )
+                                    let lastCommandLine = manager.lastCommandLine
+                                    let hrStatusLine = manager.hrStatusLine
+                                    manager.makeDebugLogSnapshot { log in
+                                        copyLogs(
+                                            lastCmd: lastCommandLine,
+                                            hrStatus: hrStatusLine,
+                                            log: log
+                                        )
+                                    }
                                 }
                                 .buttonStyle(.bordered)
 
                                 Button("Clear") {
-                                    manager.debugLog = ""
+                                    manager.clearDebugLog()
                                     manager.lastCommandLine = ""
                                     manager.hrStatusLine = ""
                                 }
@@ -4884,9 +4888,11 @@ private struct DebugView: View {
             }
             .navigationTitle("Отладка")
             .onAppear {
+                manager.startDebugLogPresentation()
                 manager.refreshWorkoutHistoryFromV2(reset: true)
             }
             .onDisappear {
+                manager.stopDebugLogPresentation()
                 diagnosticBundleTask?.cancel()
             }
         }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BoundedDebugLogTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BoundedDebugLogTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class BoundedDebugLogTests: XCTestCase {
+    func testLineAndByteRetentionKeepsNewestCompleteEntries() {
+        var lineLimited = BoundedDebugLogBuffer(
+            policy: DebugLogRetentionPolicy(maxLines: 3, maxUTF8Bytes: 100)
+        )
+        for index in 0..<10 {
+            lineLimited.append("line-\(index)")
+        }
+
+        let lineSnapshot = lineLimited.snapshot()
+        XCTAssertEqual(lineSnapshot.text, "line-7\nline-8\nline-9")
+        XCTAssertEqual(lineSnapshot.lineCount, 3)
+        XCTAssertLessThanOrEqual(lineSnapshot.retainedUTF8Bytes, 100)
+
+        var byteLimited = BoundedDebugLogBuffer(
+            policy: DebugLogRetentionPolicy(maxLines: 10, maxUTF8Bytes: 14)
+        )
+        byteLimited.append("aaaaa")
+        byteLimited.append("bbbbb")
+        byteLimited.append("ccccc")
+
+        let byteSnapshot = byteLimited.snapshot()
+        XCTAssertEqual(byteSnapshot.text, "bbbbb\nccccc")
+        XCTAssertEqual(byteSnapshot.lineCount, 2)
+        XCTAssertEqual(byteSnapshot.retainedUTF8Bytes, 12)
+    }
+
+    func testOversizedUnicodeLineIsValidAndStrictlyBounded() {
+        let policy = DebugLogRetentionPolicy(maxLines: 4, maxUTF8Bytes: 12)
+        var buffer = BoundedDebugLogBuffer(policy: policy)
+
+        buffer.append(String(repeating: "🙂", count: 20))
+
+        let snapshot = buffer.snapshot()
+        XCTAssertEqual(snapshot.text, "🙂🙂")
+        XCTAssertEqual(snapshot.lineCount, 1)
+        XCTAssertLessThanOrEqual(snapshot.retainedUTF8Bytes, policy.maxUTF8Bytes)
+        XCTAssertNotNil(snapshot.text.data(using: .utf8))
+    }
+
+    func testEmbeddedNewlinesParticipateInLineRetentionPolicy() {
+        var buffer = BoundedDebugLogBuffer(
+            policy: DebugLogRetentionPolicy(maxLines: 3, maxUTF8Bytes: 100)
+        )
+
+        buffer.append("first\nsecond\nthird\nfourth")
+
+        let snapshot = buffer.snapshot()
+        XCTAssertEqual(snapshot.text, "second\nthird\nfourth")
+        XCTAssertEqual(snapshot.lineCount, 3)
+        XCTAssertEqual(buffer.diagnostics.appendCount, 1)
+    }
+
+    func testSustainedAppendDoesNotAssembleRetainedTextUntilSnapshot() {
+        let policy = DebugLogRetentionPolicy.production
+        var buffer = BoundedDebugLogBuffer(policy: policy)
+        let payload = String(repeating: "x", count: 96)
+
+        for index in 0..<100_000 {
+            buffer.append("event=\(index) payload=\(payload)")
+        }
+
+        XCTAssertEqual(buffer.diagnostics.appendCount, 100_000)
+        XCTAssertEqual(buffer.diagnostics.snapshotAssemblyCount, 0)
+        XCTAssertLessThanOrEqual(buffer.lineCount, policy.maxLines)
+        XCTAssertLessThanOrEqual(buffer.retainedUTF8Bytes, policy.maxUTF8Bytes)
+        XCTAssertGreaterThan(
+            buffer.retainedUTF8Bytes,
+            policy.maxUTF8Bytes - 150
+        )
+
+        let snapshot = buffer.snapshot()
+        XCTAssertEqual(buffer.diagnostics.snapshotAssemblyCount, 1)
+        XCTAssertEqual(snapshot.lineCount, buffer.lineCount)
+        XCTAssertTrue(snapshot.text.hasSuffix("event=99999 payload=\(payload)"))
+    }
+
+    func testPublicationStateSuppressesUnchangedSnapshots() {
+        var buffer = BoundedDebugLogBuffer(
+            policy: DebugLogRetentionPolicy(maxLines: 20, maxUTF8Bytes: 1_000)
+        )
+        var publication = DebugLogPublicationState()
+
+        for index in 0..<10_000 {
+            buffer.append("event-\(index)")
+        }
+        let firstSnapshot = buffer.snapshot()
+        XCTAssertNotNil(publication.consume(firstSnapshot))
+        XCTAssertNil(publication.consume(firstSnapshot))
+
+        for index in 10_000..<20_000 {
+            buffer.append("event-\(index)")
+        }
+        let secondSnapshot = buffer.snapshot()
+        XCTAssertNotNil(publication.consume(secondSnapshot))
+        XCTAssertNil(publication.consume(secondSnapshot))
+
+        XCTAssertEqual(buffer.diagnostics.appendCount, 20_000)
+        XCTAssertEqual(buffer.diagnostics.snapshotAssemblyCount, 2)
+        XCTAssertEqual(DebugLogPublicationPolicy.refreshInterval, 0.5)
+    }
+
+    func testSnapshotAndClearAreDeterministic() {
+        var buffer = BoundedDebugLogBuffer(
+            policy: DebugLogRetentionPolicy(maxLines: 5, maxUTF8Bytes: 100)
+        )
+        buffer.append("first")
+        buffer.append("second")
+
+        let first = buffer.snapshot()
+        let second = buffer.snapshot()
+        XCTAssertEqual(first.text, second.text)
+        XCTAssertEqual(first.revision, second.revision)
+
+        buffer.clear()
+        let cleared = buffer.snapshot()
+        XCTAssertEqual(cleared.text, "")
+        XCTAssertEqual(cleared.lineCount, 0)
+        XCTAssertEqual(cleared.retainedUTF8Bytes, 0)
+        XCTAssertGreaterThan(cleared.revision, second.revision)
+    }
+
+    func testStoreSnapshotIncludesAllPreviouslyEnqueuedAppends() {
+        let store = DebugLogStore(
+            policy: DebugLogRetentionPolicy(maxLines: 5, maxUTF8Bytes: 100)
+        )
+        for index in 0..<20 {
+            store.append("event-\(index)")
+        }
+
+        let snapshotExpectation = expectation(description: "snapshot")
+        store.snapshot(after: nil) { snapshot in
+            XCTAssertEqual(
+                snapshot?.text,
+                "event-15\nevent-16\nevent-17\nevent-18\nevent-19"
+            )
+            XCTAssertEqual(snapshot?.lineCount, 5)
+            snapshotExpectation.fulfill()
+        }
+
+        wait(for: [snapshotExpectation], timeout: 1)
+    }
+}


### PR DESCRIPTION
## Summary

- Move the legacy human-readable Debug log into a serially owned bounded ring with explicit 4,000-line and 250,000-byte limits.
- Publish a rendered SwiftUI snapshot only while Debug is visible, at a 0.5-second revision-aware cadence; Copy renders on demand and Clear is serialized with pending appends.
- Add deterministic near-capacity, sustained-append, publication, UTF-8, snapshot, and queue-order coverage.

Closes #114

## Why

Enabled diagnostics previously split, scanned, reversed, joined, and published the entire retained text on the main thread for every technical line. This removes work proportional to the retained buffer size from runtime callbacks without changing Telemetry V2, control, BLE, HealthKit, persistence, or diagnostic bundle schemas.

## Testing

- [ ] `python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py` — not applicable; no Python changes.
- [x] `cd ios/WalkingPadRemote/WalkingPadRemote && swift test`
- [x] `cd ios/WalkingPadRemote/WalkingPadRemote && swift test --filter BoundedDebugLogTests` (7 tests)
- [x] `xcodebuild -project WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -configuration Debug -destination generic/platform=iOS -derivedDataPath /tmp/walkingpad-issue114-derived CODE_SIGNING_ALLOWED=NO build`

## Hardware / environment

- Treadmill model: Not exercised; prohibited by Issue scope.
- Protocol: No protocol changes.
- iPhone / iOS: Generic unsigned iOS build only.
- Apple Watch / watchOS: Embedded watchOS target built; no device action.

## Screenshots or logs

Not applicable. This is internal Debug logging performance work with deterministic code-first evidence.

## Notes for reviewers

- Risk areas: the visible Debug text can lag raw appends by at most the 0.5-second refresh cadence; Copy always requests a fresh ordered snapshot.
- Follow-up work: none in this PR; Issue #112 typed diagnostic evidence remains independent of this supplemental text log.
- Docs updated: no; behavior and support schema are unchanged.