### PR TITLE
Export production treadmill command evidence

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutAnalysisExportStore.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence/TelemetryWorkoutAnalysisExportStore.swift
@@ -406,13 +406,16 @@ private extension TelemetryStore {
         let connection = WorkoutEventKind.connectionTransition.rawValue
         let decision = WorkoutEventKind.controlDecision.rawValue
         let command = WorkoutEventKind.commandLifecycle.rawValue
+        let treadmill = WorkoutEventKind.treadmillEvidence.rawValue
         let cooldown = WorkoutEventKind.cooldown.rawValue
         let manualStop = WorkoutEventKind.manualStop.rawValue
         let safety = WorkoutEventKind.safety.rawValue
         let stopEvidence = WorkoutEventKind.stopEvidence.rawValue
         let recorderHealth = WorkoutEventKind.recorderHealth.rawValue
+        // V1 indexes the typed envelope kind, not treadmill subtypes. Keep the
+        // keyset fetch bounded and allowlist command projections after decode.
         let selectedKinds = [
-            lifecycle, phase, source, connection, decision, command, cooldown,
+            lifecycle, phase, source, connection, decision, command, treadmill, cooldown,
             manualStop, safety, stopEvidence, recorderHealth,
         ]
         var descriptor: FetchDescriptor<TelemetryWorkoutEventV1>
@@ -445,7 +448,7 @@ private extension TelemetryStore {
         descriptor.fetchLimit = limit
         let models = try modelContext.fetch(descriptor)
         return AnalysisEventPage(
-            projections: try models.map {
+            projections: try models.compactMap {
                 try Self.analysisEventProjection(
                     Self.domainEvent($0),
                     sessionID: sessionReference
@@ -460,7 +463,7 @@ private extension TelemetryStore {
     static func analysisEventProjection(
         _ event: WorkoutEvent,
         sessionID: SessionID
-    ) throws -> WorkoutAnalysisEventProjection {
+    ) throws -> WorkoutAnalysisEventProjection? {
         let decisionRef = event.decisionID.map { reference("decision", $0.description, sessionID) }
         let commandRef = event.commandID.map { reference("command", $0.description, sessionID) }
         let attemptRef = event.attemptID.map { reference("attempt", $0.description, sessionID) }
@@ -540,6 +543,8 @@ private extension TelemetryStore {
                 commandedSpeedNativeUnit: lifecycle.commandedUnit,
                 commandAttemptNumber: lifecycle.attemptNumber, endReason: nil
             )
+        case let .treadmillEvidence(value):
+            return treadmillCommandProjection(value, common: common)
         case let .cooldown(value):
             return .init(
                 elapsedMicroseconds: common.0, occurredAt: common.1, kind: common.2,
@@ -591,9 +596,88 @@ private extension TelemetryStore {
                 ].compactMap { $0 }
                     .joined(separator: ";")
             )
-        case .heartRateEvidence, .treadmillEvidence:
+        case .heartRateEvidence:
             throw TelemetryWorkoutReadError.corruptProjection("unselected-analysis-event-kind")
         }
+    }
+
+    static func treadmillCommandProjection(
+        _ evidence: TreadmillTelemetryEvidence,
+        common: (Int64, Date, String, String?, String?, String?)
+    ) -> WorkoutAnalysisEventProjection? {
+        let projection: (
+            name: String,
+            detail: String?,
+            commandedValue: Double?,
+            commandedUnit: String?,
+            attemptNumber: Int?
+        )
+        switch evidence {
+        case let .commandEnqueued(value):
+            let command = commandKind(value.kind)
+            let detail = [
+                "protocol=\(treadmillProtocol(value.protocolKind))",
+                command.detail.map { "kind=\($0)" },
+            ].compactMap { $0 }.joined(separator: ";")
+            projection = (
+                command.name,
+                detail,
+                command.commandedValue,
+                command.commandedUnit,
+                nil
+            )
+        case let .sendAttempt(value):
+            projection = (
+                "command_send_attempt",
+                "protocol=\(treadmillProtocol(value.protocolKind));write=\(writeType(value.writeType))",
+                nil,
+                nil,
+                Int(value.attemptNumber)
+            )
+        case let .acknowledgement(value):
+            projection = (
+                "command_acknowledged",
+                "association=\(association(value.association));protocol=\(treadmillProtocol(value.protocolKind))",
+                nil,
+                nil,
+                nil
+            )
+        case let .commandTimeout(value):
+            projection = (
+                "command_timed_out",
+                "association=\(association(value.association));protocol=\(treadmillProtocol(value.protocolKind))",
+                nil,
+                nil,
+                nil
+            )
+        case let .commandFailed(value):
+            projection = ("command_failed", failureReason(value.reason), nil, nil, nil)
+        case let .commandCancelled(value):
+            projection = ("command_cancelled", cancellationReason(value.reason), nil, nil, nil)
+        case .observation, .unitsTruth, .decision, .commandQueueDelay,
+             .unassociatedWrite, .writeResult, .stopEvidence:
+            return nil
+        }
+        return .init(
+            elapsedMicroseconds: common.0,
+            occurredAt: common.1,
+            kind: common.2,
+            name: projection.name,
+            detail: projection.detail,
+            phase: nil,
+            targetHeartRate: nil,
+            decisionReference: common.3,
+            commandReference: common.4,
+            attemptReference: common.5,
+            configurationReference: nil,
+            decisionAction: nil,
+            decisionReason: nil,
+            desiredSpeedKilometresPerHour: nil,
+            commandedSpeedNativeValue: projection.commandedValue,
+            commandedSpeedNativeUnit: projection.commandedUnit,
+            commandAttemptNumber: projection.attemptNumber,
+            endReason: nil
+        )
     }
 
     static func simpleEvent(
@@ -747,14 +831,14 @@ private extension TelemetryStore {
     ) -> (name: String, detail: String?, commandedValue: Double?, commandedUnit: String?, attemptNumber: Int?) {
         switch lifecycle {
         case let .enqueued(kind):
-            switch kind {
-            case let .setSpeed(speed):
-                return ("command_enqueued_set_speed", nil, speed.nativeValue, nativeUnit(speed.nativeUnit), nil)
-            case .stop:
-                return ("command_enqueued_stop", nil, nil, nil, nil)
-            case .other:
-                return ("command_enqueued_other", "opaque-command-kind", nil, nil, nil)
-            }
+            let command = commandKind(kind)
+            return (
+                command.name,
+                command.detail,
+                command.commandedValue,
+                command.commandedUnit,
+                nil
+            )
         case let .sendAttempt(_, attemptNumber):
             return ("command_send_attempt", nil, nil, nil, Int(attemptNumber))
         case .acknowledged:
@@ -767,6 +851,47 @@ private extension TelemetryStore {
             return ("command_cancelled", cancellationReason(reason), nil, nil, nil)
         case let .failed(_, reason):
             return ("command_failed", failureReason(reason), nil, nil, nil)
+        }
+    }
+
+    static func commandKind(
+        _ kind: CommandKind
+    ) -> (name: String, detail: String?, commandedValue: Double?, commandedUnit: String?) {
+        switch kind {
+        case let .setSpeed(speed):
+            (
+                "command_enqueued_set_speed",
+                nil,
+                speed.nativeValue,
+                nativeUnit(speed.nativeUnit)
+            )
+        case .stop:
+            ("command_enqueued_stop", nil, nil, nil)
+        case .other:
+            ("command_enqueued_other", "opaque-command-kind", nil, nil)
+        }
+    }
+
+    static func treadmillProtocol(_ value: TreadmillProtocolKind) -> String {
+        switch value {
+        case .walkingPad: "walkingpad"
+        case .ftms: "ftms"
+        case .fitShow: "fitshow"
+        case .unknown: "unknown"
+        }
+    }
+
+    static func writeType(_ value: TreadmillCommandWriteType) -> String {
+        switch value {
+        case .withResponse: "with-response"
+        case .withoutResponse: "without-response"
+        }
+    }
+
+    static func association(_ value: LegacyAcknowledgementAssociation) -> String {
+        switch value {
+        case .unresolvedByLegacyRuntime: "unresolved"
+        case .deterministicallyCorrelated: "deterministic"
         }
     }
 

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/WorkoutAnalysisExportTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetryPersistenceTests/WorkoutAnalysisExportTests.swift
@@ -291,6 +291,321 @@ final class WorkoutAnalysisExportTests: XCTestCase {
         }
     }
 
+    func testProductionWalkingPadCommandEvidenceAppearsWithoutDiagnosticChatter() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let session = session(
+            profile: "profile-production-command",
+            configuration: configuration(target: 135),
+            seed: 30
+        )
+        try await store.insertSession(session)
+
+        let treadmillSource = TelemetryPersistenceFixtures.source(seed: 201, kind: .bluetooth)
+        try await store.insertFrame(
+            frame(
+                seed: 301,
+                session: session,
+                second: 2,
+                heartRate: nil,
+                treadmill: treadmillEvidence(source: treadmillSource)
+            )
+        )
+
+        let decisionID = DecisionID(rawValue: uuid(3_001))
+        let commandID = CommandID(rawValue: uuid(3_002))
+        let attemptID = CommandAttemptID(rawValue: uuid(3_003))
+        let epoch = TreadmillConnectionEpoch(rawValue: uuid(3_004))
+        let enqueuedAt = session.startedAt.addingTimeInterval(1.1)
+        let sentAt = session.startedAt.addingTimeInterval(1.234_567)
+        var normalizer = TreadmillObservationNormalizer()
+        let observation = normalizer.normalize(
+            .walkingPad(
+                speedRawTenths: 55,
+                rawState: 2,
+                deviceState: .moving,
+                checksumValid: true,
+                connectionEpoch: epoch,
+                receivedAt: session.startedAt.addingTimeInterval(1.4)
+            ),
+            unitsTruth: .valid(
+                unit: .kilometresPerHour,
+                connectionEpoch: epoch,
+                observedAt: session.startedAt
+            ),
+            observationID: ObservationID(rawValue: uuid(3_005)),
+            recordedAt: session.startedAt.addingTimeInterval(1.401)
+        )
+        let events: [(Int64, WorkoutEventPayload)] = [
+            (
+                1_000_000,
+                .controlDecision(ControlDecision(
+                    decisionID: decisionID,
+                    observationsUsed: [],
+                    target: .heartRate(beatsPerMinute: 135),
+                    action: .enqueueSpeed(DesiredSpeedKilometresPerHour(value: 5.6)),
+                    reason: .belowTarget,
+                    versions: session.versions,
+                    configurationSnapshotID: session.configuration.id
+                ))
+            ),
+            (
+                1_050_000,
+                .treadmillEvidence(.decision(TreadmillControlDecisionEvidence(
+                    decisionID: decisionID,
+                    source: .heartRateControl,
+                    intent: .other("private-production-decision-detail"),
+                    heartRateInputs: [],
+                    occurredAt: session.startedAt.addingTimeInterval(1.05),
+                    connectionEpoch: epoch
+                )))
+            ),
+            (
+                1_100_000,
+                .treadmillEvidence(.commandEnqueued(TreadmillCommandEnqueuedEvidence(
+                    commandID: commandID,
+                    decisionID: decisionID,
+                    kind: .setSpeed(
+                        TreadmillCommandedSpeedRepresentation.walkingPad(
+                            rawControllerTenths: 56
+                        )
+                    ),
+                    protocolKind: .walkingPad,
+                    connectionEpoch: epoch,
+                    enqueuedAt: enqueuedAt
+                )))
+            ),
+            (
+                1_234_567,
+                .treadmillEvidence(.commandQueueDelay(TreadmillCommandQueueDelayEvidence(
+                    commandID: commandID,
+                    decisionID: decisionID,
+                    connectionEpoch: epoch,
+                    enqueuedAt: enqueuedAt,
+                    sentAt: sentAt
+                )))
+            ),
+            (
+                1_234_567,
+                .treadmillEvidence(.sendAttempt(TreadmillCommandSendAttemptEvidence(
+                    commandID: commandID,
+                    decisionID: decisionID,
+                    attemptID: attemptID,
+                    attemptNumber: 1,
+                    protocolKind: .walkingPad,
+                    connectionEpoch: epoch,
+                    sentAt: sentAt,
+                    writeType: .withoutResponse
+                )))
+            ),
+            (
+                1_300_000,
+                .treadmillEvidence(.unitsTruth(TreadmillUnitsTruthEvidence(
+                    truth: .valid(
+                        unit: .kilometresPerHour,
+                        connectionEpoch: epoch,
+                        observedAt: session.startedAt
+                    ),
+                    observedAt: session.startedAt.addingTimeInterval(1.3)
+                )))
+            ),
+            (1_401_000, .treadmillEvidence(.observation(observation))),
+        ]
+        for (index, item) in events.enumerated() {
+            try await store.insertEvent(event(
+                seed: 300 + index,
+                session: session,
+                elapsedMicroseconds: item.0,
+                payload: item.1
+            ))
+        }
+
+        let request = WorkoutAnalysisExportRequest(
+            sessionID: session.sessionID,
+            exactProfileLocalIdentifier: session.profileLocalIdentifier,
+            batchSize: 2
+        )
+        let first = try await store.exportWorkoutAnalysis(request)
+        defer { try? FileManager.default.removeItem(at: first.fileURL.deletingLastPathComponent()) }
+        let second = try await store.exportWorkoutAnalysis(request)
+        defer { try? FileManager.default.removeItem(at: second.fileURL.deletingLastPathComponent()) }
+        XCTAssertEqual(try Data(contentsOf: first.fileURL), try Data(contentsOf: second.fileURL))
+
+        let rows = try parseCSV(first.fileURL)
+        let header = rows[0]
+        let timeline = rows.dropFirst().map { Dictionary(uniqueKeysWithValues: zip(header, $0)) }
+        let frames = timeline.filter { $0["row_type"] == "frame" }
+        let exportedEvents = timeline.filter { $0["row_type"] == "event" }
+        let decision = try XCTUnwrap(
+            exportedEvents.first { $0["event_name"] == "control_decision" }
+        )
+        let enqueued = try XCTUnwrap(
+            exportedEvents.first { $0["event_name"] == "command_enqueued_set_speed" }
+        )
+        let sent = try XCTUnwrap(
+            exportedEvents.first { $0["event_name"] == "command_send_attempt" }
+        )
+
+        XCTAssertEqual(
+            Set(exportedEvents.compactMap { $0["event_name"] }),
+            ["control_decision", "command_enqueued_set_speed", "command_send_attempt"]
+        )
+        XCTAssertEqual(enqueued["event_kind"], "treadmillEvidence")
+        XCTAssertEqual(sent["event_kind"], "treadmillEvidence")
+        XCTAssertEqual(decision["desired_speed_kmh"], "5.600000")
+        XCTAssertEqual(decision["commanded_speed_native_value"], "")
+        XCTAssertEqual(enqueued["desired_speed_kmh"], "")
+        XCTAssertEqual(enqueued["commanded_speed_native_value"], "56.000000")
+        XCTAssertEqual(
+            enqueued["commanded_speed_native_unit"],
+            "controller-native:walkingpad-tenths"
+        )
+        XCTAssertEqual(sent["elapsed_s"], "1.234567")
+        XCTAssertEqual(sent["command_attempt_number"], "1")
+        XCTAssertEqual(sent["event_detail"], "protocol=walkingpad;write=without-response")
+        XCTAssertEqual(enqueued["command_ref"], sent["command_ref"])
+        XCTAssertEqual(enqueued["decision_ref"], sent["decision_ref"])
+        XCTAssertFalse(sent["attempt_ref"]!.isEmpty)
+        XCTAssertEqual(try XCTUnwrap(frames.first)["factual_speed_kmh"], "5.500000")
+        XCTAssertEqual(try XCTUnwrap(frames.first)["command_ref"], "")
+        XCTAssertFalse(exportedEvents.contains { event in
+            [
+                "treadmill_decision", "treadmill_observation", "treadmill_units_truth",
+                "command_queue_delay",
+            ]
+                .contains(event["event_name"]!)
+        })
+
+        let csv = try String(contentsOf: first.fileURL, encoding: .utf8)
+        for privateValue in [
+            commandID.description, attemptID.description, decisionID.description,
+            epoch.description, observation.observationID.description,
+            treadmillSource.stableLocalKey, "private-production-decision-detail",
+        ] {
+            XCTAssertFalse(csv.contains(privateValue), "CSV leaked \(privateValue)")
+        }
+    }
+
+    func testProductionCommandTerminalFactsKeepUnknownAssociationAndRedactStrings() async throws {
+        let store = try TelemetryStoreFactory.make(.inMemory)
+        let sentinel = "private-command@example.com/raw-protocol-label"
+        let session = session(
+            profile: "profile-production-terminal",
+            configuration: configuration(target: 135),
+            seed: 31
+        )
+        try await store.insertSession(session)
+
+        let decisionID = DecisionID(rawValue: uuid(3_101))
+        let commandID = CommandID(rawValue: uuid(3_102))
+        let attemptID = CommandAttemptID(rawValue: uuid(3_103))
+        let epoch = TreadmillConnectionEpoch(rawValue: uuid(3_104))
+        let base = session.startedAt
+        let payloads: [WorkoutEventPayload] = [
+            .treadmillEvidence(.commandEnqueued(TreadmillCommandEnqueuedEvidence(
+                commandID: commandID,
+                decisionID: decisionID,
+                kind: .other(sentinel),
+                protocolKind: .walkingPad,
+                connectionEpoch: epoch,
+                enqueuedAt: base
+            ))),
+            .treadmillEvidence(.acknowledgement(.unresolved(
+                protocolKind: .walkingPad,
+                connectionEpoch: epoch,
+                receivedAt: base.addingTimeInterval(1),
+                recordedAt: base.addingTimeInterval(1.001)
+            ))),
+            .treadmillEvidence(.commandTimeout(LegacyCommandTimeoutObservation(
+                protocolKind: .walkingPad,
+                connectionEpoch: epoch,
+                occurredAt: base.addingTimeInterval(2)
+            ))),
+            .treadmillEvidence(.commandFailed(TreadmillCommandFailureObservation(
+                commandID: commandID,
+                decisionID: decisionID,
+                attemptID: attemptID,
+                connectionEpoch: epoch,
+                occurredAt: base.addingTimeInterval(3),
+                reason: .other(sentinel)
+            ))),
+            .treadmillEvidence(.commandCancelled(TreadmillCommandCancellationObservation(
+                commandID: commandID,
+                decisionID: decisionID,
+                connectionEpoch: epoch,
+                occurredAt: base.addingTimeInterval(4),
+                reason: .safetyGate(sentinel)
+            ))),
+            .treadmillEvidence(.writeResult(LegacyWriteResultObservation(
+                protocolKind: .walkingPad,
+                connectionEpoch: epoch,
+                occurredAt: base.addingTimeInterval(5),
+                status: .succeeded
+            ))),
+            .treadmillEvidence(.unassociatedWrite(UnassociatedLegacyWriteObservation(
+                protocolKind: .walkingPad,
+                connectionEpoch: epoch,
+                sentAt: base.addingTimeInterval(6),
+                writeType: .withoutResponse
+            ))),
+        ]
+        for (index, payload) in payloads.enumerated() {
+            try await store.insertEvent(event(
+                seed: 400 + index,
+                session: session,
+                elapsedMicroseconds: Int64(index) * 1_000_000,
+                payload: payload
+            ))
+        }
+
+        let artifact = try await store.exportWorkoutAnalysis(
+            WorkoutAnalysisExportRequest(
+                sessionID: session.sessionID,
+                exactProfileLocalIdentifier: session.profileLocalIdentifier,
+                batchSize: 2
+            )
+        )
+        defer { try? FileManager.default.removeItem(at: artifact.fileURL.deletingLastPathComponent()) }
+        let rows = try parseCSV(artifact.fileURL)
+        let header = rows[0]
+        let events = rows.dropFirst()
+            .map { Dictionary(uniqueKeysWithValues: zip(header, $0)) }
+            .filter { $0["row_type"] == "event" }
+        let names = Set(events.compactMap { $0["event_name"] })
+
+        XCTAssertTrue(names.isSuperset(of: [
+            "command_enqueued_other", "command_acknowledged", "command_timed_out",
+            "command_failed", "command_cancelled",
+        ]))
+        XCTAssertFalse(names.contains("command_write_result_succeeded"))
+        XCTAssertFalse(names.contains("unassociated_write"))
+        for name in ["command_acknowledged", "command_timed_out"] {
+            let event = try XCTUnwrap(events.first { $0["event_name"] == name })
+            XCTAssertEqual(event["command_ref"], "")
+            XCTAssertEqual(event["attempt_ref"], "")
+            XCTAssertEqual(event["event_detail"], "association=unresolved;protocol=walkingpad")
+        }
+        let failed = try XCTUnwrap(events.first { $0["event_name"] == "command_failed" })
+        let cancelled = try XCTUnwrap(
+            events.first { $0["event_name"] == "command_cancelled" }
+        )
+        XCTAssertFalse(failed["command_ref"]!.isEmpty)
+        XCTAssertFalse(failed["attempt_ref"]!.isEmpty)
+        XCTAssertEqual(failed["event_detail"], "other")
+        XCTAssertFalse(cancelled["command_ref"]!.isEmpty)
+        XCTAssertEqual(cancelled["attempt_ref"], "")
+        XCTAssertEqual(cancelled["event_detail"], "safety-gate")
+
+        let csv = try String(contentsOf: artifact.fileURL, encoding: .utf8)
+        XCTAssertFalse(csv.contains(sentinel))
+        for privateValue in [
+            commandID.description, attemptID.description, decisionID.description,
+            epoch.description,
+        ] {
+            XCTAssertFalse(csv.contains(privateValue), "CSV leaked \(privateValue)")
+        }
+        XCTAssertTrue(csv.contains("opaque-command-kind"))
+    }
+
     func testCrossProfileAndNonNativeSessionRequestsAreRejectedBeforeTimelineReads() async throws {
         let store = try TelemetryStoreFactory.make(.inMemory)
         let session = session(profile: "profile-a", configuration: configuration(target: 135))

--- a/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/DiagnosticBundlePerformanceTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Tests/TelemetrySwiftDataGateTests/DiagnosticBundlePerformanceTests.swift
@@ -125,8 +125,8 @@ final class DiagnosticBundlePerformanceTests: XCTestCase {
                 representedMinutes: representedMinutes
             )
             XCTAssertEqual(result.frameRowCount, representedMinutes * 60 - 20)
-            XCTAssertGreaterThan(result.eventRowCount, 0)
-            XCTAssertLessThanOrEqual(result.eventRowCount, 20)
+            let commandCount = representedMinutes * 2
+            XCTAssertEqual(result.eventRowCount, 20 + commandCount * 2)
             XCTAssertGreaterThan(result.metadataRowCount, 0)
             XCTAssertGreaterThan(result.fileBytes, 0)
             XCTAssertLessThan(result.fileBytes, Int64(representedMinutes) * 150_000)
@@ -136,6 +136,7 @@ final class DiagnosticBundlePerformanceTests: XCTestCase {
             XCTAssertLessThanOrEqual(
                 result.storeFetchCount,
                 5 + ((result.frameRowCount + 127) / 128)
+                    + ((20 + commandCount * 5 + 127) / 128)
             )
             XCTAssertLessThan(result.peakResidentDeltaBytes, 128 * 1024 * 1024)
             XCTAssertGreaterThan(result.mainActorHeartbeatCount, 0)
@@ -164,6 +165,11 @@ final class DiagnosticBundlePerformanceTests: XCTestCase {
             try TelemetryStoreFactory.make(.onDisk(root.appendingPathComponent("TelemetryV2.store")))
         }.value
         try await persistFixture(generator: generator, store: store)
+        try await persistProductionTreadmillSidecar(
+            session: generator.session(index: 0),
+            representedMinutes: representedMinutes,
+            store: store
+        )
 
         let baselineResidentBytes = currentResidentBytes()
         let memorySampler = Task.detached(priority: .utility) {
@@ -362,6 +368,147 @@ final class DiagnosticBundlePerformanceTests: XCTestCase {
             try await append(.analysis(generator.analysis(sessionIndex: sessionIndex)))
         }
         try await flush(force: true)
+    }
+
+    private func persistProductionTreadmillSidecar(
+        session: WorkoutSessionRecord,
+        representedMinutes: Int,
+        store: TelemetryStore
+    ) async throws {
+        let epoch = TreadmillConnectionEpoch(rawValue: workoutAnalysisBenchmarkUUID(
+            namespace: 1,
+            index: representedMinutes
+        ))
+        var normalizer = TreadmillObservationNormalizer()
+        var records: [TelemetryGateRecord] = []
+        records.reserveCapacity(representedMinutes * 10)
+
+        func append(_ evidence: TreadmillTelemetryEvidence, at date: Date) {
+            let elapsedMicroseconds = Int64(
+                (date.timeIntervalSince(session.startedAt) * 1_000_000).rounded()
+            )
+            records.append(.event(WorkoutEvent(
+                recordID: RecordID(rawValue: workoutAnalysisBenchmarkUUID(
+                    namespace: 2,
+                    index: records.count
+                )),
+                sessionID: session.sessionID,
+                timestamp: EventTimestamp(
+                    occurredAt: date,
+                    recordedAt: date.addingTimeInterval(0.001),
+                    occurredElapsed: ElapsedDuration(microseconds: elapsedMicroseconds),
+                    recordedElapsed: ElapsedDuration(
+                        microseconds: elapsedMicroseconds + 1_000
+                    )
+                ),
+                payload: EventPayloadEnvelope(
+                    schemaVersion: 1,
+                    payload: .treadmillEvidence(evidence)
+                )
+            )))
+        }
+
+        for commandIndex in 0..<(representedMinutes * 2) {
+            let commandID = CommandID(rawValue: workoutAnalysisBenchmarkUUID(
+                namespace: 3,
+                index: commandIndex
+            ))
+            let attemptID = CommandAttemptID(rawValue: workoutAnalysisBenchmarkUUID(
+                namespace: 4,
+                index: commandIndex
+            ))
+            let enqueuedAt = session.startedAt.addingTimeInterval(
+                Double(commandIndex * 30) + 0.1
+            )
+            let sentAt = enqueuedAt.addingTimeInterval(0.125)
+            append(
+                .commandEnqueued(TreadmillCommandEnqueuedEvidence(
+                    commandID: commandID,
+                    decisionID: nil,
+                    kind: .setSpeed(
+                        TreadmillCommandedSpeedRepresentation.walkingPad(
+                            rawControllerTenths: 50 + commandIndex % 20
+                        )
+                    ),
+                    protocolKind: .walkingPad,
+                    connectionEpoch: epoch,
+                    enqueuedAt: enqueuedAt
+                )),
+                at: enqueuedAt
+            )
+            append(
+                .commandQueueDelay(TreadmillCommandQueueDelayEvidence(
+                    commandID: commandID,
+                    decisionID: nil,
+                    connectionEpoch: epoch,
+                    enqueuedAt: enqueuedAt,
+                    sentAt: sentAt
+                )),
+                at: sentAt
+            )
+            append(
+                .sendAttempt(TreadmillCommandSendAttemptEvidence(
+                    commandID: commandID,
+                    decisionID: nil,
+                    attemptID: attemptID,
+                    attemptNumber: 1,
+                    protocolKind: .walkingPad,
+                    connectionEpoch: epoch,
+                    sentAt: sentAt,
+                    writeType: .withoutResponse
+                )),
+                at: sentAt
+            )
+            let unitsAt = sentAt.addingTimeInterval(0.025)
+            let unitsTruth = TreadmillUnitsTruth.valid(
+                unit: .kilometresPerHour,
+                connectionEpoch: epoch,
+                observedAt: unitsAt
+            )
+            append(
+                .unitsTruth(TreadmillUnitsTruthEvidence(
+                    truth: unitsTruth,
+                    observedAt: unitsAt
+                )),
+                at: unitsAt
+            )
+            let observedAt = sentAt.addingTimeInterval(0.075)
+            let observation = normalizer.normalize(
+                .walkingPad(
+                    speedRawTenths: 50 + commandIndex % 20,
+                    rawState: 2,
+                    deviceState: .moving,
+                    checksumValid: true,
+                    connectionEpoch: epoch,
+                    receivedAt: observedAt
+                ),
+                unitsTruth: unitsTruth,
+                observationID: ObservationID(rawValue: workoutAnalysisBenchmarkUUID(
+                    namespace: 5,
+                    index: commandIndex
+                )),
+                recordedAt: observedAt.addingTimeInterval(0.001)
+            )
+            append(.observation(observation), at: observation.recordedAt)
+        }
+
+        for start in stride(from: 0, to: records.count, by: 128) {
+            try await store.insertGateBatch(
+                Array(records[start..<min(start + 128, records.count)])
+            )
+        }
+    }
+
+    private func workoutAnalysisBenchmarkUUID(namespace: Int, index: Int) -> UUID {
+        let value = String(
+            format: "A1230000-0000-%04X-8000-%012llX",
+            namespace,
+            UInt64(index + 1)
+        )
+        guard let uuid = UUID(uuidString: value) else {
+            preconditionFailure("Invalid deterministic benchmark UUID")
+        }
+        return uuid
     }
 
     private func profile(


### PR DESCRIPTION
## Summary
- Project production WalkingPad command enqueue, send-attempt, and terminal command facts into the compact workout-analysis timeline.
- Preserve desired, commanded-native, and factual speed domains while keeping unresolved ACK and timeout association explicitly unknown.
- Omit treadmill diagnostic sidecar chatter and cover deterministic production-shaped 30-minute and 120-minute workloads.

Closes #123

## Verification
- `swift test --filter WorkoutAnalysisExportTests` (8 passed)
- `swift test --filter DiagnosticBundlePerformanceTests.testWorkoutAnalysisThirtyAndOneHundredTwentyMinutePerformance` (passed twice; 30 min: 140 event rows, 0.23 s; 120 min: 500 event rows, 0.94-1.01 s; fetch limit 128; buffer 192)
- `swift test` (passed; full package suite, expected 1000-hour profile skip)
- `xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build` (`BUILD SUCCEEDED`)
- `python3 scripts/check_codex_governance.py`
- `/Users/dmitry/.codex/scripts/check-agents-instruction-chain.sh --path ios/WalkingPadRemote/WalkingPadRemote/Sources/TelemetryPersistence`
- `python3 -m compileall -q scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py`
- Independent safety review after final fixes: no actionable findings

## Risks / Notes
- The V1 store indexes the treadmill envelope kind rather than its command subtype, so the selected session sidecar is keyset-fetched in bounded pages and allowlisted after decode. The 30/120-minute gate verifies this bound; no schema migration is introduced.
- No BLE writes, command scheduling, HR control, Start/Stop, cooldown, units normalization, factual-speed normalization, or persistence behavior changes.
- No new dependencies, configuration, deployment steps, or backward-compatibility changes. Existing `workout-analysis-timeline-v1` columns remain unchanged. Rollback is the single commit revert.
- No physical treadmill or device verification was performed or required for this export-only change.