### PR TITLE
Maintain fresh factual WalkingPad speed evidence

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -165,6 +165,7 @@ let package = Package(
                 "TrainingUITreadmillPublicationPolicy.swift",
                 "TreadmillControlReadinessPolicy.swift",
                 "TreadmillCommandTelemetrySidecar.swift",
+                "WalkingPadStatusRefreshPolicy.swift",
                 "WorkoutLifecyclePolicy.swift"
             ]
         ),

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryAnalysisTests/WorkoutAnalyzerV1Tests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryAnalysisTests/WorkoutAnalyzerV1Tests.swift
@@ -152,6 +152,54 @@ final class WorkoutAnalyzerV1Tests: XCTestCase {
         })
     }
 
+    func testThirtyOneMinuteStableSpeedResponsesProvideFactualAverage() throws {
+        let sessionSeconds = 31 * 60
+        let fixture = AnalysisFixture(sessionSeconds: Double(sessionSeconds))
+        let treadmill = stride(from: 0, to: sessionSeconds, by: 5).enumerated().map {
+            fixture.treadmill(
+                ordinal: $0.offset + 1,
+                seconds: Double($0.element),
+                speed: 4.2,
+                factual: true
+            )
+        }
+        let frames = (0..<sessionSeconds).map { second -> CanonicalFrame in
+            let observation = treadmill[second / 5]
+            return fixture.treadmillFrame(
+                observation: observation,
+                second: Int64(second),
+                freshness: .fresh
+            )
+        }
+        let result = try WorkoutAnalyzerV1.analyze(
+            fixture.input(
+                treadmill: treadmill,
+                events: fixture.cooldownEvents(
+                    start: Double(sessionSeconds - 300),
+                    end: Double(sessionSeconds),
+                    target: 115
+                ),
+                frames: frames
+            ),
+            generatedAt: fixture.baseDate.addingTimeInterval(Double(sessionSeconds + 60))
+        )
+        let detail = try decodeDetail(result)
+
+        XCTAssertEqual(
+            try XCTUnwrap(detail.quality.treadmillFactualCoverage.coverageRatio),
+            1,
+            accuracy: 0.000_001
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(result.keyMetrics.averageFactualSpeedKilometresPerHour),
+            4.2,
+            accuracy: 0.000_001
+        )
+        XCTAssertFalse(detail.quality.issues.contains {
+            $0.code == "average-factual-speed-insufficient-coverage"
+        })
+    }
+
     func testDuplicateAndOutOfOrderNativeSamplesCannotChangeDurationMetrics() throws {
         let fixture = AnalysisFixture(sessionSeconds: 20)
         let heartRate = [

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BLETransportCodec.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BLETransportCodec.swift
@@ -65,6 +65,12 @@ enum BLETransportCodec {
         Data([0xF7, 0xA6, 0x00, 0x00, 0x00, 0x00, 0x00, 0xA6, 0xFD])
     }
 
+    /// Read-only current status query used by the controller protocol. A zero
+    /// A2 key/value requests an F8 A2 report and does not change motion state.
+    static func buildWalkingPadQueryStatusPacket() -> Data {
+        Data([0xF7, 0xA2, 0x00, 0x00, 0xA2, 0xFD])
+    }
+
     static func buildStopTruthExperimentPacket(
         role: StopTruthExperimentCommandRole
     ) -> Data {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -103,6 +103,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private var controllerUnitsTruthTracker = ControllerUnitsTruthTracker()
     private var lastControllerUnitsQueryAt: Date? = nil
     private var lastControllerUnitsQueryTrigger: String? = nil
+    private var lastWalkingPadStatusQueryAt: Date? = nil
     private var stopObservationStreamID: UUID? = nil
     private var stopObservationLifecycle: StopObservationLifecycle? = nil
     private var stopObservationCheckpointWorkItems: [DispatchWorkItem] = []
@@ -6545,7 +6546,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             }
         }
         updateTreadmillStatus()
-        maintainControllerUnitsTruthDuringActiveWorkout(now: Date())
+        maintainWalkingPadReadOnlyEvidenceDuringActiveWorkout(now: Date())
     }
 
     private func updateTreadmillStatus() {
@@ -7148,6 +7149,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         controllerUnitsTruth = controllerUnitsTruthTracker.state
         lastControllerUnitsQueryAt = nil
         lastControllerUnitsQueryTrigger = nil
+        lastWalkingPadStatusQueryAt = nil
         isTreadmillControlReady = false
         applyNativeHeartRatePreflightEffects(
             nativeHeartRatePreflightEngine.safetyChanged(
@@ -7454,19 +7456,45 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         requestControllerUnitsTruth(trigger: trigger.rawValue, now: now)
     }
 
-    private func maintainControllerUnitsTruthDuringActiveWorkout(now: Date) {
-        let refreshDecision = ControllerUnitsRefreshPolicy.activeWorkoutRefresh(
-            isHrControlRunning: isHrControlRunning,
+    private func maintainWalkingPadReadOnlyEvidenceDuringActiveWorkout(now: Date) {
+        let refreshDecision = WalkingPadStatusRefreshPolicy.activeWorkoutRefresh(
+            isWorkoutOrCooldownActive: isHrControlRunning,
             transportReady: controllerUnitsQueryTransportReady,
             motionQueueIdle: commandQueue.isEmpty
                 && !isCommandQueueProcessing
                 && nextCommandAllowedAt <= now,
             secondsUntilNextScheduledMotion: controllerUnitsNextScheduledMotionLeadSeconds,
-            lastQueryAt: lastControllerUnitsQueryAt,
+            lastStatusQueryAt: lastWalkingPadStatusQueryAt,
+            lastControllerUnitsQueryAt: lastControllerUnitsQueryAt,
             now: now
         )
-        guard let trigger = refreshDecision.trigger else { return }
-        requestControllerUnitsTruth(trigger: trigger.rawValue, now: now)
+        switch refreshDecision.kind {
+        case .status:
+            requestWalkingPadStatusRefresh(now: now)
+        case .controllerUnits:
+            requestControllerUnitsTruth(
+                trigger: ControllerUnitsRefreshTrigger.activeWorkoutIdleWindow.rawValue,
+                now: now
+            )
+        case nil:
+            break
+        }
+    }
+
+    private func requestWalkingPadStatusRefresh(now: Date) {
+        guard controllerUnitsQueryTransportReady else { return }
+        lastWalkingPadStatusQueryAt = now
+        appendLog("WalkingPad status query: command=A2 key=0 read_only=true")
+        logTrainingEvent("walkingpad_status_query_requested", fields: [
+            "command_family": "A2",
+            "key": 0,
+            "read_only": true,
+            "query_interval_s": WalkingPadStatusRefreshPolicy.preferredStatusQueryInterval
+        ])
+        writeCommand(
+            BLETransportCodec.buildWalkingPadQueryStatusPacket(),
+            label: "QUERY STATUS"
+        )
     }
 
     private var controllerUnitsNextScheduledMotionLeadSeconds: Int {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/WalkingPadStatusRefreshPolicy.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/WalkingPadStatusRefreshPolicy.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+enum WalkingPadReadOnlyRefreshKind: Equatable {
+    case status
+    case controllerUnits
+}
+
+struct WalkingPadReadOnlyRefreshDecision: Equatable {
+    let kind: WalkingPadReadOnlyRefreshKind?
+
+    var shouldRequest: Bool { kind != nil }
+}
+
+/// Coordinates read-only WalkingPad polling without occupying a motion command window.
+enum WalkingPadStatusRefreshPolicy {
+    static let preferredStatusQueryInterval: TimeInterval = 3
+    static let maximumStatusQueryInterval: TimeInterval = 5
+
+    static func activeWorkoutRefresh(
+        isWorkoutOrCooldownActive: Bool,
+        transportReady: Bool,
+        motionQueueIdle: Bool,
+        secondsUntilNextScheduledMotion: Int,
+        lastStatusQueryAt: Date?,
+        lastControllerUnitsQueryAt: Date?,
+        now: Date
+    ) -> WalkingPadReadOnlyRefreshDecision {
+        guard isWorkoutOrCooldownActive,
+              transportReady,
+              motionQueueIdle,
+              secondsUntilNextScheduledMotion
+                > ControllerUnitsRefreshPolicy.requiredMotionLeadSeconds else {
+            return WalkingPadReadOnlyRefreshDecision(kind: nil)
+        }
+
+        let statusAge = lastStatusQueryAt.map { now.timeIntervalSince($0) }
+        let unitsAge = lastControllerUnitsQueryAt.map { now.timeIntervalSince($0) }
+        let statusIsDue = statusAge.map { $0 >= preferredStatusQueryInterval } ?? true
+        let statusMustRunNow = statusAge.map { $0 >= maximumStatusQueryInterval } ?? true
+        let unitsAreDue = unitsAge.map {
+            $0 >= ControllerUnitsRefreshPolicy.activeWorkoutQueryInterval
+        } ?? true
+        let lastSafePreMotionTick = secondsUntilNextScheduledMotion
+            == ControllerUnitsRefreshPolicy.requiredMotionLeadSeconds + 1
+
+        // Pull a due status query into the final safe pre-motion tick. This prevents
+        // the two-second WalkingPad write spacing from opening a >5 s evidence gap.
+        if lastSafePreMotionTick,
+           statusAge.map({ $0 >= preferredStatusQueryInterval - 1 }) ?? true {
+            return WalkingPadReadOnlyRefreshDecision(kind: .status)
+        }
+        if statusMustRunNow {
+            return WalkingPadReadOnlyRefreshDecision(kind: .status)
+        }
+        if unitsAreDue {
+            return WalkingPadReadOnlyRefreshDecision(kind: .controllerUnits)
+        }
+        if statusIsDue {
+            // At lead=4, waiting one tick aligns the query with the final safe slot.
+            if secondsUntilNextScheduledMotion
+                == ControllerUnitsRefreshPolicy.requiredMotionLeadSeconds + 2 {
+                return WalkingPadReadOnlyRefreshDecision(kind: nil)
+            }
+            return WalkingPadReadOnlyRefreshDecision(kind: .status)
+        }
+        return WalkingPadReadOnlyRefreshDecision(kind: nil)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsReadOnlyContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/ControllerUnitsReadOnlyContractTests.swift
@@ -94,17 +94,17 @@ final class ControllerUnitsReadOnlyContractTests: XCTestCase {
         )
         let tick = try functionBody("private func tickTelemetry()", in: manager)
         let maintenance = try functionBody(
-            "private func maintainControllerUnitsTruthDuringActiveWorkout(",
+            "private func maintainWalkingPadReadOnlyEvidenceDuringActiveWorkout(",
             in: manager
         )
         let request = try functionBody("private func requestControllerUnitsTruth(", in: manager)
 
-        XCTAssertTrue(tick.contains("maintainControllerUnitsTruthDuringActiveWorkout"))
+        XCTAssertTrue(tick.contains("maintainWalkingPadReadOnlyEvidenceDuringActiveWorkout"))
         XCTAssertTrue(maintenance.contains("motionQueueIdle: commandQueue.isEmpty"))
         XCTAssertTrue(maintenance.contains("!isCommandQueueProcessing"))
         XCTAssertTrue(maintenance.contains("nextCommandAllowedAt <= now"))
         XCTAssertTrue(maintenance.contains("controllerUnitsNextScheduledMotionLeadSeconds"))
-        XCTAssertTrue(maintenance.contains("ControllerUnitsRefreshPolicy.activeWorkoutRefresh"))
+        XCTAssertTrue(maintenance.contains("WalkingPadStatusRefreshPolicy.activeWorkoutRefresh"))
         XCTAssertTrue(request.contains("BLETransportCodec.buildWalkingPadQueryParamsPacket()"))
         XCTAssertFalse(maintenance.contains("sendTreadmill"))
         XCTAssertFalse(maintenance.contains("isHrControlStartAllowed ="))

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WalkingPadStatusRefreshContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WalkingPadStatusRefreshContractTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class WalkingPadStatusRefreshContractTests: XCTestCase {
+    func testRequestCannotPublishOrInferFactualSpeed() throws {
+        let manager = try managerSource()
+        let request = try functionBody(
+            "private func requestWalkingPadStatusRefresh(",
+            in: manager
+        )
+
+        XCTAssertTrue(request.contains("buildWalkingPadQueryStatusPacket"))
+        XCTAssertTrue(request.contains("read_only"))
+        XCTAssertFalse(request.contains("observeTreadmillProviderObservation"))
+        XCTAssertFalse(request.contains("deviceReportedSpeedKmh ="))
+        XCTAssertFalse(request.contains("speedKmh ="))
+    }
+
+    func testOnlyCurrentFE01CallbackCanCreateWalkingPadObservation() throws {
+        let manager = try managerSource()
+        let callback = try functionBody(
+            "func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic:",
+            in: manager
+        )
+
+        XCTAssertTrue(callback.contains("isCurrentCharacteristicCallback(characteristic)"))
+        XCTAssertTrue(callback.contains("BLETransportCodec.parseWalkingPadStatus(data)"))
+        XCTAssertTrue(callback.contains("observeTreadmillProviderObservation"))
+        XCTAssertTrue(callback.contains("checksumValid: status.checksumOk"))
+        XCTAssertTrue(callback.contains("unitsTruth: self.treadmillUnitsTruthEvidence()"))
+    }
+
+    func testDisconnectClearsStatusQueryOwnership() throws {
+        let reset = try functionBody("private func resetProtocolState()", in: managerSource())
+        XCTAssertTrue(reset.contains("lastWalkingPadStatusQueryAt = nil"))
+        XCTAssertTrue(reset.contains("latestTreadmillObservationEvidence = nil"))
+    }
+
+    func testStatusMaintenanceUsesSameIdleWindowAsMotionSafeUnitsRefresh() throws {
+        let manager = try managerSource()
+        let maintenance = try functionBody(
+            "private func maintainWalkingPadReadOnlyEvidenceDuringActiveWorkout(",
+            in: manager
+        )
+
+        XCTAssertTrue(maintenance.contains("motionQueueIdle: commandQueue.isEmpty"))
+        XCTAssertTrue(maintenance.contains("!isCommandQueueProcessing"))
+        XCTAssertTrue(maintenance.contains("nextCommandAllowedAt <= now"))
+        XCTAssertTrue(maintenance.contains("controllerUnitsNextScheduledMotionLeadSeconds"))
+        XCTAssertFalse(maintenance.contains("highPriority: true"))
+        XCTAssertFalse(maintenance.contains("sendTreadmill"))
+    }
+
+    private func managerSource() throws -> String {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        return try String(
+            contentsOf: testsDirectory
+                .deletingLastPathComponent()
+                .appendingPathComponent("WalkingPadRemote/BluetoothManager.swift"),
+            encoding: .utf8
+        )
+    }
+
+    private func functionBody(_ signature: String, in source: String) throws -> String {
+        guard let signatureRange = source.range(of: signature),
+              let openingBrace = source[signatureRange.upperBound...].firstIndex(of: "{") else {
+            throw NSError(domain: "WalkingPadStatusRefreshContractTests", code: 1)
+        }
+        var depth = 0
+        var index = openingBrace
+        while index < source.endIndex {
+            switch source[index] {
+            case "{": depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 { return String(source[openingBrace...index]) }
+            default: break
+            }
+            index = source.index(after: index)
+        }
+        throw NSError(domain: "WalkingPadStatusRefreshContractTests", code: 2)
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WalkingPadStatusRefreshPolicyTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WalkingPadStatusRefreshPolicyTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class WalkingPadStatusRefreshPolicyTests: XCTestCase {
+    private let start = Date(timeIntervalSince1970: 1_780_000_000)
+
+    func testStatusQueryPacketIsTheProvenReadOnlyCurrentStatusRequest() {
+        XCTAssertEqual(
+            BLETransportCodec.buildWalkingPadQueryStatusPacket(),
+            Data([0xF7, 0xA2, 0x00, 0x00, 0xA2, 0xFD])
+        )
+    }
+
+    func testRefreshRequiresActiveCurrentIdleTransportAndMotionLead() {
+        let due = start.addingTimeInterval(-10)
+
+        for decision in [
+            refresh(active: false, transport: true, idle: true, lead: 10, status: due, units: due),
+            refresh(active: true, transport: false, idle: true, lead: 10, status: due, units: due),
+            refresh(active: true, transport: true, idle: false, lead: 10, status: due, units: due),
+            refresh(active: true, transport: true, idle: true, lead: 2, status: due, units: due),
+        ] {
+            XCTAssertFalse(decision.shouldRequest)
+        }
+    }
+
+    func testStatusRefreshHasPriorityAtFreshnessBoundaryAndUnitsStillRefresh() {
+        XCTAssertEqual(
+            refresh(
+                active: true,
+                transport: true,
+                idle: true,
+                lead: 8,
+                status: start.addingTimeInterval(-5),
+                units: start.addingTimeInterval(-20)
+            ).kind,
+            .status
+        )
+        XCTAssertEqual(
+            refresh(
+                active: true,
+                transport: true,
+                idle: true,
+                lead: 8,
+                status: start.addingTimeInterval(-2),
+                units: start.addingTimeInterval(-20)
+            ).kind,
+            .controllerUnits
+        )
+    }
+
+    func testThirtyOneMinuteStableWorkoutKeepsFactualCoverageAboveGate() {
+        let sessionSeconds = 31 * 60
+        var lastStatusQueryAt: Date?
+        var lastUnitsQueryAt = start
+        var nextWriteAllowedAt = start
+        var observationSeconds: [Int] = []
+        var unitsQuerySeconds: [Int] = []
+
+        for second in 1...sessionSeconds {
+            let now = start.addingTimeInterval(TimeInterval(second))
+            let remainder = second % 10
+            let motionLead = remainder == 0 ? 10 : 10 - remainder
+            let scheduledMotion = remainder == 0
+            if scheduledMotion {
+                nextWriteAllowedAt = now.addingTimeInterval(2)
+            }
+            let decision = WalkingPadStatusRefreshPolicy.activeWorkoutRefresh(
+                isWorkoutOrCooldownActive: true,
+                transportReady: true,
+                motionQueueIdle: !scheduledMotion && nextWriteAllowedAt <= now,
+                secondsUntilNextScheduledMotion: motionLead,
+                lastStatusQueryAt: lastStatusQueryAt,
+                lastControllerUnitsQueryAt: lastUnitsQueryAt,
+                now: now
+            )
+            switch decision.kind {
+            case .status:
+                lastStatusQueryAt = now
+                observationSeconds.append(second) // A real F8 A2 response is received.
+                nextWriteAllowedAt = now.addingTimeInterval(2)
+            case .controllerUnits:
+                lastUnitsQueryAt = now
+                unitsQuerySeconds.append(second)
+                nextWriteAllowedAt = now.addingTimeInterval(2)
+            case nil:
+                break
+            }
+        }
+
+        let coveredSeconds = (0..<sessionSeconds).filter { second in
+            observationSeconds.last(where: { $0 <= second }).map {
+                second - $0 < 5
+            } ?? false
+        }.count
+        let coverage = Double(coveredSeconds) / Double(sessionSeconds)
+        let observationGaps = zip(observationSeconds, observationSeconds.dropFirst()).map {
+            $1 - $0
+        }
+
+        XCTAssertGreaterThanOrEqual(coverage, 0.90)
+        XCTAssertLessThanOrEqual(observationGaps.max() ?? 0, 5)
+        XCTAssertGreaterThan(unitsQuerySeconds.count, 80)
+        XCTAssertLessThanOrEqual(observationSeconds.count, sessionSeconds / 2)
+    }
+
+    private func refresh(
+        active: Bool,
+        transport: Bool,
+        idle: Bool,
+        lead: Int,
+        status: Date?,
+        units: Date?
+    ) -> WalkingPadReadOnlyRefreshDecision {
+        WalkingPadStatusRefreshPolicy.activeWorkoutRefresh(
+            isWorkoutOrCooldownActive: active,
+            transportReady: transport,
+            motionQueueIdle: idle,
+            secondsUntilNextScheduledMotion: lead,
+            lastStatusQueryAt: status,
+            lastControllerUnitsQueryAt: units,
+            now: start
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Send the proven read-only WalkingPad A2 current-status query during active HR workouts and cooldowns, only in motion-safe idle windows.
- Coordinate factual status refresh with the existing A6 controller-units refresh without changing motion, Stop, HR, cooldown, or analyzer policies.
- Keep factual speed tied to valid current-epoch FE01 responses and add 31-minute stable-speed coverage plus safety contract tests.
- Use the existing protocol request documented by [ph4-walkingpad](https://github.com/ph4r05/ph4-walkingpad/blob/master/ph4_walkingpad/pad.py) and [QWalkingPad](https://github.com/DorianRudolph/QWalkingPad/blob/master/Protocol.cpp).

Closes #124

## Verification
- `cd ios/WalkingPadRemote/WalkingPadRemote && swift test`
- `cd ios/WalkingPadRemote/WalkingPadRemote && swift run --quiet telemetry-soak --minutes 2 --hr-ms 1000 --treadmill-ms 1000 --burst-every-seconds 30 --burst-native-records 32 --flush-every-seconds 5` (zero loss/drop, final queue depth 0, control checksum `ea1140aa71917a2a`)
- `xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build`
- `python3 scripts/check_codex_governance.py`
- `~/.codex/scripts/check-agents-instruction-chain.sh --path ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote`
- `python3 -m compileall -q scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py`

## Risks / Notes
- No factual evidence is created by sending a query; only a valid current-connection/current-epoch FE01 response enters the existing normalizer with checksum and controller-unit truth.
- No analyzer threshold, factual TTL, motion authorization, HR decisions, Start/cooldown/Stop behavior, or unit policy changed.
- The full 1000-hour SwiftData endurance profile remains opt-in and was skipped by the standard suite; the regular SwiftData gate and all five soak tests passed.
- Physical BLE/treadmill validation was not run and remains outside this Draft PR scope.
- No migrations, configuration changes, deployment steps, or expected backward-compatibility impact. Rollback is a single commit revert.