### PR TITLE
Restore accepted Start semantics and repeated manual-mode prerequisite

### DIFF
--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/BluetoothManager.swift
@@ -310,7 +310,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         }
     )
     private var latestTreadmillObservationEvidence: TreadmillObservationEvidence?
-    private var walkingPadStartTransactionConnectionEpoch: TreadmillConnectionEpoch?
     private var treadmillCommandTelemetrySidecar = TreadmillCommandTelemetrySidecar()
     private var treadmillCommandAttemptNumbers: [CommandID: UInt16] = [:]
     private struct TreadmillCommandTelemetryRequest {
@@ -4245,71 +4244,27 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         stopBeltWithToggle(reason: "manual")
     }
 
-    private func currentWalkingPadFactualMotionObservation(
-        now: Date = Date()
-    ) -> WalkingPadStartTransaction.FactualMotionObservation? {
-        guard let observation = latestTreadmillObservationEvidence,
-              observation.protocolKind == .walkingPad,
-              let factualSpeedKmh = observation.factualSpeed?.value else {
-            return nil
-        }
-        let motion: WalkingPadStartTransaction.ObservedMotion
-        if observation.deviceState == .moving || factualSpeedKmh > 0.1 {
-            motion = .moving
-        } else if observation.deviceState == .stopped {
-            motion = .stopped
-        } else {
-            motion = .unknown
-        }
-        return WalkingPadStartTransaction.FactualMotionObservation(
-            motion: motion,
-            ageSeconds: now.timeIntervalSince(observation.receivedAt),
-            isCurrentConnectionEpoch: observation.connectionEpoch
-                == treadmillTelemetryConnectionEpoch
-        )
-    }
-
-    private var isWalkingPadStartTransactionInFlight: Bool {
-        walkingPadStartTransactionConnectionEpoch != nil
-            && walkingPadStartTransactionConnectionEpoch == treadmillTelemetryConnectionEpoch
-    }
-
-    @discardableResult
-    func startWithSpeed(_ kmh: Double) -> Bool {
+    func startWithSpeed(_ kmh: Double) {
         guard !blocksNonStopTreadmillMotion else {
             infoToastMessage = "Сначала завершите восстановленную тренировку"
-            return false
+            return
         }
         guard isTreadmillControlReady else {
             infoToastMessage = isConnected
                 ? "Дождитесь готовности управления дорожкой"
                 : "Не подключено к дорожке"
-            return false
-        }
-        let v = clampRunningSpeedKmh(kmh)
-        let old = deviceTargetSpeedKmh
-        let walkingPadPlan = treadmillProtocol == .walkingPad
-            ? WalkingPadStartTransaction.plan(
-                isStartTransactionInFlight: isWalkingPadStartTransactionInFlight,
-                factualObservation: currentWalkingPadFactualMotionObservation(),
-                targetSpeedKmh: v
-            )
-            : nil
-        if case .blocked(let reason)? = walkingPadPlan {
-            appendLog("WalkingPad motion command blocked: \(reason.rawValue)")
-            if reason == .ambiguousMotion {
-                infoToastMessage = "Дождитесь актуального статуса дорожки"
-            }
-            return false
+            return
         }
         endStopObservationForNewMotion()
         // Cancel any pending delayed writes (e.g. stop retries) before starting a new run.
         resetCommandQueue(reason: "startWithSpeed")
+        let v = clampRunningSpeedKmh(kmh)
         let telemetryDecision = makeTreadmillDecision(
             source: .start,
             intent: .startAtDesiredSpeed(DesiredSpeedKilometresPerHour(value: v))
         )
         defer { observeTreadmillDecision(telemetryDecision) }
+        let old = deviceTargetSpeedKmh
         desiredSpeedKmh = v
         deviceTargetSpeedKmh = v
         recordSpeedChange(from: old, to: v, reason: "manual_go")
@@ -4317,11 +4272,10 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         let shouldSendStart = speedKmh <= 0.2 && old <= 0.1
         switch treadmillProtocol {
         case .walkingPad:
-            guard case .commands(let transaction)? = walkingPadPlan else { return false }
-            if transaction.contains(where: { $0.command == .modeManual }) {
-                walkingPadStartTransactionConnectionEpoch = treadmillTelemetryConnectionEpoch
-            }
-            for scheduled in transaction {
+            for scheduled in WalkingPadStartTransaction.commands(
+                shouldSendStart: shouldSendStart,
+                targetSpeedKmh: v
+            ) {
                 switch scheduled.command {
                 case .modeManual:
                     writeCommand(
@@ -4431,9 +4385,7 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         case .unknown:
             infoToastMessage = "Неподдерживаемая дорожка (протокол не определён)"
             appendLog("Start skipped: unknown treadmill protocol")
-            return false
         }
-        return true
     }
     func stopBelt() {
         guard isConnected else { return }
@@ -5506,41 +5458,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             return
         }
 
-        let initialMotionTargetSpeedKmh: Double? = {
-            if deviceTargetSpeedKmh <= 0.1 && speedKmh <= 0.2 {
-                return 3.0
-            }
-            if deviceTargetSpeedKmh <= 0.1 {
-                return desiredSpeedKmh
-            }
-            return nil
-        }()
-        var motionTargetSpeedKmh = initialMotionTargetSpeedKmh
-        if treadmillProtocol == .walkingPad {
-            let walkingPadTargetSpeedKmh = clampRunningSpeedKmh(
-                initialMotionTargetSpeedKmh ?? deviceTargetSpeedKmh
-            )
-            let admission = WalkingPadStartTransaction.hrStartAdmission(
-                isStartTransactionInFlight: isWalkingPadStartTransactionInFlight,
-                factualObservation: currentWalkingPadFactualMotionObservation(),
-                hasActiveTarget: deviceTargetSpeedKmh > 0.1,
-                targetSpeedKmh: walkingPadTargetSpeedKmh
-            )
-            switch admission {
-            case .commands:
-                motionTargetSpeedKmh = walkingPadTargetSpeedKmh
-            case .noMotionCommand:
-                motionTargetSpeedKmh = nil
-            case .blocked(let reason):
-                appendLog("HR start blocked before commit: \(reason.rawValue)")
-                if reason == .ambiguousMotion {
-                    infoToastMessage = "Дождитесь актуального статуса дорожки"
-                }
-                abortNativeHeartRateFlow(reason: .superseded)
-                return
-            }
-        }
-
         let adaptiveStepDescription = hrAdaptiveStepEnabled
             ? "adaptive_levels=0.1/0.2/0.3/0.4"
             : "step=\(String(format: "%.2f", hrSpeedStepKmh))"
@@ -5582,35 +5499,14 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         nativePreflightCommitTimestamps = nil
         beginTelemetryV2Session(legacySessionID: legacySessionID)
         persistQualifyingNativeHeartRateBeforeMotion()
-        if let motionTargetSpeedKmh {
+        if let motionTargetSpeedKmh = HRDomainService.initialMotionTargetSpeedKmh(
+            deviceTargetSpeedKmh: deviceTargetSpeedKmh,
+            speedKmh: speedKmh,
+            desiredSpeedKmh: desiredSpeedKmh
+        ) {
             hrControlStartedBelt = true
-            guard startWithSpeed(motionTargetSpeedKmh) else {
-                rollbackCommittedHrControlBeforeMotion()
-                return
-            }
+            startWithSpeed(motionTargetSpeedKmh)
         }
-    }
-
-    private func rollbackCommittedHrControlBeforeMotion() {
-        appendLog("HR start rolled back before motion")
-        logTrainingEvent("hr_control_start_rolled_back", fields: [
-            "reason": "motion_admission_failed",
-        ])
-        stopTrainingStructuredLog(reason: "motion_admission_failed")
-        isHrControlRunning = false
-        hrStatusLine = "HR‑контроль не запущен"
-        hrSessionTotalSeconds = 0
-        hrRemainingSeconds = 0
-        hrNextDecisionSeconds = 0
-        hrProgress = 0
-        hrDecisionDetails = ""
-        hrPredictorStatusLine = ""
-        hrNoDataSeconds = 0
-        clearCooldownRuntimeState()
-        hrControlStartedAt = nil
-        hrControlStartedBelt = false
-        abortNativeHeartRateFlow(reason: .superseded)
-        endTelemetryV2Session(reason: "motion_admission_failed")
     }
 
     private var nativeHeartRateTransportIsValid: Bool {
@@ -6746,7 +6642,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
         observeTelemetryImmediately: Bool = true
     ) -> [TreadmillCommandEnqueuedEvidence] {
         let dropped = CommandQueueService.clear(queue: &commandQueue)
-        walkingPadStartTransactionConnectionEpoch = nil
         commandQueueEpoch += 1
         isCommandQueueProcessing = false
         nextCommandAllowedAt = .distantPast
@@ -8721,12 +8616,6 @@ final class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelega
             recordedAt: recordedAt
         )
         latestTreadmillObservationEvidence = evidence
-        if evidence.protocolKind == .walkingPad,
-           evidence.connectionEpoch == walkingPadStartTransactionConnectionEpoch,
-           let factualSpeedKmh = evidence.factualSpeed?.value,
-           evidence.deviceState == .moving || factualSpeedKmh > 0.1 {
-            walkingPadStartTransactionConnectionEpoch = nil
-        }
         observeTreadmillTelemetry(.observation(evidence))
         return evidence
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/HRDomainService.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/HRDomainService.swift
@@ -1,6 +1,20 @@
 import Foundation
 
 enum HRDomainService {
+    // Motion output after the existing native-HR preflight has committed, not admission.
+    static func initialMotionTargetSpeedKmh(
+        deviceTargetSpeedKmh: Double,
+        speedKmh: Double,
+        desiredSpeedKmh: Double
+    ) -> Double? {
+        if deviceTargetSpeedKmh <= 0.1 && speedKmh <= 0.2 {
+            return 3.0
+        } else if deviceTargetSpeedKmh <= 0.1 {
+            return desiredSpeedKmh
+        }
+        return nil
+    }
+
     struct AdaptiveStepSelection {
         let level: Int
         let stepKmh: Double

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/WalkingPadStartTransaction.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/WalkingPadStartTransaction.swift
@@ -1,28 +1,6 @@
 import Foundation
 
 enum WalkingPadStartTransaction {
-    enum ObservedMotion: Equatable {
-        case stopped
-        case moving
-        case unknown
-    }
-
-    struct FactualMotionObservation: Equatable {
-        let motion: ObservedMotion
-        let ageSeconds: TimeInterval
-        let isCurrentConnectionEpoch: Bool
-
-        var isFreshCurrent: Bool {
-            isCurrentConnectionEpoch
-                && ageSeconds >= 0
-                && ageSeconds <= StopObservationPolicy.freshnessInterval
-        }
-
-        var isFreshCurrentStop: Bool {
-            isFreshCurrent && motion == .stopped
-        }
-    }
-
     enum Command: Equatable {
         case modeManual
         case start
@@ -45,69 +23,18 @@ enum WalkingPadStartTransaction {
         let delay: TimeInterval
     }
 
-    enum BlockReason: String, Equatable {
-        case startTransactionInFlight = "start_transaction_in_flight"
-        case ambiguousMotion = "ambiguous_motion"
-    }
-
-    enum Plan: Equatable {
-        case commands([ScheduledCommand])
-        case blocked(BlockReason)
-    }
-
-    enum HrStartAdmission: Equatable {
-        case commands([ScheduledCommand])
-        case noMotionCommand
-        case blocked(BlockReason)
-    }
-
-    static func plan(
-        isStartTransactionInFlight: Bool,
-        factualObservation: FactualMotionObservation?,
+    // Compose the existing Start branch only; readiness and safety stay with the caller.
+    static func commands(
+        shouldSendStart: Bool,
         targetSpeedKmh: Double
-    ) -> Plan {
-        guard !isStartTransactionInFlight else {
-            return .blocked(.startTransactionInFlight)
-        }
-        guard factualObservation?.isFreshCurrent == true else {
-            return .blocked(.ambiguousMotion)
-        }
-        if factualObservation?.motion == .moving {
-            return .commands([
-                ScheduledCommand(command: .speed(targetSpeedKmh), delay: 0.2),
-            ])
-        }
-        if factualObservation?.isFreshCurrentStop == true {
-            return .commands([
+    ) -> [ScheduledCommand] {
+        if shouldSendStart {
+            return [
                 ScheduledCommand(command: .modeManual, delay: 0),
                 ScheduledCommand(command: .start, delay: 0.2),
                 ScheduledCommand(command: .speed(targetSpeedKmh), delay: 0.45),
-            ])
+            ]
         }
-        return .blocked(.ambiguousMotion)
-    }
-
-    static func hrStartAdmission(
-        isStartTransactionInFlight: Bool,
-        factualObservation: FactualMotionObservation?,
-        hasActiveTarget: Bool,
-        targetSpeedKmh: Double
-    ) -> HrStartAdmission {
-        guard factualObservation?.isFreshCurrent == true else {
-            return .blocked(.ambiguousMotion)
-        }
-        if factualObservation?.motion == .moving, hasActiveTarget {
-            return .noMotionCommand
-        }
-        switch plan(
-            isStartTransactionInFlight: isStartTransactionInFlight,
-            factualObservation: factualObservation,
-            targetSpeedKmh: targetSpeedKmh
-        ) {
-        case .commands(let commands):
-            return .commands(commands)
-        case .blocked(let reason):
-            return .blocked(reason)
-        }
+        return [ScheduledCommand(command: .speed(targetSpeedKmh), delay: 0.2)]
     }
 }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
@@ -898,6 +898,104 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
         }
     }
 
+    func testStartAfterNormalPreflightCleanupCanCommitAndEmitFullStartOnce() throws {
+        for reason in [NativeHeartRatePreflightEngine.CancellationReason.user,
+                       .timeout, .providerFailure, .treadmillControlLost, .appBackgrounded] {
+            var engine = waitingEngine()
+            var lifecycle = NativeHeartRateProviderLifecycle()
+            lifecycle.bindAttempt(makeIntent().id)
+            let oldGeneration = lifecycle.beginProviderLifecycle()
+            XCTAssertEqual(engine.cancel(reason: reason), [.discard(reason: reason)])
+            let cleanup = lifecycle.beginCleanup()
+            XCTAssertFalse(lifecycle.acceptsObservation(providerIsCollecting: true))
+            XCTAssertTrue(lifecycle.completeCleanup(generation: cleanup, providerIsIdle: true))
+
+            let retryAt = now.addingTimeInterval(40)
+            let retry = NativeHeartRatePreflightEngine.Intent(
+                id: UUID(), targetBPM: 145, durationMinutes: 30, requestedAt: retryAt
+            )
+            lifecycle.bindAttempt(retry.id)
+            let generation = lifecycle.beginProviderLifecycle()
+            XCTAssertFalse(lifecycle.acceptsProviderCompletion(generation: oldGeneration))
+            XCTAssertTrue(lifecycle.acceptsProviderCompletion(generation: generation, attemptID: retry.id))
+            XCTAssertEqual(engine.requestStart(intent: retry, safety: safeFacts()), [.prepare])
+            XCTAssertEqual(engine.providerPrepared(at: retryAt), [
+                .startCollection(intent: retry, acquisitionStartedAt: retryAt),
+            ])
+            XCTAssertEqual(engine.collectionStarted(
+                intentID: retry.id, acquisitionStartedAt: retryAt, now: retryAt
+            ), [])
+            XCTAssertTrue(lifecycle.acceptsObservation(providerIsCollecting: true))
+            // A callback from the old acquisition cannot satisfy the new attempt.
+            XCTAssertEqual(engine.receive(
+                nativeObservation(), safety: safeFacts(), now: retryAt, freshnessLimit: 7
+            ), [])
+            let receivedAt = retryAt.addingTimeInterval(1)
+            let observation = nativeObservation(measuredAt: receivedAt, receivedAt: receivedAt)
+            let effects = engine.receive(
+                observation, safety: safeFacts(), now: receivedAt, freshnessLimit: 7
+            )
+            XCTAssertEqual(effects, [
+                .commit(intent: retry, observation: observation, acquisitionStartedAt: retryAt),
+            ])
+            XCTAssertTrue(NativeHeartRatePreflightEngine.RuntimePolicy.permitsProductionCommit(
+                intent: retry, now: receivedAt, flowOwnsController: true,
+                nativeWorkoutAlreadyCommitted: false, providerIsCollecting: true,
+                observationIsQualifying: observation.isQualifying(
+                    collectionStartedAt: retryAt, now: receivedAt, freshnessLimit: 7
+                ), safety: safeFacts()
+            ))
+            let target = try XCTUnwrap(HRDomainService.initialMotionTargetSpeedKmh(
+                deviceTargetSpeedKmh: 0, speedKmh: 0, desiredSpeedKmh: 4.2
+            ))
+            XCTAssertEqual(WalkingPadStartTransaction.commands(
+                shouldSendStart: true, targetSpeedKmh: target
+            ), [
+                .init(command: .modeManual, delay: 0),
+                .init(command: .start, delay: 0.2),
+                .init(command: .speed(3), delay: 0.45),
+            ])
+            XCTAssertEqual(engine.receive(
+                observation, safety: safeFacts(), now: receivedAt, freshnessLimit: 7
+            ), [])
+        }
+    }
+
+    func testAcceptedNegativeSafetyFactsStillForbidProductionCommit() {
+        for safety in [
+            safeFacts(treadmillControlReady: false), safeFacts(transportValid: false),
+            safeFacts(controllerUnitsAllowed: false), safeFacts(appActivity: .inactive),
+            safeFacts(appActivity: .background), safeFacts(hasConflictingWorkout: true),
+            safeFacts(stopInProgress: true),
+        ] {
+            XCTAssertFalse(NativeHeartRatePreflightEngine.RuntimePolicy.permitsProductionCommit(
+                intent: makeIntent(), now: now.addingTimeInterval(2), flowOwnsController: true,
+                nativeWorkoutAlreadyCommitted: false, providerIsCollecting: true,
+                observationIsQualifying: true, safety: safety
+            ))
+        }
+    }
+
+    func testMissingStaleAndNonqualifyingNativeHeartRateCannotCommit() {
+        var withoutHR = waitingEngine()
+        XCTAssertEqual(withoutHR.safetyChanged(
+            safeFacts(), now: now.addingTimeInterval(2), freshnessLimit: 7
+        ), [])
+        let samples: [NativeHeartRatePreflightEngine.Observation] = [
+            nativeObservation(source: .legacyWatch),
+            nativeObservation(measuredAt: now.addingTimeInterval(-1)),
+            nativeObservation(measuredAt: now, receivedAt: now),
+            .init(source: .nativeHealthKit, beatsPerMinute: 0,
+                  measuredAt: now.addingTimeInterval(9), receivedAt: now.addingTimeInterval(9)),
+        ]
+        for sample in samples {
+            var engine = waitingEngine()
+            XCTAssertEqual(engine.receive(
+                sample, safety: safeFacts(), now: now.addingTimeInterval(9), freshnessLimit: 7
+            ), [])
+        }
+    }
+
     private func preparedEngine() -> NativeHeartRatePreflightEngine {
         var engine = NativeHeartRatePreflightEngine()
         _ = engine.requestWarmPreparation()
@@ -948,6 +1046,7 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
     private func safeFacts(
         appActivity: NativeHeartRatePreflightEngine.AppActivity = .active,
         treadmillControlReady: Bool = true,
+        transportValid: Bool = true,
         controllerUnitsAllowed: Bool = true,
         hasConflictingWorkout: Bool = false,
         stopInProgress: Bool = false,
@@ -956,7 +1055,7 @@ final class NativeHeartRatePreflightEngineTests: XCTestCase {
         .init(
             appActivity: appActivity,
             treadmillControlReady: treadmillControlReady,
-            transportValid: true,
+            transportValid: transportValid,
             controllerUnitsAllowed: controllerUnitsAllowed,
             hasConflictingWorkout: hasConflictingWorkout,
             stopInProgress: stopInProgress,

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
@@ -67,12 +67,11 @@ final class NativeHeartRatePreflightIntegrationContractTests: XCTestCase {
         ], in: commit)
         assertOrdered([
             "controllerUnitsGateDecision()",
-            "WalkingPadStartTransaction.hrStartAdmission(",
-            "case .blocked(let reason):",
+            "nativeHeartRateSafetyFacts().permitsCommit",
             "isHrControlRunning = true",
             "beginTelemetryV2Session(legacySessionID: legacySessionID)",
-            "guard startWithSpeed(motionTargetSpeedKmh) else",
-            "rollbackCommittedHrControlBeforeMotion()",
+            "HRDomainService.initialMotionTargetSpeedKmh(",
+            "startWithSpeed(motionTargetSpeedKmh)",
         ], in: productionStart)
         XCTAssertEqual(productionStart.components(separatedBy: "isHrControlRunning = true").count - 1, 1)
     }

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WalkingPadStartTransactionTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/WalkingPadStartTransactionTests.swift
@@ -5,478 +5,234 @@ import XCTest
 
 final class WalkingPadStartTransactionTests: XCTestCase {
     private lazy var bluetoothManagerSource: String = {
-        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
-        let sourceURL = testsDirectory
-            .deletingLastPathComponent()
-            .appendingPathComponent("WalkingPadRemote/BluetoothManager.swift")
-        return (try? String(contentsOf: sourceURL, encoding: .utf8)) ?? ""
+        let directory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        return try! String(
+            contentsOf: directory.deletingLastPathComponent()
+                .appendingPathComponent("WalkingPadRemote/BluetoothManager.swift"),
+            encoding: .utf8
+        )
     }()
 
-    func testFirstStoppedStartOwnsFullPrerequisiteTransaction() {
-        XCTAssertEqual(
-            WalkingPadStartTransaction.plan(
-                isStartTransactionInFlight: false,
-                factualObservation: freshObservation(.stopped),
-                targetSpeedKmh: 3.0
-            ),
-            .commands([
-                .init(command: .modeManual, delay: 0),
-                .init(command: .start, delay: 0.2),
-                .init(command: .speed(3.0), delay: 0.45),
-            ])
-        )
+    func testAcceptedStartComposesFullSequenceWithoutAnyObservationPrerequisite() {
+        XCTAssertEqual(WalkingPadStartTransaction.commands(
+            shouldSendStart: true, targetSpeedKmh: 3.0
+        ), [
+            .init(command: .modeManual, delay: 0),
+            .init(command: .start, delay: 0.2),
+            .init(command: .speed(3.0), delay: 0.45),
+        ])
     }
 
-    func testOrdinaryStopThenSecondStartInSameConnectionOwnsPrerequisitesAgain() {
-        let firstStart = WalkingPadStartTransaction.plan(
-            isStartTransactionInFlight: false,
-            factualObservation: freshObservation(.stopped),
-            targetSpeedKmh: 3.0
-        )
-
-        // An ordinary Stop does not need to mutate any start-transaction cache.
-        let secondStart = WalkingPadStartTransaction.plan(
-            isStartTransactionInFlight: false,
-            factualObservation: freshObservation(.stopped),
-            targetSpeedKmh: 3.4
-        )
-
-        XCTAssertEqual(commands(from: firstStart).map(\.command), [.modeManual, .start, .speed(3.0)])
-        XCTAssertEqual(commands(from: secondStart).map(\.command), [.modeManual, .start, .speed(3.4)])
+    func testAlreadyMovingAdjustmentIsSpeedOnlyAtOriginalDelay() {
+        XCTAssertEqual(WalkingPadStartTransaction.commands(
+            shouldSendStart: false, targetSpeedKmh: 3.8
+        ), [.init(command: .speed(3.8), delay: 0.2)])
     }
 
-    func testSpeedAdjustmentWhileMovingDoesNotResendPrerequisites() {
-        XCTAssertEqual(
-            WalkingPadStartTransaction.plan(
-                isStartTransactionInFlight: false,
-                factualObservation: freshObservation(.moving),
-                targetSpeedKmh: 3.8
-            ),
-            .commands([.init(command: .speed(3.8), delay: 0.2)])
-        )
-    }
-
-    func testDisconnectReconnectDoesNotChangeStoppedStartContract() {
-        let beforeDisconnect = WalkingPadStartTransaction.plan(
-            isStartTransactionInFlight: false,
-            factualObservation: freshObservation(.stopped),
-            targetSpeedKmh: 3.0
-        )
-        let afterReconnect = WalkingPadStartTransaction.plan(
-            isStartTransactionInFlight: false,
-            factualObservation: freshObservation(.stopped),
-            targetSpeedKmh: 3.0
-        )
-
-        XCTAssertEqual(afterReconnect, beforeDisconnect)
-        XCTAssertEqual(commands(from: afterReconnect).map(\.command), [.modeManual, .start, .speed(3.0)])
-    }
-
-    func testHighPriorityStopPreemptsPartiallyQueuedSecondStartAndTelemetrySidecar() {
+    func testOrdinaryStopThenSecondWorkoutOnSameConnectionResendsMode() {
         let epoch = TreadmillConnectionEpoch(rawValue: UUID())
-        let secondStart = WalkingPadStartTransaction.plan(
-            isStartTransactionInFlight: false,
-            factualObservation: freshObservation(.stopped),
-            targetSpeedKmh: 3.0
-        )
         var queue: [CommandQueueService.Command] = []
         var sidecar = TreadmillCommandTelemetrySidecar()
-
-        for scheduled in commands(from: secondStart) {
-            let label = scheduled.command.label
-            let command = CommandQueueService.Command(data: Data(), label: label)
-            _ = CommandQueueService.enqueueRegular(
-                queue: &queue,
-                command: command,
-                isSpeedLabel: isSpeedLabel
+        for speed in [3.0, 3.4] {
+            let commands = WalkingPadStartTransaction.commands(shouldSendStart: true, targetSpeedKmh: speed)
+            enqueue(commands, epoch: epoch, queue: &queue, sidecar: &sidecar)
+            XCTAssertEqual(queue.map(\.label), [
+                "MODE MANUAL", "START", String(format: "SPEED %.1f km/h", speed),
+            ])
+            XCTAssertEqual(commands.map(\.delay), [0, 0.2, 0.45])
+            for command in queue {
+                guard case .matched(let current) = sidecar.dequeue(
+                    expectedLabel: command.label, currentEpoch: epoch
+                ) else { return XCTFail("Expected current-connection command evidence") }
+                XCTAssertEqual(current.connectionEpoch, epoch)
+            }
+            _ = CommandQueueService.clear(queue: &queue)
+            CommandQueueService.replaceWithHighPriority(
+                queue: &queue, command: .init(data: Data(), label: "STOP")
             )
-            _ = sidecar.enqueueRegular(
-                label: label,
-                evidence: evidence(for: scheduled.command, epoch: epoch),
-                isSpeedLabel: isSpeedLabel
-            )
+            _ = sidecar.replaceWithHighPriority(label: "STOP", evidence: evidence(kind: .stop, epoch: epoch))
+            XCTAssertEqual(queue.map(\.label), ["STOP"])
+            _ = CommandQueueService.clear(queue: &queue)
+            _ = sidecar.clear()
+            // Normal workout end does not reset a mode/start cache: none exists.
         }
+    }
 
-        let stopEvidence = evidence(kind: .stop, epoch: epoch)
-        CommandQueueService.replaceWithHighPriority(
-            queue: &queue,
-            command: .init(data: Data([0x00]), label: "STOP")
-        )
-        let superseded = sidecar.replaceWithHighPriority(
-            label: "STOP",
-            evidence: stopEvidence
-        )
+    func testHighPriorityStopPreemptsEveryQueuedPrefixOfSecondStart() {
+        let epoch = TreadmillConnectionEpoch(rawValue: UUID())
+        let first = WalkingPadStartTransaction.commands(shouldSendStart: true, targetSpeedKmh: 3.0)
+        let second = WalkingPadStartTransaction.commands(shouldSendStart: true, targetSpeedKmh: 3.4)
+        XCTAssertEqual(first.map(\.command).prefix(2), second.map(\.command).prefix(2))
+        for count in 1...second.count {
+            var queue: [CommandQueueService.Command] = []
+            var sidecar = TreadmillCommandTelemetrySidecar()
+            enqueue(Array(second.prefix(count)), epoch: epoch, queue: &queue, sidecar: &sidecar)
+            CommandQueueService.replaceWithHighPriority(
+                queue: &queue, command: .init(data: Data(), label: "STOP")
+            )
+            let stop = evidence(kind: .stop, epoch: epoch)
+            let cancelled = sidecar.replaceWithHighPriority(label: "STOP", evidence: stop)
+            XCTAssertEqual(cancelled.map(\.kind), second.prefix(count).map { kind(for: $0.command) })
+            XCTAssertEqual(queue.map(\.label), ["STOP"])
+            XCTAssertEqual(sidecar.dequeue(expectedLabel: "STOP", currentEpoch: epoch), .matched(stop))
+            XCTAssertEqual(sidecar.count, 0)
+        }
+    }
 
-        XCTAssertEqual(queue.map(\.label), ["STOP"])
-        XCTAssertEqual(sidecar.count, 1)
-        XCTAssertEqual(superseded.map(\.kind), [
-            .other("mode_manual"),
-            .other("start"),
-            .setSpeed(TreadmillCommandedSpeedRepresentation.walkingPad(rawControllerTenths: 30)),
-        ])
-        XCTAssertEqual(sidecar.dequeue(expectedLabel: "STOP", currentEpoch: epoch), .matched(stopEvidence))
+    func testReconnectDropsOldQueueAndNewConnectionStillGetsFullStart() {
+        let oldEpoch = TreadmillConnectionEpoch(rawValue: UUID())
+        let newEpoch = TreadmillConnectionEpoch(rawValue: UUID())
+        let commands = WalkingPadStartTransaction.commands(shouldSendStart: true, targetSpeedKmh: 3.0)
+        var queue: [CommandQueueService.Command] = []
+        var sidecar = TreadmillCommandTelemetrySidecar()
+        enqueue(commands, epoch: oldEpoch, queue: &queue, sidecar: &sidecar)
+        XCTAssertEqual(CommandQueueService.clear(queue: &queue), 3)
+        XCTAssertEqual(sidecar.clear().map(\.connectionEpoch), Array(repeating: oldEpoch, count: 3))
+        enqueue(commands, epoch: newEpoch, queue: &queue, sidecar: &sidecar)
+        XCTAssertEqual(queue.map(\.label), ["MODE MANUAL", "START", "SPEED 3.0 km/h"])
+        for command in queue {
+            guard case .matched(let current) = sidecar.dequeue(
+                expectedLabel: command.label, currentEpoch: newEpoch
+            ) else { return XCTFail("Expected new-connection evidence") }
+            XCTAssertEqual(current.connectionEpoch, newEpoch)
+        }
     }
 
     func testCommandLabelsAndTelemetryKindsRemainExact() {
-        let epoch = TreadmillConnectionEpoch(rawValue: UUID())
-        let plan = WalkingPadStartTransaction.plan(
-            isStartTransactionInFlight: false,
-            factualObservation: freshObservation(.stopped),
-            targetSpeedKmh: 3.0
-        )
-
-        let commands = commands(from: plan)
-        XCTAssertEqual(commands.map { $0.command.label }, [
-            "MODE MANUAL",
-            "START",
-            "SPEED 3.0 km/h",
-        ])
-        XCTAssertEqual(commands.map { evidence(for: $0.command, epoch: epoch).kind }, [
-            .other("mode_manual"),
-            .other("start"),
+        let commands = WalkingPadStartTransaction.commands(shouldSendStart: true, targetSpeedKmh: 3.0)
+        XCTAssertEqual(commands.map { $0.command.label }, ["MODE MANUAL", "START", "SPEED 3.0 km/h"])
+        XCTAssertEqual(commands.map { kind(for: $0.command) }, [
+            .other("mode_manual"), .other("start"),
             .setSpeed(TreadmillCommandedSpeedRepresentation.walkingPad(rawControllerTenths: 30)),
         ])
     }
 
-    func testProductionIntegrationUsesStatelessPlanAndExactTelemetryMapping() throws {
-        let body = try functionBody("func startWithSpeed(_ kmh: Double)")
-
-        XCTAssertFalse(bluetoothManagerSource.contains("manualModeSet"))
-        assertOrdered(
-            [
-                "WalkingPadStartTransaction.plan(",
-                "isStartTransactionInFlight: isWalkingPadStartTransactionInFlight",
-                "factualObservation: currentWalkingPadFactualMotionObservation()",
-                "case .modeManual:",
-                "buildCmdPacket(cmd: 0x02, value: 0x01)",
-                "label: scheduled.command.label",
-                "kind: .other(\"mode_manual\")",
-                "case .start:",
-                "buildCmdPacket(cmd: 0x04, value: 0x01)",
-                "kind: .other(\"start\")",
-                "case .speed(let targetSpeedKmh):",
-                "buildWalkingPadSetSpeedPacket(kmh: targetSpeedKmh)",
-                "kind: treadmillSetSpeedCommandKind(targetSpeedKmh)",
-            ],
-            in: body
-        )
-        XCTAssertTrue(body.contains("after: scheduled.delay"))
+    func testHrMotionOutputsMatchAllPre129BranchesAndThresholds() {
+        let cases: [(target: Double, speed: Double, desired: Double, expected: Double?)] = [
+            (0, 0, 4.2, 3), (0.1, 0.2, 4.2, 3),
+            (0, 0.21, 4.2, 4.2), (0.1, 2.5, 3.4, 3.4),
+            (0.11, 0, 4.2, nil), (3, 0, 4.2, nil), (3, 2.5, 4.2, nil),
+        ]
+        for input in cases {
+            let target = HRDomainService.initialMotionTargetSpeedKmh(
+                deviceTargetSpeedKmh: input.target,
+                speedKmh: input.speed,
+                desiredSpeedKmh: input.desired
+            )
+            XCTAssertEqual(target, input.expected)
+            let commands = target.map {
+                WalkingPadStartTransaction.commands(
+                    shouldSendStart: input.speed <= 0.2 && input.target <= 0.1,
+                    targetSpeedKmh: $0
+                )
+            } ?? []
+            if input.target > 0.1 {
+                XCTAssertTrue(commands.isEmpty, "Active target must not cause extra HR motion output")
+            } else if input.speed > 0.2 {
+                XCTAssertEqual(commands, [.init(command: .speed(input.desired), delay: 0.2)])
+            } else {
+                XCTAssertEqual(commands.map(\.command), [.modeManual, .start, .speed(3)])
+            }
+        }
     }
 
-    func testHrCommitRejectsAmbiguousWalkingPadMotionBeforeSessionSideEffects() throws {
-        let commit = try functionBody(
-            "private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)"
-        )
-
-        assertOrdered(
-            [
-                "WalkingPadStartTransaction.hrStartAdmission(",
-                "factualObservation: currentWalkingPadFactualMotionObservation()",
-                "case .blocked(let reason):",
-                "abortNativeHeartRateFlow(reason: .superseded)",
-                "return",
-                "resetSessionStats()",
-                "startTrainingStructuredLog(trigger: \"start_hr\")",
-                "isHrControlRunning = true",
-                "beginTelemetryV2Session(legacySessionID: legacySessionID)",
-            ],
-            in: commit
-        )
+    // The iOS adapter is excluded from SwiftPM. Supplement behavioral rule/queue
+    // tests above with wiring checks, including the absence of another admission gate.
+    func testProductionStartHasNoObservationGateOrCrossWorkoutCache() throws {
+        let start = try functionBody("func startWithSpeed(_ kmh: Double)")
+        let commit = try functionBody("private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)")
+        for removed in ["manualModeSet", "currentWalkingPadFactualMotionObservation",
+                        "walkingPadStartTransactionConnectionEpoch", "hrStartAdmission",
+                        "rollbackCommittedHrControlBeforeMotion", "motion_admission_failed"] {
+            XCTAssertFalse(bluetoothManagerSource.contains(removed), removed)
+        }
+        for body in [start, commit] {
+            XCTAssertFalse(body.contains("latestTreadmillObservationEvidence"))
+            XCTAssertFalse(body.contains("Дождитесь актуального статуса дорожки"))
+        }
+        assertOrdered([
+            "guard !blocksNonStopTreadmillMotion", "guard isTreadmillControlReady",
+            "resetCommandQueue(reason: \"startWithSpeed\")", "clampRunningSpeedKmh(kmh)",
+            "let old = deviceTargetSpeedKmh", "deviceTargetSpeedKmh = v",
+            "let shouldSendStart = speedKmh <= 0.2 && old <= 0.1",
+            "WalkingPadStartTransaction.commands(", "shouldSendStart: shouldSendStart",
+        ], in: start)
+        assertOrdered([
+            "nativeHeartRateSafetyFacts().permitsCommit", "unitsDecision.allowed",
+            "isHrControlRunning = true", "persistQualifyingNativeHeartRateBeforeMotion()",
+            "HRDomainService.initialMotionTargetSpeedKmh(",
+            "deviceTargetSpeedKmh: deviceTargetSpeedKmh", "speedKmh: speedKmh",
+            "desiredSpeedKmh: desiredSpeedKmh", "hrControlStartedBelt = true",
+            "startWithSpeed(motionTargetSpeedKmh)",
+        ], in: commit)
+        XCTAssertTrue(try functionBody("private func observeCurrentStopTruth(")
+            .contains("latestTreadmillObservationEvidence"))
     }
 
-    func testHrAdmissionKeepsStoppedMovingAdoptionActiveTargetAndAmbiguousBoundaries() {
-        XCTAssertEqual(
-            WalkingPadStartTransaction.hrStartAdmission(
-                isStartTransactionInFlight: false,
-                factualObservation: freshObservation(.stopped),
-                hasActiveTarget: true,
-                targetSpeedKmh: 3.4
-            ),
-            .commands([
-                .init(command: .modeManual, delay: 0),
-                .init(command: .start, delay: 0.2),
-                .init(command: .speed(3.4), delay: 0.45),
-            ])
-        )
-        XCTAssertEqual(
-            WalkingPadStartTransaction.hrStartAdmission(
-                isStartTransactionInFlight: false,
-                factualObservation: freshObservation(.moving),
-                hasActiveTarget: false,
-                targetSpeedKmh: 3.0
-            ),
-            .commands([.init(command: .speed(3.0), delay: 0.2)])
-        )
-        XCTAssertEqual(
-            WalkingPadStartTransaction.hrStartAdmission(
-                isStartTransactionInFlight: false,
-                factualObservation: freshObservation(.moving),
-                hasActiveTarget: true,
-                targetSpeedKmh: 3.4
-            ),
-            .noMotionCommand
-        )
-        XCTAssertEqual(
-            WalkingPadStartTransaction.hrStartAdmission(
-                isStartTransactionInFlight: false,
-                factualObservation: nil,
-                hasActiveTarget: true,
-                targetSpeedKmh: 3.4
-            ),
-            .blocked(.ambiguousMotion)
-        )
+    func testProductionCommandMappingAndDelayedStopEpochPreemptionStayIntact() throws {
+        let start = try functionBody("func startWithSpeed(_ kmh: Double)")
+        assertOrdered([
+            "case .modeManual:", "buildCmdPacket(cmd: 0x02, value: 0x01)",
+            "label: scheduled.command.label", "requiresControlReadiness: true",
+            "kind: .other(\"mode_manual\")", "case .start:",
+            "buildCmdPacket(cmd: 0x04, value: 0x01)", "after: scheduled.delay",
+            "requiresControlReadiness: true", "kind: .other(\"start\")",
+            "case .speed(let targetSpeedKmh):", "buildWalkingPadSetSpeedPacket(kmh: targetSpeedKmh)",
+            "after: scheduled.delay", "requiresControlReadiness: true",
+            "kind: treadmillSetSpeedCommandKind(targetSpeedKmh)",
+        ], in: start)
+        assertOrdered([
+            "let epoch = commandQueueEpoch", "guard self.commandQueueEpoch == epoch else { return }",
+            "self.writeCommand(",
+        ], in: try functionBody("private func scheduleWrite("))
+        assertOrdered([
+            "if highPriority", "resetCommandQueue(",
+            "CommandQueueService.replaceWithHighPriority", "processCommandQueue()",
+        ], in: try functionBody("private func enqueueCommand("))
+        assertOrdered([
+            "CommandQueueService.clear(queue: &commandQueue)", "commandQueueEpoch += 1",
+        ], in: try functionBody("private func resetCommandQueue("))
     }
 
-    func testHrCommitExecutesOnlyTheAdmittedMotionOutput() throws {
-        let commit = try functionBody(
-            "private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)"
-        )
-
-        assertOrdered(
-            [
-                "WalkingPadStartTransaction.hrStartAdmission(",
-                "hasActiveTarget: deviceTargetSpeedKmh > 0.1",
-                "case .commands:",
-                "motionTargetSpeedKmh = walkingPadTargetSpeedKmh",
-                "case .noMotionCommand:",
-                "motionTargetSpeedKmh = nil",
-                "case .blocked(let reason):",
-                "abortNativeHeartRateFlow(reason: .superseded)",
-                "if let motionTargetSpeedKmh",
-                "guard startWithSpeed(motionTargetSpeedKmh) else",
-            ],
-            in: commit
-        )
-    }
-
-    func testHrCommitRollsBackEveryCommittedBoundaryWhenMotionRecheckFails() throws {
-        let commit = try functionBody(
-            "private func commitExistingHrControl(preflightLatencySeconds: TimeInterval)"
-        )
-        let rollback = try functionBody(
-            "private func rollbackCommittedHrControlBeforeMotion()"
-        )
-
-        assertOrdered(
-            [
-                "beginTelemetryV2Session(legacySessionID: legacySessionID)",
-                "persistQualifyingNativeHeartRateBeforeMotion()",
-                "guard startWithSpeed(motionTargetSpeedKmh) else",
-                "rollbackCommittedHrControlBeforeMotion()",
-            ],
-            in: commit
-        )
-        assertOrdered(
-            [
-                "stopTrainingStructuredLog(reason: \"motion_admission_failed\")",
-                "isHrControlRunning = false",
-                "hrControlStartedAt = nil",
-                "hrControlStartedBelt = false",
-                "abortNativeHeartRateFlow(reason: .superseded)",
-                "endTelemetryV2Session(reason: \"motion_admission_failed\")",
-            ],
-            in: rollback
-        )
-        XCTAssertFalse(rollback.contains("stopBelt"))
-    }
-
-    func testProductionStopRaceInvalidatesDelayedStartCommands() throws {
-        let startBody = try functionBody("func startWithSpeed(_ kmh: Double)")
-        let scheduleBody = try functionBody("private func scheduleWrite(")
-        let enqueueBody = try functionBody("private func enqueueCommand(")
-
-        XCTAssertTrue(startBody.contains("case .start:"))
-        XCTAssertTrue(startBody.contains("case .speed(let targetSpeedKmh):"))
-        XCTAssertGreaterThanOrEqual(
-            startBody.components(separatedBy: "after: scheduled.delay").count - 1,
-            2
-        )
-        assertOrdered(
-            [
-                "let epoch = commandQueueEpoch",
-                "guard self.commandQueueEpoch == epoch else { return }",
-                "self.writeCommand(",
-            ],
-            in: scheduleBody
-        )
-        assertOrdered(
-            [
-                "if highPriority",
-                "resetCommandQueue(",
-                "CommandQueueService.replaceWithHighPriority",
-                "processCommandQueue()",
-            ],
-            in: enqueueBody
-        )
-    }
-
-    func testProductionTransactionOwnershipIsBoundedByStopResetAndFactualMoving() throws {
-        let startBody = try functionBody("func startWithSpeed(_ kmh: Double)")
-        let resetBody = try functionBody("private func resetCommandQueue(")
-        let observationBody = try functionBody("private func observeTreadmillProviderObservation(")
-
-        assertOrdered(
-            [
-                "WalkingPadStartTransaction.plan(",
-                "if case .blocked(let reason)? = walkingPadPlan",
-                "resetCommandQueue(reason: \"startWithSpeed\")",
-                "walkingPadStartTransactionConnectionEpoch = treadmillTelemetryConnectionEpoch",
-                "for scheduled in transaction",
-            ],
-            in: startBody
-        )
-        assertOrdered(
-            [
-                "CommandQueueService.clear(queue: &commandQueue)",
-                "walkingPadStartTransactionConnectionEpoch = nil",
-                "commandQueueEpoch += 1",
-            ],
-            in: resetBody
-        )
-        assertOrdered(
-            [
-                "latestTreadmillObservationEvidence = evidence",
-                "evidence.protocolKind == .walkingPad",
-                "let factualSpeedKmh = evidence.factualSpeed?.value",
-                "evidence.deviceState == .moving || factualSpeedKmh > 0.1",
-                "walkingPadStartTransactionConnectionEpoch = nil",
-                "observeTreadmillTelemetry(.observation(evidence))",
-            ],
-            in: observationBody
-        )
-    }
-
-    func testFreshFactualStopOwnsFullTransaction() {
-        let plan = WalkingPadStartTransaction.plan(
-            isStartTransactionInFlight: false,
-            factualObservation: freshObservation(.stopped),
-            targetSpeedKmh: 3.2
-        )
-
-        XCTAssertEqual(commands(from: plan).map(\.command), [.modeManual, .start, .speed(3.2)])
-    }
-
-    func testStaleOrWrongEpochStopFailsClosedInsteadOfTrustingLocalMovingIntent() {
-        for observation in [
-            WalkingPadStartTransaction.FactualMotionObservation(
-                motion: .stopped,
-                ageSeconds: StopObservationPolicy.freshnessInterval + 0.01,
-                isCurrentConnectionEpoch: true
-            ),
-            WalkingPadStartTransaction.FactualMotionObservation(
-                motion: .stopped,
-                ageSeconds: 0.5,
-                isCurrentConnectionEpoch: false
-            ),
-        ] {
-            XCTAssertEqual(
-                WalkingPadStartTransaction.plan(
-                    isStartTransactionInFlight: false,
-                    factualObservation: observation,
-                    targetSpeedKmh: 3.4
-                ),
-                .blocked(.ambiguousMotion)
+    private func enqueue(
+        _ commands: [WalkingPadStartTransaction.ScheduledCommand],
+        epoch: TreadmillConnectionEpoch,
+        queue: inout [CommandQueueService.Command],
+        sidecar: inout TreadmillCommandTelemetrySidecar
+    ) {
+        for scheduled in commands {
+            let label = scheduled.command.label
+            _ = CommandQueueService.enqueueRegular(
+                queue: &queue, command: .init(data: Data(), label: label), isSpeedLabel: isSpeedLabel
+            )
+            _ = sidecar.enqueueRegular(
+                label: label, evidence: evidence(kind: kind(for: scheduled.command), epoch: epoch),
+                isSpeedLabel: isSpeedLabel
             )
         }
     }
 
-    func testRepeatedStartWhileTransactionIsInFlightEmitsNoDuplicateCommands() {
-        let plan = WalkingPadStartTransaction.plan(
-            isStartTransactionInFlight: true,
-            factualObservation: freshObservation(.stopped),
-            targetSpeedKmh: 3.4
-        )
-
-        XCTAssertEqual(plan, .blocked(.startTransactionInFlight))
-    }
-
-    func testMissingFactualEvidenceFailsClosed() {
-        XCTAssertEqual(
-            WalkingPadStartTransaction.plan(
-                isStartTransactionInFlight: false,
-                factualObservation: nil,
-                targetSpeedKmh: 3.4
-            ),
-            .blocked(.ambiguousMotion)
-        )
-    }
-
-    func testFreshUnknownMotionFailsClosed() {
-        XCTAssertEqual(
-            WalkingPadStartTransaction.plan(
-                isStartTransactionInFlight: false,
-                factualObservation: freshObservation(.unknown),
-                targetSpeedKmh: 3.0
-            ),
-            .blocked(.ambiguousMotion)
-        )
-    }
-
-    private func freshObservation(
-        _ motion: WalkingPadStartTransaction.ObservedMotion
-    ) -> WalkingPadStartTransaction.FactualMotionObservation {
-        .init(
-            motion: motion,
-            ageSeconds: 0.5,
-            isCurrentConnectionEpoch: true
-        )
-    }
-
-    private func commands(
-        from plan: WalkingPadStartTransaction.Plan,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) -> [WalkingPadStartTransaction.ScheduledCommand] {
-        guard case .commands(let commands) = plan else {
-            XCTFail("Expected commands, got \(plan)", file: file, line: line)
-            return []
-        }
-        return commands
-    }
-
-    private func evidence(
-        for command: WalkingPadStartTransaction.Command,
-        epoch: TreadmillConnectionEpoch
-    ) -> TreadmillCommandEnqueuedEvidence {
+    private func kind(for command: WalkingPadStartTransaction.Command) -> CommandKind {
         switch command {
-        case .modeManual:
-            return evidence(kind: .other("mode_manual"), epoch: epoch)
-        case .start:
-            return evidence(kind: .other("start"), epoch: epoch)
-        case .speed(let targetSpeedKmh):
-            return evidence(
-                kind: .setSpeed(
-                    TreadmillCommandedSpeedRepresentation.walkingPad(
-                        rawControllerTenths: Int((targetSpeedKmh * 10).rounded())
-                    )
-                ),
-                epoch: epoch
-            )
+        case .modeManual: .other("mode_manual")
+        case .start: .other("start")
+        case .speed(let speed):
+            .setSpeed(TreadmillCommandedSpeedRepresentation.walkingPad(
+                rawControllerTenths: Int((speed * 10).rounded())
+            ))
         }
     }
 
-    private func evidence(
-        kind: CommandKind,
-        epoch: TreadmillConnectionEpoch
-    ) -> TreadmillCommandEnqueuedEvidence {
-        TreadmillCommandEnqueuedEvidence(
-            commandID: CommandID(),
-            decisionID: nil,
-            kind: kind,
-            protocolKind: .walkingPad,
-            connectionEpoch: epoch,
-            enqueuedAt: Date(timeIntervalSince1970: 1_700_000_000)
-        )
+    private func evidence(kind: CommandKind, epoch: TreadmillConnectionEpoch) -> TreadmillCommandEnqueuedEvidence {
+        .init(commandID: CommandID(), decisionID: nil, kind: kind, protocolKind: .walkingPad,
+              connectionEpoch: epoch, enqueuedAt: Date(timeIntervalSince1970: 1_700_000_000))
     }
 
-    private func isSpeedLabel(_ label: String) -> Bool {
-        label.lowercased().hasPrefix("speed")
-    }
+    private func isSpeedLabel(_ label: String) -> Bool { label.lowercased().hasPrefix("speed") }
 
     private func functionBody(_ signature: String) throws -> String {
         guard let signatureRange = bluetoothManagerSource.range(of: signature),
-              let openingBrace = bluetoothManagerSource[signatureRange.upperBound...]
-                .firstIndex(of: "{") else {
+              let openingBrace = bluetoothManagerSource[signatureRange.upperBound...].firstIndex(of: "{") else {
             throw NSError(domain: "WalkingPadStartTransactionTests", code: 1)
         }
         var depth = 0
@@ -486,9 +242,7 @@ final class WalkingPadStartTransactionTests: XCTestCase {
             case "{": depth += 1
             case "}":
                 depth -= 1
-                if depth == 0 {
-                    return String(bluetoothManagerSource[openingBrace...index])
-                }
+                if depth == 0 { return String(bluetoothManagerSource[openingBrace...index]) }
             default: break
             }
             index = bluetoothManagerSource.index(after: index)
@@ -497,18 +251,14 @@ final class WalkingPadStartTransactionTests: XCTestCase {
     }
 
     private func assertOrdered(
-        _ fragments: [String],
-        in text: String,
-        file: StaticString = #filePath,
-        line: UInt = #line
+        _ fragments: [String], in text: String, file: StaticString = #filePath, line: UInt = #line
     ) {
-        var searchStart = text.startIndex
+        var cursor = text.startIndex
         for fragment in fragments {
-            guard let range = text.range(of: fragment, range: searchStart..<text.endIndex) else {
-                XCTFail("Missing or out-of-order fragment: \(fragment)", file: file, line: line)
-                return
+            guard let range = text.range(of: fragment, range: cursor..<text.endIndex) else {
+                return XCTFail("Missing or out-of-order fragment: \(fragment)", file: file, line: line)
             }
-            searchStart = range.upperBound
+            cursor = range.upperBound
         }
     }
 }


### PR DESCRIPTION
## Summary

**READY FOR PM REVIEW:** PM merged the separate CI-timeout prerequisite in #133 and authorized continuing this same Draft PR. The #130 commit was mechanically rebased with an identical behavior diff; exact-head CI is green and the fresh independent final review returned GO.

Closes #130. Restores the accepted pre-#129 Start/HR-motion contract while retaining the confirmed #128 correction: every existing stopped-to-moving WalkingPad Start emits MODE MANUAL -> START -> SPEED at the original immediate/0.2s/0.45s scheduling points; an already-moving adjustment remains speed-only at 0.2s.

- Remove #129 factual-motion admission, in-flight cache and HR rollback. Missing/stale latest treadmill observations do not independently block Start.
- Preserve #74/#78 readiness, transport, units, native HR, lifecycle, Stop, cooldown and telemetry contracts.
- Restore HR output: target <= 0.1 and speed <= 0.2 -> start at 3.0; otherwise target <= 0.1 -> desired speed; otherwise no extra motion output.

### Review packet

- Issue: https://github.com/tourvald/walkingpad-remote/issues/130
- Active PM resume authorization: https://github.com/tourvald/walkingpad-remote/issues/130#issuecomment-5523412147
- Exact fetched/live base: 9eca40b6da13e12c3ab84a5377f5d7f46acbd27d
- Exact head: 8d6d65da8e9022942cace9ef9c4380de67690072
- Accepted behavioral reference: 240c34aae0847181ff4a86ef8f010179fcd6f737
- Branch: codex/issue-130-restore-start-semantics
- Changed files (all under ios/WalkingPadRemote/WalkingPadRemote/):
  - WalkingPadRemote/BluetoothManager.swift
  - WalkingPadRemote/HRDomainService.swift
  - WalkingPadRemote/WalkingPadStartTransaction.swift
  - WalkingPadRemoteCoreTests/NativeHeartRatePreflightEngineTests.swift
  - WalkingPadRemoteCoreTests/NativeHeartRatePreflightIntegrationContractTests.swift
  - WalkingPadRemoteCoreTests/WalkingPadStartTransactionTests.swift
- Production delta: 37 additions / 207 deletions, net -170 lines. No new files or dependencies. The retained 40-line command helper only composes the existing branch; the 14-line HR output rule lives in the established domain seam for behavioral coverage.

## Why

The physical #128 capture proved omission of MODE MANUAL on subsequent workouts, not a missing readiness/HR/status prerequisite. #129 introduced an unrelated observation gate that blocked accepted Start flows. This correction deletes that regression without introducing a replacement gate, cache, polling, retries or state machine.

## Verification

- [x] Reproducer on the uncorrected base: one intentional failing test demonstrated ambiguousMotion instead of the accepted full Start sequence when observation was absent.
- [x] Focused Start/HR-preflight/Stop/command/units/readiness/bounds/codec/connection suite: **157 tests, 0 failures**.
- [x] Post-rebase focused suite on `8d6d65da8e9022942cace9ef9c4380de67690072`: **157 tests, 0 failures**.
- [x] Mechanical integration proof: old/new complete six-file behavior diffs have identical SHA-256 `c7679254d54a5964eccbfbfe4d2414ea05a6b1db77e82fd591c10c8a13abb960`; `git range-diff` reports the single #130 commit as equivalent. Base change is only `.github/workflows/ci.yml` `timeout-minutes: 15 -> 25` from merged #133.
- [x] Full swift test: **699 XCTest cases, 0 failures, 1 existing opt-in skip**, exit 0.
- [x] Short deterministic Telemetry V2 soak: **complete; 460/460 records persisted** (120 frames / 336 native / 4 critical), lostCritical/lostNative/droppedFrames/finalQueueDepth all 0; controlOutputChecksum **ea1140aa71917a2a**. JSON invariants independently asserted with Python.
- [x] python3 scripts/check_codex_governance.py
- [x] python3 -m compileall scan_ble.py run_live_stats.py run_menu.py run_workout.py tools/mcp_xcode_server.py
- [x] git diff --check
- [x] xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' -derivedDataPath /tmp/issue130-unsigned-derived CODE_SIGNING_ALLOWED=NO build: **BUILD SUCCEEDED**, including Watch app; Xcode 27.0 (27A5194q), iOS/watchOS 27 SDKs.
- [x] Independent Terra/high safety scope challenge: **GO; no P0/P1/material-P2 findings**.
- [x] Fresh independent final review of exact base `9eca40b6da13e12c3ab84a5377f5d7f46acbd27d` to head `8d6d65da8e9022942cace9ef9c4380de67690072`: **GO; no P0/P1/material-P2 findings**.
- [x] Exact-head CI run [33738325443](https://github.com/tourvald/walkingpad-remote/actions/runs/33738325443) under the merged 25-minute Swift budget: **SUCCESS**; all four jobs green, including full Swift tests and deterministic Telemetry V2 soak. Prior 15-minute attempts and the previous final-review STOP remain historical evidence, not the final verdict for this head.

Focused command (from the Swift package directory):

~~~sh
swift test --filter 'WalkingPadStartTransactionTests|NativeHeartRatePreflightEngineTests|NativeHeartRatePreflightIntegrationContractTests|StopCommandBehaviorContractTests|StopObservationServiceTests|CommandQueueServiceTests|ControllerUnitsSafetyPolicyTests|TreadmillControlReadinessPolicyTests|TreadmillSpeedBoundsServiceTests|BluetoothAutoConnectBehaviorContractTests|BLETransportCodecParamsTests'
~~~

Full/soak commands (same package directory):

~~~sh
swift test
swift run --quiet telemetry-soak --minutes 2 --hr-ms 1000 --treadmill-ms 1000 --burst-every-seconds 30 --burst-native-records 32 --flush-every-seconds 5
~~~

Regression evidence covers the full first/second same-connection transaction, speed-only output, exact labels/kinds and scheduling, queued Stop preemption, reconnect queue ownership, all three HR-output branches/boundaries, and normal preflight cleanup followed by a successful exactly-once retry. Existing negative units/readiness/native-HR/lifecycle/Stop gates remain covered.

| Issue #130 regression | Deterministic evidence |
| --- | --- |
| 1: absent/stale observation is not a new Start blocker | Observation-free command API; testAcceptedStartComposesFullSequenceWithoutAnyObservationPrerequisite plus adapter source-wiring checks and pre-#129 comparison. No observation is interpreted as factual stopped evidence. |
| 2–5: first/second Start, no mode cache, moving adjustment | Full sequence/delay assertions; two workouts with Stop on one connection; false branch is speed-only; production has no mode or transaction cache. |
| 6: HR-output branches | testHrMotionOutputsMatchAllPre129BranchesAndThresholds, including active target with zero speed -> no extra output. |
| 7: retry after cleanup | testStartAfterNormalPreflightCleanupCanCommitAndEmitFullStartOnce covers user/timeout/provider/control/background cancellation, lifecycle-generation cleanup, new intent, rejected old HR and exactly one successful retry. |
| 8–10: accepted negative gates | Readiness policy across three protocols/current epochs, controller-units policy invalid/stale/unknown cases, native preflight missing/stale/nonqualifying HR, transport/lifecycle/conflict/Stop negative facts. |
| 11–13: Stop, reconnect, labels/kinds | Every queued transaction prefix preempted by Stop; sidecar cancellation/reconnect ownership; exact labels/kinds; existing delayed-callback epoch guard verified in adapter source and unchanged from pre-#129. |
| 14–15: unchanged protocols/domain contracts | Exact FTMS/FitShow Start branch comparison; unchanged safety/Stop/transport/observation functions; full package and telemetry soak pass; no unrelated production files changed. |

An exact function-body comparison against the accepted pre-#129 commit confirmed unchanged native Start/preflight/safety/cleanup functions, Stop, scheduleWrite/performWrite/resetCommandQueue, factual observation recording, and both FTMS/FitShow Start branches. BluetoothManager is excluded from SwiftPM: adapter wiring and delayed callback epoch checks are supplementary source-contract tests, not device execution.

## Risks / Notes

- PR #133 supplied the separately authorized 25-minute Swift job budget. PR #131 does not modify CI, skip/filter/shard tests, or change benchmark semantics.

- Draft only. No Ready transition, merge, install, launch, deploy or physical BLE/treadmill action.
- No persistence/schema/configuration/environment migration or deployment step. No external API compatibility change; Start returns its original internal void API. Reverting this correction would restore the known #129 observation-gate regression and is not a hardware safety remedy.
- Command scheduling tests do not prove physical write timing, ACK causality or belt motion. Existing transport spacing remains unchanged.
- Physical validation remains outstanding: after acceptance/merge, PM/user must validate at least two ordinary HR workouts on the same app process/unchanged WalkingPad connection. #37 stays blocked; #36 was not started.
- No HR algorithm/zones/cooldown/Stop/history/export/Telemetry V2 redesign. No screenshots: no UI changes.
- Build/test warnings in untouched code are not repaired here. An initial test rewrite compile error (wrong qualified telemetry speed constructor) was corrected before the successful focused run.
