### PR TITLE
Add a swipeable 10–60 minute duration ribbon

### DIFF
--- a/docs/design/qa-ledger.md
+++ b/docs/design/qa-ledger.md
@@ -2,6 +2,21 @@
 
 Status: passed for the binding Issue #113 workout-analysis export interaction.
 
+## Issue #134 — bounded duration ribbon
+
+Execution base: `cd98dcc858129e9ae923e6483200fff7008df64d`. The writable scope is `ContentView.swift`, its existing source-contract tests, and this ledger. The Issue freezes the visual direction; no concept phase or runtime change is needed.
+
+| Pass | State / form factor | Severity | Finding | Evidence | Owner path | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| Baseline | 30 minutes, iPhone 17 simulator, light | P1 | The initial viewport shows 20–45 with 30 selected in the third cell, preserving the accepted six-cell appearance. | `/private/tmp/issue134-qa/default-30.png` | `ContentView.swift` | Pass |
+| Baseline | 10 / 60 minutes, iPhone 17 simulator, light | P1 | Native initial scrolling clamps to each boundary and keeps the selected preset fully visible. | `/private/tmp/issue134-qa/edge-10.png`, `/private/tmp/issue134-qa/edge-60.png` | `ContentView.swift` | Pass |
+| Baseline | 30 minutes, Accessibility XL, dark | P1 | Scaled cell widths keep the selected number readable in one horizontal row; the selected blue treatment and Start remain visible. | `/private/tmp/issue134-qa/default-30-accessibility-xl-dark.png` | `ContentView.swift` | Pass |
+| Contract | Selection, scrolling, and preview/preparing ownership | P0 | All eleven presets use the same guarded Button callback. Only taps can call `onSelect`; the Hub forwards `onDurationSelect` to the existing `hrDurationMinutes` assignment. Selection styling and accessibility use `selectedMinutes`, never viewport position. A Boolean gates initial positioning; no duration state or scrolling callback is added. | 48 focused Training UI / legacy behavior source-contract tests; 691 full Swift tests | `ContentView.swift`, `HeartRateLegacyBehaviorContractTests.swift` | Pass |
+| Contract | Native scrolling and scope | P0 | `ScrollView(.horizontal)` uses view-aligned settling without a paging limit; no grid, custom gesture physics, continuous recentering, or animation is present. Start/readiness, runtime, BLE, Watch, telemetry, and persistence owners are unchanged. | Apple `ScrollTargetBehavior`, `ScrollViewProxy.scrollTo`, and `containerRelativeFrame` documentation; UI scope checker; unsigned generic iOS/embedded Watch and simulator builds | `ContentView.swift` | Pass |
+| Evidence limitation | Drag, deceleration, and VoiceOver interaction | P3 | Simulator screenshots validate initial/default and boundary positions, not a recorded finger drag. The available computer UI surface cannot resolve this Xcode Simulator; `simctl` supports fixtures/screenshots but not touch gestures. Callback and accessibility wiring are source-contract covered, not executed UI interaction tests. | Simulator-only fixture workflow; no physical device used | QA environment | Disclosed for PM review |
+
+No visual correction was required. Fixture identifiers are now `duration-10`, `duration-30`, and `duration-60`; the historical Issue #68 evidence below describes its old preset domain. No new dependency or production file was added.
+
 ## Issue #113 — workout analysis export action
 
 | Pass | State / form factor | Severity | Finding | Evidence | Owner path | Status |

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote/ContentView.swift
@@ -823,9 +823,9 @@ private func trainingHubPreviewPresentation(named name: String) -> TrainingHubPr
         return hrControl(durationMinutes: 30)
     case "duration-45":
         return hrControl(durationMinutes: 45)
-    case "duration-legacy-10":
+    case "duration-10":
         return hrControl(durationMinutes: 10)
-    case "duration-legacy-60":
+    case "duration-60":
         return hrControl(durationMinutes: 60)
     case "intervals":
         return TrainingHubPresentation(
@@ -1286,12 +1286,15 @@ private struct TrainingZoneScale: View {
     }
 }
 
