### PR TITLE
[CI Reliability] Extend Swift exact-head timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
   swift-tests:
     name: Swift Package Tests (exact head)
     runs-on: macos-26
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Increase only the `swift-tests` job timeout from 15 to 25 minutes.
- Keep the full Swift suite, Telemetry V2 soak, runner, exact-head verification, and all other workflow behavior unchanged.

## Verification

- `python3 scripts/check_codex_governance.py`
- `git diff --check`
- Base-to-head diff: one file, one scalar replacement (`1 insertion`, `1 deletion`)
- Exact-head CI run `33683463440`: all four jobs passed on `b424aed2b41fbf949b111122f03c8333c7c2fdae`
- Swift job: 17m11s total; unchanged full `swift test` completed 705 tests with 0 failures and 1 existing opt-in skip
- Unchanged deterministic Telemetry V2 soak and all assertions completed successfully after the full suite

## Risks / Notes

- CI reliability only; no Swift, Python, app, test, telemetry, or runtime source changes.
- No verification filters, skips, retries, sharding, caching, assertions, or benchmark semantics were changed.
- The successful Swift job exceeded the previous 15-minute budget, directly validating the timeout correction.
- No deployment, installation, device, BLE, treadmill, Ready transition, or merge actions.

Closes #132