### PR TITLE
Fix consecutive WalkingPad start transactions

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/Package.swift
@@ -166,6 +166,7 @@ let package = Package(
                 "TreadmillControlReadinessPolicy.swift",
                 "TreadmillCommandTelemetrySidecar.swift",
                 "WalkingPadStatusRefreshPolicy.swift",
+                "WalkingPadStartTransaction.swift",
                 "WorkoutLifecyclePolicy.swift"
             ]
         ),

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -203,7 +203,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
     private let hrCooldownHoldSeconds: Int = 20
     private var hrCooldownMaxSeconds: Int { hrCooldownMaxMinutes * 60 }
     private let hrMaxSessionMinutes: Int = 120
-    private var manualModeSet: Bool = false
     private var hrControlStartedAt: Date? = nil
     private let hrStartGraceSeconds: Int = 15
     private var hrAverageSum: Int = 0
@@ -311,6 +310,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
     )
     private var latestTreadmillObservationEvidence: TreadmillObservationEvidence?
+    private var walkingPadStartTransactionConnectionEpoch: TreadmillConnectionEpoch?
     private var treadmillCommandTelemetrySidecar = TreadmillCommandTelemetrySidecar()
     private var treadmillCommandAttemptNumbers: [CommandID: UInt16] = [:]
     private struct TreadmillCommandTelemetryRequest {
@@ -2723,7 +2723,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         knownDiscoveryGraceWorkItem?.cancel()
         knownDiscoveryGraceWorkItem = nil
         knownDiscoveryGraceCompleted = false
-        manualModeSet = false
         loadKnownPeripherals()
         loadLastSuccessfulPeripheral()
         loadProfilesState()
@@ -3307,7 +3306,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             }
             self.connectTimeoutWorkItem?.cancel()
             self.connectTimeoutWorkItem = nil