-private let trainingDurationPresets = [20, 25, 30, 35, 40, 45]
+private let trainingDurationPresets = [10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]
 
 private struct TrainingDurationPresetSelector: View {
     let selectedMinutes: Int
     let interactive: Bool
     let onSelect: (Int) -> Void
+
+    @ScaledMetric(relativeTo: .subheadline) private var minimumCellWidth = 44
+    @State private var didPositionInitially = false
 
     private var hasPresetSelection: Bool {
         trainingDurationPresets.contains(selectedMinutes)
@@ -1315,16 +1318,21 @@ private struct TrainingDurationPresetSelector: View {
                 }
             }
 
-            ViewThatFits(in: .horizontal) {
-                HStack(spacing: 6) {
-                    presetButtons
+            ScrollViewReader { proxy in
+                ScrollView(.horizontal) {
+                    HStack(spacing: 6) {
+                        presetButtons
+                    }
+                    .scrollTargetLayout()
+                    .padding(.vertical, 2)
                 }
-
-                LazyVGrid(
-                    columns: Array(repeating: GridItem(.flexible(), spacing: 6), count: 3),
-                    spacing: 6
-                ) {
-                    presetButtons
+                .scrollIndicators(.hidden)
+                .scrollTargetBehavior(.viewAligned(limitBehavior: .never))
+                .onAppear {
+                    guard !didPositionInitially else { return }
+                    didPositionInitially = true
+                    // Place 30 third in the usual six-cell viewport; boundaries clamp naturally.
+                    proxy.scrollTo(selectedMinutes, anchor: UnitPoint(x: 0.4, y: 0))
                 }
             }
         }
@@ -1343,6 +1351,9 @@ private struct TrainingDurationPresetSelector: View {
                     .monospacedDigit()
                     .foregroundStyle(isSelected ? Color.white : Color.primary)
                     .frame(minWidth: 44, maxWidth: .infinity, minHeight: 44)
+                    .containerRelativeFrame(.horizontal) { width, _ in
+                        max(minimumCellWidth, (width - 5 * 6) / 6)
+                    }
                     .background(
                         isSelected ? Color.accentColor : Color(.systemBackground).opacity(0.55),
                         in: RoundedRectangle(cornerRadius: 12, style: .continuous)
@@ -1357,6 +1368,7 @@ private struct TrainingDurationPresetSelector: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .id(minutes)
             .accessibilityLabel("\(minutes) минут")
             .accessibilityValue(isSelected ? "Выбрано" : "Не выбрано")
             .accessibilityHidden(!interactive)

--- a/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
+++ b/ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemoteCoreTests/HeartRateLegacyBehaviorContractTests.swift
@@ -608,7 +608,7 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         )
 
         XCTAssertTrue(contentViewSource.contains(
-            "private let trainingDurationPresets = [20, 25, 30, 35, 40, 45]"
+            "private let trainingDurationPresets = [10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]"
         ))
         XCTAssertTrue(mapping.contains("durationMinutes: durationMinutes"))
         XCTAssertTrue(mapping.contains("metrics: []"))
@@ -620,8 +620,6 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
         XCTAssertTrue(selector.contains("Text(\"Текущее: \\(selectedMinutes) мин\")"))
         XCTAssertTrue(selector.contains("guard interactive else { return }"))
         XCTAssertTrue(selector.contains("onSelect(minutes)"))
-        XCTAssertFalse(selector.contains("onAppear"))
-        XCTAssertFalse(selector.contains("@State"))
         XCTAssertFalse(selector.contains("@Binding"))
 
         XCTAssertTrue(controlView.contains(
@@ -634,11 +632,48 @@ final class HeartRateLegacyBehaviorContractTests: XCTestCase {
             "duration-20",
             "duration-30",
             "duration-45",
-            "duration-legacy-10",
-            "duration-legacy-60",
+            "duration-10",
+            "duration-60",
         ] {
             XCTAssertTrue(previewFixtures.contains("case \"\(fixture)\""), fixture)
         }
+    }
+
+    func testDurationRibbonViewportCannotSelectOrRecenterAfterPresentation() throws {
+        let selector = try functionBody(
+            "private struct TrainingDurationPresetSelector: View",
+            in: contentViewSource
+        )
+        let appearance = try functionBody(".onAppear", in: selector)
+        let buttonAction = try functionBody("Button ", in: selector)
+        let hub = try functionBody("private struct TrainingHubView: View", in: contentViewSource)
+
+        XCTAssertTrue(selector.contains("ScrollView(.horizontal)"))
+        XCTAssertTrue(selector.contains(".scrollTargetLayout()"))
+        XCTAssertTrue(selector.contains(".scrollTargetBehavior(.viewAligned(limitBehavior: .never))"))
+        for forbidden in ["ViewThatFits", "Grid", ".paging", "DragGesture", ".onChange", ".scrollPosition"] {
+            XCTAssertFalse(selector.contains(forbidden), forbidden)
+        }
+        XCTAssertEqual(buttonAction.split(separator: "\n").map {
+            $0.trimmingCharacters(in: .whitespaces)
+        }, ["{", "guard interactive else { return }", "onSelect(minutes)", "}"])
+        XCTAssertEqual(selector.components(separatedBy: "onSelect(minutes)").count - 1, 1)
+        XCTAssertTrue(selector.contains("ForEach(trainingDurationPresets, id: \\.self)"))
+        XCTAssertTrue(selector.contains("let selectedMinutes: Int"))
+        XCTAssertTrue(selector.contains("let isSelected = minutes == selectedMinutes"))
+        XCTAssertTrue(selector.contains(".accessibilityLabel(\"\\(minutes) минут\")"))
+        XCTAssertTrue(selector.contains(".accessibilityValue(isSelected ? \"Выбрано\" : \"Не выбрано\")"))
+        XCTAssertTrue(selector.contains(".accessibilityHidden(!interactive)"))
+        XCTAssertTrue(selector.contains("@ScaledMetric(relativeTo: .subheadline)"))
+        XCTAssertTrue(selector.contains("max(minimumCellWidth, (width - 5 * 6) / 6)"))
+        assertOrdered([
+            "guard !didPositionInitially else { return }",
+            "didPositionInitially = true",
+            "proxy.scrollTo(selectedMinutes, anchor: UnitPoint(x: 0.4, y: 0))",
+        ], in: appearance)
+        XCTAssertFalse(appearance.contains("onSelect"))
+        XCTAssertTrue(hub.contains("interactive: !presentation.isPreview && !presentation.isPreparing"))
+        XCTAssertTrue(hub.contains("onSelect: onDurationSelect"))
     }
 
     func testActiveWorkoutShellIsObservationalSparseAndTransportFree() throws {


### PR DESCRIPTION
## Summary

Closes #134

Replace the Training Hub's fixed duration row/grid fallback with one bounded native horizontal ribbon containing 10–60 minutes in five-minute steps. Native view-aligned settling moves only the viewport; taps retain the existing guarded `onDurationSelect` → `hrDurationMinutes` path. Initial presentation reveals the selected preset, with 30 retaining the familiar 20–45 viewport. Cell widths scale with Dynamic Type and preserve existing styling/accessibility.

Execution base: `cd98dcc858129e9ae923e6483200fff7008df64d`.
Production delta: **+24/-12 lines** in `ContentView.swift`; no new production files or dependencies.

## Verification

- `swift test --package-path ios/WalkingPadRemote/WalkingPadRemote --scratch-path /private/tmp/issue134-swift --filter 'HeartRateLegacyBehaviorContractTests|TrainingUI'`: 48 tests passed.
- `swift test --package-path ios/WalkingPadRemote/WalkingPadRemote --scratch-path /private/tmp/issue134-swift`: 691 tests passed.
- `python3 scripts/check_codex_governance.py`: passed.
- `.agents/skills/walkingpad-ios-redesign/scripts/check-ui-scope.sh` against the exact execution base and the two authorized Swift files: passed.
- `git diff --check`: passed.
- `xcodebuild -project ios/WalkingPadRemote/WalkingPadRemote/WalkingPadRemote.xcodeproj -scheme WalkingPadRemote -destination 'generic/platform=iOS' -derivedDataPath /private/tmp/issue134-build CODE_SIGNING_ALLOWED=NO build`: passed, including embedded Watch.
- Equivalent unsigned `generic/platform=iOS Simulator` build: passed.
- Simulator previews inspected: default 30, boundaries 10/60, and 30 at Accessibility XL in dark mode. Evidence paths and QA are in `docs/design/qa-ledger.md`.
- Initial sandbox runs could not access compiler caches; authorized reruns passed. The first focused run found a new test-extraction error, corrected before the passing runs above.
- Exact-head [CI 33847730588](https://github.com/tourvald/walkingpad-remote/actions/runs/33847730588): all four jobs passed for `49fbc958ed348fd7182024164d4afa63bbb06e2e`, including Python checks, Swift tests + deterministic soak, project metadata, and unsigned iOS/watchOS build.
- Fresh independent read-only final base-to-head review: GO / READY FOR PM REVIEW, no material P0–P2 findings. Reviewer independently rechecked final PR base/head, Draft status, green CI and clean worktree.

## Risks / Notes

Start/readiness, runtime, BLE, Watch/HealthKit, telemetry, persistence and project configuration are unchanged. No migration, environment change or deployment step is required; rollback is a normal revert of this presentation commit.

Simulator screenshots: `/private/tmp/issue134-qa/default-30.png`, `edge-10.png`, `edge-60.png`, and `default-30-accessibility-xl-dark.png`. These are local review artifacts, not repository assets. Boundary screenshots show native initial scroll placement, not a recorded drag: the available computer UI cannot resolve this Xcode Simulator, and `simctl` has no touch gesture command. Callback and accessibility wiring are source-contract covered rather than executed UI interaction tests; finger-following, deceleration and VoiceOver interaction remain a disclosed visual-QA limitation.

No physical device, BLE or treadmill validation was performed. Keep this PR Draft for PM review; no Ready, merge or deploy action is authorized.