-            self.manualModeSet = false
             _ = self.telemetryV2Coordinator.observeEvent(
                 .connectionTransition(
                     ConnectionTransition(
@@ -4247,6 +4245,35 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         stopBeltWithToggle(reason: "manual")
     }
 
+    private func currentWalkingPadFactualMotionObservation(
+        now: Date = Date()
+    ) -> WalkingPadStartTransaction.FactualMotionObservation? {
+        guard let observation = latestTreadmillObservationEvidence,
+              observation.protocolKind == .walkingPad,
+              let factualSpeedKmh = observation.factualSpeed?.value else {
+            return nil
+        }
+        let motion: WalkingPadStartTransaction.ObservedMotion
+        if observation.deviceState == .moving || factualSpeedKmh > 0.1 {
+            motion = .moving
+        } else if observation.deviceState == .stopped {
+            motion = .stopped
+        } else {
+            motion = .unknown
+        }
+        return WalkingPadStartTransaction.FactualMotionObservation(
+            motion: motion,
+            ageSeconds: now.timeIntervalSince(observation.receivedAt),
+            isCurrentConnectionEpoch: observation.connectionEpoch
+                == treadmillTelemetryConnectionEpoch
+        )
+    }
+
+    private var isWalkingPadStartTransactionInFlight: Bool {
+        walkingPadStartTransactionConnectionEpoch != nil
+            && walkingPadStartTransactionConnectionEpoch == treadmillTelemetryConnectionEpoch
+    }
+
     func startWithSpeed(_ kmh: Double) {
         guard !blocksNonStopTreadmillMotion else {
             infoToastMessage = "Сначала завершите восстановленную тренировку"
@@ -4258,16 +4285,28 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
                 : "Не подключено к дорожке"
             return
         }
+        let v = clampRunningSpeedKmh(kmh)
+        let old = deviceTargetSpeedKmh
+        let walkingPadTransaction = treadmillProtocol == .walkingPad
+            ? WalkingPadStartTransaction.plan(
+                isStartTransactionInFlight: isWalkingPadStartTransactionInFlight,
+                previousCommandedSpeedKmh: old,
+                factualObservation: currentWalkingPadFactualMotionObservation(),
+                targetSpeedKmh: v
+            )
+            : nil
+        guard walkingPadTransaction?.isEmpty != true else {
+            appendLog("WalkingPad start ignored: start transaction already in flight")
+            return
+        }
         endStopObservationForNewMotion()
         // Cancel any pending delayed writes (e.g. stop retries) before starting a new run.
         resetCommandQueue(reason: "startWithSpeed")
-        let v = clampRunningSpeedKmh(kmh)
         let telemetryDecision = makeTreadmillDecision(
             source: .start,
             intent: .startAtDesiredSpeed(DesiredSpeedKilometresPerHour(value: v))
         )
         defer { observeTreadmillDecision(telemetryDecision) }
-        let old = deviceTargetSpeedKmh
         desiredSpeedKmh = v
         deviceTargetSpeedKmh = v
         recordSpeedChange(from: old, to: v, reason: "manual_go")
@@ -4275,53 +4314,45 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let shouldSendStart = speedKmh <= 0.2 && old <= 0.1
         switch treadmillProtocol {
         case .walkingPad:
-            // Sequence: manual mode -> start -> set speed
-            let modePacket = buildCmdPacket(cmd: 0x02, value: 0x01)
-            let startPacket = buildCmdPacket(cmd: 0x04, value: 0x01)
-            if !manualModeSet {
-                writeCommand(
-                    modePacket,
-                    label: "MODE MANUAL",
-                    requiresControlReadiness: true,
-                    telemetryRequest: treadmillCommandRequest(
-                        kind: .other("mode_manual"),
-                        decision: telemetryDecision
-                    )
-                )
-                manualModeSet = true
+            let transaction = walkingPadTransaction ?? []
+            if transaction.contains(where: { $0.command == .modeManual }) {
+                walkingPadStartTransactionConnectionEpoch = treadmillTelemetryConnectionEpoch
             }
-            if shouldSendStart {
-                scheduleWrite(
-                    startPacket,
-                    label: "START",
-                    after: 0.2,
-                    requiresControlReadiness: true,
-                    telemetryRequest: treadmillCommandRequest(
-                        kind: .other("start"),
-                        decision: telemetryDecision
+            for scheduled in transaction {
+                switch scheduled.command {
+                case .modeManual:
+                    writeCommand(
+                        buildCmdPacket(cmd: 0x02, value: 0x01),
+                        label: scheduled.command.label,
+                        requiresControlReadiness: true,
+                        telemetryRequest: treadmillCommandRequest(
+                            kind: .other("mode_manual"),
+                            decision: telemetryDecision
+                        )
                     )
-                )
-                scheduleWrite(
-                    buildWalkingPadSetSpeedPacket(kmh: v),
-                    label: String(format: "SPEED %.1f km/h", v),
-                    after: 0.45,
-                    requiresControlReadiness: true,
-                    telemetryRequest: treadmillCommandRequest(
-                        kind: treadmillSetSpeedCommandKind(v),
-                        decision: telemetryDecision
+                case .start:
+                    scheduleWrite(
+                        buildCmdPacket(cmd: 0x04, value: 0x01),
+                        label: scheduled.command.label,
+                        after: scheduled.delay,
+                        requiresControlReadiness: true,
+                        telemetryRequest: treadmillCommandRequest(
+                            kind: .other("start"),
+                            decision: telemetryDecision
+                        )
                     )
-                )
-            } else {
-                scheduleWrite(
-                    buildWalkingPadSetSpeedPacket(kmh: v),
-                    label: String(format: "SPEED %.1f km/h", v),
-                    after: 0.2,
-                    requiresControlReadiness: true,
-                    telemetryRequest: treadmillCommandRequest(
-                        kind: treadmillSetSpeedCommandKind(v),
-                        decision: telemetryDecision
+                case .speed(let targetSpeedKmh):
+                    scheduleWrite(
+                        buildWalkingPadSetSpeedPacket(kmh: targetSpeedKmh),
+                        label: scheduled.command.label,
+                        after: scheduled.delay,
+                        requiresControlReadiness: true,
+                        telemetryRequest: treadmillCommandRequest(
+                            kind: treadmillSetSpeedCommandKind(targetSpeedKmh),
+                            decision: telemetryDecision
+                        )
                     )
-                )
+                }
             }
 
         case .ftms:
@@ -6653,6 +6684,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         observeTelemetryImmediately: Bool = true
     ) -> [TreadmillCommandEnqueuedEvidence] {
         let dropped = CommandQueueService.clear(queue: &commandQueue)
+        walkingPadStartTransactionConnectionEpoch = nil
         commandQueueEpoch += 1
         isCommandQueueProcessing = false
         nextCommandAllowedAt = .distantPast
@@ -8627,6 +8659,12 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             recordedAt: recordedAt
         )
         latestTreadmillObservationEvidence = evidence
+        if evidence.protocolKind == .walkingPad,
+           evidence.connectionEpoch == walkingPadStartTransactionConnectionEpoch,
+           let factualSpeedKmh = evidence.factualSpeed?.value,
+           evidence.deviceState == .moving || factualSpeedKmh > 0.1 {
+            walkingPadStartTransactionConnectionEpoch = nil
+        }
         observeTreadmillTelemetry(.observation(evidence))
         return evidence
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -4274,16 +4274,17 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             && walkingPadStartTransactionConnectionEpoch == treadmillTelemetryConnectionEpoch
     }
 
-    func startWithSpeed(_ kmh: Double) {
+    @discardableResult
+    func startWithSpeed(_ kmh: Double) -> Bool {
         guard !blocksNonStopTreadmillMotion else {
             infoToastMessage = "Сначала завершите восстановленную тренировку"
-            return
+            return false
         }
         guard isTreadmillControlReady else {
             infoToastMessage = isConnected
                 ? "Дождитесь готовности управления дорожкой"
                 : "Не подключено к дорожке"
-            return
+            return false
         }
         let v = clampRunningSpeedKmh(kmh)
         let old = deviceTargetSpeedKmh
@@ -4299,7 +4300,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             if reason == .ambiguousMotion {
                 infoToastMessage = "Дождитесь актуального статуса дорожки"
             }
-            return
+            return false
         }
         endStopObservationForNewMotion()
         // Cancel any pending delayed writes (e.g. stop retries) before starting a new run.
@@ -4316,7 +4317,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let shouldSendStart = speedKmh <= 0.2 && old <= 0.1
         switch treadmillProtocol {
         case .walkingPad:
-            guard case .commands(let transaction)? = walkingPadPlan else { return }
+            guard case .commands(let transaction)? = walkingPadPlan else { return false }
             if transaction.contains(where: { $0.command == .modeManual }) {
                 walkingPadStartTransactionConnectionEpoch = treadmillTelemetryConnectionEpoch
             }
@@ -4430,7 +4431,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         case .unknown:
             infoToastMessage = "Неподдерживаемая дорожка (протокол не определён)"
             appendLog("Start skipped: unknown treadmill protocol")
+            return false
         }
+        return true
     }
     func stopBelt() {
         guard isConnected else { return }
@@ -5503,6 +5506,43 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             return
         }
 
+        let initialMotionTargetSpeedKmh: Double? = {
+            if treadmillProtocol == .walkingPad {
+                if deviceTargetSpeedKmh <= 0.1 && speedKmh <= 0.2 {
+                    return 3.0
+                }
+                if deviceTargetSpeedKmh <= 0.1 {
+                    return desiredSpeedKmh
+                }
+                return deviceTargetSpeedKmh
+            }
+            if deviceTargetSpeedKmh <= 0.1 && speedKmh <= 0.2 {
+                return 3.0
+            }
+            if deviceTargetSpeedKmh <= 0.1 {
+                return desiredSpeedKmh
+            }
+            return nil
+        }()
+        if treadmillProtocol == .walkingPad,
+           let initialMotionTargetSpeedKmh {
+            let admission = WalkingPadStartTransaction.plan(
+                isStartTransactionInFlight: isWalkingPadStartTransactionInFlight,
+                factualObservation: currentWalkingPadFactualMotionObservation(),
+                targetSpeedKmh: clampRunningSpeedKmh(initialMotionTargetSpeedKmh)
+            )
+            guard case .commands = admission else {
+                if case .blocked(let reason) = admission {
+                    appendLog("HR start blocked before commit: \(reason.rawValue)")
+                    if reason == .ambiguousMotion {
+                        infoToastMessage = "Дождитесь актуального статуса дорожки"
+                    }
+                }
+                abortNativeHeartRateFlow(reason: .superseded)
+                return
+            }
+        }
+
         let adaptiveStepDescription = hrAdaptiveStepEnabled
             ? "adaptive_levels=0.1/0.2/0.3/0.4"
             : "step=\(String(format: "%.2f", hrSpeedStepKmh))"
@@ -5544,13 +5584,35 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         nativePreflightCommitTimestamps = nil
         beginTelemetryV2Session(legacySessionID: legacySessionID)
         persistQualifyingNativeHeartRateBeforeMotion()
-        if deviceTargetSpeedKmh <= 0.1 && speedKmh <= 0.2 {
+        if let initialMotionTargetSpeedKmh {
             hrControlStartedBelt = true
-            startWithSpeed(3.0)
-        } else if deviceTargetSpeedKmh <= 0.1 {
-            hrControlStartedBelt = true
-            startWithSpeed(desiredSpeedKmh)
+            guard startWithSpeed(initialMotionTargetSpeedKmh) else {
+                rollbackCommittedHrControlBeforeMotion()
+                return
+            }
         }
+    }
+
+    private func rollbackCommittedHrControlBeforeMotion() {
+        appendLog("HR start rolled back before motion")
+        logTrainingEvent("hr_control_start_rolled_back", fields: [
+            "reason": "motion_admission_failed",
+        ])
+        stopTrainingStructuredLog(reason: "motion_admission_failed")
+        isHrControlRunning = false
+        hrStatusLine = "HR‑контроль не запущен"
+        hrSessionTotalSeconds = 0
+        hrRemainingSeconds = 0
+        hrNextDecisionSeconds = 0
+        hrProgress = 0
+        hrDecisionDetails = ""
+        hrPredictorStatusLine = ""
+        hrNoDataSeconds = 0
+        clearCooldownRuntimeState()
+        hrControlStartedAt = nil
+        hrControlStartedBelt = false
+        abortNativeHeartRateFlow(reason: .superseded)
+        endTelemetryV2Session(reason: "motion_admission_failed")
     }
 
     private var nativeHeartRateTransportIsValid: Bool {

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -4287,16 +4287,18 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
         let v = clampRunningSpeedKmh(kmh)
         let old = deviceTargetSpeedKmh
-        let walkingPadTransaction = treadmillProtocol == .walkingPad
+        let walkingPadPlan = treadmillProtocol == .walkingPad
             ? WalkingPadStartTransaction.plan(
                 isStartTransactionInFlight: isWalkingPadStartTransactionInFlight,
-                previousCommandedSpeedKmh: old,
                 factualObservation: currentWalkingPadFactualMotionObservation(),
                 targetSpeedKmh: v
             )
             : nil
-        guard walkingPadTransaction?.isEmpty != true else {
-            appendLog("WalkingPad start ignored: start transaction already in flight")
+        if case .blocked(let reason)? = walkingPadPlan {
+            appendLog("WalkingPad motion command blocked: \(reason.rawValue)")
+            if reason == .ambiguousMotion {
+                infoToastMessage = "Дождитесь актуального статуса дорожки"
+            }
             return
         }
         endStopObservationForNewMotion()
@@ -4314,7 +4316,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let shouldSendStart = speedKmh <= 0.2 && old <= 0.1
         switch treadmillProtocol {
         case .walkingPad:
-            let transaction = walkingPadTransaction ?? []
+            guard case .commands(let transaction)? = walkingPadPlan else { return }
             if transaction.contains(where: { $0.command == .modeManual }) {
                 walkingPadStartTransactionConnectionEpoch = treadmillTelemetryConnectionEpoch
             }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -5507,15 +5507,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
 
         let initialMotionTargetSpeedKmh: Double? = {
-            if treadmillProtocol == .walkingPad {
-                if deviceTargetSpeedKmh <= 0.1 && speedKmh <= 0.2 {
-                    return 3.0
-                }
-                if deviceTargetSpeedKmh <= 0.1 {
-                    return desiredSpeedKmh
-                }
-                return deviceTargetSpeedKmh
-            }
             if deviceTargetSpeedKmh <= 0.1 && speedKmh <= 0.2 {
                 return 3.0
             }
@@ -5524,19 +5515,26 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             }
             return nil
         }()
-        if treadmillProtocol == .walkingPad,
-           let initialMotionTargetSpeedKmh {
-            let admission = WalkingPadStartTransaction.plan(
+        var motionTargetSpeedKmh = initialMotionTargetSpeedKmh
+        if treadmillProtocol == .walkingPad {
+            let walkingPadTargetSpeedKmh = clampRunningSpeedKmh(
+                initialMotionTargetSpeedKmh ?? deviceTargetSpeedKmh
+            )
+            let admission = WalkingPadStartTransaction.hrStartAdmission(
                 isStartTransactionInFlight: isWalkingPadStartTransactionInFlight,
                 factualObservation: currentWalkingPadFactualMotionObservation(),
-                targetSpeedKmh: clampRunningSpeedKmh(initialMotionTargetSpeedKmh)
+                hasActiveTarget: deviceTargetSpeedKmh > 0.1,
+                targetSpeedKmh: walkingPadTargetSpeedKmh
             )
-            guard case .commands = admission else {
-                if case .blocked(let reason) = admission {
-                    appendLog("HR start blocked before commit: \(reason.rawValue)")
-                    if reason == .ambiguousMotion {
-                        infoToastMessage = "Дождитесь актуального статуса дорожки"
-                    }
+            switch admission {
+            case .commands:
+                motionTargetSpeedKmh = walkingPadTargetSpeedKmh
+            case .noMotionCommand:
+                motionTargetSpeedKmh = nil
+            case .blocked(let reason):
+                appendLog("HR start blocked before commit: \(reason.rawValue)")
+                if reason == .ambiguousMotion {
+                    infoToastMessage = "Дождитесь актуального статуса дорожки"
                 }
                 abortNativeHeartRateFlow(reason: .superseded)
                 return
@@ -5584,9 +5582,9 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         nativePreflightCommitTimestamps = nil
         beginTelemetryV2Session(legacySessionID: legacySessionID)
         persistQualifyingNativeHeartRateBeforeMotion()
-        if let initialMotionTargetSpeedKmh {
+        if let motionTargetSpeedKmh {
             hrControlStartedBelt = true
-            guard startWithSpeed(initialMotionTargetSpeedKmh) else {
+            guard startWithSpeed(motionTargetSpeedKmh) else {
                 rollbackCommittedHrControlBeforeMotion()
                 return
             }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/WalkingPadStartTransaction.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/WalkingPadStartTransaction.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+enum WalkingPadStartTransaction {
+    enum ObservedMotion: Equatable {
+        case stopped
+        case moving
+        case unknown
+    }
+
+    struct FactualMotionObservation: Equatable {
+        let motion: ObservedMotion
+        let ageSeconds: TimeInterval
+        let isCurrentConnectionEpoch: Bool
+
+        var isFreshCurrent: Bool {
+            isCurrentConnectionEpoch
+                && ageSeconds >= 0
+                && ageSeconds <= StopObservationPolicy.freshnessInterval
+        }
+
+        var isFreshCurrentStop: Bool {
+            isFreshCurrent && motion == .stopped
+        }
+    }
+
+    enum Command: Equatable {
+        case modeManual
+        case start
+        case speed(Double)
+
+        var label: String {
+            switch self {
+            case .modeManual:
+                return "MODE MANUAL"
+            case .start:
+                return "START"
+            case .speed(let targetSpeedKmh):
+                return String(format: "SPEED %.1f km/h", targetSpeedKmh)
+            }
+        }
+    }
+
+    struct ScheduledCommand: Equatable {
+        let command: Command
+        let delay: TimeInterval
+    }
+
+    static func plan(
+        isStartTransactionInFlight: Bool,
+        previousCommandedSpeedKmh: Double,
+        factualObservation: FactualMotionObservation?,
+        targetSpeedKmh: Double
+    ) -> [ScheduledCommand] {
+        guard !isStartTransactionInFlight else { return [] }
+        if factualObservation?.isFreshCurrent == true,
+           factualObservation?.motion == .moving {
+            return [ScheduledCommand(command: .speed(targetSpeedKmh), delay: 0.2)]
+        }
+        let ownsStartPrerequisites = previousCommandedSpeedKmh <= 0.1
+            || factualObservation?.isFreshCurrentStop == true
+        if ownsStartPrerequisites {
+            return [
+                ScheduledCommand(command: .modeManual, delay: 0),
+                ScheduledCommand(command: .start, delay: 0.2),
+                ScheduledCommand(command: .speed(targetSpeedKmh), delay: 0.45),
+            ]
+        }
+        return [ScheduledCommand(command: .speed(targetSpeedKmh), delay: 0.2)]
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/WalkingPadStartTransaction.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/WalkingPadStartTransaction.swift
@@ -45,26 +45,39 @@ enum WalkingPadStartTransaction {
         let delay: TimeInterval
     }
 
+    enum BlockReason: String, Equatable {
+        case startTransactionInFlight = "start_transaction_in_flight"
+        case ambiguousMotion = "ambiguous_motion"
+    }
+
+    enum Plan: Equatable {
+        case commands([ScheduledCommand])
+        case blocked(BlockReason)
+    }
+
     static func plan(
         isStartTransactionInFlight: Bool,
-        previousCommandedSpeedKmh: Double,
         factualObservation: FactualMotionObservation?,
         targetSpeedKmh: Double
-    ) -> [ScheduledCommand] {
-        guard !isStartTransactionInFlight else { return [] }
-        if factualObservation?.isFreshCurrent == true,
-           factualObservation?.motion == .moving {
-            return [ScheduledCommand(command: .speed(targetSpeedKmh), delay: 0.2)]
+    ) -> Plan {
+        guard !isStartTransactionInFlight else {
+            return .blocked(.startTransactionInFlight)
         }
-        let ownsStartPrerequisites = previousCommandedSpeedKmh <= 0.1
-            || factualObservation?.isFreshCurrentStop == true
-        if ownsStartPrerequisites {
-            return [
+        guard factualObservation?.isFreshCurrent == true else {
+            return .blocked(.ambiguousMotion)
+        }
+        if factualObservation?.motion == .moving {
+            return .commands([
+                ScheduledCommand(command: .speed(targetSpeedKmh), delay: 0.2),
+            ])
+        }
+        if factualObservation?.isFreshCurrentStop == true {
+            return .commands([
                 ScheduledCommand(command: .modeManual, delay: 0),
                 ScheduledCommand(command: .start, delay: 0.2),
                 ScheduledCommand(command: .speed(targetSpeedKmh), delay: 0.45),
-            ]
+            ])
         }
-        return [ScheduledCommand(command: .speed(targetSpeedKmh), delay: 0.2)]
+        return .blocked(.ambiguousMotion)
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/WalkingPadStartTransaction.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/WalkingPadStartTransaction.swift
@@ -55,6 +55,12 @@ enum WalkingPadStartTransaction {
         case blocked(BlockReason)
     }
 
+    enum HrStartAdmission: Equatable {
+        case commands([ScheduledCommand])
+        case noMotionCommand
+        case blocked(BlockReason)
+    }
+
     static func plan(
         isStartTransactionInFlight: Bool,
         factualObservation: FactualMotionObservation?,
@@ -79,5 +85,29 @@ enum WalkingPadStartTransaction {
             ])
         }
         return .blocked(.ambiguousMotion)
+    }
+
+    static func hrStartAdmission(
+        isStartTransactionInFlight: Bool,
+        factualObservation: FactualMotionObservation?,
+        hasActiveTarget: Bool,
+        targetSpeedKmh: Double
+    ) -> HrStartAdmission {
+        guard factualObservation?.isFreshCurrent == true else {
+            return .blocked(.ambiguousMotion)
+        }
+        if factualObservation?.motion == .moving, hasActiveTarget {
+            return .noMotionCommand
+        }
+        switch plan(
+            isStartTransactionInFlight: isStartTransactionInFlight,
+            factualObservation: factualObservation,
+            targetSpeedKmh: targetSpeedKmh
+        ) {
+        case .commands(let commands):
+            return .commands(commands)
+        case .blocked(let reason):
+            return .blocked(reason)
+        }
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/BluetoothAutoConnectBehaviorContractTests.swift
@@ -400,7 +400,8 @@ final class BluetoothAutoConnectBehaviorContractTests: XCTestCase {
                 "if endedConnectionAttempt",
                 "self.resetProtocolState()",
                 "self.connectedPeripheral = nil",
-                "self.manualModeSet = false",
+                "self.isConnected = false",
+                "self.connectedPeripheralId = nil",
             ],
             in: didDisconnect
         )

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
@@ -67,11 +67,11 @@ final class NativeHeartRatePreflightIntegrationContractTests: XCTestCase {
         ], in: commit)
         assertOrdered([
             "controllerUnitsGateDecision()",
-            "WalkingPadStartTransaction.plan(",
-            "guard case .commands = admission else",
+            "WalkingPadStartTransaction.hrStartAdmission(",
+            "case .blocked(let reason):",
             "isHrControlRunning = true",
             "beginTelemetryV2Session(legacySessionID: legacySessionID)",
-            "guard startWithSpeed(initialMotionTargetSpeedKmh) else",
+            "guard startWithSpeed(motionTargetSpeedKmh) else",
             "rollbackCommittedHrControlBeforeMotion()",
         ], in: productionStart)
         XCTAssertEqual(productionStart.components(separatedBy: "isHrControlRunning = true").count - 1, 1)

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
@@ -67,9 +67,12 @@ final class NativeHeartRatePreflightIntegrationContractTests: XCTestCase {
         ], in: commit)
         assertOrdered([
             "controllerUnitsGateDecision()",
+            "WalkingPadStartTransaction.plan(",
+            "guard case .commands = admission else",
             "isHrControlRunning = true",
             "beginTelemetryV2Session(legacySessionID: legacySessionID)",
-            "startWithSpeed",
+            "guard startWithSpeed(initialMotionTargetSpeedKmh) else",
+            "rollbackCommittedHrControlBeforeMotion()",
         ], in: productionStart)
         XCTAssertEqual(productionStart.components(separatedBy: "isHrControlRunning = true").count - 1, 1)
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WalkingPadStartTransactionTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WalkingPadStartTransactionTests.swift
@@ -16,86 +16,73 @@ final class WalkingPadStartTransactionTests: XCTestCase {
         XCTAssertEqual(
             WalkingPadStartTransaction.plan(
                 isStartTransactionInFlight: false,
-                previousCommandedSpeedKmh: 0,
-                factualObservation: nil,
+                factualObservation: freshObservation(.stopped),
                 targetSpeedKmh: 3.0
             ),
-            [
+            .commands([
                 .init(command: .modeManual, delay: 0),
                 .init(command: .start, delay: 0.2),
                 .init(command: .speed(3.0), delay: 0.45),
-            ]
+            ])
         )
     }
 
     func testOrdinaryStopThenSecondStartInSameConnectionOwnsPrerequisitesAgain() {
         let firstStart = WalkingPadStartTransaction.plan(
             isStartTransactionInFlight: false,
-            previousCommandedSpeedKmh: 0,
-            factualObservation: nil,
+            factualObservation: freshObservation(.stopped),
             targetSpeedKmh: 3.0
         )
 
         // An ordinary Stop does not need to mutate any start-transaction cache.
         let secondStart = WalkingPadStartTransaction.plan(
             isStartTransactionInFlight: false,
-            previousCommandedSpeedKmh: 0,
-            factualObservation: nil,
+            factualObservation: freshObservation(.stopped),
             targetSpeedKmh: 3.4
         )
 
-        XCTAssertEqual(firstStart.map(\.command), [.modeManual, .start, .speed(3.0)])
-        XCTAssertEqual(secondStart.map(\.command), [.modeManual, .start, .speed(3.4)])
+        XCTAssertEqual(commands(from: firstStart).map(\.command), [.modeManual, .start, .speed(3.0)])
+        XCTAssertEqual(commands(from: secondStart).map(\.command), [.modeManual, .start, .speed(3.4)])
     }
 
     func testSpeedAdjustmentWhileMovingDoesNotResendPrerequisites() {
-        for previousCommandedSpeedKmh in [0.0, 3.0] {
-            XCTAssertEqual(
-                WalkingPadStartTransaction.plan(
-                    isStartTransactionInFlight: false,
-                    previousCommandedSpeedKmh: previousCommandedSpeedKmh,
-                    factualObservation: .init(
-                        motion: .moving,
-                        ageSeconds: 0.5,
-                        isCurrentConnectionEpoch: true
-                    ),
-                    targetSpeedKmh: 3.8
-                ),
-                [.init(command: .speed(3.8), delay: 0.2)]
-            )
-        }
+        XCTAssertEqual(
+            WalkingPadStartTransaction.plan(
+                isStartTransactionInFlight: false,
+                factualObservation: freshObservation(.moving),
+                targetSpeedKmh: 3.8
+            ),
+            .commands([.init(command: .speed(3.8), delay: 0.2)])
+        )
     }
 
     func testDisconnectReconnectDoesNotChangeStoppedStartContract() {
         let beforeDisconnect = WalkingPadStartTransaction.plan(
             isStartTransactionInFlight: false,
-            previousCommandedSpeedKmh: 0,
-            factualObservation: nil,
+            factualObservation: freshObservation(.stopped),
             targetSpeedKmh: 3.0
         )
         let afterReconnect = WalkingPadStartTransaction.plan(
             isStartTransactionInFlight: false,
-            previousCommandedSpeedKmh: 0,
-            factualObservation: nil,
+            factualObservation: freshObservation(.stopped),
             targetSpeedKmh: 3.0
         )
 
         XCTAssertEqual(afterReconnect, beforeDisconnect)
-        XCTAssertEqual(afterReconnect.map(\.command), [.modeManual, .start, .speed(3.0)])
+        XCTAssertEqual(commands(from: afterReconnect).map(\.command), [.modeManual, .start, .speed(3.0)])
     }
 
     func testHighPriorityStopPreemptsPartiallyQueuedSecondStartAndTelemetrySidecar() {
         let epoch = TreadmillConnectionEpoch(rawValue: UUID())
         let secondStart = WalkingPadStartTransaction.plan(
             isStartTransactionInFlight: false,
-            previousCommandedSpeedKmh: 0,
-            factualObservation: nil,
+            factualObservation: freshObservation(.stopped),
             targetSpeedKmh: 3.0
         )
         var queue: [CommandQueueService.Command] = []
         var sidecar = TreadmillCommandTelemetrySidecar()
 
-        for scheduled in secondStart {
+        for scheduled in commands(from: secondStart) {
             let label = scheduled.command.label
             let command = CommandQueueService.Command(data: Data(), label: label)
             _ = CommandQueueService.enqueueRegular(
@@ -134,17 +121,17 @@ final class WalkingPadStartTransactionTests: XCTestCase {
         let epoch = TreadmillConnectionEpoch(rawValue: UUID())
         let plan = WalkingPadStartTransaction.plan(
             isStartTransactionInFlight: false,
-            previousCommandedSpeedKmh: 0,
-            factualObservation: nil,
+            factualObservation: freshObservation(.stopped),
             targetSpeedKmh: 3.0
         )
 
-        XCTAssertEqual(plan.map { $0.command.label }, [
+        let commands = commands(from: plan)
+        XCTAssertEqual(commands.map { $0.command.label }, [
             "MODE MANUAL",
             "START",
             "SPEED 3.0 km/h",
         ])
-        XCTAssertEqual(plan.map { evidence(for: $0.command, epoch: epoch).kind }, [
+        XCTAssertEqual(commands.map { evidence(for: $0.command, epoch: epoch).kind }, [
             .other("mode_manual"),
             .other("start"),
             .setSpeed(TreadmillCommandedSpeedRepresentation.walkingPad(rawControllerTenths: 30)),
@@ -159,7 +146,6 @@ final class WalkingPadStartTransactionTests: XCTestCase {
             [
                 "WalkingPadStartTransaction.plan(",
                 "isStartTransactionInFlight: isWalkingPadStartTransactionInFlight",
-                "previousCommandedSpeedKmh: old",
                 "factualObservation: currentWalkingPadFactualMotionObservation()",
                 "case .modeManual:",
                 "buildCmdPacket(cmd: 0x02, value: 0x01)",
@@ -215,7 +201,7 @@ final class WalkingPadStartTransactionTests: XCTestCase {
         assertOrdered(
             [
                 "WalkingPadStartTransaction.plan(",
-                "guard walkingPadTransaction?.isEmpty != true",
+                "if case .blocked(let reason)? = walkingPadPlan",
                 "resetCommandQueue(reason: \"startWithSpeed\")",
                 "walkingPadStartTransactionConnectionEpoch = treadmillTelemetryConnectionEpoch",
                 "for scheduled in transaction",
@@ -243,22 +229,17 @@ final class WalkingPadStartTransactionTests: XCTestCase {
         )
     }
 
-    func testFreshFactualStopOverridesStaleCommandedMovingState() {
+    func testFreshFactualStopOwnsFullTransaction() {
         let plan = WalkingPadStartTransaction.plan(
             isStartTransactionInFlight: false,
-            previousCommandedSpeedKmh: 3.0,
-            factualObservation: .init(
-                motion: .stopped,
-                ageSeconds: 0.5,
-                isCurrentConnectionEpoch: true
-            ),
+            factualObservation: freshObservation(.stopped),
             targetSpeedKmh: 3.2
         )
 
-        XCTAssertEqual(plan.map(\.command), [.modeManual, .start, .speed(3.2)])
+        XCTAssertEqual(commands(from: plan).map(\.command), [.modeManual, .start, .speed(3.2)])
     }
 
-    func testStaleOrWrongEpochStopDoesNotCreateDuplicateMotionCommands() {
+    func testStaleOrWrongEpochStopFailsClosedInsteadOfTrustingLocalMovingIntent() {
         for observation in [
             WalkingPadStartTransaction.FactualMotionObservation(
                 motion: .stopped,
@@ -274,11 +255,10 @@ final class WalkingPadStartTransactionTests: XCTestCase {
             XCTAssertEqual(
                 WalkingPadStartTransaction.plan(
                     isStartTransactionInFlight: false,
-                    previousCommandedSpeedKmh: 3.0,
                     factualObservation: observation,
                     targetSpeedKmh: 3.4
                 ),
-                [.init(command: .speed(3.4), delay: 0.2)]
+                .blocked(.ambiguousMotion)
             )
         }
     }
@@ -286,16 +266,55 @@ final class WalkingPadStartTransactionTests: XCTestCase {
     func testRepeatedStartWhileTransactionIsInFlightEmitsNoDuplicateCommands() {
         let plan = WalkingPadStartTransaction.plan(
             isStartTransactionInFlight: true,
-            previousCommandedSpeedKmh: 3.0,
-            factualObservation: .init(
-                motion: .stopped,
-                ageSeconds: 0.5,
-                isCurrentConnectionEpoch: true
-            ),
+            factualObservation: freshObservation(.stopped),
             targetSpeedKmh: 3.4
         )
 
-        XCTAssertTrue(plan.isEmpty)
+        XCTAssertEqual(plan, .blocked(.startTransactionInFlight))
+    }
+
+    func testMissingFactualEvidenceFailsClosed() {
+        XCTAssertEqual(
+            WalkingPadStartTransaction.plan(
+                isStartTransactionInFlight: false,
+                factualObservation: nil,
+                targetSpeedKmh: 3.4
+            ),
+            .blocked(.ambiguousMotion)
+        )
+    }
+
+    func testFreshUnknownMotionFailsClosed() {
+        XCTAssertEqual(
+            WalkingPadStartTransaction.plan(
+                isStartTransactionInFlight: false,
+                factualObservation: freshObservation(.unknown),
+                targetSpeedKmh: 3.0
+            ),
+            .blocked(.ambiguousMotion)
+        )
+    }
+
+    private func freshObservation(
+        _ motion: WalkingPadStartTransaction.ObservedMotion
+    ) -> WalkingPadStartTransaction.FactualMotionObservation {
+        .init(
+            motion: motion,
+            ageSeconds: 0.5,
+            isCurrentConnectionEpoch: true
+        )
+    }
+
+    private func commands(
+        from plan: WalkingPadStartTransaction.Plan,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> [WalkingPadStartTransaction.ScheduledCommand] {
+        guard case .commands(let commands) = plan else {
+            XCTFail("Expected commands, got \(plan)", file: file, line: line)
+            return []
+        }
+        return commands
     }
 
     private func evidence(

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WalkingPadStartTransactionTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WalkingPadStartTransactionTests.swift
@@ -170,15 +170,80 @@ final class WalkingPadStartTransactionTests: XCTestCase {
 
         assertOrdered(
             [
-                "WalkingPadStartTransaction.plan(",
+                "WalkingPadStartTransaction.hrStartAdmission(",
                 "factualObservation: currentWalkingPadFactualMotionObservation()",
-                "guard case .commands = admission else",
+                "case .blocked(let reason):",
                 "abortNativeHeartRateFlow(reason: .superseded)",
                 "return",
                 "resetSessionStats()",
                 "startTrainingStructuredLog(trigger: \"start_hr\")",
                 "isHrControlRunning = true",
                 "beginTelemetryV2Session(legacySessionID: legacySessionID)",
+            ],
+            in: commit
+        )
+    }
+
+    func testHrAdmissionKeepsStoppedMovingAdoptionActiveTargetAndAmbiguousBoundaries() {
+        XCTAssertEqual(
+            WalkingPadStartTransaction.hrStartAdmission(
+                isStartTransactionInFlight: false,
+                factualObservation: freshObservation(.stopped),
+                hasActiveTarget: true,
+                targetSpeedKmh: 3.4
+            ),
+            .commands([
+                .init(command: .modeManual, delay: 0),
+                .init(command: .start, delay: 0.2),
+                .init(command: .speed(3.4), delay: 0.45),
+            ])
+        )
+        XCTAssertEqual(
+            WalkingPadStartTransaction.hrStartAdmission(
+                isStartTransactionInFlight: false,
+                factualObservation: freshObservation(.moving),
+                hasActiveTarget: false,
+                targetSpeedKmh: 3.0
+            ),
+            .commands([.init(command: .speed(3.0), delay: 0.2)])
+        )
+        XCTAssertEqual(
+            WalkingPadStartTransaction.hrStartAdmission(
+                isStartTransactionInFlight: false,
+                factualObservation: freshObservation(.moving),
+                hasActiveTarget: true,
+                targetSpeedKmh: 3.4
+            ),
+            .noMotionCommand
+        )
+        XCTAssertEqual(
+            WalkingPadStartTransaction.hrStartAdmission(
+                isStartTransactionInFlight: false,
+                factualObservation: nil,
+                hasActiveTarget: true,
+                targetSpeedKmh: 3.4
+            ),
+            .blocked(.ambiguousMotion)
+        )
+    }
+
+    func testHrCommitExecutesOnlyTheAdmittedMotionOutput() throws {
+        let commit = try functionBody(
+            "private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)"
+        )
+
+        assertOrdered(
+            [
+                "WalkingPadStartTransaction.hrStartAdmission(",
+                "hasActiveTarget: deviceTargetSpeedKmh > 0.1",
+                "case .commands:",
+                "motionTargetSpeedKmh = walkingPadTargetSpeedKmh",
+                "case .noMotionCommand:",
+                "motionTargetSpeedKmh = nil",
+                "case .blocked(let reason):",
+                "abortNativeHeartRateFlow(reason: .superseded)",
+                "if let motionTargetSpeedKmh",
+                "guard startWithSpeed(motionTargetSpeedKmh) else",
             ],
             in: commit
         )
@@ -196,7 +261,7 @@ final class WalkingPadStartTransactionTests: XCTestCase {
             [
                 "beginTelemetryV2Session(legacySessionID: legacySessionID)",
                 "persistQualifyingNativeHeartRateBeforeMotion()",
-                "guard startWithSpeed(initialMotionTargetSpeedKmh) else",
+                "guard startWithSpeed(motionTargetSpeedKmh) else",
                 "rollbackCommittedHrControlBeforeMotion()",
             ],
             in: commit

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WalkingPadStartTransactionTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WalkingPadStartTransactionTests.swift
@@ -1,0 +1,378 @@
+import Foundation
+import TelemetryDomain
+import XCTest
+@testable import WalkingPadCoreLogic
+
+final class WalkingPadStartTransactionTests: XCTestCase {
+    private lazy var bluetoothManagerSource: String = {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let sourceURL = testsDirectory
+            .deletingLastPathComponent()
+            .appendingPathComponent("WalkingPadRemote/BluetoothManager.swift")
+        return (try? String(contentsOf: sourceURL, encoding: .utf8)) ?? ""
+    }()
+
+    func testFirstStoppedStartOwnsFullPrerequisiteTransaction() {
+        XCTAssertEqual(
+            WalkingPadStartTransaction.plan(
+                isStartTransactionInFlight: false,
+                previousCommandedSpeedKmh: 0,
+                factualObservation: nil,
+                targetSpeedKmh: 3.0
+            ),
+            [
+                .init(command: .modeManual, delay: 0),
+                .init(command: .start, delay: 0.2),
+                .init(command: .speed(3.0), delay: 0.45),
+            ]
+        )
+    }
+
+    func testOrdinaryStopThenSecondStartInSameConnectionOwnsPrerequisitesAgain() {
+        let firstStart = WalkingPadStartTransaction.plan(
+            isStartTransactionInFlight: false,
+            previousCommandedSpeedKmh: 0,
+            factualObservation: nil,
+            targetSpeedKmh: 3.0
+        )
+
+        // An ordinary Stop does not need to mutate any start-transaction cache.
+        let secondStart = WalkingPadStartTransaction.plan(
+            isStartTransactionInFlight: false,
+            previousCommandedSpeedKmh: 0,
+            factualObservation: nil,
+            targetSpeedKmh: 3.4
+        )
+
+        XCTAssertEqual(firstStart.map(\.command), [.modeManual, .start, .speed(3.0)])
+        XCTAssertEqual(secondStart.map(\.command), [.modeManual, .start, .speed(3.4)])
+    }
+
+    func testSpeedAdjustmentWhileMovingDoesNotResendPrerequisites() {
+        for previousCommandedSpeedKmh in [0.0, 3.0] {
+            XCTAssertEqual(
+                WalkingPadStartTransaction.plan(
+                    isStartTransactionInFlight: false,
+                    previousCommandedSpeedKmh: previousCommandedSpeedKmh,
+                    factualObservation: .init(
+                        motion: .moving,
+                        ageSeconds: 0.5,
+                        isCurrentConnectionEpoch: true
+                    ),
+                    targetSpeedKmh: 3.8
+                ),
+                [.init(command: .speed(3.8), delay: 0.2)]
+            )
+        }
+    }
+
+    func testDisconnectReconnectDoesNotChangeStoppedStartContract() {
+        let beforeDisconnect = WalkingPadStartTransaction.plan(
+            isStartTransactionInFlight: false,
+            previousCommandedSpeedKmh: 0,
+            factualObservation: nil,
+            targetSpeedKmh: 3.0
+        )
+        let afterReconnect = WalkingPadStartTransaction.plan(
+            isStartTransactionInFlight: false,
+            previousCommandedSpeedKmh: 0,
+            factualObservation: nil,
+            targetSpeedKmh: 3.0
+        )
+
+        XCTAssertEqual(afterReconnect, beforeDisconnect)
+        XCTAssertEqual(afterReconnect.map(\.command), [.modeManual, .start, .speed(3.0)])
+    }
+
+    func testHighPriorityStopPreemptsPartiallyQueuedSecondStartAndTelemetrySidecar() {
+        let epoch = TreadmillConnectionEpoch(rawValue: UUID())
+        let secondStart = WalkingPadStartTransaction.plan(
+            isStartTransactionInFlight: false,
+            previousCommandedSpeedKmh: 0,
+            factualObservation: nil,
+            targetSpeedKmh: 3.0
+        )
+        var queue: [CommandQueueService.Command] = []
+        var sidecar = TreadmillCommandTelemetrySidecar()
+
+        for scheduled in secondStart {
+            let label = scheduled.command.label
+            let command = CommandQueueService.Command(data: Data(), label: label)
+            _ = CommandQueueService.enqueueRegular(
+                queue: &queue,
+                command: command,
+                isSpeedLabel: isSpeedLabel
+            )
+            _ = sidecar.enqueueRegular(
+                label: label,
+                evidence: evidence(for: scheduled.command, epoch: epoch),
+                isSpeedLabel: isSpeedLabel
+            )
+        }
+
+        let stopEvidence = evidence(kind: .stop, epoch: epoch)
+        CommandQueueService.replaceWithHighPriority(
+            queue: &queue,
+            command: .init(data: Data([0x00]), label: "STOP")
+        )
+        let superseded = sidecar.replaceWithHighPriority(
+            label: "STOP",
+            evidence: stopEvidence
+        )
+
+        XCTAssertEqual(queue.map(\.label), ["STOP"])
+        XCTAssertEqual(sidecar.count, 1)
+        XCTAssertEqual(superseded.map(\.kind), [
+            .other("mode_manual"),
+            .other("start"),
+            .setSpeed(TreadmillCommandedSpeedRepresentation.walkingPad(rawControllerTenths: 30)),
+        ])
+        XCTAssertEqual(sidecar.dequeue(expectedLabel: "STOP", currentEpoch: epoch), .matched(stopEvidence))
+    }
+
+    func testCommandLabelsAndTelemetryKindsRemainExact() {
+        let epoch = TreadmillConnectionEpoch(rawValue: UUID())
+        let plan = WalkingPadStartTransaction.plan(
+            isStartTransactionInFlight: false,
+            previousCommandedSpeedKmh: 0,
+            factualObservation: nil,
+            targetSpeedKmh: 3.0
+        )
+
+        XCTAssertEqual(plan.map { $0.command.label }, [
+            "MODE MANUAL",
+            "START",
+            "SPEED 3.0 km/h",
+        ])
+        XCTAssertEqual(plan.map { evidence(for: $0.command, epoch: epoch).kind }, [
+            .other("mode_manual"),
+            .other("start"),
+            .setSpeed(TreadmillCommandedSpeedRepresentation.walkingPad(rawControllerTenths: 30)),
+        ])
+    }
+
+    func testProductionIntegrationUsesStatelessPlanAndExactTelemetryMapping() throws {
+        let body = try functionBody("func startWithSpeed(_ kmh: Double)")
+
+        XCTAssertFalse(bluetoothManagerSource.contains("manualModeSet"))
+        assertOrdered(
+            [
+                "WalkingPadStartTransaction.plan(",
+                "isStartTransactionInFlight: isWalkingPadStartTransactionInFlight",
+                "previousCommandedSpeedKmh: old",
+                "factualObservation: currentWalkingPadFactualMotionObservation()",
+                "case .modeManual:",
+                "buildCmdPacket(cmd: 0x02, value: 0x01)",
+                "label: scheduled.command.label",
+                "kind: .other(\"mode_manual\")",
+                "case .start:",
+                "buildCmdPacket(cmd: 0x04, value: 0x01)",
+                "kind: .other(\"start\")",
+                "case .speed(let targetSpeedKmh):",
+                "buildWalkingPadSetSpeedPacket(kmh: targetSpeedKmh)",
+                "kind: treadmillSetSpeedCommandKind(targetSpeedKmh)",
+            ],
+            in: body
+        )
+        XCTAssertTrue(body.contains("after: scheduled.delay"))
+    }
+
+    func testProductionStopRaceInvalidatesDelayedStartCommands() throws {
+        let startBody = try functionBody("func startWithSpeed(_ kmh: Double)")
+        let scheduleBody = try functionBody("private func scheduleWrite(")
+        let enqueueBody = try functionBody("private func enqueueCommand(")
+
+        XCTAssertTrue(startBody.contains("case .start:"))
+        XCTAssertTrue(startBody.contains("case .speed(let targetSpeedKmh):"))
+        XCTAssertGreaterThanOrEqual(
+            startBody.components(separatedBy: "after: scheduled.delay").count - 1,
+            2
+        )
+        assertOrdered(
+            [
+                "let epoch = commandQueueEpoch",
+                "guard self.commandQueueEpoch == epoch else { return }",
+                "self.writeCommand(",
+            ],
+            in: scheduleBody
+        )
+        assertOrdered(
+            [
+                "if highPriority",
+                "resetCommandQueue(",
+                "CommandQueueService.replaceWithHighPriority",
+                "processCommandQueue()",
+            ],
+            in: enqueueBody
+        )
+    }
+
+    func testProductionTransactionOwnershipIsBoundedByStopResetAndFactualMoving() throws {
+        let startBody = try functionBody("func startWithSpeed(_ kmh: Double)")
+        let resetBody = try functionBody("private func resetCommandQueue(")
+        let observationBody = try functionBody("private func observeTreadmillProviderObservation(")
+
+        assertOrdered(
+            [
+                "WalkingPadStartTransaction.plan(",
+                "guard walkingPadTransaction?.isEmpty != true",
+                "resetCommandQueue(reason: \"startWithSpeed\")",
+                "walkingPadStartTransactionConnectionEpoch = treadmillTelemetryConnectionEpoch",
+                "for scheduled in transaction",
+            ],
+            in: startBody
+        )
+        assertOrdered(
+            [
+                "CommandQueueService.clear(queue: &commandQueue)",
+                "walkingPadStartTransactionConnectionEpoch = nil",
+                "commandQueueEpoch += 1",
+            ],
+            in: resetBody
+        )
+        assertOrdered(
+            [
+                "latestTreadmillObservationEvidence = evidence",
+                "evidence.protocolKind == .walkingPad",
+                "let factualSpeedKmh = evidence.factualSpeed?.value",
+                "evidence.deviceState == .moving || factualSpeedKmh > 0.1",
+                "walkingPadStartTransactionConnectionEpoch = nil",
+                "observeTreadmillTelemetry(.observation(evidence))",
+            ],
+            in: observationBody
+        )
+    }
+
+    func testFreshFactualStopOverridesStaleCommandedMovingState() {
+        let plan = WalkingPadStartTransaction.plan(
+            isStartTransactionInFlight: false,
+            previousCommandedSpeedKmh: 3.0,
+            factualObservation: .init(
+                motion: .stopped,
+                ageSeconds: 0.5,
+                isCurrentConnectionEpoch: true
+            ),
+            targetSpeedKmh: 3.2
+        )
+
+        XCTAssertEqual(plan.map(\.command), [.modeManual, .start, .speed(3.2)])
+    }
+
+    func testStaleOrWrongEpochStopDoesNotCreateDuplicateMotionCommands() {
+        for observation in [
+            WalkingPadStartTransaction.FactualMotionObservation(
+                motion: .stopped,
+                ageSeconds: StopObservationPolicy.freshnessInterval + 0.01,
+                isCurrentConnectionEpoch: true
+            ),
+            WalkingPadStartTransaction.FactualMotionObservation(
+                motion: .stopped,
+                ageSeconds: 0.5,
+                isCurrentConnectionEpoch: false
+            ),
+        ] {
+            XCTAssertEqual(
+                WalkingPadStartTransaction.plan(
+                    isStartTransactionInFlight: false,
+                    previousCommandedSpeedKmh: 3.0,
+                    factualObservation: observation,
+                    targetSpeedKmh: 3.4
+                ),
+                [.init(command: .speed(3.4), delay: 0.2)]
+            )
+        }
+    }
+
+    func testRepeatedStartWhileTransactionIsInFlightEmitsNoDuplicateCommands() {
+        let plan = WalkingPadStartTransaction.plan(
+            isStartTransactionInFlight: true,
+            previousCommandedSpeedKmh: 3.0,
+            factualObservation: .init(
+                motion: .stopped,
+                ageSeconds: 0.5,
+                isCurrentConnectionEpoch: true
+            ),
+            targetSpeedKmh: 3.4
+        )
+
+        XCTAssertTrue(plan.isEmpty)
+    }
+
+    private func evidence(
+        for command: WalkingPadStartTransaction.Command,
+        epoch: TreadmillConnectionEpoch
+    ) -> TreadmillCommandEnqueuedEvidence {
+        switch command {
+        case .modeManual:
+            return evidence(kind: .other("mode_manual"), epoch: epoch)
+        case .start:
+            return evidence(kind: .other("start"), epoch: epoch)
+        case .speed(let targetSpeedKmh):
+            return evidence(
+                kind: .setSpeed(
+                    TreadmillCommandedSpeedRepresentation.walkingPad(
+                        rawControllerTenths: Int((targetSpeedKmh * 10).rounded())
+                    )
+                ),
+                epoch: epoch
+            )
+        }
+    }
+
+    private func evidence(
+        kind: CommandKind,
+        epoch: TreadmillConnectionEpoch
+    ) -> TreadmillCommandEnqueuedEvidence {
+        TreadmillCommandEnqueuedEvidence(
+            commandID: CommandID(),
+            decisionID: nil,
+            kind: kind,
+            protocolKind: .walkingPad,
+            connectionEpoch: epoch,
+            enqueuedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+
+    private func isSpeedLabel(_ label: String) -> Bool {
+        label.lowercased().hasPrefix("speed")
+    }
+
+    private func functionBody(_ signature: String) throws -> String {
+        guard let signatureRange = bluetoothManagerSource.range(of: signature),
+              let openingBrace = bluetoothManagerSource[signatureRange.upperBound...]
+                .firstIndex(of: "{") else {
+            throw NSError(domain: "WalkingPadStartTransactionTests", code: 1)
+        }
+        var depth = 0
+        var index = openingBrace
+        while index < bluetoothManagerSource.endIndex {
+            switch bluetoothManagerSource[index] {
+            case "{": depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 {
+                    return String(bluetoothManagerSource[openingBrace...index])
+                }
+            default: break
+            }
+            index = bluetoothManagerSource.index(after: index)
+        }
+        throw NSError(domain: "WalkingPadStartTransactionTests", code: 2)
+    }
+
+    private func assertOrdered(
+        _ fragments: [String],
+        in text: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        var searchStart = text.startIndex
+        for fragment in fragments {
+            guard let range = text.range(of: fragment, range: searchStart..<text.endIndex) else {
+                XCTFail("Missing or out-of-order fragment: \(fragment)", file: file, line: line)
+                return
+            }
+            searchStart = range.upperBound
+        }
+    }
+}

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WalkingPadStartTransactionTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WalkingPadStartTransactionTests.swift
@@ -163,6 +163,58 @@ final class WalkingPadStartTransactionTests: XCTestCase {
         XCTAssertTrue(body.contains("after: scheduled.delay"))
     }
 
+    func testHrCommitRejectsAmbiguousWalkingPadMotionBeforeSessionSideEffects() throws {
+        let commit = try functionBody(
+            "private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)"
+        )
+
+        assertOrdered(
+            [
+                "WalkingPadStartTransaction.plan(",
+                "factualObservation: currentWalkingPadFactualMotionObservation()",
+                "guard case .commands = admission else",
+                "abortNativeHeartRateFlow(reason: .superseded)",
+                "return",
+                "resetSessionStats()",
+                "startTrainingStructuredLog(trigger: \"start_hr\")",
+                "isHrControlRunning = true",
+                "beginTelemetryV2Session(legacySessionID: legacySessionID)",
+            ],
+            in: commit
+        )
+    }
+
+    func testHrCommitRollsBackEveryCommittedBoundaryWhenMotionRecheckFails() throws {
+        let commit = try functionBody(
+            "private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)"
+        )
+        let rollback = try functionBody(
+            "private func rollbackCommittedHrControlBeforeMotion()"
+        )
+
+        assertOrdered(
+            [
+                "beginTelemetryV2Session(legacySessionID: legacySessionID)",
+                "persistQualifyingNativeHeartRateBeforeMotion()",
+                "guard startWithSpeed(initialMotionTargetSpeedKmh) else",
+                "rollbackCommittedHrControlBeforeMotion()",
+            ],
+            in: commit
+        )
+        assertOrdered(
+            [
+                "stopTrainingStructuredLog(reason: \"motion_admission_failed\")",
+                "isHrControlRunning = false",
+                "hrControlStartedAt = nil",
+                "hrControlStartedBelt = false",
+                "abortNativeHeartRateFlow(reason: .superseded)",
+                "endTelemetryV2Session(reason: \"motion_admission_failed\")",
+            ],
+            in: rollback
+        )
+        XCTAssertFalse(rollback.contains("stopBelt"))
+    }
+
     func testProductionStopRaceInvalidatesDelayedStartCommands() throws {
         let startBody = try functionBody("func startWithSpeed(_ kmh: Double)")
         let scheduleBody = try functionBody("private func scheduleWrite(")


### PR DESCRIPTION
## Summary

Make every genuine stopped-to-moving WalkingPad start own the complete `MODE MANUAL -> START -> initial speed` command transaction. Keep already-moving speed adjustments speed-only, and bound duplicate-start admission plus delayed writes to the current connection/queue epoch.

Closes #128

## Why

After an ordinary Stop, the previous connection-scoped `manualModeSet` cache could suppress `MODE MANUAL` on later starts in the same BLE connection. Physical diagnostics linked in Issue #128 showed those later sessions remained factually stopped until the app reconnected.

## Testing

- [x] `python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py`
- [x] `cd ios/WalkingPadRemote/WalkingPadRemote && swift test`
- [x] `xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`\n- [x] `python3 scripts/check_codex_governance.py`\n- [x] Short deterministic Telemetry V2 soak (2 minutes; complete, zero lost/dropped records)\n\n## Hardware / environment\n\n- Treadmill model: Not run; hardware validation is outside this implementation scope\n- Protocol: WalkingPad FE00 command path; unit/contract tests only\n- iPhone / iOS: Unsigned generic iOS build with local Xcode/iOS 27 SDK\n- Apple Watch / watchOS: Compiled as part of the unsigned app build; no device run\n\n## Screenshots or logs\n\nNo UI change. Exact command labels and Telemetry V2 kinds are covered by `WalkingPadStartTransactionTests`; no live BLE action was performed.\n\n## Notes for reviewers\n\n- Risk areas: stopped-vs-moving admission, duplicate start taps, and Stop preemption of delayed commands\n- Follow-up work: PM/device role retains physical acceptance and merge authorization\n- Docs updated: No; behavior and regression tests only\n